### PR TITLE
reduce scaling group minimums to 1 for dev/test

### DIFF
--- a/cloudformation_templates/edx-reference-architecture.json
+++ b/cloudformation_templates/edx-reference-architecture.json
@@ -1652,7 +1652,7 @@
         "LaunchConfigurationName":{
           "Ref":"EdxappServer"
         },
-        "MinSize":"2",
+        "MinSize":"1",
         "MaxSize":"2",
         "DesiredCapacity":{
           "Ref":"EdxappDesiredCapacity"
@@ -2028,7 +2028,7 @@
         "LaunchConfigurationName":{
           "Ref":"XqueueServer"
         },
-        "MinSize":"2",
+        "MinSize":"1",
         "MaxSize":"2",
         "DesiredCapacity":{
           "Ref":"XqueueDesiredCapacity"
@@ -2401,7 +2401,7 @@
         "LaunchConfigurationName":{
           "Ref":"RabbitMQServer"
         },
-        "MinSize":"2",
+        "MinSize":"1",
         "MaxSize":"2",
         "DesiredCapacity":{
           "Ref":"RabbitMQDesiredCapacity"
@@ -2786,7 +2786,7 @@
         "LaunchConfigurationName":{
           "Ref":"XServer"
         },
-        "MinSize":"2",
+        "MinSize":"1",
         "MaxSize":"2",
         "DesiredCapacity":{
           "Ref":"XServerDesiredCapacity"


### PR DESCRIPTION
Another one @e0d -- scaling groups have to be smaller to work with single-machine deploys

Part of the reason I'm doing this is I'm hitting machine caps in us-west-1.  I have a request out to Amazon to up those limits, but in the meantime I have to be careful.  Grr.
