### PR TITLE
Parameterizing edx git repository location

### DIFF
--- a/playbooks/edxapp_custom.yml
+++ b/playbooks/edxapp_custom.yml
@@ -11,5 +11,6 @@
     - nginx
     - gunicorn
     - lms
+    - cms
     - ruby
     - npm

--- a/playbooks/edxapp_stage.yml
+++ b/playbooks/edxapp_stage.yml
@@ -9,5 +9,6 @@
     - nginx
     - gunicorn
     - lms
+    - cms
     - ruby
     - npm

--- a/playbooks/group_vars/all
+++ b/playbooks/group_vars/all
@@ -2,10 +2,12 @@
 app_base_dir: /opt/wwc
 log_base_dir: /mnt/logs
 venv_dir: /opt/edx
+platform_code_dir: $app_base_dir/edx-platform
 
 # these pathes are relative to the playbook dir
 # directory for secret settings (keys, etc)
 secure_dir: 'secure_example'
+
 # this indicates the path to site-specific (with precedence)
 # things like nginx template files
 local_dir:  '../../ansible_local'

--- a/playbooks/roles/common/tasks/software_update.yml
+++ b/playbooks/roles/common/tasks/software_update.yml
@@ -1,5 +1,5 @@
 ---
 - name: edx-update.sh, manual lms/cms update script
-  copy: src=roles/common/files/edx-update.sh dest=/usr/local/bin/edx-update.sh owner=ubuntu group=adm mode=0775
+  template: src=roles/common/templates/edx-update.sh.j2 dest=/usr/local/bin/edx-update.sh owner=ubuntu group=adm mode=0775
   tags:
   - update

--- a/playbooks/roles/common/templates/edx-update.sh.j2
+++ b/playbooks/roles/common/templates/edx-update.sh.j2
@@ -1,4 +1,6 @@
 #!/bin/bash
+# Placed by ansible; some hardcoded values originate from variables substituted
+# by jinja
 
 function usage() {
     echo "update.sh [cms|lms|all|none]"
@@ -41,10 +43,10 @@ function run() {
 }
 
 source /etc/profile
-source /opt/edx/bin/activate
+source {{venv_dir}}/bin/activate
 export PATH=$PATH:/opt/www/.gem/bin
 
-cd /opt/wwc/mitx
+cd {{platform_code_dir}}
 
 BRANCH="origin/feature/edx-west/stanford-theme"
 

--- a/playbooks/roles/gunicorn/templates/cms.conf.j2
+++ b/playbooks/roles/gunicorn/templates/cms.conf.j2
@@ -1,4 +1,5 @@
 # gunicorn
+# Templated and placed by ansible from jinja2 source
  
 description "gunicorn server"
 author "Calen Pennington <cpennington@mitx.mit.edu>"
@@ -17,8 +18,8 @@ env PORT=8010
 env LANG=en_US.UTF-8
 env DJANGO_SETTINGS_MODULE=cms.envs.aws
 env SERVICE_VARIANT="cms"
-  
-chdir ${app_base_dir}/mitx
+ 
+chdir {{platform_code_dir}}
 setuid www-data
  
-exec ${venv_dir}/bin/gunicorn_django -b 127.0.0.1:$PORT -w $WORKERS --timeout=300 --pythonpath=${app_base_dir}/mitx --settings=cms.envs.aws
+exec ${venv_dir}/bin/gunicorn_django -b 127.0.0.1:$PORT -w $WORKERS --timeout=300 --pythonpath={{platform_code_dir}} --settings=cms.envs.aws

--- a/playbooks/roles/gunicorn/templates/lms.conf.j2
+++ b/playbooks/roles/gunicorn/templates/lms.conf.j2
@@ -17,11 +17,11 @@ env PORT=8000
 env LANG=en_US.UTF-8
 env DJANGO_SETTINGS_MODULE=lms.envs.aws
 env SERVICE_VARIANT="lms"
-  
-chdir ${app_base_dir}/mitx
+
+chdir {{platform_code_dir}}
 setuid www-data
 
-exec ${venv_dir}/bin/gunicorn --preload -b 127.0.0.1:$PORT -w $WORKERS --timeout=300 --pythonpath=${app_base_dir}/mitx lms.wsgi
+exec ${venv_dir}/bin/gunicorn --preload -b 127.0.0.1:$PORT -w $WORKERS --timeout=300 --pythonpath={{platform_code_dir}} lms.wsgi
 
 post-start script
   while true

--- a/playbooks/roles/lms/tasks/main.yml
+++ b/playbooks/roles/lms/tasks/main.yml
@@ -35,12 +35,12 @@
 # If we set up LMS, we have to set up edx logging
 - include: ../../common/tasks/edx_logging_base.yml
 
-# Install ssh keys for ubuntu account to be able to check out from mitx
+# Install ssh keys for ubuntu account to be able to check out from edx-platform
 # Temprory behavior, not needed after June 1. Perhaps still useful as a recipe.
 # {{ secure_dir }} is relative to the top-level playbooks dir so there is some
 # ugly relative pathing here
 
-- name: install read-only ssh key for mitx repo (private)
+- name: install read-only ssh key for edx-platform repo (private)
   copy: src=../../../{{ secure_dir }}/files/git-identity dest=/etc/git-identity force=yes owner=ubuntu group=adm mode=600
   tags:
   - lms
@@ -52,14 +52,15 @@
   - lms
   - cms
 
-# Check out mitx repo to $app_base_dir
+# Check out edx-platform repo to $app_base_dir
 - name: install git and its recommends
   apt: pkg=git state=present install_recommends=yes 
   tags:
   - lms
   - cms
-- name: git checkout mitx repo into $app_base_dir
-  git: dest={{app_base_dir}}/mitx repo={{lms_source_repo}}
+
+- name: git checkout edx-platform repo into $app_base_dir
+  git: dest={{platform_code_dir}} repo={{lms_source_repo}}
   environment:
     GIT_SSH: /tmp/git_ssh.sh
   tags:
@@ -68,7 +69,7 @@
 
 ## Install the debian package requirements system-wide
 - name: store remote apt_repos list for ansible use
-  command: cat {{app_base_dir}}/mitx/apt-repos.txt
+  command: cat {{platform_code_dir}}/apt-repos.txt
   register: apt_repos_list
   tags:
   - lms
@@ -89,7 +90,7 @@
   - lms
   - cms
 - name: store remote apt_packages list for ansible use
-  command: cat {{app_base_dir}}/mitx/apt-packages.txt
+  command: cat {{platform_code_dir}}/apt-packages.txt
   register: apt_packages_list
   tags:
   - lms
@@ -103,18 +104,18 @@
 
 # Install the python requirements into $venv_dir 
 - name : install python pre-requirements
-  pip: requirements="{{app_base_dir}}/mitx/pre-requirements.txt" virtualenv="{{venv_dir}}" state=present
+  pip: requirements="{{platform_code_dir}}/pre-requirements.txt" virtualenv="{{venv_dir}}" state=present
   tags:
   - lms
   - cms
 
 # Install the python modules into $venv_dir 
 - name : install python packages using the shell
-  #pip: requirements="{{app_base_dir}}/mitx/requirements.txt" virtualenv="{{venv_dir}}" 
+  #pip: requirements="{{platform_code_dir}}/requirements.txt" virtualenv="{{venv_dir}}" 
   # Need to use shell rather than pip so that we can maintain the context of our current working directory; some 
-  # requirements are pathed relative to the mitx repo. Using the pip from inside the virtual environment implicitly
+  # requirements are pathed relative to the edx-platform repo. Using the pip from inside the virtual environment implicitly
   # installs everything into that virtual environment.
-  shell: cd {{app_base_dir}}/mitx && {{venv_dir}}/bin/pip install --use-mirrors -r {{app_base_dir}}/mitx/requirements.txt
+  shell: cd {{platform_code_dir}} && {{venv_dir}}/bin/pip install --use-mirrors -r {{platform_code_dir}}/requirements.txt
   tags:
   - lms
   - cms

--- a/playbooks/roles/npm/tasks/main.yml
+++ b/playbooks/roles/npm/tasks/main.yml
@@ -7,8 +7,8 @@
   tags:
   - npm
   
-- name: Install mitx npm dependencies
-  shell: npm install chdir=${app_base_dir}/mitx
+- name: Install edx-platform npm dependencies
+  shell: npm install chdir=${platform_code_dir}
   tags:
   - npm
 

--- a/playbooks/roles/ruby/tasks/main.yml
+++ b/playbooks/roles/ruby/tasks/main.yml
@@ -96,11 +96,11 @@
   - ruby
 
 - name: gem | gem install bundler
-  shell: RBENV_ROOT=${rbenv_root} GEM_HOME=${gem_home} ${rbenv_root}/shims/gem install bundle chdir=${app_base_dir}/mitx
+  shell: RBENV_ROOT=${rbenv_root} GEM_HOME=${gem_home} ${rbenv_root}/shims/gem install bundle chdir=${platform_code_dir}
   tags:
   - ruby
 
 - name: bundle | bundle install
-  shell: RBENV_ROOT=${rbenv_root} GEM_HOME=${gem_home} ${gem_home}/bin/bundle install --binstubs chdir=${app_base_dir}/mitx
+  shell: RBENV_ROOT=${rbenv_root} GEM_HOME=${gem_home} ${gem_home}/bin/bundle install --binstubs chdir=${platform_code_dir}
   tags:
   - ruby


### PR DESCRIPTION
- Creates global variable $platform_code_dir to store
  /opt/wwc/edx-platform, to replace the semihardcoded /opt/wwc/mitx that
  we had before.
- Plugs $platform_code_dir in a lot of different places
- Templatize sef's update script hack

For @jarv to look over. This has been looked at and tested by @jrbl and @jbau, and seems ok in nature.
