### PR TITLE
Forum role port test now properly uses host argument

### DIFF
--- a/playbooks/roles/forum/tasks/test.yml
+++ b/playbooks/roles/forum/tasks/test.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: forum | test that the required service are listening
-  wait_for: port={{ item.port }} timeout=10
+  wait_for: port={{ item.port }} host={{ item.host }} timeout=10
   with_items: "{{ forum_services }}"
   tags:
   - forum


### PR DESCRIPTION
It was using localhost for every test, and without a mongo instance running locally it failed. The host argument was already defined in defaults so it seemed like just a glitch.
