### PR TITLE
DO NOT MERGE: Pure ansible provisioning and MITx style architecture

### DIFF
--- a/playbooks/roles/loadbalancer/defaults/main.yml
+++ b/playbooks/roles/loadbalancer/defaults/main.yml
@@ -1,0 +1,1 @@
+course_static_dir: /mnt/data/repos

--- a/playbooks/roles/loadbalancer/tasks/main.yml
+++ b/playbooks/roles/loadbalancer/tasks/main.yml
@@ -1,0 +1,25 @@
+---
+# This adds nginx sites for each app server, enables them, and configures any
+# high level load balancer needs. 
+
+- name: loadbalancer | copy over key
+  copy: src={{ item }} dest="~/.ssh/" mode="0600"
+  with_first_found:
+    - '~/.ssh/id_dsa'
+    - '~/.ssh/id_rsa'
+  tags: 
+    - loadbalancer
+    - deploy
+
+- name: loadbalancer | rsync static files from app server
+  command: rsync -r -e "ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null" ubuntu@{{ provision_apps1_az1_ip }}:/{{ app_base_dir }}/staticfiles/ {{ app_base_dir }}/staticfiles/
+  tags: 
+    - loadbalancer
+    - deploy
+
+- name: loadbalancer | delete key
+  file: dest={{ item }} state="absent"
+  with_items:
+    - '~/.ssh/id_dsa'
+    - '~/.ssh/id_rsa'
+

--- a/playbooks/roles/loadbalancer/templates/ssl_combined.conf.j2
+++ b/playbooks/roles/loadbalancer/templates/ssl_combined.conf.j2
@@ -1,0 +1,4 @@
+log_format ssl_combined '$remote_addr - $ssl_client_s_dn [$time_local]  '
+	                    '"$request" $status $body_bytes_sent '
+  	                    '"$http_referer" "$http_user_agent"';
+

--- a/playbooks/roles/provision/defaults/main.yml
+++ b/playbooks/roles/provision/defaults/main.yml
@@ -1,0 +1,51 @@
+---
+# provision_ec2_keypair not defined, needed in secure_vars
+provision_org: my_org
+provision_ha: yes
+
+provision_backup_type: t1.micro
+provision_selenium_type: t1.micro
+provision_mongo_type: m1.small
+provision_apps_type: m1.medium
+provision_lb_type: t1.micro
+
+provision_backup_ip: 254.20
+provision_selenium_ip: 254.30
+provision_lb1_az1_ip: 0.10
+provision_lb1_az2_ip: 1.10
+provision_mongo1_az1_ip: 128.10
+provision_mongo1_az2_ip: 129.10
+provision_mongo1_az3_ip: 130.10
+provision_apps1_az1_ip: 16.10
+provision_apps1_az2_ip: 17.10
+
+provision_backup_ver: 0
+provision_selenium_ver: 0
+provision_lb1_az1_ver: 0
+provision_lb1_az2_ver: 0
+provision_mongo1_az1_ver: 0
+provision_mongo1_az2_ver: 0
+provision_mongo1_az3_ver: 0
+provision_apps1_az1_ver: 0
+provision_apps1_az2_ver: 0
+
+# 12.04 LTS ebs amd64 in US-West-2
+provsion_ec2_image: ami-30079e00
+
+# Use a little jinja magic to get the subnet IDs out of the vpc dictionary
+vpc_subnet_admin: >
+  {% for s in vpc.subnets %}{% if s['cidr']=='%s254.0/24'|format(vpc_cidr_top) %}{{ s['id'] }}{% endif %}{%endfor%}
+vpc_subnet_data_1: >
+  {% for s in vpc.subnets %}{% if s['cidr']=='%s128.0/24'|format(vpc_cidr_top) %}{{ s['id'] }}{% endif %}{%endfor%}
+vpc_subnet_data_2: >
+  {% for s in vpc.subnets %}{% if s['cidr']=='%s129.0/24'|format(vpc_cidr_top) %}{{ s['id'] }}{% endif %}{%endfor%}
+vpc_subnet_data_3: >
+  {% for s in vpc.subnets %}{% if s['cidr']=='%s130.0/24'|format(vpc_cidr_top) %}{{ s['id'] }}{% endif %}{%endfor%}
+vpc_subnet_apps_1: >
+  {% for s in vpc.subnets %}{% if s['cidr']=='%s16.0/24'|format(vpc_cidr_top) %}{{ s['id'] }}{% endif %}{%endfor%}
+vpc_subnet_apps_2: >
+  {% for s in vpc.subnets %}{% if s['cidr']=='%s17.0/24'|format(vpc_cidr_top) %}{{ s['id'] }}{% endif %}{%endfor%}
+vpc_subnet_lb_1: >
+  {% for s in vpc.subnets %}{% if s['cidr']=='%s0.0/24'|format(vpc_cidr_top) %}{{ s['id'] }}{% endif %}{%endfor%}
+vpc_subnet_lb_2: >
+  {% for s in vpc.subnets %}{% if s['cidr']=='%s1.0/24'|format(vpc_cidr_top) %}{{ s['id'] }}{% endif %}{%endfor%}

--- a/playbooks/roles/provision/tasks/main.yml
+++ b/playbooks/roles/provision/tasks/main.yml
@@ -1,0 +1,315 @@
+# requires:
+#   - vpc/tasks/main.yml
+# This will build all the needed instances
+# for the stack
+
+---
+
+- name: provision | Create Backup Instance
+  local_action:
+    module: ec2
+    keypair: "{{ provision_ec2_keypair }}"
+    instance_type: "{{ provision_backup_type }}"
+    image: "{{ provision_ec2_image }}"
+    group_id: 
+      - "{{ ssh_only.group_id }}"
+      - "{{ snmpd_monitor.group_id }}"
+    region: "{{ vpc_ec2_region }}"
+    vpc_subnet_id: "{{ vpc_subnet_admin }}"
+    private_ip: "{{ vpc_cidr_top}}{{ provision_backup_ip }}"
+    id: backupsv{{ provision_backup_ver }}
+    count: 1
+    wait: yes
+    instance_tags: '{"Name": "backup-launched", "env": "{{ env }}",  "group": "backup", "status": "launched", "metagroup": "infrastructure", "org": "{{ provision_org }}" }'
+  when: provision_create_backup is defined
+  register: ec2b
+  tags: backup
+
+- name: provision | Create Selenium Instance
+  local_action:
+    module: ec2
+    keypair: "{{ provision_ec2_keypair }}"
+    instance_type: "{{ provision_selenium_type }}"
+    image: "{{ provision_ec2_image }}"
+    group_id: 
+      - "{{ ssh_only.group_id }}"
+      - "{{ snmpd_monitor.group_id }}"
+    region: "{{ vpc_ec2_region }}"
+    vpc_subnet_id: "{{ vpc_subnet_admin }}"
+    private_ip: "{{ provision_selenium_ip }}"
+    count: 1
+    id: seleniumsv{{ provision_selenium_ver }}
+    wait: yes
+    instance_tags: '{"Name": "selenium-launched", "env": "{{ env }}", "group": "selenium", "status": "launched", "metagroup": "infrastructure", "org": "{{ provision_org }}" }'
+  when: provision_create_selenium is defined
+  register: ec2s
+  tags: selenium      
+
+- name: provision | Create AZ1 Mongo1 Instance
+  local_action:
+    module: ec2
+    keypair: "{{ provision_ec2_keypair }}"
+    instance_type: "{{ provision_mongo_type }}"
+    image: "{{ provision_ec2_image }}"
+    group_id: 
+      - "{{ mongo_group.group_id }}"
+      - "{{ ssh_only.group_id }}"
+      - "{{ intra_mongo_group.group_id }}"
+      - "{{ rabbitmq_group.group_id }}"
+      - "{{ intra_mongo_group.group_id }}"
+      - "{{ snmpd_monitor.group_id }}"
+    region: "{{ vpc_ec2_region }}"
+    vpc_subnet_id: "{{ vpc_subnet_data_1 }}"
+    private_ip: "{{ provision_mongo1_az1_ip }}"
+    id: mongo1-az1v{{ provision_mongo1_az1_ver }}
+    count: 1
+    wait: yes
+    instance_tags: '{"Name": "mongo1-az1-launched", "env": "{{ env }}", "group": "mongo", "status": "launched", "metagroup": "app", "org": "{{ provision_org }}" }'
+  register: ec2m1az1
+  tags: mongo
+
+- name: provision | Create AZ2 Mongo1 Instance
+  local_action:
+    module: ec2
+    keypair: "{{ provision_ec2_keypair }}"
+    instance_type: "{{ provision_mongo_type }}"
+    image: "{{ provision_ec2_image }}"
+    group_id: 
+      - "{{ mongo_group.group_id }}"
+      - "{{ ssh_only.group_id }}"
+      - "{{ intra_mongo_group.group_id }}"
+      - "{{ snmpd_monitor.group_id }}"
+      - "{{ rabbitmq_group.group_id }}"
+    region: "{{ vpc_ec2_region }}"
+    vpc_subnet_id: "{{ vpc_subnet_data_2 }}"
+    private_ip: "{{ provision_mongo1_az2_ip }}"
+    id: mongo1-az2v{{ provision_mongo1_az2_ver }}
+    count: 1
+    wait: yes
+    instance_tags: '{"Name": "mongo1-az2-launched", "env": "staging", "group": "mongo", "status": "launched", "metagroup": "app", "org": "{{ provision_org }}" }'
+  when: provision_ha is defined and provision_ha
+  register: ec2m1az2
+  tags: mongo
+
+- name: provision | Create AZ3 Mongo1 Instance
+  local_action:
+    module: ec2
+    keypair: "{{ provision_ec2_keypair }}"
+    instance_type: "{{ provision_mongo_type }}"
+    image: "{{ provision_ec2_image }}"
+    group_id: 
+      - "{{ mongo_group.group_id }}"
+      - "{{ ssh_only.group_id }}"
+      - "{{ intra_mongo_group.group_id }}"
+      - "{{ rabbitmq_group.group_id }}"
+      - "{{ intra_mongo_group.group_id }}"
+      - "{{ snmpd_monitor.group_id }}"
+    region: "{{ vpc_ec2_region }}"
+    vpc_subnet_id: "{{ vpc_subnet_data_3 }}"
+    private_ip: "{{ provision_mongo1_az3_ip }}"
+    id: mongo1-az3v{{ provision_mongo1_az3_ver }}
+    count: 1
+    wait: yes
+    instance_tags: '{"Name": "mongo1-az3-launched", "env": "staging", "group": "mongo", "status": "launched", "metagroup": "app", "org": "{{ provision_org }}" }'
+  when: provision_ha is defined and provision_ha
+  register: ec2m1az3
+  tags: mongo
+
+- name: provision | Create AZ1 Apps1 Instance
+  local_action:
+    module: ec2
+    keypair: "{{ provision_ec2_keypair }}"
+    instance_type: "{{ provision_apps_type }}"
+    image: "{{ provision_ec2_image }}"
+    group_id: 
+      - "{{ apps_group.group_id }}"
+      - "{{ ssh_only.group_id }}"
+      - "{{ gluster_group.group_id }}"
+      - "{{ snmpd_monitor.group_id }}"
+    region: "{{ vpc_ec2_region }}"
+    vpc_subnet_id: "{{ vpc_subnet_apps_1 }}"
+    private_ip: "{{ provision_apps1_az1_ip }}"
+    id: apps1-az1v{{ provision_apps1_az1_ver }}
+    count: 1
+    wait: yes
+    instance_tags: '{"Name": "apps1-az1-launched", "env": "staging", "group": "apps", "status": "launched", "metagroup": "app", "org": "{{ provision_org }}"}'
+  register: ec2a1az1
+  tags: apps
+
+- name: provision | Create AZ2 Apps1 Instance
+  local_action:
+    module: ec2
+    keypair: "{{ provision_ec2_keypair }}"
+    instance_type: "{{ provision_apps_type }}"
+    image: "{{ provision_ec2_image }}"
+    group_id:
+      - "{{ apps_group.group_id }}"
+      - "{{ ssh_only.group_id }}"
+      - "{{ gluster_group.group_id }}"
+      - "{{ snmpd_monitor.group_id }}"
+    region: "{{ vpc_ec2_region }}"
+    vpc_subnet_id: "{{ vpc_subnet_apps_2 }}"
+    private_ip: "{{ provision_apps1_az2_ip }}"
+    id: apps1-az2v{{ provision_apps1_az2_ver }}
+    count: 1
+    wait: yes
+    instance_tags: '{"Name": "apps1-az2-launched", "env": "staging", "group": "apps", "status": "launched", "metagroup": "app", "org": "{{ provision_org }}"}'
+  when: provision_ha is defined and provision_ha
+  register: ec2a1az2
+  tags: apps
+
+- name: provision | Create AZ1 LB1 Instance
+  local_action:
+    module: ec2
+    keypair: "{{ provision_ec2_keypair }}"
+    instance_type: "{{ provision_lb_type }}"
+    image: "{{ provision_ec2_image }}"
+    group_id: 
+      - "{{ load_balancer_group.group_id }}"
+      - "{{ ssh_only.group_id }}"
+      - "{{ gluster_group.group_id }}"
+      - "{{ snmpd_monitor.group_id }}"
+    region: "{{ vpc_ec2_region }}"
+    vpc_subnet_id: "{{ vpc_subnet_lb_1 }}"
+    private_ip: "{{ provision_lb1_az1_ip }}"
+    id: lb-az1v{{ provision_lb1_az1_ver }}
+    count: 1
+    wait: yes
+    instance_tags: '{"Name": "lb1-az1-launched", "env": "staging", "group": "lb", "status": "launched", "metagroup": "app", "org": "{{ provision_org }}"}'
+  register: ec2lb1az1
+  tags: load_balancer
+
+- name: provision | Create AZ1 LB2 Instance
+  local_action:
+    module: ec2
+    keypair: "{{ provision_ec2_keypair }}"
+    instance_type: "{{ provision_lb_type }}"
+    image: "{{ provision_ec2_image }}"
+    group_id: 
+      - "{{ load_balancer_group.group_id }}"
+      - "{{ ssh_only.group_id }}"
+      - "{{ gluster_group.group_id }}"
+      - "{{ snmpd_monitor.group_id }}"
+    region: "{{ vpc_ec2_region }}"
+    vpc_subnet_id: "{{ vpc_subnet_lb_2 }}"
+    private_ip: "{{ provision_lb1_az2_ip }}"
+    id: lb-az2v{{ provision_lb1_az2_ver }}
+    count: 1
+    wait: yes
+    instance_tags: '{"Name": "lb1-az2-launched", "env": "staging", "group": "lb", "status": "launched", "metagroup": "app", "org": "{{ provision_org }}"}'
+  when: provision_ha is defined and provision_ha  
+  register: ec2lb1az2
+  tags: load_balancer
+
+- name: provision | Create backup volume
+  local_action: ec2_vol volume_size=100 instance={{ item.id }} device_name=sdf region={{ vpc_ec2_region }}
+  with_items: ec2b.instances
+  when: provision_create_backup is defined
+  register: backup_vol
+  tags: backup
+
+# Start adding all the hosts to a dynamic inventory group to configure them now that they are provisioned
+- name: provision | Add new backup instance to staging group
+  local_action: add_host hostname={{ item.public_ip }} groupname=backup_launched ansible_ssh_private_key_file={{ secure_dir }}/keys/{{ provision_ec2_keypair }} ansible_ssh_user=ubuntu
+  with_items: ec2b.instances
+  when: provision_create_backup is defined
+  tags: backup
+
+- name: provision | Add new selenium instance to staging group
+  local_action: add_host hostname={{ item.public_ip }} groupname=selenium_launched ansible_ssh_private_key_file={{ secure_dir }}/keys/{{ provision_ec2_keypair }} ansible_ssh_user=ubuntu
+  with_items: ec2s.instances
+  when: provision_create_selenium is defined
+  tags: selenium
+
+- name: provision | Add first new mongo instance to staging group
+  local_action: add_host hostname={{ item }} groupname=mongo_launched ansible_ssh_private_key_file={{ secure_dir }}/keys/{{ provision_ec2_keypair }} ansible_ssh_user=ubuntu
+  with_items:
+    - "{{ ec2m1az1.instances[0].public_ip }}"
+  tags: mongo
+
+- name: provision | Add other mongo instance(s) to staging group
+  local_action: add_host hostname={{ item }} groupname=mongo_launched ansible_ssh_private_key_file={{ secure_dir }}/keys/{{ provision_ec2_keypair }} ansible_ssh_user=ubuntu
+  with_items:
+    - "{{ ec2m1az2.instances[0].public_ip }}"
+    - "{{ ec2m1az3.instances[0].public_ip }}"
+  when: provision_ha is defined and provision_ha
+  tags: mongo
+
+- name: provision | Add first new apps instance to staging group
+  local_action: add_host hostname={{ item }} groupname=apps_launched ansible_ssh_private_key_file={{ secure_dir }}/keys/{{ provision_ec2_keypair }} ansible_ssh_user=ubuntu
+  with_items: 
+    - "{{ ec2a1az1.instances[0].public_ip }}"
+  when: item is defined
+  tags: apps
+
+- name: provision | Add other new apps instance(s) to staging group
+  local_action: add_host hostname={{ item }} groupname=apps_launched ansible_ssh_private_key_file={{ secure_dir }}/keys/{{ provision_ec2_keypair }} ansible_ssh_user=ubuntu
+  with_items: 
+    - "{{ ec2a1az2.instances[0].public_ip }}"
+  when: provision_ha is defined and provision_ha
+  tags: apps
+
+- name: provision | Add first new lb instance to staging group
+  local_action: add_host hostname={{ item }} groupname=lb_launched ansible_ssh_private_key_file={{ secure_dir }}/keys/{{ provision_ec2_keypair }} ansible_ssh_user=ubuntu
+  with_items: 
+    - "{{ ec2lb1az1.instances[0].public_ip }}"
+  tags: load_balancer
+
+- name: provision | Add other new lb instance(s) to staging group
+  local_action: add_host hostname={{ item }} groupname=lb_launched ansible_ssh_private_key_file={{ secure_dir }}/keys/{{ provision_ec2_keypair }} ansible_ssh_user=ubuntu
+  with_items: 
+    - "{{ ec2lb1az2.instances[0].public_ip }}"
+  when: provision_ha is defined and provision_ha
+  tags: load_balancer
+
+- name: provision | Wait for SSH to come up on backup
+  local_action: wait_for host={{ item.public_ip }} port=22 delay=10 timeout=320 state=started
+  with_items: ec2b.instances
+  when: provision_create_backup is defined
+  tags: backup
+
+- name: provision | Wait for SSH to come up on selenium
+  local_action: wait_for host={{ item.public_ip }} port=22 delay=10 timeout=320 state=started
+  with_items: ec2s.instances
+  when: provision_create_selenium is defined
+  tags: selenium
+
+- name: provision | Wait for SSH to come up on first mongo instance
+  local_action: wait_for host={{ item }} port=22 delay=10 timeout=320 state=started
+  with_items: 
+    - "{{ ec2m1az1.instances[0].public_ip }}"
+  tags: mongo
+
+- name: provision | Wait for SSH to come up on other mongo instances
+  local_action: wait_for host={{ item }} port=22 delay=10 timeout=320 state=started
+  with_items: 
+    - "{{ ec2m1az2.instances[0].public_ip }}"
+    - "{{ ec2m1az3.instances[0].public_ip }}"
+  when: provision_ha is defined and provision_ha
+  tags: mongo
+
+- name: provision | Wait for SSH to come up on first app instances
+  local_action: wait_for host={{ item }} port=22 delay=10 timeout=320 state=started
+  with_items: 
+    - "{{ ec2a1az1.instances[0].public_ip }}"
+  tags: apps
+
+- name: provision | Wait for SSH to come up on other apps instances
+  local_action: wait_for host={{ item }} port=22 delay=10 timeout=320 state=started
+  with_items: 
+    - "{{ ec2a1az2.instances[0].public_ip }}"
+  when: provision_ha is defined and provision_ha
+  tags: apps
+
+- name: provision | Wait for SSH to come up on first lb instance
+  local_action: wait_for host={{ item }} port=22 delay=10 timeout=320 state=started
+  with_items: 
+    - "{{ ec2lb1az1.instances[0].public_ip }}"
+  tags: load_balancer
+
+- name: provision | Wait for SSH to come up on other lb instances
+  local_action: wait_for host={{ item }} port=22 delay=10 timeout=320 state=started
+  with_items: 
+    - "{{ ec2lb1az2.instances[0].public_ip }}"
+  when: provision_ha is defined and provision_ha
+  tags: load_balancer

--- a/playbooks/roles/vpc/defaults/main.yml
+++ b/playbooks/roles/vpc/defaults/main.yml
@@ -1,0 +1,22 @@
+---
+vpc_cidr_top: 172.23.
+vpc_ec2_region: us-west-2
+vpc_azs:
+  - a
+  - b
+  - c
+vpc_monitor_server: 127.0.0.1/32
+rds_subnet: edx-rds
+
+rds:
+  db_engine: MySQL
+  engine_version: 5.5.27
+  backup_window: 02:00-06:00
+  backup_retention: 7
+  instance_name: edx-primary
+  instance_type: db.m1.small
+  multi_zone: yes
+  size: 100
+
+# not defining rds_secure so that the play will fail if it isn't defined in
+# secure_vars

--- a/playbooks/roles/vpc/tasks/main.yml
+++ b/playbooks/roles/vpc/tasks/main.yml
@@ -1,0 +1,288 @@
+# Creates VPC, Security Groups, and RDS instance for building an HA EdX Stack
+---
+- name: vpc | create vpc
+  local_action:
+    module: vpc
+    state: present
+    cidr_block: "{{ vpc_cidr_top }}0.0/16"
+    subnets: 
+      - cidr: "{{ vpc_cidr_top }}254.0/24"   # Admin network
+        az: "{{ vpc_ec2_region }}{{ vpc_azs[0] }}"
+      - cidr: "{{ vpc_cidr_top }}0.0/24"     # LB AZ 1
+        az: "{{ vpc_ec2_region }}{{ vpc_azs[0] }}"
+      - cidr: "{{ vpc_cidr_top }}1.0/24"     # LB AZ 2
+        az: "{{ vpc_ec2_region }}{{ vpc_azs[1] }}"
+      - cidr: "{{ vpc_cidr_top }}16.0/24"    # App AZ 1
+        az: "{{ vpc_ec2_region }}{{ vpc_azs[0] }}"
+      - cidr: "{{ vpc_cidr_top }}17.0/24"    # App AZ 2
+        az: "{{ vpc_ec2_region }}{{ vpc_azs[1] }}"
+      - cidr: "{{ vpc_cidr_top }}128.0/24"   # Data AZ 1
+        az: "{{ vpc_ec2_region }}{{ vpc_azs[0] }}"
+      - cidr: "{{ vpc_cidr_top }}129.0/24"   # Data AZ 2
+        az: "{{ vpc_ec2_region }}{{ vpc_azs[1] }}"
+      - cidr: "{{ vpc_cidr_top }}130.0/24"   # Data AZ 3
+        az: "{{ vpc_ec2_region }}{{ vpc_azs[2] }}"
+    internet_gateway: True
+    route_tables:
+      - subnets: 
+          - "{{ vpc_cidr_top }}254.0/24"
+          - "{{ vpc_cidr_top }}0.0/24"
+          - "{{ vpc_cidr_top }}1.0/24"
+          - "{{ vpc_cidr_top }}16.0/24"
+          - "{{ vpc_cidr_top }}17.0/24"
+          - "{{ vpc_cidr_top }}128.0/24"
+          - "{{ vpc_cidr_top }}129.0/24"
+          - "{{ vpc_cidr_top }}130.0/24"
+        routes: 
+          - dest: 0.0.0.0/0
+            gw: igw
+    region: "{{ vpc_ec2_region }}"
+  register: vpc
+  tags: vpc
+
+- name: vpc | Create sshonly group
+  local_action:
+    module: ec2_group
+    name: ssh_only
+    description: Allows SSH from everywhere only
+    vpc_id: "{{ vpc.vpc_id }}"
+    region: "{{ vpc_ec2_region }}"
+    rules:
+      - proto: tcp
+        from_port: 22
+        to_port: 22
+        cidr_ip: 0.0.0.0/0
+      - proto: tcp # ansible accelerate port
+        from_port: 5099
+        to_port: 5099
+        cidr_ip: 0.0.0.0/0
+  register: ssh_only
+  tags: sec_groups
+
+- name: vpc | Create snmpd group
+  local_action:
+    module: ec2_group
+    name: snmpd_monitor
+    description: Allows SNMP and ICMP from monitoring machine
+    vpc_id: "{{ vpc.vpc_id }}"
+    region: "{{ vpc_ec2_region }}"
+    rules:
+      - proto: udp
+        from_port: 161
+        to_port: 161
+        cidr_ip: "{{ vpc_monitor_server }}"
+      - proto: icmp
+        from_port: -1
+        to_port: -1
+        cidr_ip: "{{ vpc_monitor_server }}"
+  register: snmpd_monitor
+  tags: sec_groups
+
+- name: vpc | Create RDS Group
+  local_action:
+    module: ec2_group
+    name: rds_access
+    description: Allows Access to RDS
+    vpc_id: "{{ vpc.vpc_id }}"
+    region: "{{ vpc_ec2_region }}"
+    rules:
+      - proto: tcp
+        from_port: 3306
+        to_port: 3306
+        cidr_ip: "{{ vpc_cidr_top }}254.0/24"
+      - proto: tcp
+        from_port: 3306
+        to_port: 3306
+        cidr_ip: "{{ vpc_cidr_top }}16.0/23"
+      - proto: tcp
+        from_port: 3306
+        to_port: 3306
+        cidr_ip: "{{ vpc_cidr_top }}128.0/22"
+  register: rds_access
+  ignore_errors: true
+  tags: sec_groups
+
+- name: vpc | load balancer group
+  local_action:
+    module: ec2_group
+    name: load_balancer
+    description: Allows Web from everywhere
+    vpc_id: "{{ vpc.vpc_id }}"
+    region: "{{ vpc_ec2_region }}"
+    rules:
+      - proto: tcp
+        from_port: 443
+        to_port: 443
+        cidr_ip: 0.0.0.0/0
+      - proto: tcp
+        from_port: 80
+        to_port: 80
+        cidr_ip: 0.0.0.0/0
+  register: load_balancer_group
+  tags: sec_groups
+
+- name: vpc | Create mongo group
+  local_action:
+    module: ec2_group
+    name: mongo
+    description: Allows access to mongo from data, app, and admin
+    vpc_id: "{{ vpc.vpc_id }}"
+    region: "{{ vpc_ec2_region }}"
+    rules:
+      - proto: tcp
+        from_port: 27017
+        to_port: 27017
+        cidr_ip: "{{ vpc_cidr_top }}254.0/24"
+      - proto: tcp
+        from_port: 28017
+        to_port: 28017
+        cidr_ip: "{{ vpc_cidr_top }}254.0/24"
+      - proto: tcp
+        from_port: 27017
+        to_port: 27017
+        cidr_ip: "{{ vpc_cidr_top }}16.0/23"
+      - proto: tcp
+        from_port: 28017
+        to_port: 28017
+        cidr_ip: "{{ vpc_cidr_top }}16.0/23"
+      - proto: tcp
+        from_port: 27017
+        to_port: 27017
+        cidr_ip: "{{ vpc_cidr_top }}128.0/22"
+      - proto: tcp
+        from_port: 28017
+        to_port: 28017
+        cidr_ip: "{{ vpc_cidr_top }}128.0/22"
+  register: mongo_group
+  ignore_errors: True
+  tags: sec_groups
+
+- name: vpc | rabbit mq group
+  local_action:
+    module: ec2_group
+    name: rabbitmq
+    description: Allows access to rabbit from data, app, and admin
+    vpc_id: "{{ vpc.vpc_id }}"
+    region: "{{ vpc_ec2_region }}"
+    rules:
+      - proto: tcp
+        from_port: 5672
+        to_port: 5672
+        cidr_ip: "{{ vpc_cidr_top }}254.0/24"
+      - proto: tcp
+        from_port: 5672
+        to_port: 5672
+        cidr_ip: "{{ vpc_cidr_top }}16.0/23"
+      - proto: tcp
+        from_port: 5672
+        to_port: 5672
+        cidr_ip: "{{ vpc_cidr_top }}128.0/22"
+      - proto: tcp
+        from_port: 15672
+        to_port: 15672
+        cidr_ip: "{{ vpc_cidr_top }}254.0/24"
+      - proto: tcp
+        from_port: 4369
+        to_port: 4369
+        cidr_ip: "{{ vpc_cidr_top }}128.0/22"
+      - proto: tcp
+        from_port: 4369
+        to_port: 4369
+        cidr_ip: "{{ vpc_cidr_top }}254.0/24"
+      - proto: tcp
+        from_port: 35197
+        to_port: 35197
+        cidr_ip: "{{ vpc_cidr_top }}128.0/22"
+  register: rabbitmq_group
+  tags: sec_groups
+
+- name: vpc | Create app group
+  local_action:
+    module: ec2_group
+    name: apps
+    description: Allows access from the load balancers to app servers
+    vpc_id: "{{ vpc.vpc_id }}"
+    region: "{{ vpc_ec2_region }}"
+    rules:
+      # cms_app_port, lms_app_port, lms_xml_app_port lms_preview_app_port
+      - proto: tcp
+        from_port: 8000
+        to_port: 8100
+        cidr_ip: "{{ vpc_cidr_top }}0.0/23"
+      - proto: tcp
+        from_port: 8000
+        to_port: 8100
+        cidr_ip: "{{ vpc_cidr_top }}254.0/24"
+  register: apps_group
+  ignore_errors: True
+  tags: sec_groups
+
+- name: vpc | Create intra mongo group
+  local_action:
+    module: ec2_group
+    name: intra_mongo
+    description: Allows access across AZs for mongo instances
+    vpc_id: "{{ vpc.vpc_id }}"
+    region: "{{ vpc_ec2_region }}"
+    rules:
+      - proto: tcp
+        from_port: 0
+        to_port: 65535
+        cidr_ip: "{{ vpc_cidr_top }}128.0/22"
+  register: intra_mongo_group
+  ignore_errors: True
+  tags: sec_groups
+
+- name: vpc | Create gluster group
+  local_action:
+    module: ec2_group
+    name: gluster
+    description: Gluster port access among members
+    vpc_id: "{{ vpc.vpc_id }}"
+    region: "{{ vpc_ec2_region }}"
+    rules:
+      - proto: tcp
+        from_port: 24007
+        to_port: 24100
+        cidr_ip: "{{ vpc_cidr_top }}0.0/19"
+      - proto: tcp
+        from_port: 34865
+        to_port: 34867
+        cidr_ip: "{{ vpc_cidr_top }}0.0/19"
+      - proto: udp
+        from_port: 111
+        to_port: 111
+        cidr_ip: "{{ vpc_cidr_top }}0.0/19"
+      - proto: tcp
+        from_port: 111
+        to_port: 111
+        cidr_ip: "{{ vpc_cidr_top }}0.0/19"
+  register: gluster_group
+  ignore_errors: True
+  tags: sec_groups
+
+
+# This will need to be run after initial VPC creation since ansible can't
+# do DB subnet groups. So you will have to make one or this will go in the
+# default subnet group (likely the default vpc)
+# Ignores errors because it will only create it once
+- name: vpc | create RDS instance
+  local_action:
+    module: rds
+    command: create
+    db_engine: "{{ rds.db_engine }}"
+    engine_version: "{{ rds.engine_version }}"
+    backup_window: "{{ rds.backup_window }}"
+    backup_retention: "{{ rds.backup_retention }}"
+    instance_name: "{{ rds.instance_name }}"
+    instance_type: "{{ rds.instance_type }}"
+    multi_zone: "{{ rds.multi_zone }}"
+    size: "{{ rds.size }}"
+    region: "{{ vpc_ec2_region }}"
+    username: "{{ rds_secure.username }}"
+    password: "{{ rds_secure.password }}"
+    subnet: "{{ rds_subnet }}"
+    security_groups: "{{ rds_access.group_id }}"
+  register: rds_info
+  tags: rds
+  ignore_errors: yes

--- a/playbooks/vpc.yml
+++ b/playbooks/vpc.yml
@@ -1,0 +1,150 @@
+---
+# This will build and run an entire VPC environment.
+# requires:
+# python-boto >=2.13
+# ansible
+# github.com:carsongee/ansible/feature-merge (unless they merge my pulls)
+# AWS ID environment variables
+#
+# Ansible is unable currently to create DB Subnet Groups so you have
+# to create one before the RDS creation will work, and you will have
+# to create the VPC before then. Running with --tags vpc first
+# should solve that.
+
+- name: vpc site | Build entire MITx Stack
+  hosts: localhost
+  gather_facts: False
+  vars_files:
+    - $playbook_dir/environments/{{ env }}.yml
+    - $secure_dir/vars/{{ env }}_vpc.yml
+  roles:
+    - vpc
+    - provision
+
+- name: vpc site | Configure instance storage
+  hosts: "*_launched"
+  sudo: True
+  tasks:
+    - name: vpc site | Mount instance store
+      mount: name=/mnt src=/dev/xvdb fstype=ext3 state=mounted
+      ignore_errors: yes
+      register: instance_store
+    
+    - name: vpc site | Unmount non-existent instance store
+      mount: name=/mnt src=/dev/xvdb fstype=ext3 state=absent
+      when: instance_store|failed
+      ignore_errors: yes
+
+
+- name: provision | Configure backup instance(s)
+  hosts: backup_launched
+  sudo: True
+  gather_facts: True
+  vars_files: 
+    - $secure_dir/vars/{{ env }}_backup.yml
+    - $secure_dir/vars/smtp.yml
+  pre_tasks:
+    - name: provision | Partition backup volume
+      shell: /sbin/parted /dev/xvdf -s -- mklabel gpt; /sbin/parted /dev/xvdf -s  -- mkpart primary 0 -1; /sbin/parted /dev/xvdf --s -- name 1 backup; mkfs.ext4 /dev/xvdf1; touch /etc/ansible_xvdf_formated creates=/etc/ansible_xvdf_formated
+
+    - name: provision | Mount backup volume
+      mount: name=/opt/ops/backup src=/dev/xvdf1 fstype=ext4 state=mounted
+  roles:
+    - common
+    - backup
+    - smtp
+  tags: backup
+
+- name: provision | Configure selenium instance(s)
+  hosts: selenium_launched
+  sudo: True
+  gather_facts: True
+  vars_files: 
+    - $secure_dir/vars/smtp.yml
+  roles:
+    - common
+    - selenium
+    - mitxmon
+    - smtp
+  tags: selenium
+
+- name: provision | Configure mongo instance(s)
+  hosts: mongo_launched
+  sudo: True
+  gather_facts: True
+  vars_files: 
+    - $secure_dir/vars/smtp.yml
+    - $secure_dir/vars/mongo.yml
+    - $secure_dir/vars/rabbitmq.yml
+    - $secure_dir/vars/mitx-edx.yml
+    - $playbook_dir/environments/{{ env }}.yml
+  roles:
+    - common
+    - mongo
+    - rabbitmq
+    - smtp
+  tags: mongo
+
+- name: provision | Configure apps instance(s)
+  hosts: apps_launched
+  sudo: True
+  gather_facts: True
+  vars_files: 
+    - $secure_dir/vars/smtp.yml
+    - $secure_dir/vars/{{ env }}_edxapp.yml
+    - $secure_dir/vars/{{ env }}_forum.yml
+    - $secure_dir/vars/{{ env }}_xqueue.yml
+    - $secure_dir/vars/{{ env }}_xserver.yml
+    - $secure_dir/vars/{{ env }}_ora.yml
+    - $playbook_dir/environments/{{ env }}.yml
+  vars:
+    migrate_db: "yes"
+    sync_db: "yes"
+    openid_workaround: True
+    service_variants_enabled:
+      - lms
+      - lms-preview
+      - cms
+  roles:
+    - common
+    - edxapp  # edxapp, so nice we run it twice
+    - { role: 'edxapp', celery_worker: True }
+    - oraclejdk
+    - edx-elasticsearch
+    - role: rbenv
+      rbenv_user: "{{ forum_user }}"
+      rbenv_user_home: "{{ forum_home }}"
+      rbenv_ruby_version: "{{ forum_ruby_version }}"
+    - forum
+    - role: virtualenv
+      virtualenv_user: "{{ xqueue_user }}"
+      virtualenv_user_home: "{{ xqueue_user_home }}"
+      virtualenv_name: "{{ xqueue_user }}"
+    - role: xqueue
+      update_users: True
+    - role: virtualenv
+      virtualenv_user: "{{ ora_user }}"
+      virtualenv_user_home: "{{ ora_user_home }}"
+      virtualenv_name: "{{ ora_user }}"
+    - ora
+    - xserver
+    - smtp
+  tags: apps
+
+- name: provision | Configure load balancer instance(s)
+  hosts: lb_launched
+  sudo: True
+  gather_facts: True
+  vars_files: 
+    - $secure_dir/vars/smtp.yml
+    - $secure_dir/vars/nginx.yml
+    - $playbook_dir/environments/{{ env }}.yml
+  roles:
+    - common
+    - role: nginx
+      nginx_sites:
+        - lms
+        - cms
+        - lms-preview
+    - loadbalancer
+  tags: lb_servers


### PR DESCRIPTION
This adds roles and a play for _mostly_ building a stack using pure
ansible. The roles build the MITx style stack with split AZ simple
tiers.  There is also a config variable to have this build a non
HA stack.  There is also a "load balancer" role that just rsyncs
the static content from the first app server to the nginx roled server
using whatever ssh key it can find.

Mostly this is just to show what is going on and isn't what I would
call public ready.  Particularly because it relies on two of my
PRs to the ansible repo.  One is just a module, but the other is an
enhancement to an existing module that lets you assign public IPs to
instances in a non-default VPC so that you don't need all the NAT
stuff.
