### PR TITLE
Initial set of files to bring up a staging edx

### DIFF
--- a/playbooks/edx-west/edxapp_stage.yml
+++ b/playbooks/edx-west/edxapp_stage.yml
@@ -1,0 +1,15 @@
+- hosts: tag_environment_stage:&tag_function_webserver
+  sudo: True
+  vars:
+    secure_dir: ../../../edx-secret/ansible
+    local_dir: ../../../edx-secret/ansible/local
+  vars_files:
+    - "{{ secure_dir }}/vars/edxapp_stage_vars.yml"
+    - "{{ secure_dir }}/vars/users.yml"
+    - "{{ secure_dir }}/vars/edxapp_stage_users.yml"
+  roles:
+    - common
+    - nginx
+    # - gunicorn
+    - edxapp
+    #- in_production

--- a/playbooks/edx-west/stage-ansible.cfg
+++ b/playbooks/edx-west/stage-ansible.cfg
@@ -1,0 +1,21 @@
+# ansible reads $ANSIBLE_CONFIG, ansible.cfg, ~/.ansible.cfg or /etc/ansible/ansible.cfg
+
+[defaults]
+# Always have these for using the configuration repo
+jinja2_extensions=jinja2.ext.do
+hash_behaviour=merge
+
+# These are environment-specific defaults
+forks=10
+#forks=1
+log_path=stage-edx-ansible.log
+transport=ssh
+hostfile=./ec2.py
+extra_vars='key=deployment name=edx-stage group=edx-stage region=us-west-1'
+user=ubuntu
+
+[ssh_connection]
+# example from https://github.com/ansible/ansible/blob/devel/examples/ansible.cfg
+#ssh_args=-o ControlMaster=auto -o ControlPersist=60s -o ControlPath=/tmp/ansible-ssh-%h-%p-%r
+ssh_args=-F stage-ssh-config
+scp_if_ssh=True

--- a/playbooks/edx-west/stage-ssh-config
+++ b/playbooks/edx-west/stage-ssh-config
@@ -1,0 +1,20 @@
+#### edx-stage VPC 
+
+Host 54.241.183.3
+#Host vpc-jumpbox
+    HostName 54.241.183.3
+    User ubuntu
+    ForwardAgent yes
+
+Host *.us-west-1.compute.internal
+    User ubuntu
+    ForwardAgent yes
+    ProxyCommand ssh -W %h:%p ubuntu@54.241.183.3
+
+Host *
+    ForwardAgent yes
+    SendEnv LANG LC_*
+    HashKnownHosts yes
+    GSSAPIAuthentication yes
+    GSSAPIDelegateCredentials no
+

--- a/playbooks/stage-ansible.cfg
+++ b/playbooks/stage-ansible.cfg
@@ -1,0 +1,21 @@
+# ansible reads $ANSIBLE_CONFIG, ansible.cfg, ~/.ansible.cfg or /etc/ansible/ansible.cfg
+
+[defaults]
+# Always have these for using the configuration repo
+jinja2_extensions=jinja2.ext.do
+hash_behaviour=merge
+
+# These are environment-specific defaults
+forks=10
+#forks=1
+log_path=stage-edx-ansible.log
+transport=ssh
+hostfile=./ec2.py
+extra_vars='key=deployment name=edx-stage group=edx-stage region=us-west-1'
+user=ubuntu
+
+[ssh_connection]
+# example from https://github.com/ansible/ansible/blob/devel/examples/ansible.cfg
+#ssh_args=-o ControlMaster=auto -o ControlPersist=60s -o ControlPath=/tmp/ansible-ssh-%h-%p-%r
+ssh_args=-F stage-ssh-config
+scp_if_ssh=True

--- a/playbooks/stage-ssh-config
+++ b/playbooks/stage-ssh-config
@@ -1,0 +1,24 @@
+#### edx-stage VPC 
+
+Host 54.241.183.3
+#Host ec2-54-241-183-3.us-west-1.compute.amazonaws.com
+#Host vpc-jumpbox
+    #HostName ec2-54-241-183-3.us-west-1.compute.amazonaws.com
+    HostName 54.241.183.3
+    User ubuntu
+    ForwardAgent yes
+
+Host *.us-west-1.compute.internal
+    User ubuntu
+    ForwardAgent yes
+    #ProxyCommand ssh -W %h:%p ec2-54-241-183-3.us-west-1.compute.amazonaws.com
+    #ProxyCommand ssh -W %h:%p vpc-jumpbox
+    ProxyCommand ssh -W %h:%p ubuntu@54.241.183.3
+
+Host *
+    ForwardAgent yes
+    SendEnv LANG LC_*
+    HashKnownHosts yes
+    GSSAPIAuthentication yes
+    GSSAPIDelegateCredentials no
+


### PR DESCRIPTION
The main thing of interest here is stage-ansible.cfg and
stage-ssh-config, which taken together offer a way to have an
environment with different access control policies and a different VPC
jumpbox without disturbing the usual case of working with your VPC
production hosts.

To run this, edit stage-ssh-config with a sensible jumpbox configuration
and make sure the options in stage-ansible.cfg are the set of ansible
options you expect to use, then invoke ansible with ANSIBLE_CONFIG like
so:

```
ANSIBLE_CONFIG=stage-ansible.cfg ansible-playbook -v -i './ec2.py' edxapp_stage.yml
```
