### PR TITLE
don't require 2 caches for dev/test cases

### DIFF
--- a/cloudformation_templates/edx-reference-architecture.json
+++ b/cloudformation_templates/edx-reference-architecture.json
@@ -135,9 +135,9 @@
       "Default":"2",
       "Description":"The number of Cache Nodes the Cache Cluster should have",
       "Type":"Number",
-      "MinValue":"2",
+      "MinValue":"1",
       "MaxValue":"10",
-      "ConstraintDescription":"must be between 2 and 10."
+      "ConstraintDescription":"must be between 1 and 10."
     },
     "DBName":{
       "Default":"wwc",


### PR DESCRIPTION
@e0d : Eventually we might want to set these thresholds to have better ranges, but for trying the stack out I say that we shouldn't require an more than the minimum number of machines. 
