### PR TITLE
Add logrotation to Stanford datadog setup

### DIFF
--- a/playbooks/roles/datadog/tasks/main.yml
+++ b/playbooks/roles/datadog/tasks/main.yml
@@ -61,6 +61,8 @@
     src=usr/share/datadog/agent/nginx_log_http_response_counter.py
     dest=/usr/share/datadog/agent/nginx_log_http_response_counter.py
     owner=root group=root mode=0644
+  notify:
+    - datadog | restart the datadog service
   tags:
     - datadog
 
@@ -80,6 +82,12 @@
     - datadog | restart the datadog service
   when: nginx_sites is defined
   tags:
+    - datadog
+
+- name: datadog | Install logrotate configuration for datadog
+  template: dest=/etc/logrotate.d/datadog src=datadog_logrotate.j2 owner=root group=root mode=644
+  tags:
+    - logging
     - datadog
 
 # quoting intentional, missing space after line=api_key: also

--- a/playbooks/roles/datadog/templates/datadog_logrotate.j2
+++ b/playbooks/roles/datadog/templates/datadog_logrotate.j2
@@ -1,0 +1,12 @@
+/var/log/datadog/*.log {
+  create
+  compress
+  copytruncate
+  delaycompress
+  dateext
+  missingok
+  notifempty
+  daily
+  rotate 90
+  size 1M
+}

--- a/playbooks/roles/nginx/templates/edx_logrotate_nginx_access.j2
+++ b/playbooks/roles/nginx/templates/edx_logrotate_nginx_access.j2
@@ -1,7 +1,7 @@
 # Put in place by ansible
 
 {{log_base_dir}}/nginx/access.log {
-  create 0640 www-data adm
+  create 0640 www-data syslog
   compress
   delaycompress
   dateext

--- a/playbooks/roles/nginx/templates/edx_logrotate_nginx_error.j2
+++ b/playbooks/roles/nginx/templates/edx_logrotate_nginx_error.j2
@@ -1,7 +1,7 @@
 # Put in place by ansible
 
 {{log_base_dir}}/nginx/error.log {
-  create 0640 www-data adm
+  create 0640 www-data syslog
   compress
   delaycompress
   dateext


### PR DESCRIPTION
- Datadog logs now get rotated like other system logs
- nginx logs get rotated to have group syslog, so the datadog agent will
  continue to be able to read them

@jbau please look over
