### PR TITLE
Create "pinned" files to allow upgrading plugins bundled with Jenkins.

### DIFF
--- a/playbooks/roles/jenkins_master/defaults/main.yml
+++ b/playbooks/roles/jenkins_master/defaults/main.yml
@@ -41,6 +41,12 @@ jenkins_plugins:
     - { name: "multiple-scms", version: "0.2" }
     - { name: "timestamper", version: "1.5.7" }
 
+jenkins_bundled_plugins:
+    - "credentials"
+    - "git"
+    - "ssh-credentials"
+    - "ssh-slaves"
+
 jenkins_custom_plugins:
     - { repo_name: "git-client-plugin",
         repo_url: "https://github.com/edx/git-client-plugin.git",

--- a/playbooks/roles/jenkins_master/tasks/main.yml
+++ b/playbooks/roles/jenkins_master/tasks/main.yml
@@ -86,6 +86,16 @@
         owner={{ jenkins_user }} group={{ jenkins_group }} mode=700
   with_items: "{{ jenkins_custom_plugins }}"
 
+
+# Plugins that are bundled with Jenkins are "pinned".
+# Jenkins will overwrite updated plugins with its built-in version
+# unless we create a ".pinned" file for the plugin.
+# See https://issues.jenkins-ci.org/browse/JENKINS-13129
+- name: jenkins_master | Create plugin pin files
+  command: touch {{ jenkins_home }}/plugins/${item}.jpi.pinned
+           creates={{ jenkins_home }}/plugins/${item}.jpi.pinned
+  with_items: "{{ jenkins_bundled_plugins }}"
+
 - name: jenkins_master | Setup nginix vhost
   template:
     src=etc/nginx/sites-available/jenkins.j2


### PR DESCRIPTION
I noticed that some (but not all) of the Jenkins plugins were not being upgraded correctly by the Ansible scripts.

According to https://issues.jenkins-ci.org/browse/JENKINS-13129
- Jenkins "pins" built-in plugins.  From the Jenkins docs:
  
  Normally whenever Jenkins is upgraded or downgraded, its built-in plugins overwrite whatever versions of the plugins are currently installed in $JENKINS_HOME. This ensures that consistent versions of those plugins are used. However, this behavior also means that those plugins cannot be manually updated, as every time Jenkins is started they will be replaced by the bundled versions.
- The workaround is to create a ".pinned" file in the plugins directory for these built-in plugins.

@feanil 
