### PR TITLE
edxapp-extra-vars: Expose extra variables for configuration of the edxapp role

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -57,6 +57,8 @@ EDXAPP_ZENDESK_API_KEY: ''
 EDXAPP_CELERY_USER: 'celery'
 EDXAPP_CELERY_PASSWORD: 'celery'
 
+EDXAPP_PLATFORM_NAME: 'edX'
+
 EDXAPP_MITX_FEATURES:
   AUTH_USE_OPENID_PROVIDER: true
   CERTIFICATES_ENABLED: true
@@ -90,6 +92,16 @@ EDXAPP_LMS_BASIC_AUTH: False
 EDXAPP_CMS_BASIC_AUTH: False
 EDXAPP_LMS_PREVIEW_BASIC_AUTH: False
 EDXAPP_LANG: 'en_US.UTF-8'
+EDXAPP_TIME_ZONE: 'America/New_York'
+
+EDXAPP_TECH_SUPPORT_EMAIL: ''
+EDXAPP_CONTACT_EMAIL: ''
+EDXAPP_BUGS_EMAIL: ''
+
+EDXAPP_ENV_EXTRA: {}
+EDXAPP_AUTH_EXTRA: {}
+EDXAPP_MKTG_URL_LINK_MAP: {}
+
 
 #-------- Everything below this line is internal to the role ------------
 
@@ -232,6 +244,7 @@ generic_env_config:  &edxapp_generic_env
   LMS_BASE: $EDXAPP_LMS_BASE
   CMS_BASE: $EDXAPP_CMS_BASE
   BOOK_URL:  $EDXAPP_BOOK_URL
+  PLATFORM_NAME: $EDXAPP_PLATFORM_NAME
   CERT_QUEUE:  'certificates'
   LOCAL_LOGLEVEL: $EDXAPP_LOG_LEVEL
   # default email backed set to local SMTP
@@ -244,7 +257,8 @@ generic_env_config:  &edxapp_generic_env
   MEDIA_URL:  $EDXAPP_MEDIA_URL
   ANALYTICS_SERVER_URL:  $EDXAPP_ANALYTICS_SERVER_URL
   FEEDBACK_SUBMISSION_EMAIL: $EDXAPP_FEEDBACK_SUBMISSION_EMAIL
-  TIME_ZONE: 'America/New_York'
+  TIME_ZONE: $EDXAPP_TIME_ZONE
+  MKTG_URL_LINK_MAP: $EDXAPP_MKTG_URL_LINK_MAP
   CACHES:
     default: &default_generic_cache
       BACKEND:  'django.core.cache.backends.memcached.MemcachedCache'
@@ -270,6 +284,10 @@ generic_env_config:  &edxapp_generic_env
   SESSION_COOKIE_DOMAIN:  !!null
   COMMENTS_SERVICE_KEY: $EDXAPP_COMMENTS_SERVICE_KEY
   SEGMENT_IO_LMS: true
+  THEME_NAME: $edxapp_theme_name
+  TECH_SUPPORT_EMAIL: $EDXAPP_TECH_SUPPORT_EMAIL
+  CONTACT_EMAIL: $EDXAPP_CONTACT_EMAIL
+  BUGS_EMAIL: $EDXAPP_BUGS_EMAIL
   CODE_JAIL:
     limits:
       VMEM: 0

--- a/playbooks/roles/edxapp/templates/cms.auth.json.j2
+++ b/playbooks/roles/edxapp/templates/cms.auth.json.j2
@@ -1,2 +1,2 @@
-{# {% do auth_config.update( { < override some hash keys > } )  %} #}
+{% do cms_auth_config.update(EDXAPP_AUTH_EXTRA) %}
 {{ cms_auth_config | to_nice_json }}

--- a/playbooks/roles/edxapp/templates/cms.env.json.j2
+++ b/playbooks/roles/edxapp/templates/cms.env.json.j2
@@ -1,1 +1,2 @@
+{% do cms_env_config.update(EDXAPP_ENV_EXTRA) %}
 {{ cms_env_config | to_nice_json }}

--- a/playbooks/roles/edxapp/templates/lms-preview.auth.json.j2
+++ b/playbooks/roles/edxapp/templates/lms-preview.auth.json.j2
@@ -1,1 +1,2 @@
+{% do lms_auth_config.update(EDXAPP_AUTH_EXTRA) %}
 {{ lms_preview_auth_config | to_nice_json }}

--- a/playbooks/roles/edxapp/templates/lms-preview.env.json.j2
+++ b/playbooks/roles/edxapp/templates/lms-preview.env.json.j2
@@ -1,1 +1,2 @@
+{% do lms_preview_env_config.update(EDXAPP_ENV_EXTRA) %}
 {{ lms_preview_env_config | to_nice_json }}

--- a/playbooks/roles/edxapp/templates/lms.auth.json.j2
+++ b/playbooks/roles/edxapp/templates/lms.auth.json.j2
@@ -1,1 +1,2 @@
+{% do lms_auth_config.update(EDXAPP_AUTH_EXTRA) %}
 {{ lms_auth_config | to_nice_json }}

--- a/playbooks/roles/edxapp/templates/lms.env.json.j2
+++ b/playbooks/roles/edxapp/templates/lms.env.json.j2
@@ -1,1 +1,2 @@
+{% do lms_env_config.update(EDXAPP_ENV_EXTRA) %}
 {{ lms_env_config | to_nice_json }}


### PR DESCRIPTION
Expose extra variables for configuration overload. These were things that I was missing to migrate the codecoalition.com instance.

Of specific note, `EDXAPP_ENV_EXTRA` and `EDXAPP_AUTH_EXTRA` allow to add variables to `auth.json` and `env.json` without having to overload the whole generic_env_config/generic_auth_config dictionary. This is especially useful when adding custom djangoapps or code which define extra configuration variables.
