### PR TITLE
Added task to make sure elasticsearch is started

### DIFF
--- a/playbooks/roles/elasticsearch/tasks/main.yml
+++ b/playbooks/roles/elasticsearch/tasks/main.yml
@@ -28,3 +28,9 @@
   tags:
     - elasticsearch
     - install
+
+- name: elasticsearch | Ensure elasticsearch is enabled and started
+  service: name=elasticsearch state=started enabled=yes
+  tags:
+    - elasticsearch
+    - install


### PR DESCRIPTION
I recently had a build where elasticsearch hadn't auto started so
I added that check here.
