### PR TITLE
Older syntax cleanup

### DIFF
--- a/playbooks/edx_sandbox_plus.yml
+++ b/playbooks/edx_sandbox_plus.yml
@@ -21,6 +21,7 @@
   vars:
     migrate_db: "yes"
     openid_workaround: True
+    c_skip_grader_checkout: True
   roles:
     - common
     - nginx

--- a/playbooks/edx_sandbox_plus.yml
+++ b/playbooks/edx_sandbox_plus.yml
@@ -1,0 +1,40 @@
+# This playbook is to configure
+# the official edX sandbox instance
+# sandbox.edx.org
+#
+# On the machine you want to configure run the following
+# command from the configuration/playbooks directory:
+#   ansible-playbook -c local --limit "localhost:127.0.0.1" /path/to/configuration/playbooks/edx_sandbox.yml -i "localhost,"
+# 
+# To use different default ports for lms-preview, cms and to set the lms_base and lms_preview_base,
+# for the following configuration:
+#   studio listening on port 80 - studio.example.com
+#   lms listening on port 80 - example.com
+#   lms-preview listening on port 80 - preview.example.com
+#
+#   ansible-playbook -c local --limit "localhost:127.0.0.1" path/to/configuration/playbooks/edx_sandbox.yml -i "localhost," -e "cms_nginx_port=80 lms_preview_nginx_port=80 c_lms_base=example.com  c_preview_lms_base=preview.example.com"
+#
+- name: Configure instance(s)
+  hosts: localhost
+  sudo: True
+  gather_facts: True
+  vars:
+    migrate_db: "yes"
+    openid_workaround: True
+  roles:
+    - common
+    - nginx
+    - edxlocal
+    - edxapp
+    - rabbitmq
+    - xqueue
+    - xserver
+    - ora
+    - { role: 'edxapp', celery_worker: True }
+    - oraclejdk
+    - elasticsearch
+    - role: rbenv
+      rbenv_user: "{{ forum_user }}"
+      rbenv_user_home: "{{ forum_home }}"
+      rbenv_ruby_version: "{{ forum_ruby_version }}"
+    - forum

--- a/playbooks/roles/apache/tasks/apache_site.yml
+++ b/playbooks/roles/apache/tasks/apache_site.yml
@@ -7,7 +7,7 @@
     # seems like paths in first_available_file must be relative to the playbooks dir
     - "roles/apache/templates/{{ site_name }}.j2"
   notify: apache | restart apache
-  when_set: $apache_role_run
+  when: apache_role_run is defined
   tags:
     - apache
     - update
@@ -15,7 +15,7 @@
 - name: apache | Creating apache2 config link {{ site_name }}
   file: src=/etc/apache2/sites-available/{{ site_name }} dest=/etc/apache2/sites-enabled/{{ site_name }} state={{ state }} owner=root group=root
   notify: apache | restart apache
-  when_set: $apache_role_run
+  when: apache_role_run is defined
   tags:
     - apache
     - update

--- a/playbooks/roles/edxapp/tasks/ruby.yml
+++ b/playbooks/roles/edxapp/tasks/ruby.yml
@@ -57,28 +57,28 @@
 - name: rbenv | create temporary directory
   command: mktemp -d
   register: tempdir
-  when_failed: $rbuild_present
+  when: rbuild_present|failed
   tags:
   - ruby
   - install
 
 - name: rbenv | clone ruby-build repo
   git: repo=https://github.com/sstephenson/ruby-build.git dest=${tempdir.stdout}/ruby-build
-  when_failed: $rbuild_present
+  when: rbuild_present|failed
   tags:
   - ruby
   - install
 
 - name: rbenv | install ruby-build
   command: ./install.sh chdir=${tempdir.stdout}/ruby-build
-  when_failed: $rbuild_present
+  when: rbuild_present|failed
   tags:
   - ruby
   - install
 
 - name: rbenv | remove temporary directory
   file: path=${tempdir.stdout} state=absent
-  when_failed: $rbuild_present
+  when: rbuild_present|failed
   tags:
   - ruby
   - install
@@ -93,21 +93,21 @@
 
 - name: rbenv | install ruby $ruby_version
   shell: RBENV_ROOT=${rbenv_root} rbenv install $ruby_version
-  when_failed: $ruby_installed
+  when: ruby_installed|failed
   tags:
   - ruby
   - install
 
 - name: rbenv | set global ruby $ruby_version
   shell: RBENV_ROOT=${rbenv_root} rbenv global $ruby_version
-  when_failed: $ruby_installed
+  when: ruby_installed|failed
   tags:
   - ruby
   - install
 
 - name: rbenv | rehash
   shell: RBENV_ROOT=${rbenv_root} rbenv rehash
-  when_failed: $ruby_installed
+  when: ruby_installed|failed
   tags:
   - ruby
   - install

--- a/playbooks/roles/nginx/tasks/nginx_site.yml
+++ b/playbooks/roles/nginx/tasks/nginx_site.yml
@@ -7,7 +7,7 @@
   # seems like paths in first_available_file must be relative to the playbooks dir
   - "roles/nginx/templates/{{ site_name }}.j2" 
   notify: nginx | restart nginx
-  when_set: $nginx_role_run
+  when: nginx_role_run is defined
   tags:
   - nginx
   - lms
@@ -18,7 +18,7 @@
 - name: nginx | Creating nginx config link {{ site_name }}
   file: src=/etc/nginx/sites-available/{{ site_name }} dest=/etc/nginx/sites-enabled/{{ site_name }} state={{ state }} owner=root group=root
   notify: nginx | restart nginx
-  when_set: $nginx_role_run
+  when: nginx_role_run is defined
   tags:
   - nginx
   - lms


### PR DESCRIPTION
I've been using the development branch of ansible for some newer features and these were preventing that from working.  I've moved them to 1.2 syntax so they work on the current release and the upcoming release of 1.3
