### PR TITLE
java-link-var: Replace `java_link` var by `oraclejdk_link`

### DIFF
--- a/playbooks/roles/oraclejdk/templates/java.sh.j2
+++ b/playbooks/roles/oraclejdk/templates/java.sh.j2
@@ -1,2 +1,2 @@
-export JAVA_HOME="{{ java_link }}"
+export JAVA_HOME="{{ oraclejdk_link }}"
 export PATH=$JAVA_HOME/bin:$PATH


### PR DESCRIPTION
This variable doesn't seem to be defined anywhere, and (in v1.3?) ansible
complains about the missing value. Since there is a `oraclejdk_link` which
seem to correspond, replacing.

(Had this after upgrading to ansible 1.3 & running the edx_sandbox from scratch with the current configuration master)
