### PR TITLE
fixing default for THEME_NAME

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -386,7 +386,7 @@ worker_core_mult:
 #Theming
 #To turn off theming, specify edxapp_theme_name: ''
 #Stanford, for example, uses edxapp_theme_name: 'stanford'
-edxapp_theme_name: ''
+edxapp_theme_name: !!null
 edxapp_theme_source_repo: 'https://{{ COMMON_GIT_MIRROR }}/Stanford-Online/edx-theme.git'
 edxapp_theme_version: 'HEAD'
 

--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -383,9 +383,10 @@ worker_core_mult:
   lms_preview: 2
   cms: 2
 
-#Theming
-#To turn off theming, specify edxapp_theme_name: ''
-#Stanford, for example, uses edxapp_theme_name: 'stanford'
+# Theming
+# To turn off theming, specify edxapp_theme_name: !!null
+# Stanford, for example, uses edxapp_theme_name: 'stanford'
+#
 edxapp_theme_name: !!null
 edxapp_theme_source_repo: 'https://{{ COMMON_GIT_MIRROR }}/Stanford-Online/edx-theme.git'
 edxapp_theme_version: 'HEAD'


### PR DESCRIPTION
@feanil @antoviaque

If THEME_NAME is set to an empty string it will cause a sass error due
to this mako code:

```
% if env.get('THEME_NAME') is not None:
  // import theme's Sass overrides
  @import '${env.get('THEME_NAME')}';
% endif
```
