### PR TITLE
enabling 'private_ip_address' so ec2.py can find hosts in the VPC

### DIFF
--- a/playbooks/ec2.ini
+++ b/playbooks/ec2.ini
@@ -1,6 +1,6 @@
 [ec2]
 regions=all
 destination_variable=public_dns_name
-vpc_destination_variable=ip_address
+vpc_destination_variable=private_ip_address
 cache_path=/tmp
 cache_max_age=300


### PR DESCRIPTION
This presumes that we have some way to actually _get_ to hosts in the VPC.  We still need to figure that out -- could be DNS with some fancy routing, could be a statically generated/distributed ssh config file. But we have to still do ssh forwarding through the Bastion to get to these machines, even if ec2.py will now list them.

I'll do separate tooling for that next, probably in the same branch.
