### PR TITLE
Added ansible.cfg symlink for shortstack and shortstack-xml

### DIFF
--- a/vagrant/shortstack-xml/ansible.cfg
+++ b/vagrant/shortstack-xml/ansible.cfg
@@ -1,0 +1,1 @@
+../../playbooks/ansible.cfg

--- a/vagrant/shortstack/ansible.cfg
+++ b/vagrant/shortstack/ansible.cfg
@@ -1,0 +1,1 @@
+../../playbooks/ansible.cfg


### PR DESCRIPTION
#413 introduced "do" tags into some of the Jinja templates, which requires a Jinja extension that shortstack and shortstack-xml hadn't enabled.

I've added symlinks to `ansible.cfg` which enables this extension.  This is the same setup as fullstack.

Suggested reviewer: @feanil 
