### PR TITLE
Allow configuration of IP Address of app servers to listen on

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -172,6 +172,11 @@ edxapp_lms_app_port: 8000
 edxapp_lms_xml_app_port: 8030
 edxapp_lms_preview_app_port: 8020
 
+edxapp_cms_app_address: 127.0.0.1
+edxapp_lms_app_address: 127.0.0.1
+edxapp_lms_xml_app_address: 127.0.0.1
+edxapp_lms_preview_app_address: 127.0.0.1
+
 # These vars are for creating the application json config
 # files.  There are two for each service that uses the
 # 'edx-platform' code.  Defining them will create the upstart

--- a/playbooks/roles/edxapp/templates/cms.conf.j2
+++ b/playbooks/roles/edxapp/templates/cms.conf.j2
@@ -17,6 +17,7 @@ env WORKERS={{ ansible_processor|length * worker_core_mult.cms }}
 env WORKERS={{ worker_core_mult.cms }}
 {% endif %}
 env PORT={{edxapp_cms_app_port}}
+env ADDRESS={{edxapp_cms_app_address}}
 env LANG=en_US.UTF-8
 env DJANGO_SETTINGS_MODULE=cms.envs.aws
 env SERVICE_VARIANT="cms"
@@ -24,4 +25,4 @@ env SERVICE_VARIANT="cms"
 chdir {{edx_platform_code_dir}}
 setuid www-data
 
-exec {{venv_dir}}/bin/gunicorn_django -b 127.0.0.1:$PORT -w $WORKERS --timeout=300 --pythonpath={{edx_platform_code_dir}} --settings=cms.envs.aws
+exec {{venv_dir}}/bin/gunicorn_django -b $ADDRESS:$PORT -w $WORKERS --timeout=300 --pythonpath={{edx_platform_code_dir}} --settings=cms.envs.aws

--- a/playbooks/roles/edxapp/templates/lms-preview.conf.j2
+++ b/playbooks/roles/edxapp/templates/lms-preview.conf.j2
@@ -18,6 +18,7 @@ env WORKERS={{ ansible_processor|length * worker_core_mult.lms_preview }}
 env WORKERS={{ worker_core_mult.lms_preview }}
 {% endif %}
 env PORT={{edxapp_lms_preview_app_port}}
+env ADDRESS={{edxapp_lms_preview_app_address}}
 env LANG=en_US.UTF-8
 env DJANGO_SETTINGS_MODULE=lms.envs.aws
 env SERVICE_VARIANT="lms-preview"
@@ -25,7 +26,7 @@ env SERVICE_VARIANT="lms-preview"
 chdir {{edx_platform_code_dir}}
 setuid www-data
 
-exec {{venv_dir}}/bin/gunicorn --preload -b 127.0.0.1:$PORT -w $WORKERS --timeout=300 --pythonpath={{edx_platform_code_dir}} lms.wsgi
+exec {{venv_dir}}/bin/gunicorn --preload -b $ADDRESS:$PORT -w $WORKERS --timeout=300 --pythonpath={{edx_platform_code_dir}} lms.wsgi
 
 post-start script
   while true

--- a/playbooks/roles/edxapp/templates/lms-xml.conf.j2
+++ b/playbooks/roles/edxapp/templates/lms-xml.conf.j2
@@ -17,6 +17,7 @@ env WORKERS={{ ansible_processor|length * worker_core_mult.lms_xml }}
 env WORKERS={{ worker_core_mult.lms_xml }}
 {% endif %}
 env PORT={{edxapp_lms_xml_app_port}}
+env ADDRESS={{edxapp_lms_xml_app_address}}
 env LANG=en_US.UTF-8
 env DJANGO_SETTINGS_MODULE=lms.envs.aws
 env SERVICE_VARIANT="lms-xml"
@@ -24,7 +25,7 @@ env SERVICE_VARIANT="lms-xml"
 chdir {{edx_platform_code_dir}}
 setuid www-data
 
-exec {{venv_dir}}/bin/gunicorn --preload -b 127.0.0.1:$PORT -w $WORKERS --timeout=300 --pythonpath={{edx_platform_code_dir}}  lms.wsgi
+exec {{venv_dir}}/bin/gunicorn --preload -b $ADDRESS:$PORT -w $WORKERS --timeout=300 --pythonpath={{edx_platform_code_dir}}  lms.wsgi
 
 post-start script
   while true

--- a/playbooks/roles/edxapp/templates/lms.conf.j2
+++ b/playbooks/roles/edxapp/templates/lms.conf.j2
@@ -15,6 +15,7 @@ env WORKERS={{ ansible_processor|length * worker_core_mult.lms }}
 env WORKERS={{ worker_core_mult.lms }}
 {% endif %}
 env PORT={{edxapp_lms_app_port}}
+env ADDRESS={{edxapp_lms_app_address}}
 env LANG=en_US.UTF-8
 env DJANGO_SETTINGS_MODULE={{ edxapp_lms_env }}
 env SERVICE_VARIANT="lms"
@@ -22,7 +23,7 @@ env SERVICE_VARIANT="lms"
 chdir {{edx_platform_code_dir}}
 setuid www-data
 
-exec {{venv_dir}}/bin/gunicorn --preload -b 127.0.0.1:$PORT -w $WORKERS --timeout=300 --pythonpath={{edx_platform_code_dir}} lms.wsgi
+exec {{venv_dir}}/bin/gunicorn --preload -b $ADDRESS:$PORT -w $WORKERS --timeout=300 --pythonpath={{edx_platform_code_dir}} lms.wsgi
 
 post-start script
   while true


### PR DESCRIPTION
I added defaults of 127.0.0.1 so it shouldn't change anything unless
you overide the values with something 0.0.0.0. This allows for a
split tier type rollout of the app with central Web servers on
a different machine.
