### PR TITLE
Update 'edx' group to 'adm' group in LMS setup

### DIFF
--- a/playbooks/roles/lms/tasks/main.yml
+++ b/playbooks/roles/lms/tasks/main.yml
@@ -24,22 +24,22 @@
 # ugly relative pathing here
 
 - name: install read-only ssh key for mitx repo (private)
-  copy: src=../../../{{ secure_dir }}/files/git-identity dest=/etc/git-identity force=yes owner=root group=edx mode=640
+  copy: src=../../../{{ secure_dir }}/files/git-identity dest=/etc/git-identity force=yes owner=root group=adm mode=640
   sudo: True
   tags:
   - lms
   - cms
 
 - name: upload ssh script
-  copy: src=git_ssh.sh dest=/tmp/git_ssh.sh force=yes owner=root group=edx mode=750
+  copy: src=git_ssh.sh dest=/tmp/git_ssh.sh force=yes owner=root group=adm mode=750
   sudo: True
   tags:
   - lms
   - cms
 
 # Check out mitx repo to $app_base_dir
-- name: set permissions on $app_base_dir sgid for edx
-  file: path=$app_base_dir owner=root group=edx mode=2775 state=directory
+- name: set permissions on $app_base_dir sgid for adm
+  file: path=$app_base_dir owner=root group=adm mode=2775 state=directory
   sudo: True
   tags:
   - lms


### PR DESCRIPTION
- Use the 'adm' group for permissioning assets needed during LMS
  initialization, because ubuntu doesn't have the edx user until it logs
  out and logs back in.

This is needed, @jarv, because of the VPC stuff. When you use the paramiko transport, ansible logs in and then out for every play. But to run ansible through a bastion to a VPC subnet, you have to use the SSH transport with a forward, which establishes a single connection and uses it the whole time.  So for soup-to-nuts host bringup in one playbook, ubuntu doesn't have a way to get its new group membership. So we use a group that ubuntu already belongs to instead.
