### PR TITLE
Make the condition on migrate_db a bit safer for using in var_prompt

### DIFF
--- a/playbooks/edx-west/edxapp_prod.yml
+++ b/playbooks/edx-west/edxapp_prod.yml
@@ -1,7 +1,7 @@
 # this gets all running prod webservers
 #- hosts: tag_environment_prod:&tag_function_webserver
 # or we can get subsets of them by name
-- hosts: ~tag_Name_app(12|22)_prod
+- hosts: ~tag_Name_app(4)_prod
 #- hosts: ~tag_Name_app(11|21)_prod
 ## these are cold hosts:
 #- hosts: ~tag_Name_app(12|22)_prod
@@ -12,8 +12,8 @@
   sudo: True
   vars_prompt:
     - name: "migrate_db"
-      prompt: "Should this playbook run database migrations? (<Return> for false, anything else for true)"
-      default: false
+      prompt: "Should this playbook run database migrations? (Type 'yes' to run, anything else to skip migrations)"
+      default: "no"
       private: no
   vars:
     secure_dir: '../../../configuration-secure/ansible'

--- a/playbooks/edx-west/edxworker_prod.yml
+++ b/playbooks/edx-west/edxworker_prod.yml
@@ -1,8 +1,7 @@
 # this gets all running prod webservers
-#- hosts: tag_environment_prod:&tag_function_ora
+- hosts: tag_environment_prod:&tag_function_util
 # or we can get subsets of them by name
-- hosts: ~tag_Name_ora(10|11)_prod
-#- hosts: security_group_edx-prod-EdxappServerSecurityGroup-NSKCQTMZIPQB
+#- hosts: ~tag_Name_util(1|2)_prod
   sudo: True
   vars:
     secure_dir: '../../../configuration-secure/ansible'
@@ -11,10 +10,10 @@
     local_dir:  '../../../configuration-secure/ansible/local'
     migrate_db: "no"
   vars_files:
-    - "{{ secure_dir }}/vars/ora_prod_vars.yml"
+    - "{{ secure_dir }}/vars/edxapp_prod_vars.yml"
     - "{{ secure_dir }}/vars/users.yml"
     - "{{ secure_dir }}/vars/edxapp_prod_users.yml"
+    - "{{ secure_dir }}/vars/shib_prod_vars.yml"
   roles:
     - common
-    - nginx
-    - ora
+    - { role: 'edxapp', celery_worker: True }

--- a/playbooks/edx_jenkins_tests.yml
+++ b/playbooks/edx_jenkins_tests.yml
@@ -3,7 +3,7 @@
   sudo: True
   gather_facts: True
   vars:
-    migrate_db: True
+    migrate_db: "yes"
     openid_workaround: True
     ansible_ssh_private_key_file: /var/lib/jenkins/continuous-integration.pem
   vars_files:

--- a/playbooks/edx_provision_test.yml
+++ b/playbooks/edx_provision_test.yml
@@ -17,7 +17,7 @@
   sudo: True
   gather_facts: True
   vars:
-    migrate_db: True
+    migrate_db: "yes"
     openid_workaround: True
     ansible_ssh_private_key_file: /var/lib/jenkins/continuous-integration.pem
   vars_files:

--- a/playbooks/edx_sandbox.yml
+++ b/playbooks/edx_sandbox.yml
@@ -19,7 +19,7 @@
   sudo: True
   gather_facts: True
   vars:
-    migrate_db: True
+    migrate_db: "yes"
     openid_workaround: True
   roles:
     - common

--- a/playbooks/roles/edxapp/tasks/deploy.yml
+++ b/playbooks/roles/edxapp/tasks/deploy.yml
@@ -189,7 +189,7 @@
 
 - name: syncdb and migrate
   shell: sudo -u www-data SERVICE_VARIANT=lms /opt/edx/bin/django-admin.py syncdb --migrate --noinput --settings=lms.envs.aws --pythonpath=/opt/wwc/edx-platform
-  when: migrate_db is defined
+  when: migrate_db is defined and migrate_db|lower == "yes"
   tags:
   - deploy
   - lms

--- a/playbooks/roles/ora/tasks/deploy.yml
+++ b/playbooks/roles/ora/tasks/deploy.yml
@@ -86,7 +86,7 @@
 
 - name: syncdb and migrate
   shell: sudo -u www-data {{ora_venv_dir}}/bin/django-admin.py syncdb --migrate --noinput --settings=edx_ora.aws --pythonpath={{ora_code_dir}}
-  when: migrate_db
+  when: migrate_db is defined and migrate_db|lower == "yes"
   notify:
     - restart edx-ora
     - restart edx-ora-celery

--- a/playbooks/roles/xqueue/tasks/deploy.yml
+++ b/playbooks/roles/xqueue/tasks/deploy.yml
@@ -53,7 +53,7 @@
 
 - name: syncdb and migrate
   shell: sudo -u www-data /opt/edx/bin/django-admin.py syncdb --migrate --noinput --settings=xqueue.aws_settings --pythonpath=/opt/wwc/xqueue
-  when: migrate_db
+  when: migrate_db is defined and migrate_db|lower == "yes"
   tags:
   - xqueue
   - syncdb

--- a/playbooks/vagrant.yml
+++ b/playbooks/vagrant.yml
@@ -3,7 +3,7 @@
   sudo: True
   gather_facts: True
   vars:
-    migrate_db: True
+    migrate_db: "yes"
     openid_workaround: True
   vars_files:
     - "group_vars/all"


### PR DESCRIPTION
@feanil  @jarv 

Since we use vars_prompt for migrate_db, I wanted to reduce the possibility of accidentally running migrations.  So I've make the condition on it a bit stronger.
