### PR TITLE
Upgrade git version used on the Jenkins worker

### DIFF
--- a/playbooks/roles/jenkins_worker/tasks/system.yml
+++ b/playbooks/roles/jenkins_worker/tasks/system.yml
@@ -31,6 +31,12 @@
         owner={{ jenkins_user }} group={{ jenkins_group }}
         mode=400
 
+# Ensure that we get a current version of Git
+# GitHub requires version 1.7.10 or later
+# https://help.github.com/articles/https-cloning-errors
+- name: jenkins_worker | Add git apt repository
+  apt_repository: repo='ppa:git-core/ppa'
+
 - name: jenkins_worker | Install system packages
   apt: pkg={{','.join(jenkins_debian_pkgs)}}
        state=present update_cache=yes


### PR DESCRIPTION
GitHub requires version 1.7.10 or later, but we were using a slightly older version.  I think this may be responsible for the three times I've observed the Jenkins git plugin hanging on `git fetch`.  

By adding the git-core apt-repo, we will use git version 1.8.4.

Reviewer: @feanil
