### PR TITLE
forum-ports-config: Use configuration variables to set services ports

### DIFF
--- a/playbooks/roles/forum/defaults/main.yml
+++ b/playbooks/roles/forum/defaults/main.yml
@@ -52,7 +52,5 @@ forum_elasticsearch_url: "http://{{ forum_elasticsearch_host }}:{{ forum_elastic
 #
 forum_services:
   - {service: "sinatra", host: "localhost", port: "4567"}
-  - {service: "mongo", host: "{{ forum_mongo_host  }}", port: "27017"}
-  - {service: "mongo", host: "{{ forum_mongo_host }}", port: "28017"}
-  - {service: "elasticsearch", host: "{{ forum_elasticsearch_host }}", port: "9200"}
-  - {service: "elasticsearch", host: "{{ forum_elasticsearch_host }}", port: "9300"}
+  - {service: "mongo", host: "{{ forum_mongo_host  }}", port: "{{ forum_mongo_port }}"}
+  - {service: "elasticsearch", host: "{{ forum_elasticsearch_host }}", port: "{{ forum_elasticsearch_port }}"}


### PR DESCRIPTION
When using a custom mongo host/port which doesn't use the default mongo port (like mongolab instances), a lookup of the default mongo port doesn't work. Same issue with elasticsearch port.
