### PR TITLE
use edxapp instead of individual gunicorn processes

### DIFF
--- a/playbooks/edx-west/edxapp_prod.yml
+++ b/playbooks/edx-west/edxapp_prod.yml
@@ -1,5 +1,5 @@
 #- hosts: tag_environment_prod:&tag_function_webserver
-- hosts: ~tag_Name_app(10|20)_prod
+- hosts: ~tag_Name_app(test)_prod
 #- hosts: tag_environment_prod:&tag_function_webserver
 #- hosts: security_group_edx-prod-EdxappServerSecurityGroup-NSKCQTMZIPQB
   sudo: True
@@ -7,6 +7,8 @@
     - "{{ secure_dir }}/vars/edxapp_prod_vars.yml"
     - "{{ secure_dir }}/vars/users.yml"
     - "{{ secure_dir }}/vars/edxapp_prod_users.yml"
+    - "{{ secure_dir }}/vars/shib_prod_vars.yml"
+
   vars:
     secure_dir: '../../../configuration-secure/ansible'
     # this indicates the path to site-specific (with precedence)
@@ -17,5 +19,7 @@
     - common
     - nginx
     - edxapp
+    - apache
+    - shibboleth
     # run this role last
     - in_production

--- a/playbooks/edx-west/edxapp_prod_apache.yml
+++ b/playbooks/edx-west/edxapp_prod_apache.yml
@@ -6,6 +6,7 @@
     - "{{ secure_dir }}/vars/users.yml"
     - "{{ secure_dir }}/vars/edxapp_prod_users.yml"
     - "{{ secure_dir }}/vars/shib_prod_vars.yml"
+
   vars:
     secure_dir: '../../../configuration-secure/ansible'
     # this indicates the path to site-specific (with precedence)

--- a/playbooks/roles/apache/templates/lms.j2
+++ b/playbooks/roles/apache/templates/lms.j2
@@ -15,9 +15,9 @@ WSGIRestrictEmbedded On
 
     SetEnv SERVICE_VARIANT lms
     
-    WSGIScriptAlias / {{platform_code_dir}}/lms/wsgi_apache_lms.py
+    WSGIScriptAlias / {{edx_platform_code_dir}}/lms/wsgi_apache_lms.py
 
-    <Directory {{platform_code_dir}}/lms>
+    <Directory {{edx_platform_code_dir}}/lms>
     <Files wsgi_apache_lms.py>
         Order deny,allow
         Allow from all
@@ -39,7 +39,7 @@ WSGIRestrictEmbedded On
         require valid-user
     </Location>
 
-    WSGIDaemonProcess lms user=www-data group=adm processes=1 python-path={{platform_code_dir}}:{{venv_dir}}/lib/python2.7/site-packages display-name=%{GROUP}
+    WSGIDaemonProcess lms user=www-data group=adm processes=1 python-path={{edx_platform_code_dir}}:{{venv_dir}}/lib/python2.7/site-packages display-name=%{GROUP}
     WSGIProcessGroup lms
     WSGIApplicationGroup %{GLOBAL}
     

--- a/playbooks/roles/common/tasks/create_users.yml
+++ b/playbooks/roles/common/tasks/create_users.yml
@@ -34,7 +34,7 @@
   - update
 
 - name: Creating env users
-  user: name={{ item.user }} groups={{ ",".join(item.groups) }} shell=/bin/bash
+  user: name={{ item.user }} {% if item.groups %}groups={{ ",".join(item.groups) }}{% endif %} shell=/bin/bash
   with_items: env_users
   when: env_users is defined
   tags:

--- a/playbooks/roles/edxapp/vars/main.yml
+++ b/playbooks/roles/edxapp/vars/main.yml
@@ -150,4 +150,4 @@ deploy_environment:
   SKIP_WS_MIGRATIONS: 1
   RBENV_ROOT: "{{ rbenv_root }}"
   GEM_HOME: "{{ gem_home }}"
-  PATH: "{{ venv_dir }}/bin:{{ edx_platform_code_dir }}/bin:{{ rbenv_root }}/bin:{{ rbenv_root }}/shims:{{ gem_home }}/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games"
+  PATH: "{{ venv_dir }}/bin:{{ edx_platform_code_dir }}/bin:{{ rbenv_root }}/bin:{{ rbenv_root }}/shims:{{ gem_home }}/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"

--- a/playbooks/roles/in_production/tasks/main.yml
+++ b/playbooks/roles/in_production/tasks/main.yml
@@ -6,27 +6,9 @@
 #  - ruby/tasks/main.yml
 #  - npm/tasks/main.yml
 ---
-- name: Make sure LMS is running
-  service: name=lms state=started
+- name: Make sure edxapp is running
+  service: name=edxapp state=started
   tags:
-  - lms
-  - lms-env
-  - production
-  - update
-
-- name: Make sure CMS is running
-  service: name=cms state=started
-  tags:
-  - cms
-  - cms-env
-  - production
-  - update
-
-- name: Make sure LMS-preview is running
-  service: name=lms-preview state=started
-  tags:
-  - lms-preview
-  - lms-preview-env
   - production
   - update
 


### PR DESCRIPTION
just a bunch of little bugfixes:  mainly in_production now just makes sure that edxapp is running instead of individual upstart jobs for lms, cms, etc

also handles the case where an env user is assigned no new groups.

@jarv should be quick
