### PR TITLE
Change inventory_file to inventory_path in Vagrantfiles

### DIFF
--- a/vagrant/fullstack/Vagrantfile
+++ b/vagrant/fullstack/Vagrantfile
@@ -18,7 +18,7 @@ Vagrant.configure("2") do |config|
     # point Vagrant at the location of your playbook you want to run
     ansible.playbook = "../../playbooks/vagrant-fullstack.yml"
 
-    ansible.inventory_file = "../../playbooks/vagrant/inventory.ini"
+    ansible.inventory_path = "../../playbooks/vagrant/inventory.ini"
     ansible.extra_vars = { c_skip_grader_checkout: 'True' }
     ansible.verbose = true
   end

--- a/vagrant/shortstack-xml/Vagrantfile
+++ b/vagrant/shortstack-xml/Vagrantfile
@@ -18,7 +18,7 @@ Vagrant.configure("2") do |config|
     # point Vagrant at the location of your playbook you want to run
     ansible.playbook = "../../playbooks/vagrant-shortstack-xml.yml"
 
-    ansible.inventory_file = "../../playbooks/vagrant/inventory.ini"
+    ansible.inventory_path = "../../playbooks/vagrant/inventory.ini"
     ansible.verbose = true
   end
 end

--- a/vagrant/shortstack/Vagrantfile
+++ b/vagrant/shortstack/Vagrantfile
@@ -18,7 +18,7 @@ Vagrant.configure("2") do |config|
     # point Vagrant at the location of your playbook you want to run
     ansible.playbook = "../../playbooks/vagrant-shortstack.yml"
 
-    ansible.inventory_file = "../../playbooks/vagrant/inventory.ini"
+    ansible.inventory_path = "../../playbooks/vagrant/inventory.ini"
     ansible.verbose = true
   end
 end


### PR DESCRIPTION
According to http://docs.vagrantup.com/v2/provisioning/ansible.html the property iventory_file is now iventory_path. Trying to run "vagrant up" with the current Vagrantfiles and the newest Vagrant version results in the following error:

ansible provisioner:
- The following settings don't exist: inventory_file
