### PR TITLE
a potporri of edx-west fixes

### DIFF
--- a/playbooks/edx-west/stage-debug.yml
+++ b/playbooks/edx-west/stage-debug.yml
@@ -1,12 +1,7 @@
-- hosts: tag_environment_stage:&tag_function_webserver
+- hosts: localhost
 #- hosts: tag_Name_app1_stage
-  sudo: True
-  vars_prompt:
-    - name: "migrate_db"
-      prompt: "Should this playbook run database migrations? (Type 'yes' to run, anything else to skip migrations)"
-      default: "no"
-      private: no
   vars:
+    migrate_db: "no"
     not_prod: true
     secure_dir: ../../../edx-secret/ansible
     local_dir: ../../../edx-secret/ansible/local
@@ -14,10 +9,11 @@
     - "{{ secure_dir }}/vars/edxapp_stage_vars.yml"
     - "{{ secure_dir }}/vars/users.yml"
     - "{{ secure_dir }}/vars/edxapp_stage_users.yml"
-    - "{{ secure_dir }}/vars/shib_stage_vars.yml"
+    #- "{{ secure_dir }}/vars/shib_stage_vars.yml"
   roles:
     - common
     - nginx
     - edxapp
-    - apache
-    - shibboleth
+    - ansible_debug
+    #- apache
+    #- shibboleth

--- a/playbooks/edx-west/stage-notifier-only.yml
+++ b/playbooks/edx-west/stage-notifier-only.yml
@@ -1,0 +1,15 @@
+# run the notifier on the first util machine only
+- hosts: ~tag_Name_util10_stage
+  sudo: True
+  vars:
+    secure_dir: '../../../configuration-secure/ansible'
+    migrate_db: "no"
+  vars_files:
+    - "{{ secure_dir }}/vars/edxapp_stage_vars.yml"
+    - "{{ secure_dir }}/vars/notifier_stage_vars.yml"
+  roles:
+    - role: virtualenv
+      virtualenv_user: "notifier"
+      virtualenv_user_home: "/opt/wwc/notifier"
+      virtualenv_name: "notifier"
+    - notifier

--- a/playbooks/edx-west/stage-worker.yml
+++ b/playbooks/edx-west/stage-worker.yml
@@ -1,4 +1,4 @@
-# this gets all running stage util machiens
+  # this gets all running stage util machiens
 - hosts: tag_environment_stage:&tag_function_util
 # or we can get subsets of them by name
 #- hosts: ~tag_Name_util(1|2)_stage

--- a/playbooks/roles/shibboleth/templates/shibboleth2.xml.j2
+++ b/playbooks/roles/shibboleth/templates/shibboleth2.xml.j2
@@ -43,7 +43,7 @@
     -->
 
     <!-- The ApplicationDefaults element is where most of Shibboleth's SAML bits are defined. -->
-    <ApplicationDefaults entityID="{{shib.sp_entity_id}}" REMOTE_USER="eppn persistent-id targeted-id">
+    <ApplicationDefaults entityID="{{shib.sp_entity_id}}" REMOTE_USER="eppn">
         <!--
         Controls session lifetimes, address checks, cookie handling, and the protocol handlers.
         You MUST supply an effectively unique handlerURL value for each of your applications.


### PR DESCRIPTION
@jrbl this is basically a bunch of small playbook changes in edx-west

the only substantive change is removing persistent-id and targeted-id from being assigned to REMOTE_USER (this is to fix the account cross-wiring)
