### PR TITLE
Disable mongo journaling on devstack and Jenkins

### DIFF
--- a/playbooks/jenkins_worker.yml
+++ b/playbooks/jenkins_worker.yml
@@ -6,6 +6,8 @@
   hosts: jenkins_worker
   sudo: True
   gather_facts: True
+  vars:
+    mongo_enable_journal: False
   roles:
     - common
     - edxlocal

--- a/playbooks/roles/jenkins_worker/tasks/main.yml
+++ b/playbooks/roles/jenkins_worker/tasks/main.yml
@@ -10,5 +10,4 @@
 
 - include: system.yml
 - include: python.yml
-- include: browsers.yml
 - include: jscover.yml

--- a/playbooks/roles/mongo/defaults/main.yml
+++ b/playbooks/roles/mongo/defaults/main.yml
@@ -35,3 +35,7 @@ mongo_create_users: !!null
 # cloudformation stack, this group name can used to pull out
 # the name of the stack the mongo server resides in.
 mongo_aws_stack_name: "tag_aws_cloudformation_stack-name_"
+
+# In environments that do not require durability (devstack / Jenkins)
+# you can disable the journal to reduce disk usage
+mongo_enable_journal: True

--- a/playbooks/roles/mongo/templates/mongodb.conf.j2
+++ b/playbooks/roles/mongo/templates/mongodb.conf.j2
@@ -19,7 +19,12 @@ bind_ip = {{ MONGO_BIND_IP }}
 port = {{ mongo_port }}
 
 # Enable journaling, http://www.mongodb.org/display/DOCS/Journaling
+{% if mongo_enable_journal %}
 journal=true
+{% else %}
+journal=false
+nojournal=true
+{% endif %}
 
 {% if MONGO_CLUSTERED %}
 keyFile = {{ mongo_key_file }}

--- a/playbooks/vagrant-devstack.yml
+++ b/playbooks/vagrant-devstack.yml
@@ -7,6 +7,7 @@
     openid_workaround: True
     devstack: True
     edx_platform_commit: 'master'
+    mongo_enable_journal: False
   vars_files:
     - "group_vars/all"
   roles:


### PR DESCRIPTION
The Mongo journal files are taking up a lot of disk space on Jenkins workers and in devstack.  This PR provides an option to disable journaling in these environments.

According to the [docs](http://docs.mongodb.org/manual/reference/configuration-options/#journal), you need two options to disable journaling on 64-bit systems:

```
journal=false
nojournal=true
```

I also noticed that the `browsers` task was included in the Jenkins worker, leftover from devstack changes, so I removed it.
