### PR TITLE
Added ability for mongo role to do simple replica set clusters

### DIFF
--- a/playbooks/roles/mongo/defaults/main.yml
+++ b/playbooks/roles/mongo/defaults/main.yml
@@ -4,6 +4,9 @@ mongo_logappend: true
 mongo_version: 2.4.7
 mongo_bind_ip: 127.0.0.1
 mongo_extra_conf: ''
+mongo_key_file: '/etc/mongodb_key'
+mongo_repl_set: rs0
+mongo_cluster_members: 
 
 MONGO_USERS:
   - user: cs_comments_service

--- a/playbooks/roles/mongo/tasks/main.yml
+++ b/playbooks/roles/mongo/tasks/main.yml
@@ -38,6 +38,15 @@
   file: src={{ storage_base_dir }}/mongodb dest=/var/lib/mongodb state=link
   tags: mongo
 
+- name: mongo | copy mongodb key file
+  copy: >
+    src={{ secure_dir }}/files/mongo_key
+    dest={{ mongo_key_file }}
+    mode=0600
+    owner=mongodb
+    group=mongodb
+  when: mongo_clustered is defined
+
 - name: mongo | copy configuration template
   template: src=mongodb.conf.j2 dest=/etc/mongodb.conf backup=yes
   notify: restart mongo
@@ -51,6 +60,18 @@
   wait_for: port=27017 delay=2
   tags: mongo
 
+- name: mongo | Create the file to initialize the mongod replica set
+  template: src=repset_init.j2 dest=/tmp/repset_init.js
+  when: mongo_clustered is defined
+  tags: mongo
+
+- name: mongo | Initialize the replication set
+  shell: /usr/bin/mongo  /tmp/repset_init.js 
+  when: mongo_clustered is defined
+  tags: mongo
+
+# Ignoring errors here because slave instances will fail this command
+# since slaveOk is false in ansible 1.3.
 - name: mongo | create a mongodb user
   mongodb_user: >
     database={{ item.database }}
@@ -59,3 +80,4 @@
     state=present
   with_items: MONGO_USERS
   tags: mongo
+  ignore_errors: yes

--- a/playbooks/roles/mongo/templates/mongodb.conf.j2
+++ b/playbooks/roles/mongo/templates/mongodb.conf.j2
@@ -15,6 +15,11 @@ bind_ip = {{ mongo_bind_ip }}
 # Enable journaling, http://www.mongodb.org/display/DOCS/Journaling
 journal=true
 
+{% if mongo_clustered is defined %}
+keyFile = {{ mongo_key_file }}
+replSet = {{ mongo_repl_set }}
+{% endif %}
+
 # Enables periodic logging of CPU utilization and I/O wait
 #cpu = true
 

--- a/playbooks/roles/mongo/templates/repset_init.j2
+++ b/playbooks/roles/mongo/templates/repset_init.j2
@@ -1,0 +1,10 @@
+config = {_id: '{{ mongo_repl_set }}', members: [
+	   {% for host in mongo_cluster_members %}
+	   {_id: {{ loop.index }}, host: '{{ host }}'}{% if not loop.last %},{% endif %}
+	   {% endfor %}
+           ]};
+rs.initiate(config)
+
+sleep(30000)
+rs.slaveOk()
+printjson(rs.status())


### PR DESCRIPTION
By default this should keep the role the same.  The only catch with this implementation
is that the ansible mongodb_user module doesn't handle slaves particularly well. So if you
have a cluster than any task that creates a user will succeed on the master and fail on all
slaves. As a result the play has been changed to ignore failure at user creation.
