### PR TITLE
support creation of a datajam specific devstack image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,10 +5,6 @@
 \#*\#
 *~
 .#*
-vagrant/devstack/cs_comments_service
-vagrant/devstack/edx-platform
-vagrant/datajam/cs_comments_service
-vagrant/datajam/insights
-vagrant/datajam/edx-platform
-vagrant/release/*/devstack/cs_comments_service
-vagrant/release/*/devstack/edx-platform
+vagrant/*/cs_comments_service
+vagrant/*/insights
+vagrant/*/edx-platform

--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,8 @@
 .#*
 vagrant/devstack/cs_comments_service
 vagrant/devstack/edx-platform
+vagrant/datajam/cs_comments_service
+vagrant/datajam/insights
+vagrant/datajam/edx-platform
 vagrant/release/*/devstack/cs_comments_service
 vagrant/release/*/devstack/edx-platform

--- a/playbooks/roles/insights/defaults/main.yml
+++ b/playbooks/roles/insights/defaults/main.yml
@@ -31,7 +31,7 @@ insights_debian_pkgs:
 insights_app_dir: "{{ COMMON_APP_DIR }}/insights"
 insights_venv_dir: "{{ insights_app_dir }}/venv"
 
-INSIGHTS_VERSION: datajam1
+INSIGHTS_VERSION: master
 INSIGHTS_DJEVENTSTREAM_VERSION: master
 INSIGHTS_LOGHANDLERPLUS_VERSION: master
 

--- a/playbooks/roles/insights/defaults/main.yml
+++ b/playbooks/roles/insights/defaults/main.yml
@@ -1,20 +1,53 @@
 ---
+#
+# edX Configuration
+#
+# github:     https://github.com/edx/configuration
+# wiki:       https://github.com/edx/configuration/wiki
+# code style: https://github.com/edx/configuration/wiki/Ansible-Coding-Conventions
+# license:    https://github.com/edx/configuration/blob/master/LICENSE.TXT
+#
+##
+# Defaults for role insights
+#
+
+#
+# vars are namespace with the module name.
+#
+insights_role_name: insights
+
+#
+# OS packages
+#
+
+insights_debian_pkgs:
+  - git
+  - python-pip
+  - python-virtualenv
+  - redis-server
+  - mongodb
+  - nginx
 
 insights_app_dir: "{{ COMMON_APP_DIR }}/insights"
 insights_venv_dir: "{{ insights_app_dir }}/venv"
+
+INSIGHTS_VERSION: datajam1
+INSIGHTS_DJEVENTSTREAM_VERSION: master
+INSIGHTS_LOGHANDLERPLUS_VERSION: master
 
 insights_repos:
   insights:
     code_dir: "{{ insights_app_dir }}/insights"
     repo: https://github.com/edx/insights.git
-    version: master
+    version: "{{ INSIGHTS_VERSION }}"
   djeventstream:
     code_dir: "{{ insights_app_dir }}/djeventstream"
     repo: https://github.com/edx/djeventstream.git
-    version: master
+    version: "{{ INSIGHTS_DJEVENTSTREAM_VERSION }}"
   loghandlersplus:
     code_dir: "{{ insights_app_dir }}/loghandlersplus"
     repo: https://github.com/edx/loghandlersplus.git
-    version: master
+    version: "{{ INSIGHTS_LOGHANDLERPLUS_VERSION }}"
 
 insights_requirements_file: "{{ insights_repos.insights.code_dir }}/requirements.txt"
+

--- a/playbooks/roles/insights/defaults/main.yml
+++ b/playbooks/roles/insights/defaults/main.yml
@@ -1,0 +1,20 @@
+---
+
+insights_app_dir: "{{ COMMON_APP_DIR }}/insights"
+insights_venv_dir: "{{ insights_app_dir }}/venv"
+
+insights_repos:
+  insights:
+    code_dir: "{{ insights_app_dir }}/insights"
+    repo: https://github.com/edx/insights.git
+    version: master
+  djeventstream:
+    code_dir: "{{ insights_app_dir }}/djeventstream"
+    repo: https://github.com/edx/djeventstream.git
+    version: master
+  loghandlersplus:
+    code_dir: "{{ insights_app_dir }}/loghandlersplus"
+    repo: https://github.com/edx/loghandlersplus.git
+    version: master
+
+insights_requirements_file: "{{ insights_repos.insights.code_dir }}/requirements.txt"

--- a/playbooks/roles/insights/tasks/main.yml
+++ b/playbooks/roles/insights/tasks/main.yml
@@ -1,0 +1,71 @@
+---
+
+- name: insights | system packages
+  apt: pkg={{item}}
+  with_items:
+    - git
+    - python-pip
+    - python-virtualenv
+    - redis-server
+    - mongodb
+    - nginx
+  tags:
+    - insights
+    - deploy
+
+- name: insights | create directories
+  file: >
+    path="{{item}}" state=directory
+    owner="{{ edxapp_user }}" group="{{ common_web_group }}"
+  with_items:
+    - "{{insights_app_dir}}"
+    - "{{insights_venv_dir}}"
+  tags:
+    - insights
+    - deploy
+
+- name: insights | create code directories
+  file: >
+    path="{{item}}" state=directory
+    owner="{{ edxapp_user }}" group="{{ common_web_group }}"
+  with_items:
+    - "{{insights_repos.djeventstream.code_dir}}"
+    - "{{insights_repos.loghandlersplus.code_dir}}"
+  tags:
+    - insights
+    - deploy
+
+- name: insights | checked out insights repo into {{insights_code_dir}}
+  git: dest={{item.code_dir}} repo={{item.repo}} version={{item.version}}
+  sudo_user: "{{ edxapp_user }}"
+  with_items: insights_repos.values()
+  tags:
+    - insights
+    - deploy
+
+- name : insights | install python requirements
+  pip: >
+    requirements="{{insights_requirements_file}}"
+    virtualenv="{{insights_venv_dir}}"
+    state=present
+  sudo_user: "{{ edxapp_user }}"
+  tags:
+    - insights
+    - deploy
+
+- name: insights | install projects
+  shell: >
+     . {{insights_venv_dir}}/bin/activate && cd {{item.code_dir}} && python setup.py install && deactivate
+  sudo_user: "{{ edxapp_user }}"
+  with_items: insights_repos.values()
+  tags:
+    - insights
+    - deploy
+
+- name: insights | database setup
+  shell: >
+     . {{insights_venv_dir}}/bin/activate && cd {{insights_repos.insights.code_dir}}/src && python manage.py syncdb --migrate --noinput && deactivate
+  sudo_user: "{{ edxapp_user }}"
+  tags:
+    - insights
+    - deploy

--- a/playbooks/roles/insights/tasks/main.yml
+++ b/playbooks/roles/insights/tasks/main.yml
@@ -1,16 +1,30 @@
 ---
+#
+# edX Configuration
+#
+# github:     https://github.com/edx/configuration
+# wiki:       https://github.com/edx/configuration/wiki
+# code style: https://github.com/edx/configuration/wiki/Ansible-Coding-Conventions
+# license:    https://github.com/edx/configuration/blob/master/LICENSE.TXT
+#
+#
+#
+# Tasks for role insights
+#
+# Overview:
+#
+#
+# Dependencies:
+#
+#
+# Example play:
+#
+#
 
 - name: insights | system packages
   apt: pkg={{item}}
-  with_items:
-    - git
-    - python-pip
-    - python-virtualenv
-    - redis-server
-    - mongodb
-    - nginx
+  with_items: insights_debian_pkgs
   tags:
-    - insights
     - deploy
 
 - name: insights | create directories
@@ -20,19 +34,9 @@
   with_items:
     - "{{insights_app_dir}}"
     - "{{insights_venv_dir}}"
-  tags:
-    - insights
-    - deploy
-
-- name: insights | create code directories
-  file: >
-    path="{{item}}" state=directory
-    owner="{{ edxapp_user }}" group="{{ common_web_group }}"
-  with_items:
     - "{{insights_repos.djeventstream.code_dir}}"
     - "{{insights_repos.loghandlersplus.code_dir}}"
   tags:
-    - insights
     - deploy
 
 - name: insights | checked out insights repo into {{insights_code_dir}}
@@ -40,7 +44,6 @@
   sudo_user: "{{ edxapp_user }}"
   with_items: insights_repos.values()
   tags:
-    - insights
     - deploy
 
 - name : insights | install python requirements
@@ -50,7 +53,6 @@
     state=present
   sudo_user: "{{ edxapp_user }}"
   tags:
-    - insights
     - deploy
 
 - name: insights | install projects
@@ -59,7 +61,6 @@
   sudo_user: "{{ edxapp_user }}"
   with_items: insights_repos.values()
   tags:
-    - insights
     - deploy
 
 - name: insights | database setup
@@ -67,5 +68,4 @@
      . {{insights_venv_dir}}/bin/activate && cd {{insights_repos.insights.code_dir}}/src && python manage.py syncdb --migrate --noinput && deactivate
   sudo_user: "{{ edxapp_user }}"
   tags:
-    - insights
     - deploy

--- a/playbooks/vagrant-datajam.yml
+++ b/playbooks/vagrant-datajam.yml
@@ -1,0 +1,22 @@
+- name: Configure instance(s)
+  hosts: vagrant
+  sudo: True
+  gather_facts: True
+  vars:
+    migrate_db: "yes"
+    openid_workaround: True
+    devstack: True
+    edx_platform_commit: 'master'
+  vars_files:
+    - "group_vars/all"
+  roles:
+    - common
+    - edxlocal
+    - mongo
+    - edxapp
+    - oraclejdk
+    - elasticsearch
+    - forum
+    - browsers
+    - local_dev
+    - insights

--- a/playbooks/vagrant-datajam.yml
+++ b/playbooks/vagrant-datajam.yml
@@ -6,7 +6,7 @@
     migrate_db: "yes"
     openid_workaround: True
     devstack: True
-    edx_platform_commit: 'datajam'
+    edx_platform_commit: 'master'
   vars_files:
     - "group_vars/all"
   roles:

--- a/playbooks/vagrant-datajam.yml
+++ b/playbooks/vagrant-datajam.yml
@@ -6,7 +6,7 @@
     migrate_db: "yes"
     openid_workaround: True
     devstack: True
-    edx_platform_commit: 'master'
+    edx_platform_commit: 'datajam'
   vars_files:
     - "group_vars/all"
   roles:
@@ -19,4 +19,4 @@
     - forum
     - browsers
     - local_dev
-    - insights
+    - { role: insights, tags:['insights'] }

--- a/vagrant/datajam/Vagrantfile
+++ b/vagrant/datajam/Vagrantfile
@@ -1,0 +1,46 @@
+MEMORY = 2048
+CPU_COUNT = 2
+edx_platform_mount_dir = "edx-platform"
+forum_mount_dir = "cs_comments_service"
+insights_mount_dir = "insights"
+
+if ENV['VAGRANT_MOUNT_BASE']
+
+  edx_platform_mount_dir = ENV['VAGRANT_MOUNT_BASE'] + "/" + edx_platform_mount_dir
+  forum_mount_dir = ENV['VAGRANT_MOUNT_BASE'] + "/" + forum_mount_dir
+  insights_mount_dir = ENV['VAGRANT_MOUNT_BASE'] + "/" + insights_mount_dir
+
+end
+
+Vagrant.configure("2") do |config|
+
+  config.vm.box    = "edx-devstack"
+  config.vm.box_url = "http://edx-static.s3.amazonaws.com/vagrant-images/20131113-dosa-devstack.box"
+
+  config.vm.network :private_network, ip: "192.168.33.10"
+  config.vm.network :forwarded_port, guest: 8000, host: 8000
+  config.vm.network :forwarded_port, guest: 8001, host: 8001
+  config.vm.network :forwarded_port, guest: 8002, host: 8002
+  config.vm.network :forwarded_port, guest: 4567, host: 4567
+
+  config.vm.synced_folder "#{edx_platform_mount_dir}", "/edx/app/edxapp/edx-platform", :create => true, nfs: true
+  config.vm.synced_folder "#{forum_mount_dir}", "/edx/app/forum/cs_comments_service", :create => true, nfs: true
+  config.vm.synced_folder "#{insights_mount_dir}", "/edx/app/insights/insights", :create => true, nfs: true
+
+  config.hostsupdater.aliases = ["preview.localhost"]
+
+  config.vm.provider :virtualbox do |vb|
+    vb.customize ["modifyvm", :id, "--memory", MEMORY.to_s]
+    vb.customize ["modifyvm", :id, "--cpus", CPU_COUNT.to_s]
+  end
+
+  edxapp_version = "master"
+  forum_version = "master"
+  config.vm.provision :ansible do |ansible|
+    ansible.playbook = "../../playbooks/vagrant-datajam.yml"
+    ansible.inventory_path = "../../playbooks/vagrant/inventory.ini"
+    ansible.tags = "deploy"
+    ansible.verbose = "extra"
+  end
+
+end

--- a/vagrant/datajam/Vagrantfile
+++ b/vagrant/datajam/Vagrantfile
@@ -34,7 +34,7 @@ Vagrant.configure("2") do |config|
     vb.customize ["modifyvm", :id, "--cpus", CPU_COUNT.to_s]
   end
 
-  edxapp_version = "datajam"
+  edxapp_version = "master"
   forum_version = "master"
   config.vm.provision :ansible do |ansible|
     ansible.playbook = "../../playbooks/vagrant-datajam.yml"

--- a/vagrant/datajam/Vagrantfile
+++ b/vagrant/datajam/Vagrantfile
@@ -34,7 +34,7 @@ Vagrant.configure("2") do |config|
     vb.customize ["modifyvm", :id, "--cpus", CPU_COUNT.to_s]
   end
 
-  edxapp_version = "master"
+  edxapp_version = "datajam"
   forum_version = "master"
   config.vm.provision :ansible do |ansible|
     ansible.playbook = "../../playbooks/vagrant-datajam.yml"

--- a/vagrant/datajam/ansible.cfg
+++ b/vagrant/datajam/ansible.cfg
@@ -1,0 +1,1 @@
+../../playbooks/ansible.cfg


### PR DESCRIPTION
Including:
- LMS
- CMS
- Forums
- Insights

Note: this is very rudimentary, and kind of just hacked together so that we can repeatably build vagrant images for the datajam as we iterate.

Outstanding issues:
- It should probably check out the "datajam" branches of stuff instead of "master"
- I wasn't able to import a course without first creating the /edx/app/edxapp/data directory even though that directory remains empty after I import the course.  I suspect some part of the code is erroneously checking for it's existence (reading the wrong setting etc).

Reviewers: @rocha, @brianhw, @e0d
