### PR TITLE
ora-virtualenv: Use different virtual envs for ORA and EASE to avoid conflicts

### DIFF
--- a/playbooks/roles/ora/tasks/ease.yml
+++ b/playbooks/roles/ora/tasks/ease.yml
@@ -53,6 +53,12 @@
   - ease
   - deploy
 
+# Base the virtualenv off the main venv
+- name: ora | clone base virtualenv to create the ora virtualenv
+  shell: cp -ar "{{venv_dir}}" "{{ease_venv_dir}}"
+  tags:
+  - ease
+  - deploy
 
 # Install the python pre requirements into {{ ease_venv_dir }}
 - name: ora | install ease python pre-requirements

--- a/playbooks/roles/ora/vars/main.yml
+++ b/playbooks/roles/ora/vars/main.yml
@@ -4,8 +4,8 @@ ora_code_dir: "{{ app_base_dir }}/edx-ora"
 # Default nginx listen port
 # These should be overrided if you want
 # to serve all content on port 80
-ora_venv_dir: "{{ venv_dir }}"
-ease_venv_dir: "{{ venv_dir }}"
+ora_venv_dir: "{{ venv_dir }}_ora"
+ease_venv_dir: "{{ venv_dir }}_ora"
 ora_gunicorn_workers: 4
 ora_nginx_port: 18091
 ora_gunicorn_port: 8091


### PR DESCRIPTION
On a single instance, some libraries versions would conflict - like requests==0.14.2 (LMS) vs requests==1.1.0 (ORA)

The symptomatic error would then be:

```
(edx)www-data@edx-sandbox:/opt/edx$  DJANGO_SETTINGS_MODULE=lms.envs.aws SERVICE_VARIANT="lms-xml" /opt/edx/bin/gunicorn --preload -b 127.0.0.1:8030 -w 2 --timeout=300 --pythonpath=/opt/wwc/edx-platform  lms.wsgi
[...]
2013-08-08 13:08:31,185 ERROR 5392 [gunicorn.error] glogging.py:190 - Error handling request
Traceback (most recent call last):
  File "/opt/edx/local/lib/python2.7/site-packages/gunicorn/workers/sync.py", line 103, in handle_request
    respiter = self.wsgi(environ, resp.start_response)
  File "/opt/edx/local/lib/python2.7/site-packages/django/core/handlers/wsgi.py", line 219, in __call__
    self.load_middleware()
  File "/opt/edx/local/lib/python2.7/site-packages/django/core/handlers/base.py", line 45, in load_middleware
    mod = import_module(mw_module)
  File "/opt/edx/local/lib/python2.7/site-packages/django/utils/importlib.py", line 35, in import_module
    __import__(name)
  File "/opt/wwc/edx-platform/lms/djangoapps/course_wiki/course_nav.py", line 9, in <module>
    from courseware.courses import get_course_with_access
  File "/opt/wwc/edx-platform/lms/djangoapps/courseware/courses.py", line 9, in <module>
    from .module_render import get_module
  File "/opt/wwc/edx-platform/lms/djangoapps/courseware/module_render.py", line 54, in <module>
    requests_auth,
  File "/opt/wwc/edx-platform/common/lib/capa/capa/xqueue_interface.py", line 67, in __init__
    self.session = requests.session(auth=requests_auth)
TypeError: session() takes no arguments (1 given)
```
