### PR TITLE
Jarv/single instance updates

### DIFF
--- a/playbooks/roles/devpi/meta/main.yml
+++ b/playbooks/roles/devpi/meta/main.yml
@@ -7,3 +7,4 @@ dependencies:
     supervisor_venv_dir: $devpi_supervisor_venv_dir
     supervisor_service_user: $devpi_supervisor_user
     supervisor_service: "supervisor.devpi"
+    supervisor_http_port: '127.0.0.1:9002'

--- a/playbooks/roles/devpi/meta/main.yml
+++ b/playbooks/roles/devpi/meta/main.yml
@@ -1,10 +1,10 @@
 ---
 dependencies:
   - role: supervisor
-    supervisor_app_dir: $devpi_supervisor_app_dir
-    supervisor_data_dir: $devpi_supervisor_data_dir
-    supervisor_log_dir: $devpi_supervisor_log_dir
-    supervisor_venv_dir: $devpi_supervisor_venv_dir
-    supervisor_service_user: $devpi_supervisor_user
+    supervisor_app_dir: "{{ devpi_supervisor_app_dir }}"
+    supervisor_data_dir: "{{ devpi_supervisor_data_dir }}"
+    supervisor_log_dir: "{{ devpi_supervisor_log_dir }}"
+    supervisor_venv_dir: "{{ devpi_supervisor_venv_dir }}"
+    supervisor_service_user: "{{ devpi_supervisor_user }}"
     supervisor_service: "supervisor.devpi"
-    supervisor_http_port: '127.0.0.1:9002'
+    supervisor_http_bind_port: '9002'

--- a/playbooks/roles/devpi/templates/devpi.conf.j2
+++ b/playbooks/roles/devpi/templates/devpi.conf.j2
@@ -5,3 +5,5 @@ priority=999
 stdout_logfile={{ devpi_supervisor_log_dir }}/%(program_name)-stdout.log
 stderr_logfile={{ devpi_supervisor_log_dir }}/%(program_name)-stderr.log
 autostart=True
+killasgroup=true
+stopasgroup=true

--- a/playbooks/roles/discern/templates/discern.conf.j2
+++ b/playbooks/roles/discern/templates/discern.conf.j2
@@ -10,3 +10,5 @@ directory={{ discern_code_dir }}
 environment=LANG={{ DISCERN_LANG }},DJANGO_SETTINGS_MODULE={{ discern_settings }},SERVICE_VARIANT=discern
 stdout_logfile={{ supervisor_log_dir }}/%(program_name)-stdout.log
 stderr_logfile={{ supervisor_log_dir }}/%(program_name)-stderr.log
+killasgroup=true
+stopasgroup=true

--- a/playbooks/roles/discern/templates/discern_celery.conf.j2
+++ b/playbooks/roles/discern/templates/discern_celery.conf.j2
@@ -10,3 +10,5 @@ environment=DJANGO_SETTINGS_MODULE=discern.aws,SERVICE_VARIANT=discern
 stdout_logfile={{ supervisor_log_dir }}/%(program_name)-stdout.log
 stderr_logfile={{ supervisor_log_dir }}/%(program_name)-stderr.log
 
+killasgroup=true
+stopasgroup=true

--- a/playbooks/roles/edxapp/templates/cms.conf.j2
+++ b/playbooks/roles/edxapp/templates/cms.conf.j2
@@ -10,3 +10,5 @@ directory={{ edxapp_code_dir }}
 environment=PORT={{edxapp_cms_gunicorn_port}},ADDRESS={{edxapp_cms_gunicorn_host}},LANG={{ EDXAPP_LANG }},DJANGO_SETTINGS_MODULE={{ edxapp_cms_env }},SERVICE_VARIANT="cms"
 stdout_logfile={{ supervisor_log_dir }}/%(program_name)-stdout.log
 stderr_logfile={{ supervisor_log_dir }}/%(program_name)-stderr.log
+killasgroup=true
+stopasgroup=true

--- a/playbooks/roles/edxapp/templates/lms.conf.j2
+++ b/playbooks/roles/edxapp/templates/lms.conf.j2
@@ -10,3 +10,5 @@ directory={{ edxapp_code_dir }}
 environment=PORT={{edxapp_lms_gunicorn_port}},ADDRESS={{edxapp_lms_gunicorn_host}},LANG={{ EDXAPP_LANG }},DJANGO_SETTINGS_MODULE={{ edxapp_lms_env }},SERVICE_VARIANT="lms"
 stdout_logfile={{ supervisor_log_dir }}/%(program_name)-stdout.log
 stderr_logfile={{ supervisor_log_dir }}/%(program_name)-stderr.log
+killasgroup=true
+stopasgroup=true

--- a/playbooks/roles/edxapp/templates/workers.conf.j2
+++ b/playbooks/roles/edxapp/templates/workers.conf.j2
@@ -8,6 +8,8 @@ stdout_logfile={{ supervisor_log_dir }}/%(program_name)-stdout.log
 stderr_logfile={{ supervisor_log_dir }}/%(program_name)-stderr.log
 
 command={{ edxapp_venv_bin}}/python {{ edxapp_code_dir }}/manage.py {{ w.service_variant }} --settings=aws celery worker --loglevel=info --queues=edx.{{ w.service_variant }}.core.{{ w.queue }} --hostname=edx.{{ w.service_variant }}.core.{{ w.queue }}.`hostname` --concurrency={{ w.concurrency }}
+killasgroup=true
+stopasgroup=true
 
 {% endfor %}
 

--- a/playbooks/roles/forum/templates/forum.conf.j2
+++ b/playbooks/roles/forum/templates/forum.conf.j2
@@ -2,7 +2,6 @@
 command={{ forum_supervisor_wrapper }}
 priority=999
 user={{ common_web_user }}
-startsecs=10
 stdout_logfile={{ supervisor_log_dir }}/%(program_name)-stdout.log
 stderr_logfile={{ supervisor_log_dir }}/%(program_name)-stderr.log
 killasgroup=true

--- a/playbooks/roles/ora/templates/ora.conf.j2
+++ b/playbooks/roles/ora/templates/ora.conf.j2
@@ -9,4 +9,6 @@ environment=PID=/var/run/gunicorn/edx-ora.pid,WORKERS={{ ora_gunicorn_workers }}
 
 stdout_logfile={{ supervisor_log_dir }}/%(program_name)-stdout.log
 stderr_logfile={{ supervisor_log_dir }}/%(program_name)-stderr.log
+killasgroup=true
+stopasgroup=true
 

--- a/playbooks/roles/ora/templates/ora_celery.conf.j2
+++ b/playbooks/roles/ora/templates/ora_celery.conf.j2
@@ -9,4 +9,6 @@ environment=DJANGO_SETTINGS_MODULE=edx_ora.aws,SERVICE_VARIANT=ora
 
 stdout_logfile={{ supervisor_log_dir }}/%(program_name)-stdout.log
 stderr_logfile={{ supervisor_log_dir }}/%(program_name)-stderr.log
+killasgroup=true
+stopasgroup=true
 

--- a/playbooks/roles/supervisor/defaults/main.yml
+++ b/playbooks/roles/supervisor/defaults/main.yml
@@ -18,6 +18,7 @@ supervisor_venvs_dir: "{{ supervisor_app_dir }}/venvs"
 supervisor_venv_dir: "{{ supervisor_venvs_dir }}/supervisor"
 supervisor_venv_bin: "{{ supervisor_venv_dir }}/bin"
 supervisor_ctl: "{{ supervisor_venv_bin }}/supervisorctl"
+supervisor_http_port: '127.0.0.1:9001'
 
 # by default supervisor runs as the web user
 # which by default is set to www-data in

--- a/playbooks/roles/supervisor/defaults/main.yml
+++ b/playbooks/roles/supervisor/defaults/main.yml
@@ -11,6 +11,12 @@
 # Defaults for role supervisor
 #
 ---
+SUPERVISOR_HTTP_BIND_IP: '127.0.0.1'
+
+# do not override the bind_port since
+# all supervisors will then try to listen
+# on the same one
+supervisor_http_bind_port: '9001'
 supervisor_app_dir: "{{ COMMON_APP_DIR }}/supervisor"
 supervisor_cfg_dir: "{{ supervisor_app_dir }}/conf.d"
 supervisor_data_dir: "{{ COMMON_DATA_DIR }}/supervisor"
@@ -18,7 +24,6 @@ supervisor_venvs_dir: "{{ supervisor_app_dir }}/venvs"
 supervisor_venv_dir: "{{ supervisor_venvs_dir }}/supervisor"
 supervisor_venv_bin: "{{ supervisor_venv_dir }}/bin"
 supervisor_ctl: "{{ supervisor_venv_bin }}/supervisorctl"
-supervisor_http_port: '127.0.0.1:9001'
 
 # by default supervisor runs as the web user
 # which by default is set to www-data in

--- a/playbooks/roles/supervisor/templates/supervisord.conf.j2
+++ b/playbooks/roles/supervisor/templates/supervisord.conf.j2
@@ -25,7 +25,7 @@ serverurl=unix://{{ supervisor_data_dir }}/supervisor.sock ; use a unix:// URL  
 ; include files themselves.
 
 [inet_http_server]
-port = {{ supervisor_http_port }}
+port = {{ SUPERVISOR_HTTP_BIND_IP }}:{{ supervisor_http_bind_port }}
 
 [include]
 files = {{ supervisor_cfg_dir }}/*.conf

--- a/playbooks/roles/supervisor/templates/supervisord.conf.j2
+++ b/playbooks/roles/supervisor/templates/supervisord.conf.j2
@@ -24,6 +24,9 @@ serverurl=unix://{{ supervisor_data_dir }}/supervisor.sock ; use a unix:// URL  
 ; interpreted as relative to this file.  Included files *cannot*
 ; include files themselves.
 
+[inet_http_server]
+port = {{ supervisor_http_port }}
+
 [include]
 files = {{ supervisor_cfg_dir }}/*.conf
 

--- a/playbooks/roles/xqueue/templates/xqueue.conf.j2
+++ b/playbooks/roles/xqueue/templates/xqueue.conf.j2
@@ -13,4 +13,5 @@ environment=PID=/var/tmp/xqueue.pid,PORT={{ xqueue_gunicorn_port }},ADDRESS={{ x
 
 stdout_logfile={{ supervisor_log_dir }}/%(program_name)-stdout.log
 stderr_logfile={{ supervisor_log_dir }}/%(program_name)-stderr.log
-
+killasgroup=true
+stopasgroup=true

--- a/playbooks/roles/xqueue/templates/xqueue_consumer.conf.j2
+++ b/playbooks/roles/xqueue/templates/xqueue_consumer.conf.j2
@@ -9,4 +9,5 @@ environment=LANG={{ XQUEUE_LANG }},WORKERS_PER_QUEUE={{xqueue_env_config.XQUEUE_
 
 stdout_logfile={{ supervisor_log_dir }}/%(program_name)-stdout.log
 stderr_logfile={{ supervisor_log_dir }}/%(program_name)-stderr.log
-
+killasgroup=true
+stopasgroup=true

--- a/playbooks/roles/xserver/templates/xserver.conf.j2
+++ b/playbooks/roles/xserver/templates/xserver.conf.j2
@@ -9,4 +9,5 @@ environment=PID=/var/tmp/xserver.pid,NEW_RELIC_CONFIG_FILE={{ xserver_app_dir }}
 
 stdout_logfile={{ supervisor_log_dir }}/%(program_name)-stdout.log
 stderr_logfile={{ supervisor_log_dir }}/%(program_name)-stderr.log
-
+killasgroup=true
+stopasgroup=true


### PR DESCRIPTION
adds the inet_http_server to the supervisor config, by default will listen on localhost:9001
override added so that you can open it up to the world which is not recommended but appropriate for development sandboxes.

added stopasgroup/killasgroup options to supervisord which helps resolve an issue where processes were not being sent the stop/term signals when supervisor is reloaded.
