### PR TITLE
Create the synced folder if it doesn't exist

### DIFF
--- a/vagrant/devstack/Vagrantfile
+++ b/vagrant/devstack/Vagrantfile
@@ -13,7 +13,7 @@ Vagrant.configure("2") do |config|
   config.ssh.forward_agent = true
 
   nfs_setting = RUBY_PLATFORM =~ /darwin/ || RUBY_PLATFORM =~ /linux/
-  config.vm.synced_folder "edx-platform", "/opt/edx/edx-platform", id: "vagrant-root", :nfs => nfs_setting
+  config.vm.synced_folder "edx-platform", "/opt/edx/edx-platform", id: "vagrant-root", :nfs => nfs_setting, :create => true
 
   # Configure /etc/hosts on the host machine
   # This requires the vagrant-hostsupdater plugin


### PR DESCRIPTION
Otherwise we get an error if the edx-platform folder doesn't already exist.
