### PR TITLE
Replaced older style when_ with updated forms

### DIFF
--- a/playbooks/roles/apache/tasks/apache_site.yml
+++ b/playbooks/roles/apache/tasks/apache_site.yml
@@ -7,7 +7,7 @@
     # seems like paths in first_available_file must be relative to the playbooks dir
     - "roles/apache/templates/{{ site_name }}.j2"
   notify: apache | restart apache
-  when_set: $apache_role_run
+  when: apache_role_run is defined
   tags:
     - apache
     - update
@@ -15,7 +15,7 @@
 - name: apache | Creating apache2 config link {{ site_name }}
   file: src=/etc/apache2/sites-available/{{ site_name }} dest=/etc/apache2/sites-enabled/{{ site_name }} state={{ state }} owner=root group=root
   notify: apache | restart apache
-  when_set: $apache_role_run
+  when: apache_role_run is defined
   tags:
     - apache
     - update

--- a/playbooks/roles/edxapp/tasks/ruby.yml
+++ b/playbooks/roles/edxapp/tasks/ruby.yml
@@ -57,28 +57,28 @@
 - name: rbenv | create temporary directory
   command: mktemp -d
   register: tempdir
-  when_failed: $rbuild_present
+  when: rbuild_present|failed
   tags:
   - ruby
   - install
 
 - name: rbenv | clone ruby-build repo
   git: repo=https://github.com/sstephenson/ruby-build.git dest=${tempdir.stdout}/ruby-build
-  when_failed: $rbuild_present
+  when: rbuild_present|failed
   tags:
   - ruby
   - install
 
 - name: rbenv | install ruby-build
   command: ./install.sh chdir=${tempdir.stdout}/ruby-build
-  when_failed: $rbuild_present
+  when: rbuild_present|failed
   tags:
   - ruby
   - install
 
 - name: rbenv | remove temporary directory
   file: path=${tempdir.stdout} state=absent
-  when_failed: $rbuild_present
+  when: rbuild_present|failed
   tags:
   - ruby
   - install
@@ -93,21 +93,21 @@
 
 - name: rbenv | install ruby $ruby_version
   shell: RBENV_ROOT=${rbenv_root} rbenv install $ruby_version
-  when_failed: $ruby_installed
+  when: ruby_installed|failed
   tags:
   - ruby
   - install
 
 - name: rbenv | set global ruby $ruby_version
   shell: RBENV_ROOT=${rbenv_root} rbenv global $ruby_version
-  when_failed: $ruby_installed
+  when: ruby_installed|failed
   tags:
   - ruby
   - install
 
 - name: rbenv | rehash
   shell: RBENV_ROOT=${rbenv_root} rbenv rehash
-  when_failed: $ruby_installed
+  when: ruby_installed|failed
   tags:
   - ruby
   - install

--- a/playbooks/roles/nginx/tasks/nginx_site.yml
+++ b/playbooks/roles/nginx/tasks/nginx_site.yml
@@ -7,7 +7,7 @@
   # seems like paths in first_available_file must be relative to the playbooks dir
   - "roles/nginx/templates/{{ site_name }}.j2" 
   notify: nginx | restart nginx
-  when_set: $nginx_role_run
+  when: nginx_role_run is defined
   tags:
   - nginx
   - lms
@@ -18,7 +18,7 @@
 - name: nginx | Creating nginx config link {{ site_name }}
   file: src=/etc/nginx/sites-available/{{ site_name }} dest=/etc/nginx/sites-enabled/{{ site_name }} state={{ state }} owner=root group=root
   notify: nginx | restart nginx
-  when_set: $nginx_role_run
+  when: nginx_role_run is defined
   tags:
   - nginx
   - lms


### PR DESCRIPTION
Ansible 1.3 (from git) doesn't removed the when_ syntax that was deprecated in 1.2. This corrects those.
