### PR TITLE
Fix paths to Mongo in jenkins_worker

### DIFF
--- a/playbooks/roles/jenkins_worker/defaults/main.yml
+++ b/playbooks/roles/jenkins_worker/defaults/main.yml
@@ -47,8 +47,8 @@ jscover_url: "http://superb-dca2.dl.sourceforge.net/project/jscover/JSCover-1.0.
 jscover_version: "1.0.2"
 
 # Mongo config
-mongo_dir: "{{ COMMON_DATA_DIR }}/mongodb"
-mongo_log_dir: "{{ COMMON_DATA_DIR }}/logs/mongodb"
+mongo_dir: "{{ COMMON_DATA_DIR }}/mongo/mongodb"
+mongo_log_dir: "{{ COMMON_DATA_DIR }}/log/mongo"
 
 # URL of S3 bucket containing pre-compiled Python packages
 python_pkg_url: "https://s3.amazonaws.com/jenkins.python_pkgs"


### PR DESCRIPTION
@feanil While cutting a new Jenkins worker AMI, I noticed a mismatch between the Mongo directories created by the Jenkins worker upstart script and the directories in the Mongo role config.

Longer term, there's probably a better way to do this.  Maybe an optional play in the mongo role for using ephemeral storage?  Short term, though, I'd like to get this in so I can update the Jenkins workers.
