### PR TITLE
Jbau upstart restart handler

### DIFF
--- a/playbooks/edxapp_prod.yml
+++ b/playbooks/edxapp_prod.yml
@@ -10,6 +10,7 @@
     - gunicorn
     - lms
     - cms
+    - lms-preview
     - ruby
     - npm
     # run this role last

--- a/playbooks/roles/cms/tasks/main.yml
+++ b/playbooks/roles/cms/tasks/main.yml
@@ -4,13 +4,13 @@
 #  - nginx/tasks/main.yml
 ---
 - name: create cms application config
-  template: src=env.json.j2 dest=$app_base_dir/cms.env.json mode=644
+  template: src=env.json.j2 dest=$app_base_dir/cms.env.json mode=640 owner=www-data group=adm
   tags:
   - cms-env
   - cms
 
 - name: create cms auth file
-  template: src=auth.json.j2 dest=$app_base_dir/cms.auth.json mode=644
+  template: src=auth.json.j2 dest=$app_base_dir/cms.auth.json mode=640 owner=www-data group=adm
   tags:
   - cms-env
   - cms

--- a/playbooks/roles/gunicorn/handlers/main.yml
+++ b/playbooks/roles/gunicorn/handlers/main.yml
@@ -1,0 +1,12 @@
+---
+- name: restart lms
+  service: name=lms state=restarted
+  sudo: True
+
+- name: restart cms
+  service: name=cms state=restarted
+  sudo: True
+
+- name: restart lms-preview
+  service: name=lms-preview state=restarted
+  sudo: True

--- a/playbooks/roles/gunicorn/tasks/upstart.yml
+++ b/playbooks/roles/gunicorn/tasks/upstart.yml
@@ -6,6 +6,7 @@
   - "{{ local_dir }}/gunicorn/templates/{{ service_variant }}.conf.j2"
   # seems like paths in first_available_file must be relative to the playbooks dir
   - "roles/gunicorn/templates/{{ service_variant }}.conf.j2"
+  notify: restart {{ service_variant }}
   tags:
   - upstart
   - gunicorn

--- a/playbooks/roles/gunicorn/templates/cms.conf.j2
+++ b/playbooks/roles/gunicorn/templates/cms.conf.j2
@@ -17,8 +17,7 @@ env PORT=8010
 env LANG=en_US.UTF-8
 env DJANGO_SETTINGS_MODULE=cms.envs.aws
 env SERVICE_VARIANT="cms"
- 
- 
+  
 chdir ${app_base_dir}/mitx
 setuid www-data
  

--- a/playbooks/roles/gunicorn/templates/lms-preview.conf.j2
+++ b/playbooks/roles/gunicorn/templates/lms-preview.conf.j2
@@ -17,8 +17,7 @@ env PORT=8020
 env LANG=en_US.UTF-8
 env DJANGO_SETTINGS_MODULE=lms.envs.aws
 env SERVICE_VARIANT="lms-preview"
-
-
+  
 chdir ${app_base_dir}/mitx
 setuid www-data
 

--- a/playbooks/roles/gunicorn/templates/lms.conf.j2
+++ b/playbooks/roles/gunicorn/templates/lms.conf.j2
@@ -17,8 +17,7 @@ env PORT=8000
 env LANG=en_US.UTF-8
 env DJANGO_SETTINGS_MODULE=lms.envs.aws
 env SERVICE_VARIANT="lms"
-
-
+  
 chdir ${app_base_dir}/mitx
 setuid www-data
 

--- a/playbooks/roles/lms-preview/tasks/main.yml
+++ b/playbooks/roles/lms-preview/tasks/main.yml
@@ -4,13 +4,13 @@
 #  - nginx/tasks/main.yml
 ---
 - name: create lms application config
-  template: src=env.json.j2 dest=$app_base_dir/lms-preview.env.json
+  template: src=env.json.j2 dest=$app_base_dir/lms-preview.env.json mode=640 owner=www-data group=adm
   tags:
   - lms-preview
   - lms-preview-env
 
 - name: create lms auth file
-  template: src=auth.json.j2 dest=$app_base_dir/lms-preview.auth.json
+  template: src=auth.json.j2 dest=$app_base_dir/lms-preview.auth.json mode=640 owner=www-data group=adm
   tags:
   - lms-preview
   - lms-preview-env

--- a/playbooks/roles/lms/tasks/main.yml
+++ b/playbooks/roles/lms/tasks/main.yml
@@ -4,13 +4,13 @@
 #  - nginx/tasks/main.yml
 ---
 - name: create lms application config
-  template: src=env.json.j2 dest=$app_base_dir/lms.env.json
+  template: src=env.json.j2 dest=$app_base_dir/lms.env.json mode=640 owner=www-data group=adm
   tags:
   - lms
   - lms-env
 
 - name: create lms auth file
-  template: src=auth.json.j2 dest=$app_base_dir/lms.auth.json
+  template: src=auth.json.j2 dest=$app_base_dir/lms.auth.json mode=640 owner=www-data group=adm
   tags:
   - lms
   - lms-env


### PR DESCRIPTION
We were missing this service handler before.  It's not the prettiest, because it hardcodes service names "lms" "cms" and "lms-preview", but those are role names anyway.
