### PR TITLE
Fixes bug where WORKERS was sometimes being set to "NAN"

### DIFF
--- a/playbooks/roles/edxapp/templates/cms.conf.j2
+++ b/playbooks/roles/edxapp/templates/cms.conf.j2
@@ -13,10 +13,12 @@ respawn limit 3 30
 env PID=/var/tmp/cms.pid
 #env NEW_RELIC_CONFIG_FILE={{app_base_dir}}/newrelic.ini
 #env NEWRELIC={{venv_dir}}/bin/newrelic-admin
-{% if facter_processorcount %}
+{% if facter_processorcount|int(default="NaN") is number  %}
 env WORKERS={{ worker_core_mult.cms * facter_processorcount|int }}
+{% elif ansible_processor_cores|int(default="NaN") is number %}
+env WORKERS={{ worker_core_mult.cms * ansible_processor_cores|int }}
 {% else %}
-env WORKERS={{ worker_core_mult.cms * ansible_processor_cores }}
+env WORKERS={{ worker_core_mult.cms }}
 {% endif %}
 env PORT=8010
 env LANG=en_US.UTF-8

--- a/playbooks/roles/edxapp/templates/lms-preview.conf.j2
+++ b/playbooks/roles/edxapp/templates/lms-preview.conf.j2
@@ -12,10 +12,12 @@ respawn limit 3 30
 env PID=/var/tmp/lms.pid
 #env NEW_RELIC_CONFIG_FILE={{app_base_dir}}/newrelic.ini
 #env NEWRELIC={{venv_dir}}/bin/newrelic-admin
-{% if facter_processorcount %}
+{% if facter_processorcount|int(default="NaN") is number  %}
 env WORKERS={{ worker_core_mult.lms_preview * facter_processorcount|int }}
+{% elif ansible_processor_cores|int(default="NaN") is number %}
+env WORKERS={{ worker_core_mult.lms_preview * ansible_processor_cores|int }}
 {% else %}
-env WORKERS={{ worker_core_mult.lms_preview * ansible_processor_cores }}
+env WORKERS={{ worker_core_mult.lms_preview }}
 {% endif %}
 env PORT=8020
 env LANG=en_US.UTF-8

--- a/playbooks/roles/edxapp/templates/lms-xml.conf.j2
+++ b/playbooks/roles/edxapp/templates/lms-xml.conf.j2
@@ -12,10 +12,12 @@ respawn limit 3 30
 env PID=/var/tmp/lms-xml.pid
 #env NEW_RELIC_CONFIG_FILE={{app_base_dir}}/newrelic.ini
 #env NEWRELIC={{venv_dir}}/bin/newrelic-admin
-{% if facter_processorcount %}
+{% if facter_processorcount|int(default="NaN") is number %}
 env WORKERS={{ worker_core_mult.lms_xml * facter_processorcount|int  }}
+{% elif ansible_processor_cores|int(default="NaN") is number %}
+env WORKERS={{ worker_core_mult.lms_xml * ansible_processor_cores|int  }}
 {% else %}
-env WORKERS={{ worker_core_mult.lms_xml * ansible_processor_cores  }}
+env WORKERS={{ worker_core_mult.lms_xml }}
 {% endif %}
 env PORT=8030
 env LANG=en_US.UTF-8

--- a/playbooks/roles/edxapp/templates/lms.conf.j2
+++ b/playbooks/roles/edxapp/templates/lms.conf.j2
@@ -12,10 +12,12 @@ respawn limit 3 30
 env PID=/var/tmp/lms.pid
 #env NEW_RELIC_CONFIG_FILE={{app_base_dir}}/newrelic.ini
 #env NEWRELIC={{venv_dir}}/bin/newrelic-admin
-{% if facter_processorcount %}
+{% if facter_processorcount|int(default="NaN") is number  %}
 env WORKERS={{ worker_core_mult.lms * facter_processorcount|int }}
+{% elif ansible_processor_cores|int(default="NaN") is number %}
+env WORKERS={{ worker_core_mult.lms * ansible_processor_cores|int }}
 {% else %}
-env WORKERS={{ worker_core_mult.lms * ansible_processor_cores }}
+env WORKERS={{ worker_core_mult.lms }}
 {% endif %}
 env PORT=8000
 env LANG=en_US.UTF-8


### PR DESCRIPTION
For the case where  "ansible_processor_cores": "NA"  and
facter_processorcount wasn't the WORKERS was set to the string "NA" *
the multiplier (like batman).
This will try to convert both to numbers and if the conversion fails it
will fall through and just set the WORKERS to the multiplier.
