### PR TITLE
Introduce POST size limit for ORA submissions

### DIFF
--- a/playbooks/roles/nginx/templates/ora.j2
+++ b/playbooks/roles/nginx/templates/ora.j2
@@ -34,6 +34,7 @@ server {
   }
 
   location @proxy_to_app {
+    client_max_body_size 75K;
     proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
     proxy_set_header X-Forwarded-Port $http_x_forwarded_port;
     proxy_set_header X-Forwarded-For $http_x_forwarded_for;


### PR DESCRIPTION
The ORA machinery gets gummed up when it gets very large submissions and
throws a lot of 500s.

Co-Authored-By: Jason Bau jbau@stanford.edu

@jarv please review.
@VikParuchuri please confirm that you don't know of anyone counting on being able to send large files.
