### PR TITLE
turns off ora and discern by default since they are broken on the single

### DIFF
--- a/playbooks/roles/discern/handlers/main.yml
+++ b/playbooks/roles/discern/handlers/main.yml
@@ -1,6 +1,8 @@
 ---
+# FIXME: discern is not running properly yet in the single-server
+# ansible environment, leaving it stopped until it is fixed
 - name: discern | restart discern
-  service: name=discern state=restarted
+  service: name=discern state=stopped
 
 - name: discern | restart celery
-  service: name=celery state=restarted
+  service: name=celery state=stopped

--- a/playbooks/roles/ora/handlers/main.yml
+++ b/playbooks/roles/ora/handlers/main.yml
@@ -1,5 +1,7 @@
 ---
+# FIXME: ORA is not running properly yet in the single-server
+# ansible environment, leaving it stopped until it is fixed
 - name: ora | restart edx-ora
-  service: name=edx-ora state=restarted
+  service: name=edx-ora state=stopped
 - name: ora | restart edx-ora-celery
-  service: name=edx-ora-celery state=restarted
+  service: name=edx-ora-celery state=stopped


### PR DESCRIPTION
@jrbl @jbau @carsongee @feanil turns off ora/discern by default since they are both broken on master on the single instance sandbox
