### PR TITLE
Certain tasks (like generating grades) require a great deal of

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -129,6 +129,10 @@ edxapp_workers:
   - queue: high
     service_variant: lms
     concurrency: 4
+  - queue: high_mem
+    service_variant: lms
+    concurrency: 2
+
 
 
 


### PR DESCRIPTION
memory that isn't properly freed up. This creates a queue for such
workers so that we can give them different configuration settings
-- in this case, setting CELERYD_MAX_TASKS_PER_CHILD=1 to force
workers to die after they process one job. Because these jobs tend
to run for hours, the overhead is not a big deal.
