### PR TITLE
Include item.host for service checking

### DIFF
--- a/playbooks/roles/forum/tasks/test.yml
+++ b/playbooks/roles/forum/tasks/test.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: forum | test that the required service are listening
-  wait_for: port={{ item.port }} timeout=10
+  wait_for: port={{ item.port }} host={{ item.host }} timeout=10
   with_items: "{{ forum_services }}"
   tags:
   - forum


### PR DESCRIPTION
Useful when database host isn't localhost (default value)
