### PR TITLE
temporary software update script

### DIFF
--- a/playbooks/roles/common/files/edx-update.sh
+++ b/playbooks/roles/common/files/edx-update.sh
@@ -49,7 +49,7 @@ cd /opt/wwc/mitx
 BRANCH="origin/feature/edx-west/stanford-theme"
 
 export GIT_SSH="/tmp/git_ssh.sh"
-run git remote update
+run git fetch origin -p
 run git checkout $BRANCH
 
 if [[ $do_CMS ]]; then

--- a/playbooks/roles/common/files/edx-update.sh
+++ b/playbooks/roles/common/files/edx-update.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+function usage() {
+    echo "update.sh [cms|lms|all|none]"
+    echo "    option is what services to collectstatic and restart (default=all)"
+}
+
+if [ $# -gt 1 ]; then
+    usage
+    exit 1
+fi
+
+if [ $# == 0 ]; then
+    do_CMS=1
+    do_LMS=1
+else
+    case $1 in
+        cms)
+            do_CMS=1
+            ;;
+        lms)
+            do_LMS=1
+            ;;
+        both|all)
+            do_CMS=1
+            do_LMS=1
+            ;;
+        none)
+            ;;
+        *)
+            usage
+            exit 1
+            ;;
+    esac
+fi
+
+function run() {
+    echo
+    echo "======== $@"
+    $@
+}
+
+source /etc/profile
+source /opt/edx/bin/activate
+export PATH=$PATH:/opt/www/.gem/bin
+
+cd /opt/wwc/mitx
+
+BRANCH="origin/feature/edx-west/stanford-theme"
+
+export GIT_SSH="/tmp/git_ssh.sh"
+run git remote update
+run git checkout $BRANCH
+
+if [[ $do_CMS ]]; then
+    export SERVICE_VARIANT=cms
+    run rake cms:gather_assets:aws
+    run sudo restart cms
+fi
+
+if [[ $do_LMS ]]; then
+    export SERVICE_VARIANT=lms
+    run rake lms:gather_assets:aws
+    run sudo restart lms
+fi
+

--- a/playbooks/roles/common/tasks/main.yml
+++ b/playbooks/roles/common/tasks/main.yml
@@ -51,3 +51,4 @@
   tags:
   - pre_install
 
+- include: software_update.yml

--- a/playbooks/roles/common/tasks/software_update.yml
+++ b/playbooks/roles/common/tasks/software_update.yml
@@ -1,0 +1,5 @@
+---
+- name: edx-update.sh, manual lms/cms update script
+  copy: src=roles/common/files/edx-update.sh dest=/usr/local/bin/edx-update.sh owner=ubuntu group=adm mode=0775
+  tags:
+  - update


### PR DESCRIPTION
Until we figure out rolling upgrades I needed some way to install.  Doing so completely via an ansible command proved really hard given all the environmental state we needed (virtenv, paths, etc) so this script does that for me.

Currently hardcodes the stanford branch. 

I know this is terrible.  I look forward to the day when we can update software a nicer way.  Can someone get onto master in the interim though?
