### PR TITLE
Fixes #159 - Playbook fails on "'facter_processorcount' is undefined"

### DIFF
--- a/playbooks/roles/edxapp/templates/cms.conf.j2
+++ b/playbooks/roles/edxapp/templates/cms.conf.j2
@@ -11,9 +11,9 @@ respawn limit 3 30
 env PID=/var/tmp/cms.pid
 #env NEW_RELIC_CONFIG_FILE={{app_base_dir}}/newrelic.ini
 #env NEWRELIC={{venv_dir}}/bin/newrelic-admin
-{% if facter_processorcount|int(default="NaN") is number  %}
+{% if facter_processorcount|default('')|int(default="NaN") is number  %}
 env WORKERS={{ worker_core_mult.cms * facter_processorcount|int }}
-{% elif ansible_processor_cores|int(default="NaN") is number %}
+{% elif ansible_processor_cores|default('')|int(default="NaN") is number %}
 env WORKERS={{ worker_core_mult.cms * ansible_processor_cores|int }}
 {% else %}
 env WORKERS={{ worker_core_mult.cms }}

--- a/playbooks/roles/edxapp/templates/lms-preview.conf.j2
+++ b/playbooks/roles/edxapp/templates/lms-preview.conf.j2
@@ -12,9 +12,9 @@ respawn limit 3 30
 env PID=/var/tmp/lms.pid
 #env NEW_RELIC_CONFIG_FILE={{app_base_dir}}/newrelic.ini
 #env NEWRELIC={{venv_dir}}/bin/newrelic-admin
-{% if facter_processorcount|int(default="NaN") is number  %}
+{% if facter_processorcount|default('')|int(default="NaN") is number  %}
 env WORKERS={{ worker_core_mult.lms_preview * facter_processorcount|int }}
-{% elif ansible_processor_cores|int(default="NaN") is number %}
+{% elif ansible_processor_cores|default('')|int(default="NaN") is number %}
 env WORKERS={{ worker_core_mult.lms_preview * ansible_processor_cores|int }}
 {% else %}
 env WORKERS={{ worker_core_mult.lms_preview }}

--- a/playbooks/roles/edxapp/templates/lms-xml.conf.j2
+++ b/playbooks/roles/edxapp/templates/lms-xml.conf.j2
@@ -11,9 +11,9 @@ respawn limit 3 30
 env PID=/var/tmp/lms-xml.pid
 #env NEW_RELIC_CONFIG_FILE={{app_base_dir}}/newrelic.ini
 #env NEWRELIC={{venv_dir}}/bin/newrelic-admin
-{% if facter_processorcount|int(default="NaN") is number %}
+{% if facter_processorcount|default('')|int(default="NaN") is number %}
 env WORKERS={{ worker_core_mult.lms_xml * facter_processorcount|int  }}
-{% elif ansible_processor_cores|int(default="NaN") is number %}
+{% elif ansible_processor_cores|default('')|int(default="NaN") is number %}
 env WORKERS={{ worker_core_mult.lms_xml * ansible_processor_cores|int  }}
 {% else %}
 env WORKERS={{ worker_core_mult.lms_xml }}

--- a/playbooks/roles/edxapp/templates/lms.conf.j2
+++ b/playbooks/roles/edxapp/templates/lms.conf.j2
@@ -9,9 +9,9 @@ respawn limit 3 30
 env PID=/var/tmp/lms.pid
 #env NEW_RELIC_CONFIG_FILE={{app_base_dir}}/newrelic.ini
 #env NEWRELIC={{venv_dir}}/bin/newrelic-admin
-{% if facter_processorcount|int(default="NaN") is number  %}
+{% if facter_processorcount|default('')|int(default="NaN") is number  %}
 env WORKERS={{ worker_core_mult.lms * facter_processorcount|int }}
-{% elif ansible_processor_cores|int(default="NaN") is number %}
+{% elif ansible_processor_cores|default('')|int(default="NaN") is number %}
 env WORKERS={{ worker_core_mult.lms * ansible_processor_cores|int }}
 {% else %}
 env WORKERS={{ worker_core_mult.lms }}


### PR DESCRIPTION
Fixes #159, related to #158

When facter isn't installed, the `facter_processorcount` variable makes
the integer conversion fail by being undefined.
