### PR TITLE
Update git source repos to https

### DIFF
--- a/playbooks/edx-west/edxapp_prod.yml
+++ b/playbooks/edx-west/edxapp_prod.yml
@@ -1,21 +1,30 @@
+# this gets all running prod webservers
 #- hosts: tag_environment_prod:&tag_function_webserver
+# or we can get subsets of them by name
 - hosts: ~tag_Name_app(10|20)_prod
-#- hosts: tag_environment_prod:&tag_function_webserver
+#- hosts: ~tag_Name_app(11|21)_prod
+## these are cold hosts:
+#- hosts: ~tag_Name_app(12|22)_prod
+## this is the test box
+#- hosts: ~tag_Name_app4_prod
+## you can also do security group, but don't do that
 #- hosts: security_group_edx-prod-EdxappServerSecurityGroup-NSKCQTMZIPQB
   sudo: True
-  vars_files:
-    - "{{ secure_dir }}/vars/edxapp_prod_vars.yml"
-    - "{{ secure_dir }}/vars/users.yml"
-    - "{{ secure_dir }}/vars/edxapp_prod_users.yml"
   vars:
     secure_dir: '../../../configuration-secure/ansible'
     # this indicates the path to site-specific (with precedence)
     # things like nginx template files
     local_dir:  '../../../configuration-secure/ansible/local'
-
+  vars_files:
+    - "{{ secure_dir }}/vars/edxapp_prod_vars.yml"
+    - "{{ secure_dir }}/vars/users.yml"
+    - "{{ secure_dir }}/vars/edxapp_prod_users.yml"
+    - "{{ secure_dir }}/vars/shib_prod_vars.yml"
   roles:
     - common
     - nginx
     - edxapp
+    - apache
+    - shibboleth
     # run this role last
     - in_production

--- a/playbooks/roles/common/templates/edx-update.sh.j2
+++ b/playbooks/roles/common/templates/edx-update.sh.j2
@@ -50,7 +50,6 @@ cd {{edx_platform_code_dir}}
 
 BRANCH="origin/feature/edx-west/stanford-theme"
 
-export GIT_SSH="/tmp/git_ssh.sh"
 run git fetch origin -p
 run git checkout $BRANCH
 

--- a/playbooks/roles/discern/tasks/main.yml
+++ b/playbooks/roles/discern/tasks/main.yml
@@ -40,10 +40,6 @@
 - name: change memory commit settings -- needed for redis
   command: sysctl vm.overcommit_memory=1
 
-#Upload custom git ssh script
-- name: upload ssh script
-  copy: src=git_ssh.sh dest=/tmp/git_ssh.sh force=yes owner=root group=adm mode=750
-
 - name: set permissions on app_base_dir sgid for edx
   file: path={{app_base_dir}} owner=root group=edx mode=2775 state=directory
   file: path={{venv_dir}} owner=root group=edx mode=2775 state=directory
@@ -61,16 +57,12 @@
 #Grab both repos or update
 - name: git checkout discern repo into discern_dir
   git: dest={{discern_dir}} repo={{discern_source_repo}} version={{discern_branch}}
-  environment:
-    GIT_SSH: /tmp/git_ssh.sh
   notify:
     - restart celery
     - restart discern
 
 - name: git checkout ease repo into ease_dir
   git: dest={{ease_dir}} repo={{ease_source_repo}} version={{ease_branch}}
-  environment:
-    GIT_SSH: /tmp/git_ssh.sh
   notify:
     - restart celery
     - restart discern

--- a/playbooks/roles/discern/vars/main.yml
+++ b/playbooks/roles/discern/vars/main.yml
@@ -1,5 +1,5 @@
-discern_source_repo: git@github.com:edx/discern.git
-ease_source_repo: git@github.com:edx/ease.git
+discern_source_repo: https://github.com/edx/discern.git
+ease_source_repo: https://github.com/edx/ease.git
 ease_dir: $app_base_dir/ease
 discern_dir: $app_base_dir/discern
 discern_settings: discern.aws

--- a/playbooks/roles/edxapp/files/git_ssh.sh
+++ b/playbooks/roles/edxapp/files/git_ssh.sh
@@ -1,2 +1,0 @@
-#!/bin/sh
-exec /usr/bin/ssh -o StrictHostKeyChecking=no -i /etc/git-identity "$@"

--- a/playbooks/roles/edxapp/tasks/deploy.yml
+++ b/playbooks/roles/edxapp/tasks/deploy.yml
@@ -11,8 +11,6 @@
 # Do A Checkout
 - name: git checkout edx-platform repo into $app_base_dir
   git: dest={{edx_platform_code_dir}} repo={{lms_source_repo}} version={{lms_version}}
-  environment:
-    GIT_SSH: /tmp/git_ssh.sh
   tags:
   - lms
   - cms

--- a/playbooks/roles/edxapp/tasks/main.yml
+++ b/playbooks/roles/edxapp/tasks/main.yml
@@ -28,24 +28,6 @@
   - lms-env
   - update
 
-# Install ssh keys for ubuntu account to be able to check out from edx-platform
-# Temprory behavior, not needed after June 1. Perhaps still useful as a recipe.
-# {{ secure_dir }} is relative to the top-level playbooks dir so there is some
-
-- name: install read-only ssh key for edx-platform repo (private)
-  copy: src={{ secure_dir }}/files/git-identity dest=/etc/git-identity force=yes owner=ubuntu group=adm mode=600
-  tags:
-  - lms
-  - cms
-  - update
-
-- name: upload ssh script
-  copy: src=git_ssh.sh dest=/tmp/git_ssh.sh force=yes owner=root group=adm mode=750
-  tags:
-  - lms
-  - cms
-  - update
-
 # Check out edx-platform repo to $app_base_dir
 - name: install git and its recommends
   apt: pkg=git state=present install_recommends=yes 

--- a/playbooks/roles/edxapp/tasks/ruby.yml
+++ b/playbooks/roles/edxapp/tasks/ruby.yml
@@ -29,7 +29,7 @@
   - install
 
 - name: rbenv | update rbenv repo
-  git: repo=git://github.com/sstephenson/rbenv.git dest=$rbenv_root version=v0.4.0
+  git: repo=https://github.com/sstephenson/rbenv.git dest=$rbenv_root version=v0.4.0
   tags:
   - ruby
   - install
@@ -63,7 +63,7 @@
   - install
 
 - name: rbenv | clone ruby-build repo
-  git: repo=git://github.com/sstephenson/ruby-build.git dest=${tempdir.stdout}/ruby-build
+  git: repo=https://github.com/sstephenson/ruby-build.git dest=${tempdir.stdout}/ruby-build
   when_failed: $rbuild_present
   tags:
   - ruby

--- a/playbooks/roles/edxapp/vars/main.yml
+++ b/playbooks/roles/edxapp/vars/main.yml
@@ -48,11 +48,11 @@ worker_core_mult:
 #To turn off theming, specify edxapp_theme_name: ''
 #Stanford, for example, uses edxapp_theme_name: 'stanford'
 edxapp_theme_name: ''
-edxapp_theme_source_repo: 'git://github.com/Stanford-Online/edx-theme.git'
+edxapp_theme_source_repo: 'https://github.com/Stanford-Online/edx-theme.git'
 edxapp_theme_version: 'HEAD'
 
 # make this the public URL instead of writable
-lms_source_repo: git://github.com/edx/edx-platform.git
+lms_source_repo: https://github.com/edx/edx-platform.git
 lms_version: 'HEAD'
 local_requirements_file:  "{{ edx_platform_code_dir }}/requirements/edx/local.txt"
 pre_requirements_file:    "{{ edx_platform_code_dir }}/requirements/edx/pre.txt"


### PR DESCRIPTION
- Now that edx-platform is fully open source, the right thing to do is
  have read-only http URLs be the default and get rid of all the
  nonsense ssh-oriented infrastructure for config/deployment.
- Also contains updates to edx-west/edxapp_prod.yml which make its
  behavior less mysterious. (but this isn't the important part)

@jarv does this look ok to you?
