### PR TITLE
rsyslog should log to {{log_bas_dir}}

### DIFF
--- a/playbooks/edx-west/stage-all.yml
+++ b/playbooks/edx-west/stage-all.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: tag_environment_stage
+- hosts: tag_environment_stage:!tag_function_nat
+  # exclude nat host b/c we can't log in to do thing with it anyway
 #- hosts: tag_Name_bastion_stage
   sudo: True
   vars:

--- a/playbooks/roles/common/templates/edx_rsyslog.j2
+++ b/playbooks/roles/common/templates/edx_rsyslog.j2
@@ -27,12 +27,12 @@ auth,authpriv.*                                         /var/log/auth.log
 $template tracking,"%syslogtag%%msg%\n"
 
 # looks for [service_name=<name>] in the beginning of the log message,
-# if it exists the log will go into /mnt/logs/<name>/edx.log, otherwise
-# it will go into /mnt/logs/edx.log
-$template DynaFile,"/mnt/logs/%syslogtag:R,ERE,1,BLANK:\[service_variant=([a-zA-Z_-]*)\].*--end%/edx.log"
+# if it exists the log will go into {{log_base_dir}}/<name>/edx.log, otherwise
+# it will go into {{log_base_dir}}/edx.log
+$template DynaFile,"{{log_base_dir}}/%syslogtag:R,ERE,1,BLANK:\[service_variant=([a-zA-Z_-]*)\].*--end%/edx.log"
 
 local0.*                        -?DynaFile
-local1.*                        /mnt/logs/tracking.log;tracking
+local1.*                        {{log_base_dir}}/tracking.log;tracking
 #cron.*                         /var/log/cron.log
 #daemon.*                       -/var/log/daemon.log
 kern.*                          -/var/log/kern.log


### PR DESCRIPTION
- /mnt/logs crept into the common recipes, when logs should be written
  to wherever {{log_base_dir}} says

This broke our log rotation for the month it took us to notice, so it would be nice to get this fix into configuration's master.

@feanil and @jbau please.
