### PR TITLE
ruby playbook: remove "--deployment" from bundle

### DIFF
--- a/playbooks/roles/ruby/tasks/main.yml
+++ b/playbooks/roles/ruby/tasks/main.yml
@@ -81,4 +81,4 @@
   sudo: true
 
 - name: bundle | bundle install
-  shell: RBENV_ROOT=${rbenv_root} GEM_HOME=${gem_home} ${gem_home}/bin/bundle install --deployment --binstubs chdir=${app_base_dir}/mitx
+  shell: RBENV_ROOT=${rbenv_root} GEM_HOME=${gem_home} ${gem_home}/bin/bundle install --binstubs chdir=${app_base_dir}/mitx


### PR DESCRIPTION
Using the this flag requires Gemfile.lock, which was removed. Was causing install failures. Removing the this flag let this run to completion, for me at least.
