### PR TITLE
re-apply ec2.py fixes for inifile

### DIFF
--- a/playbooks/ec2.py
+++ b/playbooks/ec2.py
@@ -137,8 +137,8 @@ class Ec2Inventory(object):
         self.index = {}
 
         # Read settings and parse CLI arguments
-        self.read_settings()
         self.parse_cli_args()
+        self.read_settings()
 
         # Cache
         if self.args.refresh_cache:
@@ -177,7 +177,7 @@ class Ec2Inventory(object):
         ''' Reads the settings from the ec2.ini file '''
 
         config = ConfigParser.SafeConfigParser()
-        config.read(os.path.dirname(os.path.realpath(__file__)) + '/ec2.ini')
+        config.read(self.args.inifile)
 
         # is eucalyptus?
         self.eucalyptus_host = None
@@ -230,6 +230,10 @@ class Ec2Inventory(object):
                            help='Get all the variables about a specific instance')
         parser.add_argument('--refresh-cache', action='store_true', default=False,
                            help='Force refresh of cache by making API requests to EC2 (default: False - use cache files)')
+
+        default_inifile = os.environ.get("ANSIBLE_EC2_INI", os.path.dirname(os.path.realpath(__file__))+'/ec2.ini')
+
+        parser.add_argument('--inifile', dest='inifile', help='Path to init script to use', default=default_inifile)
         self.args = parser.parse_args()
 
 

--- a/playbooks/edx-west/ec2.ini
+++ b/playbooks/edx-west/ec2.ini
@@ -1,6 +1,8 @@
 [ec2]
 regions=us-west-1
+regions_exclude = us-gov-west-1
 destination_variable=public_dns_name
 vpc_destination_variable=private_dns_name
 cache_path=/tmp
 cache_max_age=300
+route53=False


### PR DESCRIPTION
Our changes was undone by 80b5f3e1edf37676829bed98e5ee7887c79dabb8.  Reapplying.  Pair-programmed with @jrbl, can you pull Joe?

Re-enable set by command-line option and environment file.  We need this at Stanford so we can get private DNS names to use with VPC's.

The only interesting change is moving the option parsing up a bit.
