### PR TITLE
setting auto-scaling min/max to 2

### DIFF
--- a/cloudformation_templates/edx-reference-architecture.json
+++ b/cloudformation_templates/edx-reference-architecture.json
@@ -1672,8 +1672,8 @@
         "LaunchConfigurationName":{
           "Ref":"EdxappServer"
         },
-        "MinSize":"1",
-        "MaxSize":"6",
+        "MinSize":"2",
+        "MaxSize":"2",
         "DesiredCapacity":{
           "Ref":"EdxappDesiredCapacity"
         },
@@ -2048,7 +2048,7 @@
         "LaunchConfigurationName":{
           "Ref":"XqueueServer"
         },
-        "MinSize":"1",
+        "MinSize":"2",
         "MaxSize":"2",
         "DesiredCapacity":{
           "Ref":"XqueueDesiredCapacity"
@@ -2421,7 +2421,7 @@
         "LaunchConfigurationName":{
           "Ref":"RabbitMQServer"
         },
-        "MinSize":"1",
+        "MinSize":"2",
         "MaxSize":"2",
         "DesiredCapacity":{
           "Ref":"RabbitMQDesiredCapacity"
@@ -2806,7 +2806,7 @@
         "LaunchConfigurationName":{
           "Ref":"XServer"
         },
-        "MinSize":"1",
+        "MinSize":"2",
         "MaxSize":"2",
         "DesiredCapacity":{
           "Ref":"XServerDesiredCapacity"


### PR DESCRIPTION
Until we support autoscaling we should keep min/max
the same.  We might want to make it 1/1.
