### PR TITLE
Fix Jenkins version to last known stable.

### DIFF
--- a/playbooks/roles/jenkins_master/defaults/main.yml
+++ b/playbooks/roles/jenkins_master/defaults/main.yml
@@ -4,6 +4,9 @@ jenkins_group: "edx"
 jenkins_server_name: "jenkins.testeng.edx.org"
 jenkins_port: 8080
 
+jenkins_deb_url: "http://pkg.jenkins-ci.org/debian/binary/jenkins_1.530_all.deb"
+jenkins_deb: "jenkins_1.530_all.deb"
+
 jenkins_plugins:
     - { name: "build-name-setter", version: "1.3" }
     - { name: "build-pipeline-plugin", version: "1.4" }
@@ -53,4 +56,5 @@ jenkins_debian_pkgs:
     - nginx
     - git
     - maven
+    - daemon
     - python-pycurl

--- a/playbooks/roles/jenkins_master/tasks/main.yml
+++ b/playbooks/roles/jenkins_master/tasks/main.yml
@@ -13,14 +13,11 @@
 - name: jenkins_master | Add the jenkins user to the group
   user: name={{ jenkins_user }} append=yes groups={{ jenkins_group }}
 
-- name: jenkins_master | Install Jenkins apt key
-  apt_key: url=http://pkg.jenkins-ci.org/debian/jenkins-ci.org.key state=present
+- name: jenkins_master | Download Jenkins package
+  get_url: url="{{ jenkins_deb_url }}" dest="/tmp/{{ jenkins_deb }}"
 
-- name: jenkins_master | Add apt repository
-  apt_repository: repo='deb http://pkg.jenkins-ci.org/debian binary/' state=present
-
-- name: jenkins_master | Install jenkins package
-  apt: pkg=jenkins state=present update_cache=yes
+- name: jenkins_master | Install Jenkins package
+  command: dpkg -i --force-depends "/tmp/{{ jenkins_deb }}"
 
 - name: jenkins_master | Stop Jenkins
   service: name=jenkins state=stopped


### PR DESCRIPTION
Apparently the latest version of Jenkins has a show-stopping bug: https://issues.jenkins-ci.org/browse/JENKINS-20123

This change ensures that we install the same version we're using in the Jenkins cluster, which does not have this problem.

@jzoldak @feanil 
