### PR TITLE
Added GEM_HOME environment to rbenv gem install

### DIFF
--- a/playbooks/roles/rbenv/tasks/main.yml
+++ b/playbooks/roles/rbenv/tasks/main.yml
@@ -14,12 +14,14 @@
 #     rbenv_user: "{{ forum_user }}"
 #     rbenv_user_home: "{{ forum_rbenv_dir }}"
 #     rbenv_ruby_version: "{{ forum_ruby_version }}"
+#     rbenv_gem_home: "{{ forum_rbenv_dir }}/.gem"
 #
 # Parameters:
 #  
 #   * rbenv_user
 #   * rbenv_user_home
 #   * rbenv_ruby_version
+#   * rbenv_gem_home
 #
 # cribbed from https://github.com/mmoya/ansible-playbooks/blob/master/rbenv/main.yml
 # with a number of changes.
@@ -197,6 +199,8 @@
   - install
 
 - name: rbenv | install bundler
+  environment:
+    GEM_HOME: "{{ rbenv_gem_home }}"
   shell: "{{ rbenv_user_home }}/.rbenv/shims/gem install bundler -v {{ rbenv_bundler_version }}"
   sudo: true
   sudo_user: "{{ rbenv_user }}" 


### PR DESCRIPTION
Add parameter to configure GEM_HOME for rbenv.

This resolves an issue I'm seeing with the Jenkins scripts in which the second time you run `gem install bundler` it tries to install to `/var/lib/gems` and gets a permission denied.  Explicitly specifying `GEM_HOME` ensures that gems are installed where you expect.

I tested this with the Jenkins script and Vagrant shortstack, and both scripts were able to install bundler successfully.

@e0d 
