### PR TITLE
Added gettext requirement for i18n

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -448,6 +448,8 @@ edxapp_debian_pkgs:
   - ntp
   # for shapely
   - libgeos-dev
+  # i18n
+  - gettext
 
 # Ruby Specific Vars
 edxapp_ruby_version: "1.9.3-p374"


### PR DESCRIPTION
The edx-platform i18n rake tasks complain if `gettext` isn't installed with this error message:

```
    Cannot locate GNU gettext utilities, which are required by django for internationalization.
    (see https://docs.djangoproject.com/en/dev/topics/i18n/translation/#message-files)
    Try downloading them from http://www.gnu.org/software/gettext/
```
