### PR TITLE
nginx configuration for long site names

### DIFF
--- a/playbooks/edx-west/carnegie-prod-app.yml
+++ b/playbooks/edx-west/carnegie-prod-app.yml
@@ -15,7 +15,7 @@
     - "{{ secure_dir }}/vars/edxapp_prod_users.yml"
   roles:
     - common
-    - nginx
+    - {'role': 'nginx', 'nginx_conf': true} 
     - {'role': 'edxapp', 'openid_workaround': true, 'template_subdir': 'carnegie'}
     # run this role last
     # - in_production

--- a/playbooks/edx-west/carnegie-prod-app.yml
+++ b/playbooks/edx-west/carnegie-prod-app.yml
@@ -3,6 +3,11 @@
 
 - hosts: ~tag_Name_app(10|20)_carn
   sudo: True
+  vars_prompt:
+    - name: "migrate_db"
+      prompt: "Should this playbook run database migrations? (Type 'yes' to run, anything else to skip migrations)"
+      default: "no"
+      private: no
   vars:
     secure_dir: '../../../edx-secret/ansible'
     # this indicates the path to site-specific (with precedence)

--- a/playbooks/edx-west/carnegie-prod-app.yml
+++ b/playbooks/edx-west/carnegie-prod-app.yml
@@ -1,25 +1,8 @@
+# we never want to migrate from these machines, so note no vars_prompt
+# section like other appservers
 
-# set up the fireball transport
-#- hosts: ~tag_Name_app(10|20)_cme
-#  gather_facts: no
-#  connection: ssh # or paramiko
-#  sudo: yes
-#  tasks:
-#      - apt: pkg=gcc state=present
-#      - apt: pkg=libzmq-dev,python-zmq state=present
-#      - action: fireball
-
-
-# this gets all running prod webservers
-#- hosts: tag_environment_prod:&tag_function_webserver
-# or we can get subsets of them by name
 - hosts: ~tag_Name_app(10|20)_carn
   sudo: True
-  vars_prompt:
-    - name: "migrate_db"
-      prompt: "Should this playbook run database migrations? (Type 'yes' to run, anything else to skip migrations)"
-      default: "no"
-      private: no
   vars:
     secure_dir: '../../../edx-secret/ansible'
     # this indicates the path to site-specific (with precedence)
@@ -33,6 +16,6 @@
   roles:
     - common
     - nginx
-    - {'role': 'edxapp', 'openid_workaround': true}
+    - {'role': 'edxapp', 'openid_workaround': true, 'template_subdir': 'carnegie'}
     # run this role last
     # - in_production

--- a/playbooks/edx-west/carnegie-prod-app.yml
+++ b/playbooks/edx-west/carnegie-prod-app.yml
@@ -12,7 +12,8 @@
     secure_dir: '../../../edx-secret/ansible'
     # this indicates the path to site-specific (with precedence)
     # things like nginx template files
-    local_dir:  '../../../../../../edx-secret/ansible/local'
+    #local_dir:  '../../../edx-secret/ansible/local'
+    local_dir: "{{secure_dir}}/local"
     not_prod: true
   vars_files:
     - "{{ secure_dir }}/vars/edxapp_carnegie_vars.yml"

--- a/playbooks/edx-west/stage-ansible.cfg
+++ b/playbooks/edx-west/stage-ansible.cfg
@@ -8,7 +8,7 @@ hash_behaviour=merge
 # These are environment-specific defaults
 forks=10
 #forks=1
-log_path=stage-edx-ansible.log
+log_path=~/stage-edx-ansible.log
 transport=ssh
 hostfile=./ec2.py
 extra_vars='key=deployment name=edx-stage group=edx-stage region=us-west-1'
@@ -16,6 +16,5 @@ user=ubuntu
 
 [ssh_connection]
 # example from https://github.com/ansible/ansible/blob/devel/examples/ansible.cfg
-#ssh_args=-o ControlMaster=auto -o ControlPersist=60s -o ControlPath=/tmp/ansible-ssh-%h-%p-%r
 ssh_args=-F stage-ssh-config -o ControlMaster=auto -o ControlPersist=60s -o ControlPath=/tmp/ansible-ssh-%h-%p-%r
 scp_if_ssh=True

--- a/playbooks/roles/nginx/tasks/main.yml
+++ b/playbooks/roles/nginx/tasks/main.yml
@@ -8,6 +8,13 @@
   - nginx
   - install
 
+- name: nginx | Server configuration file
+  copy: src={{secure_dir}}/files/nginx.conf dest=/etc/nginx/nginx.conf owner=root group=root mode=0644
+  notify: nginx | restart nginx
+  tags:
+  - nginx
+  - install
+
 # Standard configuration that is common across all roles
 # Default values for these variables are set in group_vars/all
 # Note: remove spaces in {{..}}, otherwise you will get a template parsing error.

--- a/playbooks/roles/nginx/tasks/main.yml
+++ b/playbooks/roles/nginx/tasks/main.yml
@@ -10,6 +10,7 @@
 
 - name: nginx | Server configuration file
   copy: src={{secure_dir}}/files/nginx.conf dest=/etc/nginx/nginx.conf owner=root group=root mode=0644
+  when: nginx_conf is defined
   notify: nginx | restart nginx
   tags:
   - nginx

--- a/playbooks/roles/nginx/tasks/nginx_site.yml
+++ b/playbooks/roles/nginx/tasks/nginx_site.yml
@@ -1,8 +1,9 @@
 # Requires nginx package
 ---
 - name: nginx | Copying nginx config {{ site_name }}
-  template: src={{ item }} dest=/etc/nginx/sites-available/{{ site_name }}
+  template: src={{ item }} dest=/etc/nginx/sites-available/{{ site_name }} owner=root group=root mode=0600
   first_available_file:
+  - "{{ local_dir }}/nginx/templates/{{ template_subdir }}/{{ site_name }}.j2"
   - "{{ local_dir }}/nginx/templates/{{ site_name }}.j2"
   # seems like paths in first_available_file must be relative to the playbooks dir
   - "roles/nginx/templates/{{ site_name }}.j2" 


### PR DESCRIPTION
Three fixes in here needed for Carnegie / CME
1. Add support for specifying a "template_subdir" var that will be used when setting up the nginx sites-available.  If it's absent then no problem, but if it's there, look in that subdirectory of the templates dir first.  
2. Install our own nginx.conf.  This way we can specify a wider site_name_hash line, required with really long site names (like `preview.class.claslite.carnegiescience.edu`)
3. Noticed that perms were wrong on sites-available files, fixed those while I was in there.

@jbau pls review
