### PR TITLE
add edx-west/.gitignore for symlink to config repo

### DIFF
--- a/playbooks/edx-west/.gitignore
+++ b/playbooks/edx-west/.gitignore
@@ -1,0 +1,2 @@
+configuration-secure
+edx-secret


### PR DESCRIPTION
Not checking those symlinks in since they are symlinks to another repo,
but generally people will want these.  On my machine they look like
this:
    configuration-secure@ -> ../../../configuration-secure
    edx-secret@ -> ../../../configuration-secure

Just for the edx-west configuration files.

Please comment and review @jrbl and @jbau.
