### PR TITLE
rabbitmq-atp-update: Fixes "Failed to find required executable rabbitmq-plugins"

### DIFF
--- a/playbooks/roles/rabbitmq/tasks/main.yml
+++ b/playbooks/roles/rabbitmq/tasks/main.yml
@@ -13,7 +13,7 @@
   apt_repository: repo="{{rabbitmq_repository}}" state=present
 
 - name: rabbitmq | install rabbitmq
-  apt: pkg={{rabbitmq_pkg}} state=present
+  apt: pkg={{rabbitmq_pkg}} state=present update_cache=yes
 
 - name: rabbitmq | stop rabbit cluster
   service: name=rabbitmq-server state=stopped


### PR DESCRIPTION
(Fix for another issue I've had since the upgrade to ansible 1.3)

Without the `apt-get update`, the apt cache is out of date while attempting to install
rabbitmq. An older version from the Ubuntu repo is installed instead of the one from
the rabbit repository, which makes the role fail later on with:

```
TASK: [rabbitmq | install plugins] ********************************************
[...]
failed: [10.145.2.22] => {"failed": true, "item": ""}
msg: Failed to find required executable rabbitmq-plugins
```
