### PR TITLE
Skip gather assets in devstack

### DIFF
--- a/playbooks/roles/edxapp/tasks/service_variant_config.yml
+++ b/playbooks/roles/edxapp/tasks/service_variant_config.yml
@@ -63,7 +63,7 @@
     executable=/bin/bash
     chdir={{ edxapp_code_dir }}
   sudo_user: "{{ edxapp_user }}"
-  when: celery_worker is not defined
+  when: celery_worker is not defined and not devstack
   with_items: service_variants_enabled
   notify:
   - "edxapp | restart edxapp"


### PR DESCRIPTION
Since the devstack settings use Django staticfiles, I think it's safe to disable asset collection while provisioning the VM.  This should greatly speed up the initial `vagrant up` and subsequent `vagrant provision` commands.

@jarv
