### PR TITLE
Extend ec2.py to accept an ini file

### DIFF
--- a/playbooks/ec2.py
+++ b/playbooks/ec2.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python
 
+import sys
+import os
+
 '''
 EC2 external inventory script
 =================================
@@ -135,8 +138,8 @@ class Ec2Inventory(object):
         self.index = {}
 
         # Read settings and parse CLI arguments
-        self.read_settings()
         self.parse_cli_args()
+        self.read_settings()
 
         # Cache
         if self.args.refresh_cache:
@@ -175,7 +178,7 @@ class Ec2Inventory(object):
         ''' Reads the settings from the ec2.ini file '''
 
         config = ConfigParser.SafeConfigParser()
-        config.read(os.path.dirname(os.path.realpath(__file__)) + '/ec2.ini')
+        config.read(self.args.inifile)
 
         # is eucalyptus?
         self.eucalyptus_host = None
@@ -219,6 +222,7 @@ class Ec2Inventory(object):
                            help='Get all the variables about a specific instance')
         parser.add_argument('--refresh-cache', action='store_true', default=False,
                            help='Force refresh of cache by making API requests to EC2 (default: False - use cache files)')
+        parser.add_argument('--inifile', dest='inifile', help='Path to init script to use', default=os.path.dirname(os.path.realpath(__file__))+'/ec2.ini',)
         self.args = parser.parse_args()
 
 
@@ -430,4 +434,5 @@ class Ec2Inventory(object):
 
 # Run the script
 Ec2Inventory()
+
 

--- a/playbooks/edx-west/ec2.ini
+++ b/playbooks/edx-west/ec2.ini
@@ -1,0 +1,6 @@
+[ec2]
+regions=us-west-1
+destination_variable=public_dns_name
+vpc_destination_variable=private_dns_name
+cache_path=/tmp
+cache_max_age=300


### PR DESCRIPTION
- End the constant reversion of ec2.ini preferences by allowing ec2.py
  to accept an ini file on the command line, and checking in an ini for
  edx-west that suits their needs.

@jbau check it out.
