### PR TITLE
Use debian packages from S3 to fix the browser versions for Chrome and FF

### DIFF
--- a/playbooks/roles/browsers/defaults/main.yml
+++ b/playbooks/roles/browsers/defaults/main.yml
@@ -1,17 +1,21 @@
 browser_deb_pkgs:
     - xvfb
-    - firefox
     - dbus-x11
     - libgconf2-4
     - libxss1
     - libnss3-1d
     - libcurl3
     - xdg-utils
-    - google-chrome-stable
+    - gdebi
+
+# Debian packages we host in S3 to ensure correct browser version
+# Both Chrome and FireFox update their apt repos with the latest version,
+# which often causes spurious acceptance test failures.
+browser_s3_deb_pkgs:
+    - { name: "google-chrome-stable_30.0.1599.114-1_amd64.deb", url: "https://s3.amazonaws.com/vagrant.testeng.edx.org/google-chrome-stable_30.0.1599.114-1_amd64.deb" }
+    - { name: "firefox_25.0+build3-0ubuntu0.12.04.1_amd64.deb", url: "https://s3.amazonaws.com/vagrant.testeng.edx.org/firefox_25.0%2Bbuild3-0ubuntu0.12.04.1_amd64.deb" }
 
 # Chrome and ChromeDriver
-chrome_apt_key: "https://dl-ssl.google.com/linux/linux_signing_key.pub"
-chrome_apt_repo: "http://dl.google.com/linux/chrome/deb/"
 chromedriver_version: 2.6
 chromedriver_url: "http://chromedriver.storage.googleapis.com/{{ chromedriver_version }}/chromedriver_linux64.zip"
 

--- a/playbooks/roles/browsers/tasks/main.yml
+++ b/playbooks/roles/browsers/tasks/main.yml
@@ -1,15 +1,19 @@
 # Install browsers required to run the JavaScript
 # and acceptance test suite locally without a display
 ---
-- name: browsers | Google Chrome apt key
-  apt_key: url={{ chrome_apt_key }} state=present
-
-- name: browsers | Google Chrome apt repo
-  apt_repository: repo='deb {{ chrome_apt_repo }} stable main'
-
 - name: browsers | install system packages
   apt: pkg={{','.join(browser_deb_pkgs)}}
        state=present update_cache=yes
+
+- name: browsers | download browser debian packages from S3
+  get_url: dest="/tmp/{{ item.name }}" url="{{ item.url }}"
+  register: download_deb
+  with_items: "{{ browser_s3_deb_pkgs }}"
+
+- name: browsers | install browser debian packages
+  shell: gdebi -nq /tmp/{{ item.name }}
+  when: download_deb.changed
+  with_items: "{{ browser_s3_deb_pkgs }}"
 
 - name: browsers | Install ChromeDriver
   get_url:


### PR DESCRIPTION
Downloads the debian packages for Chrome and FF from S3 instead of using the apt-repositories, since the apt-repos don't maintain older versions of the browsers.

For now I've uploaded the deb packages by hand to S3, but I'll automate this in Jenkins when I get a chance.

@feanil 
