### PR TITLE
bump ansible to 1.3.2 to fix too many open files

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,4 +28,4 @@ six==1.2.0
 -e git+https://github.com/bos/statprof.py.git@a17f7923b102c9039763583be9e377e8422e8f5f#egg=statprof-dev
 ujson==1.30
 wsgiref==0.1.2
-ansible==1.3.1
+ansible==1.3.2


### PR DESCRIPTION
@jarv @carsongee 

c.f. https://github.com/ansible/ansible/pull/4132#issuecomment-24751997

1.3.2 fixes "too many files open" error that popped up on every install in 1.3.1
