### PR TITLE
Basic role for consistently creating roles.

### DIFF
--- a/playbooks/roles/ansible-role/tasks/main.yml
+++ b/playbooks/roles/ansible-role/tasks/main.yml
@@ -1,0 +1,17 @@
+---
+
+- name: ansible-role | create role directories
+  file: path=roles/{{role_name}}/{{ item }} state=directory
+  with_items:
+    - tasks
+    - handlers
+    - vars
+    - templates
+    - files
+
+- name: ansible-role | make an ansible role
+  template: src={{ item }}/main.yml.j2 dest=roles/{{ role_name }}/{{ item }}/main.yml
+  with_items:
+    - tasks
+    - handlers
+    - vars

--- a/playbooks/roles/ansible-role/templates/handlers/main.yml.j2
+++ b/playbooks/roles/ansible-role/templates/handlers/main.yml.j2
@@ -1,0 +1,8 @@
+---
+
+#
+# Tasks for role {{ role_name }}
+# 
+# Overview:
+# 
+#

--- a/playbooks/roles/ansible-role/templates/handlers/main.yml.j2
+++ b/playbooks/roles/ansible-role/templates/handlers/main.yml.j2
@@ -1,8 +1,11 @@
 ---
+{% include 'roles/ansible-role/templates/header.txt' %}
 
 #
-# Tasks for role {{ role_name }}
+# Handlers for role {{ role_name }}
 # 
 # Overview:
 # 
 #
+- name: {{ role_name }} | notify me
+  debug: msg="stub handler"

--- a/playbooks/roles/ansible-role/templates/handlers/main.yml.j2
+++ b/playbooks/roles/ansible-role/templates/handlers/main.yml.j2
@@ -1,5 +1,5 @@
 ---
-{% include 'roles/ansible-role/templates/header.txt' %}
+{% include 'roles/ansible-role/templates/header.j2' %}
 
 #
 # Handlers for role {{ role_name }}

--- a/playbooks/roles/ansible-role/templates/header.j2
+++ b/playbooks/roles/ansible-role/templates/header.j2
@@ -1,0 +1,9 @@
+#
+# edX Configuration
+#
+# github:     https://github.com/edx/configuration
+# wiki:       https://github.com/edx/configuration/wiki
+# code style: https://github.com/edx/configuration/wiki/Ansible-Coding-Conventions
+# license:    https://github.com/edx/configuration/blob/master/LICENSE.TXT
+#
+#

--- a/playbooks/roles/ansible-role/templates/header.j2
+++ b/playbooks/roles/ansible-role/templates/header.j2
@@ -1,3 +1,0 @@
-#
-# This file was created by the edX ansible-role ansible role.
-#

--- a/playbooks/roles/ansible-role/templates/header.j2
+++ b/playbooks/roles/ansible-role/templates/header.j2
@@ -1,0 +1,3 @@
+#
+# This file was created by the edX ansible-role ansible role.
+#

--- a/playbooks/roles/ansible-role/templates/header.txt
+++ b/playbooks/roles/ansible-role/templates/header.txt
@@ -1,8 +1,0 @@
-#
-# edX Configuration
-#
-# github:     https://github.com/edx/configuration
-# wiki:       https://github.com/edx/configuration/wiki
-# code style: https://github.com/edx/configuration/wiki/Ansible-Coding-Conventions
-# license:    https://github.com/edx/configuration/blob/master/LICENSE.TXT
-#

--- a/playbooks/roles/ansible-role/templates/header.txt
+++ b/playbooks/roles/ansible-role/templates/header.txt
@@ -1,0 +1,8 @@
+#
+# edX Configuration
+#
+# github:     https://github.com/edx/configuration
+# wiki:       https://github.com/edx/configuration/wiki
+# code style: https://github.com/edx/configuration/wiki/Ansible-Coding-Conventions
+# license:    https://github.com/edx/configuration/blob/master/LICENSE.TXT
+#

--- a/playbooks/roles/ansible-role/templates/tasks/main.yml.j2
+++ b/playbooks/roles/ansible-role/templates/tasks/main.yml.j2
@@ -1,4 +1,5 @@
 ---
+{% include 'roles/ansible-role/templates/header.txt' %}
 
 #
 # Tasks for role {{ role_name }}
@@ -15,3 +16,4 @@
 
 - name: {{ role_name }} | stub ansible task
   debug: msg="This is a stub task created by the ansible-role role"
+  notify: {{ role_name }} | notify me

--- a/playbooks/roles/ansible-role/templates/tasks/main.yml.j2
+++ b/playbooks/roles/ansible-role/templates/tasks/main.yml.j2
@@ -1,0 +1,17 @@
+---
+
+#
+# Tasks for role {{ role_name }}
+# 
+# Overview:
+# 
+#
+# Dependencies:
+#
+# 
+# Example play:
+#
+#
+
+- name: {{ role_name }} | stub ansible task
+  debug: msg="This is a stub task created by the ansible-role role"

--- a/playbooks/roles/ansible-role/templates/tasks/main.yml.j2
+++ b/playbooks/roles/ansible-role/templates/tasks/main.yml.j2
@@ -1,5 +1,5 @@
 ---
-{% include 'roles/ansible-role/templates/header.txt' %}
+{% include 'roles/ansible-role/templates/header.j2' %}
 
 #
 # Tasks for role {{ role_name }}

--- a/playbooks/roles/ansible-role/templates/vars/main.yml.j2
+++ b/playbooks/roles/ansible-role/templates/vars/main.yml.j2
@@ -1,9 +1,12 @@
 ---
-
+{% include 'roles/ansible-role/templates/header.txt' %}
 #
 # Vars for role {{ role_name }}
 # 
 
+#
+# vars are namespace with the module name.
+#
 {{ role_name }}_role_name: {{ role_name }}
 
 #

--- a/playbooks/roles/ansible-role/templates/vars/main.yml.j2
+++ b/playbooks/roles/ansible-role/templates/vars/main.yml.j2
@@ -1,0 +1,15 @@
+---
+
+#
+# Vars for role {{ role_name }}
+# 
+
+{{ role_name }}_role_name: {{ role_name }}
+
+#
+# OS packages
+#
+
+{{ role_name }}_debian_pkgs: []
+
+{{ role_name }}_redhat_pkgs: []

--- a/playbooks/roles/ansible-role/templates/vars/main.yml.j2
+++ b/playbooks/roles/ansible-role/templates/vars/main.yml.j2
@@ -1,5 +1,5 @@
 ---
-{% include 'roles/ansible-role/templates/header.txt' %}
+{% include 'roles/ansible-role/templates/header.j2' %}
 #
 # Vars for role {{ role_name }}
 # 


### PR DESCRIPTION
I've been creating a lot of new roles and thought something like this would be useful.  It creates a role and stubs out some files.  I'd like it to include a header file in all the templates, but it's not working currently.  I think this would help us enforce consistency as we create more and more roles.

Runs something like so.

```
ansible-playbook ansible_role.yml -i local.ini --connection=local --extra-vars "role_name=haproxy"
```
