### PR TITLE
Nginx log reconfiguration

### DIFF
--- a/playbooks/roles/common/tasks/edx_logging_base.yml
+++ b/playbooks/roles/common/tasks/edx_logging_base.yml
@@ -16,7 +16,7 @@
   - logging
 
 - name: Set permissions on tracking file
-  file: path={{log_base_dir}}/tracking.log owner=syslog group=adm mode=750
+  file: path={{log_base_dir}}/tracking.log owner=syslog group=adm mode=640
   tags:
   - logging
 

--- a/playbooks/roles/common/tasks/main.yml
+++ b/playbooks/roles/common/tasks/main.yml
@@ -56,7 +56,7 @@
 
 - name: Set permissions on edx log file
   # This is done for the benefit of the rake commands, which expect it
-  file: path={{log_base_dir}}/edx.log owner=syslog group=adm mode=770
+  file: path={{log_base_dir}}/edx.log owner=syslog group=adm mode=640
   tags:
   - pre_install
   - logging

--- a/playbooks/roles/nginx/tasks/main.yml
+++ b/playbooks/roles/nginx/tasks/main.yml
@@ -6,27 +6,15 @@
   notify: restart nginx
   tags:
   - nginx
-# removing default link
-- name: Removing default nginx config (enabled)
-  file: path=/etc/nginx/sites-enabled/default state=absent
-  notify: restart nginx
-  tags:
-  - nginx
-- name: Removing default nginx config (available)
-  file: path=/etc/nginx/sites-available/default state=absent
-  tags:
-  - nginx
+
 # Standard configuration that is common across all roles
 # Default values for these variables are set in group_vars/all
 # Note: remove spaces in {{..}}, otherwise you will get a template parsing error.
 - include: nginx_site.yml state={{nginx_cfg.sites_enabled.edx_release}} site_name=edx-release
 - include: nginx_site.yml state={{nginx_cfg.sites_enabled.basic_auth}} site_name=basic-auth
-# Default htpassword file, required for basic auth
-- copy: content={{ nginx_cfg.htpasswd }} dest=/etc/nginx/nginx.htpasswd
-  tags:
-  - nginx
-- name: Ensuring that nginx is running
-  service: name=nginx state=started
+
+- name: Write out default htpasswd file
+  copy: content={{ nginx_cfg.htpasswd }} dest=/etc/nginx/nginx.htpasswd
   tags:
   - nginx
 
@@ -36,15 +24,32 @@
   - nginx
   - logging
 
-# Commented out until default config has nginx log to {{log_base_dir}}/nginx
-# and also until default logrotate task 'nginx' gets removed
-###
-#- name: Set up nginx access log rotation
-#  template: dest=/etc/logrotate.d/nginx-access src=edx_logrotate_nginx_access.j2 owner=root group=root mode=644
-#  tags:
-#  - logging
-#
-#- name: Set up nginx access log rotation
-#  template: dest=/etc/logrotate.d/nginx-error src=edx_logrotate_nginx_error.j2 owner=root group=root mode=644
-#  tags:
-#  - logging
+# removing default link
+- name: Removing default nginx config and restart (enabled)
+  file: path=/etc/nginx/sites-enabled/default state=absent
+  notify: restart nginx
+  tags:
+  - nginx
+
+- name: Ensuring that nginx is running
+  service: name=nginx state=started
+  tags:
+  - nginx
+
+# Note that nginx logs to /var/log until it reads its configuration, so /etc/logrotate.d/nginx is still good
+
+- name: Set up nginx access log rotation
+  template: dest=/etc/logrotate.d/nginx-access src=edx_logrotate_nginx_access.j2 owner=root group=root mode=644
+  tags:
+  - logging
+
+- name: Set up nginx access log rotation
+  template: dest=/etc/logrotate.d/nginx-error src=edx_logrotate_nginx_error.j2 owner=root group=root mode=644
+  tags:
+  - logging
+
+- name: Removing default nginx config (available)
+  file: path=/etc/nginx/sites-available/default state=absent
+  tags:
+  - nginx
+

--- a/playbooks/roles/nginx/templates/cms.j2
+++ b/playbooks/roles/nginx/templates/cms.j2
@@ -5,13 +5,13 @@ server {
 
   server_name trace-cms.*
               studio.lms-dev.m.edx.org;
+  access_log {{log_base_dir}}/nginx/access.log;
+  error_log {{log_base_dir}}/nginx/error.log error;
 
-  #
   # Send error response when request host isn't under our control
   # We will no longer respond to proxy attempts like this with 
   # anything.
   # curl -i -A '' -x http://www.edx.org:80 --proxy-negotiate -U u:p -u u:p http://chat.sdtz.com
-  #
 
   set $reject 'no';
 

--- a/playbooks/roles/nginx/templates/edx_logrotate_nginx_access.j2
+++ b/playbooks/roles/nginx/templates/edx_logrotate_nginx_access.j2
@@ -1,3 +1,5 @@
+# Put in place by ansible
+
 {{log_base_dir}}/nginx/access.log {
   create
   compress

--- a/playbooks/roles/nginx/templates/edx_logrotate_nginx_error.j2
+++ b/playbooks/roles/nginx/templates/edx_logrotate_nginx_error.j2
@@ -1,3 +1,5 @@
+# Put in place by ansible
+
 {{log_base_dir}}/nginx/error.log {
   create
   compress

--- a/playbooks/roles/nginx/templates/lms.j2
+++ b/playbooks/roles/nginx/templates/lms.j2
@@ -3,7 +3,9 @@ server {
 
   listen 80;
 
-  server_name *.edx.org
+  server_name *.edx.org;
+  access_log {{log_base_dir}}/nginx/access.log;
+  error_log {{log_base_dir}}/nginx/error.log error;
 
   #
   # Send error response when request host isn't under our control


### PR DESCRIPTION
- sends logs to /mnt/logs/nginx instead of /var/log. Note that on fresh
  server startup, nginx will still log to /var/log until it reads its
  configuration.
- Installs logrotate configuration for freshly moved nginx logs
- Some directory and file permissions fixups
- Improved order of operations on nginx installation/bringup

There is a corresponding change in stanford's local repo in the nginx templates.
