### PR TITLE
Will/jenkins custom git plugin

### DIFF
--- a/playbooks/roles/jenkins_master/defaults/main.yml
+++ b/playbooks/roles/jenkins_master/defaults/main.yml
@@ -13,7 +13,6 @@ jenkins_plugins:
     - { name: "credentials", version: "1.8.3" }
     - { name: "dashboard-view", version: "2.9.1" }
     - { name: "ec2", version: "1.19" }
-    - { name: "git", version: "1.5.0" }
     - { name: "github", version: "1.8" }
     - { name: "github-api", version: "1.44" }
     - { name: "github-oauth", version: "0.14" }
@@ -39,8 +38,19 @@ jenkins_plugins:
     - { name: "multiple-scms", version: "0.2" }
     - { name: "timestamper", version: "1.5.7" }
 
+jenkins_custom_plugins:
+    - { repo_name: "git-client-plugin",
+        repo_url: "https://github.com/edx/git-client-plugin.git",
+        package: "git-client.hpi",
+        version: "2f7fc4648fe7239918a7babd0515930d40d0a761" }
+    - { repo_name: "git-plugin",
+        repo_url: "https://github.com/edx/git-plugin.git",
+        package: "git.hpi",
+        version: "4c2fb3517ca11b04dfc06c714530f885698fcfb7" }
+
 jenkins_debian_pkgs:
     - openjdk-7-jdk
     - nginx
     - git
     - maven
+    - python-pycurl

--- a/playbooks/roles/jenkins_master/defaults/main.yml
+++ b/playbooks/roles/jenkins_master/defaults/main.yml
@@ -12,7 +12,7 @@ jenkins_plugins:
     - { name: "copyartifact", version: "1.28" }
     - { name: "credentials", version: "1.8.3" }
     - { name: "dashboard-view", version: "2.9.1" }
-    - { name: "ec2", version: "1.18" }
+    - { name: "ec2", version: "1.19" }
     - { name: "git", version: "1.5.0" }
     - { name: "github", version: "1.8" }
     - { name: "github-api", version: "1.44" }
@@ -29,8 +29,8 @@ jenkins_plugins:
     - { name: "postbuild-task", version: "1.8" }
     - { name: "s3", version: "0.5" }
     - { name: "ssh-agent", version: "1.3" }
-    - { name: "ssh-credentials", version: "0.3" }
-    - { name: "ssh-slaves", version: "0.25" }
+    - { name: "ssh-credentials", version: "1.5.1" }
+    - { name: "ssh-slaves", version: "1.4" }
     - { name: "shiningpanda", version: "0.20" }
     - { name: "tmpcleaner", version: "1.1" }
     - { name: "token-macro", version: "1.8.1" }

--- a/playbooks/roles/jenkins_master/tasks/main.yml
+++ b/playbooks/roles/jenkins_master/tasks/main.yml
@@ -46,38 +46,48 @@
   sudo_user: jenkins
   shell: mkdir -p {{ jenkins_home }}/plugins
 
-- name: jenkins_master | Install Jenkins plugins
-  sudo_user: jenkins
+# We first download the plugins to a temp directory and include
+# the version in the file name.  That way, if we increment
+# the version, the plugin will be updated in Jenkins
+- name: jenkins_master | Download Jenkins plugins
   get_url: url=http://updates.jenkins-ci.org/download/plugins/${item.name}/${item.version}/${item.name}.hpi
-           dest={{ jenkins_home }}/plugins/${item.name}.hpi
+           dest=/tmp/${item.name}_${item.version}
+  with_items: "{{ jenkins_plugins }}"
+
+- name: jenkins_master | Install Jenkins plugins
+  command: cp /tmp/${item.name}_${item.version} {{ jenkins_home }}/plugins/${item.name}.hpi
+  with_items: "{{ jenkins_plugins }}"
+
+- name: jenkins_master | Set Jenkins plugin permissions
+  file: path={{ jenkins_home }}/plugins/${item.name}.hpi
+        owner={{ jenkins_user }} group={{ jenkins_group }} mode=700
   with_items: "{{ jenkins_plugins }}"
   notify:
     - jenkins_master | restart Jenkins
 
-# We had to fork the git-client plugin repo
-# to fix an obscure bug.  If and when the PR gets
-# merged into the main repo and released,
-# we can use the regular plugin install process.
-# Until then, we need to compile and install it ourselves.
-- name: jenkins_master | Checkout custom git-client plugin repo
-  git: repo=https://github.com/edx/git-client-plugin.git
-       dest=/tmp/git-client-plugin
+# We had to fork some plugins to workaround
+# certain issues.  If these changes get merged
+# upstream, we may be able to use the regular plugin install process.
+# Until then, we compile and install the forks ourselves.
+- name: jenkins_master | Checkout custom plugin repo
+  git: repo=${item.repo_url} dest=/tmp/${item.repo_name} version=${item.version}
+  with_items: "{{ jenkins_custom_plugins }}"
 
-- name: jenkins_master | Compile custom git-client plugin
-  command: mvn install chdir=/tmp/git-client-plugin
-           creates=/tmp/git-client-plugin/target/git-client.hpi
+- name: jenkins_master | Compile custom plugins
+  command: mvn -Dmaven.test.skip=true install chdir=/tmp/${item.repo_name}
+  with_items: "{{ jenkins_custom_plugins }}"
 
-- name: jenkins_master | Install custom git-client
-  command: mv /tmp/git-client-plugin/target/git-client.hpi
-           {{ jenkins_home }}/plugins/git-client.hpi
-           creates={{ jenkins_home }}/plugins/git-client.hpi
+- name: jenkins_master | Install custom plugins
+  command: mv /tmp/${item.repo_name}/target/${item.package}
+           {{ jenkins_home }}/plugins/${item.package}
+  with_items: "{{ jenkins_custom_plugins }}"
   notify:
     - jenkins_master | restart Jenkins
 
-- name: jenkins_master | Set git-client plugin permissions
-  file: path={{ jenkins_home }}/plugins/git-client.hpi
-        owner={{ jenkins_user }} group={{ jenkins_group }}
-        mode=700
+- name: jenkins_master | Set custom plugin permissions
+  file: path={{ jenkins_home }}/plugins/${item.package}
+        owner={{ jenkins_user }} group={{ jenkins_group }} mode=700
+  with_items: "{{ jenkins_custom_plugins }}"
 
 - name: jenkins_master | Setup nginix vhost
   template:


### PR DESCRIPTION
- Add forked git-plugin repo (resolves an issue with duplicate builds)
- Refactor plugin installation to install updated versions.
- Stop running tests after compiling forked plugins.
- Update plugin versions to the ones we're using in Jenkins now.
