### PR TITLE
Coudformation refarch template: fix elasticache creation output

### DIFF
--- a/cloudformation_templates/edx-reference-architecture.json
+++ b/cloudformation_templates/edx-reference-architecture.json
@@ -3131,64 +3131,40 @@
       }
     },
     "ElasticCacheCreateSubnetGroupCommand":{
-      "Description":"Commands to be run to create the elatic cache.  Creation isn't fully supported in CF today.",
+      "Description":"MANUAL COMMAND #1: create subnet group. (these commands have to be run by hand because they aren't supported by CloudFormation yet.",
       "Value":{
         "Fn::Join":[
           "",
           [
-            "elasticache-create-cache-subnet-group",
-            " ",
-            {
-              "Ref":"EdxVPC"
-            },
-            "-ElasticCacheSubnetGroup --description  'VPC ElasticCache Subnet Group'",
-            " --subnet-ID-list",
-            " ",
-            {
-              "Ref":"Cache01"
-            },
-            ",",
-            {
-              "Ref":"Cache02"
-            }
+            "elasticache-create-cache-subnet-group ", { "Ref":"EdxVPC" }, "-ElasticCacheSubnetGroup ",
+            "--description 'VPC ElasticCache Subnet Group' ",
+            "--subnet-ID-list ", { "Ref":"Cache01" }, ",", { "Ref":"Cache02" }
           ]
         ]
       }
     },
     "ElasticCacheCreateCacheClusterCommand":{
-      "Description":"Foo",
+      "Description":"MANUAL COMMAND #2: Create cache cluster.",
       "Value":{
         "Fn::Join":[
           "",
           [
-            "elasticache-create-cache-cluster",
-            " ",
-            {
-              "Ref":"EdxVPC"
-            },
-            "-Cache --num-cache-nodes ",
-            {
-              "Ref":"NumberOfCacheNodes"
-            },
-            " --cache-node-type ",
-            {
-              "Ref":"CacheNodeType"
-            },
-            " --engine memcached --engine-version 1.4.5 --port 12345 --preferred-availability-zone ",
-            {
-              "Fn::FindInMap":[
+            "elasticache-create-cache-cluster ", { "Ref":"EdxVPC" }, "-Cache ",
+            "--num-cache-nodes ", { "Ref":"NumberOfCacheNodes" }, " ",
+            "--cache-node-type ", { "Ref":"CacheNodeType" }, " ",
+            "--engine memcached ",
+            "--engine-version 1.4.5 ",
+            "--port 12345 ",
+            "--preferred-availability-zone ",
+            { "Fn::FindInMap":[
                 "MapRegionsToAvailZones",
                 { "Ref":"AWS::Region" },
                 "AZone0"
               ]
-            },
-            " --cache-parameter-group-name default.memcached1.4 --auto-minor-version-upgrade true",
-            " --cache-subnet-group-name ElasticCacheSubnetGroup",
-            " ",
-            {
-              "Ref":"EdxVPC"
-            },
-            "-ElasticCacheSubnetGroup"
+            }, " ",
+            "--cache-parameter-group-name default.memcached1.4 "
+            "--auto-minor-version-upgrade true ",
+            "--cache-subnet-group-name ", { "Ref":"EdxVPC" },"-ElasticCacheSubnetGroup"
           ]
         ]
       }

--- a/cloudformation_templates/edx-reference-architecture.json
+++ b/cloudformation_templates/edx-reference-architecture.json
@@ -4,7 +4,7 @@
   "Parameters":{
     "EnvironmentTag":{
       "Type":"String",
-      "Description":"A tag value applied to the hosts in the VPC indicating which environment to use during the configuration phase, e.g., development, stage, production",
+      "Description":"A tag value applied to the hosts in the VPC indicating which environment to use during the configuration phase, e.g., dev, stage, prod",
       "Default":"stage"
     },
     "KeyName":{
@@ -3162,7 +3162,7 @@
                 "AZone0"
               ]
             }, " ",
-            "--cache-parameter-group-name default.memcached1.4 "
+            "--cache-parameter-group-name default.memcached1.4 ",
             "--auto-minor-version-upgrade true ",
             "--cache-subnet-group-name ", { "Ref":"EdxVPC" },"-ElasticCacheSubnetGroup"
           ]


### PR DESCRIPTION
Another for you @e0d.

The elasticache creation commands that are spit out of the end of the CFN bringup script has a typo.  While fixing that I made the comments more clear, and made the source a bit easier to read.
