### PR TITLE
sandbox-ora: Include xqueue & ORA on the `edx_sandbox` playbook

### DIFF
--- a/playbooks/edx_sandbox.yml
+++ b/playbooks/edx_sandbox.yml
@@ -35,3 +35,12 @@
       rbenv_user_home: "{{ forum_home }}"
       rbenv_ruby_version: "{{ forum_ruby_version }}"
     - forum
+    - { role: "xqueue", update_users: True }
+    - role: virtualenv
+      virtualenv_user: "edx-ora"
+      virtualenv_user_home: "/opt/edx-ora"
+      virtualenv_name: "edx-ora"
+    - role: ora
+      ora_user: "edx-ora"
+      ora_venv_dir: "/opt/edx-ora/virtualenvs/edx-ora"
+      ease_venv_dir: "/opt/edx-ora/virtualenvs/edx-ora"

--- a/playbooks/edx_sandbox.yml
+++ b/playbooks/edx_sandbox.yml
@@ -35,6 +35,10 @@
       rbenv_user_home: "{{ forum_home }}"
       rbenv_ruby_version: "{{ forum_ruby_version }}"
     - forum
+    - role: virtualenv
+      virtualenv_user: "{{ xqueue_user }}"
+      virtualenv_user_home: "{{ xqueue_user_home }}"
+      virtualenv_name: "{{ xqueue_user }}"
     - { role: "xqueue", update_users: True }
     - role: virtualenv
       virtualenv_user: "{{ ora_user }}"

--- a/playbooks/edx_sandbox.yml
+++ b/playbooks/edx_sandbox.yml
@@ -37,10 +37,7 @@
     - forum
     - { role: "xqueue", update_users: True }
     - role: virtualenv
-      virtualenv_user: "edx-ora"
-      virtualenv_user_home: "/opt/edx-ora"
-      virtualenv_name: "edx-ora"
+      virtualenv_user: "{{ ora_user }}"
+      virtualenv_user_home: "{{ ora_user_home }}"
+      virtualenv_name: "{{ ora_user }}"
     - role: ora
-      ora_user: "edx-ora"
-      ora_venv_dir: "/opt/edx-ora/virtualenvs/edx-ora"
-      ease_venv_dir: "/opt/edx-ora/virtualenvs/edx-ora"

--- a/playbooks/edx_sandbox.yml
+++ b/playbooks/edx_sandbox.yml
@@ -26,7 +26,7 @@
     - nginx
     - edxlocal
     - edxapp
-    - rabbitmq
+    - { role: 'rabbitmq', rabbitmq_ip: '127.0.0.1' }
     - { role: 'edxapp', celery_worker: True }
     - oraclejdk
     - elasticsearch

--- a/playbooks/roles/edxapp/vars/main.yml
+++ b/playbooks/roles/edxapp/vars/main.yml
@@ -23,7 +23,7 @@ edxapp_generic_auth_config:  &edxapp_generic_auth
     'basic_auth': [ 'edx',  'edx']
     'django_auth': { 'password':  'password',
       'username':  'lms'}
-    'url':  'https://localhost:18040'
+    'url':  'http://localhost:18040'
   'CONTENTSTORE':
     'ENGINE':  'xmodule.contentstore.mongo.MongoContentStore'
     'OPTIONS':

--- a/playbooks/roles/edxapp/vars/main.yml
+++ b/playbooks/roles/edxapp/vars/main.yml
@@ -60,7 +60,7 @@ edxapp_generic_auth_config:  &edxapp_generic_auth
       'PORT': '3306'
   'PEARSON_TEST_PASSWORD':  ''
   'OPEN_ENDED_GRADING_INTERFACE':
-    'url':  'http://localhost:18091'
+    'url':  'http://localhost:18091/'
     'password':  'password'
     'peer_grading':  'peer_grading'
     'staff_grading':  'staff_grading'

--- a/playbooks/roles/ora/tasks/deploy.yml
+++ b/playbooks/roles/ora/tasks/deploy.yml
@@ -85,7 +85,7 @@
   - deploy
 
 - name: ora | syncdb and migrate
-  shell: sudo -u {{ ora_user }} {{ora_venv_dir}}/bin/django-admin.py syncdb --migrate --noinput --settings=edx_ora.aws --pythonpath={{ora_code_dir}}
+  shell: sudo -u {{ ora_user }} SERVICE_VARIANT=ora {{ora_venv_dir}}/bin/django-admin.py syncdb --migrate --noinput --settings=edx_ora.aws --pythonpath={{ora_code_dir}}
   when: migrate_db is defined and migrate_db|lower == "yes"
   notify:
     - ora | restart edx-ora
@@ -96,7 +96,7 @@
   - deploy
 
 - name: ora | create users
-  shell: sudo -u {{ ora_user }} {{ora_venv_dir}}/bin/django-admin.py update_users --settings=edx_ora.aws --pythonpath={{ora_code_dir}}
+  shell: sudo -u {{ ora_user }} SERVICE_VARIANT=ora {{ora_venv_dir}}/bin/django-admin.py update_users --settings=edx_ora.aws --pythonpath={{ora_code_dir}}
   notify:
     - ora | restart edx-ora
     - ora | restart edx-ora-celery

--- a/playbooks/roles/ora/tasks/deploy.yml
+++ b/playbooks/roles/ora/tasks/deploy.yml
@@ -41,7 +41,7 @@
 
 # Do Post Checkout Tasks.
 - name: ora | change permissions on ora code dir
-  file: path={{ora_code_dir}} state=directory owner=www-data group=www-data mode=755 recurse=yes
+  file: path={{ora_code_dir}} state=directory owner={{ ora_user }} group={{ ora_user }} mode=755 recurse=yes
   notify:
     - ora | restart edx-ora
     - ora | restart edx-ora-celery
@@ -85,7 +85,7 @@
   - deploy
 
 - name: ora | syncdb and migrate
-  shell: sudo -u www-data {{ora_venv_dir}}/bin/django-admin.py syncdb --migrate --noinput --settings=edx_ora.aws --pythonpath={{ora_code_dir}}
+  shell: sudo -u {{ ora_user }} {{ora_venv_dir}}/bin/django-admin.py syncdb --migrate --noinput --settings=edx_ora.aws --pythonpath={{ora_code_dir}}
   when: migrate_db is defined and migrate_db|lower == "yes"
   notify:
     - ora | restart edx-ora
@@ -96,7 +96,7 @@
   - deploy
 
 - name: ora | create users
-  shell: sudo -u www-data {{ora_venv_dir}}/bin/django-admin.py update_users --settings=edx_ora.aws --pythonpath={{ora_code_dir}}
+  shell: sudo -u {{ ora_user }} {{ora_venv_dir}}/bin/django-admin.py update_users --settings=edx_ora.aws --pythonpath={{ora_code_dir}}
   notify:
     - ora | restart edx-ora
     - ora | restart edx-ora-celery

--- a/playbooks/roles/ora/tasks/ease.yml
+++ b/playbooks/roles/ora/tasks/ease.yml
@@ -37,7 +37,7 @@
 
 # Do Post Checkout Tasks.
 - name: ora | change permissions on ease code dir
-  file: path={{ease_code_dir}} state=directory owner=www-data group=www-data mode=755 recurse=yes
+  file: path={{ease_code_dir}} state=directory owner={{ ora_user }} group={{ ora_user }} mode=755 recurse=yes
   tags:
   - ease
   - deploy

--- a/playbooks/roles/ora/tasks/main.yml
+++ b/playbooks/roles/ora/tasks/main.yml
@@ -9,7 +9,7 @@
   - ora
 
 - name: ora | Create ml_models directory
-  file: path={{ora_code_dir}}/../ml_models state=directory owner=www-data group=www-data
+  file: path={{ora_code_dir}}/../ml_models state=directory owner={{ ora_user }} group={{ ora_user }}
   tags:
   - ora
 
@@ -20,12 +20,12 @@
   - ora
 
 - name: ora | create ora application config
-  template: src=ora.env.json.j2 dest={{ora_code_dir}}/../env.json mode=0640 owner=www-data group=adm
+  template: src=ora.env.json.j2 dest={{ora_code_dir}}/../env.json mode=0640 owner={{ ora_user }} group=adm
   tags:
   - ora
 
 - name: ora | create ora auth file
-  template: src=ora.auth.json.j2 dest={{ora_code_dir}}/../auth.json mode=0640 owner=www-data group=adm
+  template: src=ora.auth.json.j2 dest={{ora_code_dir}}/../auth.json mode=0640 owner={{ ora_user }} group=adm
   tags:
   - ora
 

--- a/playbooks/roles/ora/tasks/main.yml
+++ b/playbooks/roles/ora/tasks/main.yml
@@ -15,12 +15,12 @@
   - ora
 
 - name: ora | create ora application config
-  template: src=ora.env.json.j2 dest={{ora_code_dir}}/../env.json mode=0640 owner={{ ora_user }} group=adm
+  template: src=ora.env.json.j2 dest={{ora_code_dir}}/../ora.env.json mode=0640 owner={{ ora_user }} group=adm
   tags:
   - ora
 
 - name: ora | create ora auth file
-  template: src=ora.auth.json.j2 dest={{ora_code_dir}}/../auth.json mode=0640 owner={{ ora_user }} group=adm
+  template: src=ora.auth.json.j2 dest={{ora_code_dir}}/../ora.auth.json mode=0640 owner={{ ora_user }} group=adm
   tags:
   - ora
 

--- a/playbooks/roles/ora/tasks/main.yml
+++ b/playbooks/roles/ora/tasks/main.yml
@@ -3,11 +3,6 @@
 #  - common/tasks/main.yml
 #  - nginx/tasks/main.yml
 ---
-- name: ora | Change permissions on datadir
-  file: path={{ora_code_dir}}/../data state=directory owner=www-data group=www-data
-  tags:
-  - ora
-
 - name: ora | Create ml_models directory
   file: path={{ora_code_dir}}/../ml_models state=directory owner={{ ora_user }} group={{ ora_user }}
   tags:
@@ -42,16 +37,6 @@
 - name: ora | install debian packages that ora needs
   apt: pkg={{item}} state=present
   with_items: ora_debian_pkgs
-  tags:
-  - ora
-
-- name: ora | create the ora virtual environment
-  file: path={{ ora_venv_dir }} owner=root group=adm mode=2775 state=directory
-  tags:
-  - ora
-
-- name: ora | bootstrap the ora virtual environment
-  command: /usr/local/bin/virtualenv {{ ora_venv_dir }} --distribute creates={{ora_venv_dir}}/bin/activate
   tags:
   - ora
 

--- a/playbooks/roles/ora/templates/edx-ora-celery.conf.j2
+++ b/playbooks/roles/ora/templates/edx-ora-celery.conf.j2
@@ -12,6 +12,6 @@ respawn limit 3 30
 env DJANGO_SETTINGS_MODULE=edx_ora.aws
 
 chdir {{ ora_code_dir }}
-setuid www-data
+setuid {{ ora_user }}
 
 exec {{ ora_venv_dir }}/bin/python {{ ora_code_dir }}/manage.py celeryd --loglevel=info --settings=edx_ora.aws --pythonpath={{ ora_code_dir}} -B --autoscale=4,1

--- a/playbooks/roles/ora/templates/edx-ora-celery.conf.j2
+++ b/playbooks/roles/ora/templates/edx-ora-celery.conf.j2
@@ -10,6 +10,7 @@ respawn
 respawn limit 3 30
 
 env DJANGO_SETTINGS_MODULE=edx_ora.aws
+env SERVICE_VARIANT=ora
 
 chdir {{ ora_code_dir }}
 setuid {{ ora_user }}

--- a/playbooks/roles/ora/templates/edx-ora.conf.j2
+++ b/playbooks/roles/ora/templates/edx-ora.conf.j2
@@ -19,6 +19,6 @@ pre-start script
 end script
 
 chdir {{ ora_code_dir }}
-setuid www-data
+setuid {{ ora_user }}
 
 exec {{ ora_venv_dir}}/bin/gunicorn --preload -b 127.0.0.1:$PORT -w $WORKERS --timeout=90 --pythonpath={{ ora_code_dir}} edx_ora.wsgi

--- a/playbooks/roles/ora/templates/edx-ora.conf.j2
+++ b/playbooks/roles/ora/templates/edx-ora.conf.j2
@@ -14,6 +14,7 @@ env WORKERS={{ ora_gunicorn_workers }}
 env PORT={{ ora_gunicorn_port }}
 env LANG=en_US.UTF-8
 env DJANGO_SETTINGS_MODULE=edx_ora.aws
+env SERVICE_VARIANT=ora
 
 pre-start script
 end script

--- a/playbooks/roles/ora/vars/main.yml
+++ b/playbooks/roles/ora/vars/main.yml
@@ -6,6 +6,7 @@ ora_code_dir: "{{ app_base_dir }}/edx-ora"
 # to serve all content on port 80
 ora_venv_dir: "{{ venv_dir }}"
 ease_venv_dir: "{{ venv_dir }}"
+ora_user: "www-data"
 ora_gunicorn_workers: 4
 ora_nginx_port: 18091
 ora_gunicorn_port: 8091

--- a/playbooks/roles/ora/vars/main.yml
+++ b/playbooks/roles/ora/vars/main.yml
@@ -4,9 +4,10 @@ ora_code_dir: "{{ app_base_dir }}/edx-ora"
 # Default nginx listen port
 # These should be overrided if you want
 # to serve all content on port 80
-ora_venv_dir: "{{ venv_dir }}"
-ease_venv_dir: "{{ venv_dir }}"
-ora_user: "www-data"
+ora_user: "edx-ora"
+ora_user_home: "/opt/edx-ora"
+ora_venv_dir: "{{ ora_user_home }}/virtualenvs/{{ ora_user }}"
+ease_venv_dir: "{{ ora_venv_dir }}"
 ora_gunicorn_workers: 4
 ora_nginx_port: 18091
 ora_gunicorn_port: 8091

--- a/playbooks/roles/rabbitmq/templates/rabbitmq-env.conf.j2
+++ b/playbooks/roles/rabbitmq/templates/rabbitmq-env.conf.j2
@@ -1,2 +1,2 @@
 RABBITMQ_NODE_PORT={{ rabbitmq_port }}
-RABBITMQ_NODE_IP_ADDRESS={{ ansible_default_ipv4.address }}
+RABBITMQ_NODE_IP_ADDRESS={{ rabbitmq_ip }}

--- a/playbooks/roles/rabbitmq/vars/main.yml
+++ b/playbooks/roles/rabbitmq/vars/main.yml
@@ -18,9 +18,11 @@ rabbitmq_ip: "{{ ansible_default_ipv4.address }}"
 
 rabbitmq_auth_config:
   erlang_cookie: "CHANGE ME"
-  admin:
+  admins:
   - name: 'admin'
     password: 'the example admin password'
+  - name: 'edx'
+    password: 'edx'
 
 # If the system is running out of an Amazon Web Services
 # cloudformation stack, this group name can used to pull out

--- a/playbooks/roles/rabbitmq/vars/main.yml
+++ b/playbooks/roles/rabbitmq/vars/main.yml
@@ -14,6 +14,7 @@ rabbitmq_mnesia_folder: "{{rabbitmq_cookie_dir}}/mnesia"
 
 rabbitmq_port: 5672
 rabbitmq_management_port: 15672
+rabbitmq_ip: "{{ ansible_default_ipv4.address }}"
 
 rabbitmq_auth_config:
   erlang_cookie: "CHANGE ME"

--- a/playbooks/roles/xqueue/tasks/deploy.yml
+++ b/playbooks/roles/xqueue/tasks/deploy.yml
@@ -20,7 +20,7 @@
 
 # Do Post Checkout Tasks.
 - name: xqueue | create xqueue code dir
-  file: path={{xqueue_code_dir}} state=directory owner=www-data group=www-data mode=755
+  file: path={{xqueue_code_dir}} state=directory owner={{ xqueue_user }} group={{ xqueue_user }} mode=755
   tags:
   - xqueue
   - deploy
@@ -30,29 +30,29 @@
 # portions of the deploy needs to be incorporated here.
 
 - name: xqueue | sets permissions on xqueue code dir and contents
-  file: path={{xqueue_code_dir}} state=directory owner=www-data group=www-data recurse=yes
+  file: path={{xqueue_code_dir}} state=directory owner={{ xqueue_user }} group={{ xqueue_user }} recurse=yes
   # Post Checkout tasks will get run as handlers when the {{ xqueue_code_dir }} is ready.
   # Look at the handlers/main.yml in this role for a description of the tasks stated below.
   tags:
   - xqueue
   - deploy
 
-# Install the python pre requirements into {{ venv_dir }}
+# Install the python pre requirements into {{ xqueue_venv_dir }}
 - name : install python pre-requirements
-  pip: requirements="{{xqueue_pre_requirements_file}}" virtualenv="{{venv_dir}}" state=present
+  pip: requirements="{{xqueue_pre_requirements_file}}" virtualenv="{{xqueue_venv_dir}}" state=present
   tags:
   - xqueue
   - deploy
 
-# Install the python post requirements into {{ venv_dir }}
+# Install the python post requirements into {{ xqueue_venv_dir }}
 - name : install python post-requirements
-  pip: requirements="{{xqueue_post_requirements_file}}" virtualenv="{{venv_dir}}" state=present
+  pip: requirements="{{xqueue_post_requirements_file}}" virtualenv="{{xqueue_venv_dir}}" state=present
   tags:
   - xqueue
   - deploy
 
 - name: xqueue | syncdb and migrate
-  shell: sudo -u www-data SERVICE_VARIANT=xqueue /opt/edx/bin/django-admin.py syncdb --migrate --noinput --settings=xqueue.aws_settings --pythonpath=/opt/wwc/xqueue
+  shell: sudo -u {{ xqueue_user }} SERVICE_VARIANT=xqueue {{ xqueue_venv_dir }}/bin/django-admin.py syncdb --migrate --noinput --settings=xqueue.aws_settings --pythonpath=/opt/wwc/xqueue
   when: migrate_db is defined and migrate_db|lower == "yes"
   tags:
   - xqueue
@@ -60,7 +60,7 @@
   - deploy
 
 - name: xqueue | create users
-  shell: sudo -u www-data SERVICE_VARIANT=xqueue /opt/edx/bin/django-admin.py update_users --settings=xqueue.aws_settings --pythonpath=/opt/wwc/xqueue
+  shell: sudo -u {{ xqueue_user }} SERVICE_VARIANT=xqueue {{ xqueue_venv_dir }}/bin/django-admin.py update_users --settings=xqueue.aws_settings --pythonpath=/opt/wwc/xqueue
   when: update_users is defined
   tags:
   - xqueue

--- a/playbooks/roles/xqueue/tasks/deploy.yml
+++ b/playbooks/roles/xqueue/tasks/deploy.yml
@@ -52,7 +52,7 @@
   - deploy
 
 - name: xqueue | syncdb and migrate
-  shell: sudo -u www-data /opt/edx/bin/django-admin.py syncdb --migrate --noinput --settings=xqueue.aws_settings --pythonpath=/opt/wwc/xqueue
+  shell: sudo -u www-data SERVICE_VARIANT=xqueue /opt/edx/bin/django-admin.py syncdb --migrate --noinput --settings=xqueue.aws_settings --pythonpath=/opt/wwc/xqueue
   when: migrate_db is defined and migrate_db|lower == "yes"
   tags:
   - xqueue
@@ -60,7 +60,7 @@
   - deploy
 
 - name: xqueue | create users
-  shell: sudo -u www-data /opt/edx/bin/django-admin.py update_users --settings=xqueue.aws_settings --pythonpath=/opt/wwc/xqueue
+  shell: sudo -u www-data SERVICE_VARIANT=xqueue /opt/edx/bin/django-admin.py update_users --settings=xqueue.aws_settings --pythonpath=/opt/wwc/xqueue
   when: update_users is defined
   tags:
   - xqueue

--- a/playbooks/roles/xqueue/tasks/main.yml
+++ b/playbooks/roles/xqueue/tasks/main.yml
@@ -32,7 +32,7 @@
     encoding=utf8
 
 - name: xqueue | create xqueue application config
-  template: src=xqueue.env.json.j2 dest={{app_base_dir}}/env.json mode=0640 owner=www-data group=adm
+  template: src=xqueue.env.json.j2 dest={{app_base_dir}}/xqueue.env.json mode=0640 owner=www-data group=adm
   notify:
   - xqueue | restart xqueue
   - xqueue | restart xqueue consumer
@@ -40,7 +40,7 @@
   - xqueue
 
 - name: xqueue | create xqueue auth file
-  template: src=xqueue.auth.json.j2 dest={{app_base_dir}}/auth.json mode=0640 owner=www-data group=adm
+  template: src=xqueue.auth.json.j2 dest={{app_base_dir}}/xqueue.auth.json mode=0640 owner=www-data group=adm
   notify:
   - xqueue | restart xqueue
   - xqueue | restart xqueue consumer

--- a/playbooks/roles/xqueue/tasks/main.yml
+++ b/playbooks/roles/xqueue/tasks/main.yml
@@ -3,11 +3,6 @@
 #  - common/tasks/main.yml
 #  - nginx/tasks/main.yml
 ---
-- name: xqueue | Change permissions on datadir
-  file: path={{app_base_dir}}/data state=directory owner=www-data group=www-data
-  tags:
-  - xqueue
-
 # Check out xqueue repo to {{xqueue_code_dir}}
 - name: xqueue | install git and its recommends
   apt: pkg=git state=present install_recommends=yes 
@@ -32,7 +27,7 @@
     encoding=utf8
 
 - name: xqueue | create xqueue application config
-  template: src=xqueue.env.json.j2 dest={{app_base_dir}}/xqueue.env.json mode=0640 owner=www-data group=adm
+  template: src=xqueue.env.json.j2 dest={{app_base_dir}}/xqueue.env.json mode=0640 owner={{ xqueue_user }} group=adm
   notify:
   - xqueue | restart xqueue
   - xqueue | restart xqueue consumer
@@ -40,7 +35,7 @@
   - xqueue
 
 - name: xqueue | create xqueue auth file
-  template: src=xqueue.auth.json.j2 dest={{app_base_dir}}/xqueue.auth.json mode=0640 owner=www-data group=adm
+  template: src=xqueue.auth.json.j2 dest={{app_base_dir}}/xqueue.auth.json mode=0640 owner={{ xqueue_user }} group=adm
   notify:
   - xqueue | restart xqueue
   - xqueue | restart xqueue consumer

--- a/playbooks/roles/xqueue/tasks/main.yml
+++ b/playbooks/roles/xqueue/tasks/main.yml
@@ -25,6 +25,7 @@
     login_password={{xqueue_auth_config.DATABASES.default.PASSWORD}}
     state=present
     encoding=utf8
+  when: xqueue_create_db is defined and xqueue_create_db|lower == "yes"
 
 - name: xqueue | create xqueue application config
   template: src=xqueue.env.json.j2 dest={{app_base_dir}}/xqueue.env.json mode=0640 owner={{ xqueue_user }} group=adm

--- a/playbooks/roles/xqueue/templates/xqueue.conf.j2
+++ b/playbooks/roles/xqueue/templates/xqueue.conf.j2
@@ -7,7 +7,11 @@ respawn
 respawn limit 3 30
 
 env PID=/var/tmp/xqueue.pid
-env WORKERS={{ ansible_processor_cores * 2 }}
+{% if ansible_processor|length > 0 %}
+env WORKERS={{ ansible_processor|length * 2 }}
+{% else %}
+env WORKERS=2
+{% endif %}
 env PORT={{ xqueue_gunicorn_port }}
 env LANG=en_US.UTF-8
 env DJANGO_SETTINGS_MODULE=xqueue.aws_settings

--- a/playbooks/roles/xqueue/templates/xqueue.conf.j2
+++ b/playbooks/roles/xqueue/templates/xqueue.conf.j2
@@ -19,6 +19,6 @@ env SERVICE_VARIANT="xqueue"
 
 
 chdir {{ xqueue_code_dir }}
-setuid www-data
+setuid {{ xqueue_user }}
 
-exec {{ venv_dir }}/bin/gunicorn --preload -b 127.0.0.1:$PORT -w $WORKERS --timeout=300 --pythonpath={{ xqueue_code_dir }} xqueue.wsgi
+exec {{ xqueue_venv_dir }}/bin/gunicorn --preload -b 127.0.0.1:$PORT -w $WORKERS --timeout=300 --pythonpath={{ xqueue_code_dir }} xqueue.wsgi

--- a/playbooks/roles/xqueue/templates/xqueue_consumer.conf.j2
+++ b/playbooks/roles/xqueue/templates/xqueue_consumer.conf.j2
@@ -11,6 +11,7 @@ respawn limit 3 30
 
 env LANG=en_US.UTF-8
 env WORKERS_PER_QUEUE={{xqueue_env_config.XQUEUE_WORKERS_PER_QUEUE}}
+env SERVICE_VARIANT="xqueue"
 chdir {{xqueue_code_dir}}
 setuid www-data
 

--- a/playbooks/roles/xqueue/templates/xqueue_consumer.conf.j2
+++ b/playbooks/roles/xqueue/templates/xqueue_consumer.conf.j2
@@ -13,6 +13,6 @@ env LANG=en_US.UTF-8
 env WORKERS_PER_QUEUE={{xqueue_env_config.XQUEUE_WORKERS_PER_QUEUE}}
 env SERVICE_VARIANT="xqueue"
 chdir {{xqueue_code_dir}}
-setuid www-data
+setuid {{ xqueue_user }}
 
-exec {{venv_dir}}/bin/django-admin.py run_consumer --pythonpath={{xqueue_code_dir}} --settings=xqueue.aws_settings $WORKERS_PER_QUEUE
+exec {{xqueue_venv_dir}}/bin/django-admin.py run_consumer --pythonpath={{xqueue_code_dir}} --settings=xqueue.aws_settings $WORKERS_PER_QUEUE

--- a/playbooks/roles/xqueue/vars/main.yml
+++ b/playbooks/roles/xqueue/vars/main.yml
@@ -39,6 +39,7 @@ xqueue_auth_config:
   'DATABASES':
     'default': { 'ENGINE': 'django.db.backends.mysql', 'NAME': 'xqueue', 'USER': 'root', 'PASSWORD': '', 'HOST': 'localhost', 'PORT': '3306' }
 
+xqueue_create_db: 'yes'
 xqueue_source_repo: https://github.com/edx/xqueue.git
 xqueue_version: 'HEAD'
 xqueue_pre_requirements_file:    "{{ xqueue_code_dir }}/pre-requirements.txt"

--- a/playbooks/roles/xqueue/vars/main.yml
+++ b/playbooks/roles/xqueue/vars/main.yml
@@ -10,6 +10,10 @@ xqueue_code_dir: "{{ app_base_dir }}/xqueue"
 xqueue_nginx_port: 18040
 xqueue_gunicorn_port: 8040
 
+xqueue_user: "xqueue"
+xqueue_user_home: "/opt/xqueue"
+xqueue_venv_dir: "{{ xqueue_user_home }}/virtualenvs/{{ xqueue_user }}"
+
 xqueue_env_config:
   'XQUEUES':
     # push queue


### PR DESCRIPTION
Includes modifications to allow to run on the xqueue & ORA services on the same instance as the LMS & CMS, to fit them all into the sandbox VM.
- Switches to use the `virtualenv` role as suggested by @feanil in https://github.com/edx/configuration/pull/207
- Uses its own user to prevent the `virtualenv` role from attempting to modify the user `www-data`, which fails
- Adds handling of the `SERVICE_VARIANT` variable by xqueue and ORA (cf pull request https://github.com/edx/xqueue/pull/65 and https://github.com/edx/edx-ora/pull/136 ), which works the same way as for the LMS/CMS services, and allows to use a non-default filename for the env/auth configuration JSON files. Support for service variants is more than what is strictly needed here, but I thought it would be useful to maintain the configuration file naming mechanisms consistent across services.
- Allowed to configure the binding IP of rabbitmq, which by default binds on the main IP, while the default configuration of the other services expects localhost
- Added creation of edx/edx user in the default configuration of rabbitmq, to allow Xqueue to connect
- Fixed various issues with the default configuration values for ORA & Xqueue: missing '/' in config, 'NaN' printed in configuration files when ansible can't guess the number of cores, HTTP instead of HTTPS, etc.

You will need to set the following ansible variables to use the modified versions of ora and xqueue:

```
xqueue_source_repo: https://github.com/antoviaque/xqueue.git
ora_source_repo: https://github.com/antoviaque/edx-ora.git
```
