### PR TITLE
Added deploy tags for some local_dev tasks

### DIFF
--- a/playbooks/roles/local_dev/tasks/main.yml
+++ b/playbooks/roles/local_dev/tasks/main.yml
@@ -7,12 +7,14 @@
 - name: local_dev | set login shell for app accounts
   user: name={{ item.user }} shell="/bin/bash"
   with_items: "{{ localdev_accounts }}"
+  tags: deploy
 
 # Ensure forum user has permissions to access .gem and .rbenv
 # This is a little twisty: the forum role sets the owner and group to www-data
 # So we add the forum user to the www-data group and give group write permissions
 - name: local_dev | add forum user to www-data group
   user: name={{ forum_user }} groups={{ common_web_group }} append=yes
+  tags: deploy
 
 - name: local_dev | set forum rbenv and gem permissions
   file:
@@ -20,6 +22,7 @@
   with_items:
     - "{{ forum_app_dir }}/.gem"
     - "{{ forum_app_dir }}/.rbenv"
+  tags: deploy
 
 # Create scripts to configure environment
 - name: local_dev | create login scripts


### PR DESCRIPTION
When provisioning vagrant devstack, we only run Ansible deploy tasks.  This means that some of the work done by the `local_dev` role can be reverted (namely, setting login shells and permissions).

This PR tags the `local_dev` tasks that should run when deploying.

@feanil 
