### PR TITLE
Clustering config for rabbitmq

### DIFF
--- a/playbooks/ec2.ini
+++ b/playbooks/ec2.ini
@@ -1,6 +1,6 @@
 [ec2]
 regions=all
 destination_variable=public_dns_name
-vpc_destination_variable=private_ip_address
+vpc_destination_variable=private_dns_name
 cache_path=/tmp
 cache_max_age=300

--- a/playbooks/rabbit_prod.yml
+++ b/playbooks/rabbit_prod.yml
@@ -1,0 +1,17 @@
+- hosts:
+    - tag_Group_mlapi-rabbitmq_prod
+  #both machines restarting at the same time may break cluster formation,
+  #so we do these serially
+  serial: 1
+  vars_files:
+    - "{{ secure_dir }}/vars/mlapi_prod_vars.yml"
+    - "{{ secure_dir }}/vars/users.yml"
+  roles:
+    - common
+    - rabbitmq
+  sudo: True
+  tasks:
+    - debug: msg="{{ groups[ha_group_tag] | join(', ') }}"
+      tags:
+        - debug
+

--- a/playbooks/roles/rabbitmq/handlers/main.yml
+++ b/playbooks/roles/rabbitmq/handlers/main.yml
@@ -1,4 +1,10 @@
 ---
+- name: use rabbitmqctl to stop rabbitmq
+  shell: rabbitmqctl {{ item }}
+  with_items:
+    - stop_app
+    - reset
+    - stop
+
 - name: restart rabbitmq
-  service: name=rabbitmq-server state=restarted
-  sudo: True
+  service: name=rabbitmq-server state=started

--- a/playbooks/roles/rabbitmq/handlers/main.yml
+++ b/playbooks/roles/rabbitmq/handlers/main.yml
@@ -1,4 +1,4 @@
 ---
 - name: restart rabbitmq
-  service: name=rabbitmqctl state=restarted
+  service: name=rabbitmq-server state=restarted
   sudo: True

--- a/playbooks/roles/rabbitmq/tasks/main.yml
+++ b/playbooks/roles/rabbitmq/tasks/main.yml
@@ -11,7 +11,9 @@
 
 - name: install rabbitmq
   apt: pkg=rabbitmq-server install_recommends=yes state=present update_cache=yes
-  notify: restart rabbitmq
+  notify: 
+    - use rabbitmqctl to stop rabbitmq
+    - restart rabbitmq
   tags:
     - rabbitmq
 
@@ -20,13 +22,17 @@
   with_items:
     - rabbitmq_management
     - rabbitmq_stomp
-  notify: restart rabbitmq
+  notify: 
+    - use rabbitmqctl to stop rabbitmq
+    - restart rabbitmq
   tags:
     - rabbitmq
 
 - name: sets erlang cookie if ha clustering
   template: src=erlang_cookie.j2 dest=/var/lib/rabbitmq/.erlang.cookie owner=rabbitmq group=rabbitmq mode=0400
-  notify: restart rabbitmq
+  notify: 
+    - use rabbitmqctl to stop rabbitmq
+    - restart rabbitmq
   when: enable_ha
   tags:
     - rabbitmq
@@ -36,7 +42,9 @@
   with_items:
     - rabbitmq.config
     - rabbitmq-env.conf
-  notify: restart rabbitmq
+  notify: 
+    - use rabbitmqctl to stop rabbitmq
+    - restart rabbitmq
   tags:
     - rabbitmq
 

--- a/playbooks/roles/rabbitmq/tasks/main.yml
+++ b/playbooks/roles/rabbitmq/tasks/main.yml
@@ -1,16 +1,42 @@
 #Add rabbitmq to sources.  See http://www.rabbitmq.com/install-debian.html
 - name: add in rabbitmq line to sources.list
   lineinfile: dest=/etc/apt/sources.list state=present line="deb http://www.rabbitmq.com/debian/ testing main" regexp='^deb http://www.rabbitmq.com/debian/ testing main'
+  tags:
+    - rabbitmq
 
 - name: add rabbit key
   apt_key: url=http://www.rabbitmq.com/rabbitmq-signing-key-public.asc state=present
+  tags:
+    - rabbitmq
 
 - name: install rabbitmq
   apt: pkg=rabbitmq-server install_recommends=yes state=present update_cache=yes
   notify: restart rabbitmq
+  tags:
+    - rabbitmq
 
+- name: enable rabbitmq plugins
+  shell: "rabbitmq-plugins enable {{ item }}"
+  with_items:
+    - rabbitmq_management
+    - rabbitmq_stomp
+  notify: restart rabbitmq
+  tags:
+    - rabbitmq
 
+- name: sets erlang cookie if ha clustering
+  template: src=erlang_cookie.j2 dest=/var/lib/rabbitmq/.erlang.cookie owner=rabbitmq group=rabbitmq mode=0400
+  notify: restart rabbitmq
+  when: enable_ha
+  tags:
+    - rabbitmq
 
-
-
+- name: write out rabbitmq.config and rabbitmq-env.conf configurations
+  template: src={{item}}.j2 dest=/etc/rabbitmq/{{item}} owner=rabbitmq group=rabbitmq mode=0640
+  with_items:
+    - rabbitmq.config
+    - rabbitmq-env.conf
+  notify: restart rabbitmq
+  tags:
+    - rabbitmq
 

--- a/playbooks/roles/rabbitmq/templates/erlang_cookie.j2
+++ b/playbooks/roles/rabbitmq/templates/erlang_cookie.j2
@@ -1,0 +1,1 @@
+{{erlang_cookie}}

--- a/playbooks/roles/rabbitmq/templates/rabbitmq-env.conf.j2
+++ b/playbooks/roles/rabbitmq/templates/rabbitmq-env.conf.j2
@@ -1,0 +1,2 @@
+RABBITMQ_NODE_PORT={{ rabbitmq_node_port }}
+RABBITMQ_NODENAME=rabbit@{{ ansible_hostname }}

--- a/playbooks/roles/rabbitmq/templates/rabbitmq.config.j2
+++ b/playbooks/roles/rabbitmq/templates/rabbitmq.config.j2
@@ -1,18 +1,20 @@
 % This file managed by ansible
 % keep erlang kernel communcations to a range
 [
+ {% if enable_ha %}
  {kernel,
   [{inet_dist_listen_min, 65500},
    {inet_dist_listen_max, 65510}
   ]
  },
+ {% endif %}
  {rabbit, [
     {% if enable_ha %}
        {cluster_nodes, {[
          {% for svr in groups[ha_group_tag] %}
            'rabbit@{{hostvars[svr]['ansible_hostname']}}'{% if loop.index != loop.length %},{% endif %}
          {% endfor %}
-       ], 'disk'}}
+       ], 'disc'}}
     {% endif %} 
  ]},
   % Configure the Stomp Plugin listening port

--- a/playbooks/roles/rabbitmq/templates/rabbitmq.config.j2
+++ b/playbooks/roles/rabbitmq/templates/rabbitmq.config.j2
@@ -1,0 +1,20 @@
+% This file managed by ansible
+% keep erlang kernel communcations to a range
+[
+ {kernel,
+  [{inet_dist_listen_min, 65500},
+   {inet_dist_listen_max, 65510}
+  ]
+ },
+ {rabbit, [
+    {% if enable_ha %}
+       {cluster_nodes, {[
+         {% for svr in groups[ha_group_tag] %}
+           'rabbit@{{hostvars[svr]['ansible_hostname']}}'{% if loop.index != loop.length %},{% endif %}
+         {% endfor %}
+       ], 'disk'}}
+    {% endif %} 
+ ]},
+  % Configure the Stomp Plugin listening port
+ {rabbitmq_stomp, [{tcp_listeners, [${rabbitmq_stomp_port}]} ]}
+].

--- a/playbooks/roles/rabbitmq/vars/main.yml
+++ b/playbooks/roles/rabbitmq/vars/main.yml
@@ -1,0 +1,5 @@
+ha_group_tag: tag_Group_mlapi-rabbitmq_prod
+enable_ha: true
+rabbitmq_node_port: 5672
+rabbitmq_stomp_port: 6163
+erlang_cookie: REPLACE_ME_PLEASE


### PR DESCRIPTION
@VikParuchuri these are the changes in configuration I did to enable a 2-node cluster.  See the `enable_ha` var

Writing out the configuration files works, but I think is restarting/starting rabbitmq is pretty brittle, so I'm actually not sure that ansible is the right tool for that.  Maybe @jarv can comment.
