### PR TITLE
Symlink /var/lib/jenkins to /mnt/jenkins to avoid running out of disk space

### DIFF
--- a/playbooks/roles/jenkins_master/defaults/main.yml
+++ b/playbooks/roles/jenkins_master/defaults/main.yml
@@ -1,4 +1,4 @@
-jenkins_home: /var/lib/jenkins
+jenkins_home: /mnt/jenkins
 jenkins_user: "jenkins"
 jenkins_group: "edx"
 jenkins_server_name: "jenkins.testeng.edx.org"

--- a/playbooks/roles/jenkins_master/tasks/main.yml
+++ b/playbooks/roles/jenkins_master/tasks/main.yml
@@ -22,6 +22,26 @@
 - name: jenkins_master | Install jenkins package
   apt: pkg=jenkins state=present update_cache=yes
 
+- name: jenkins_master | Stop Jenkins
+  service: name=jenkins state=stopped
+
+# Move /var/lib/jenkins to Jenkins home (on the EBS)
+- name: jenkins_master | Move /var/lib/jenkins
+  command: mv /var/lib/jenkins {{ jenkins_home }}
+           creates={{ jenkins_home }}
+
+- name: jenkins_master | Set owner for Jenkins home
+  file: path={{ jenkins_home }} recurse=yes state=directory
+        owner={{ jenkins_user }} group={{ jenkins_group }}
+
+# Symlink /var/lib/jenkins to /mnt/jenkins
+# since Jenkins will expect its files to be in /var/lib/jenkins
+- name: jenkins_master | Symlink /var/lib/jenkins
+  file: src={{ jenkins_home }} dest=/var/lib/jenkins state=link
+        owner={{ jenkins_user }} group={{ jenkins_group }}
+  notify:
+    - jenkins_master | restart Jenkins
+
 - name: jenkins_master | Make plugins directory
   sudo_user: jenkins
   shell: mkdir -p {{ jenkins_home }}/plugins


### PR DESCRIPTION
When I started archiving reports, Jenkins ran out of disk space in /var/lib/jenkins.

@feanil 
