### PR TITLE
cloudformation: open tcp/9418 for git

### DIFF
--- a/cloudformation_templates/edx-reference-architecture.json
+++ b/cloudformation_templates/edx-reference-architecture.json
@@ -1316,6 +1316,12 @@
             "CidrIp":{
               "Ref":"SSHLocation"
             }
+          },
+          {
+            "IpProtocol":"tcp",
+            "FromPort":"9418",
+            "ToPort":"9418",
+            "CidrIp":"0.0.0.0/0"
           }
         ],
         "SecurityGroupEgress":[
@@ -1338,6 +1344,12 @@
             "CidrIp":{
               "Ref":"SSHLocation"
             }
+          },
+          {
+            "IpProtocol":"tcp",
+            "FromPort":"9418",
+            "ToPort":"9418",
+            "CidrIp":"0.0.0.0/0"
           }
         ]
       }

--- a/cloudformation_templates/edx-reference-architecture.json
+++ b/cloudformation_templates/edx-reference-architecture.json
@@ -3135,7 +3135,7 @@
                 "Endpoint.Address"
               ]
             },
-            "'\n",
+            "',\n",
             "        'PORT': '",
             {
               "Fn::GetAtt":[


### PR DESCRIPTION
We need to use the git protocol to access read-only git repos.  It's a quirk that when these are referenced from pip files, they need to go over a source control protocol.  I wish it could go over http/s or ssh, but it can't, so port 9418 it is.

I had to open inbound and outbound 9418 to get this working, don't know why.  Leaving both open for now, will debug later so we can close down.
