### PR TITLE
version.py: remote repo fix for http remotes

### DIFF
--- a/version-script/version.py
+++ b/version-script/version.py
@@ -96,7 +96,7 @@ def main():
         for line in remote_output.splitlines():
             if ' (fetch)' in line:
                 repo_url = re.search(
-                        'git@(.*) \(fetch\)', line).group(1).replace(
+                        '(git@|git://)(.*) \(fetch\)', line).group(2).replace(
                                                                 ':', '/')
                 break
         if not repo_url:


### PR DESCRIPTION
We check out theme repos using a git HTTP url (git://) instead of git ssh url (git@).  To make the version script work we need to generalize the regexp used to parse out the remotes.  This was causing errors.

To test I just tried this out in a REPL, see below:

```
In [15]: for line in lines:
    print line
   ....:
origingit@github.com:edx/edx-platform.git (fetch)
origingit@github.com:edx/edx-platformrm.git (push)
origingit://github.com/Stanford-Online/edx-theme.git (fetchtch)
origingit://github.com/Stanford-Online/edx-theme.git (push)

In [In16]: for line in lines:
   ....:     if ' (fetch)' in line:
   ....:         repo_url = re.search(
   ....:         '(git@|git://)(.*) \(fetch\)', line).group(2).replace(
   ....:         ':', '/')
   ....:         print repo_url
   ....:
github.com/edx/edx-platform.git
github.com/Stanford-Online/edx-theme.git
```

Please review @e0d or @jarv 
