### PR TITLE
Stanford 'certificates' stopgap branch

### DIFF
--- a/playbooks/edx-west/prod-app.yml
+++ b/playbooks/edx-west/prod-app.yml
@@ -1,6 +1,7 @@
 # this gets all running prod webservers
 #- hosts: tag_environment_prod:&tag_function_webserver
 # or we can get subsets of them by name
+#- hosts: ~tag_Name_app(4|11|21|10|20)_prod
 #- hosts: ~tag_Name_app(10|20)_prod
 #- hosts: ~tag_Name_app(11|21)_prod
 ## this is the test box

--- a/playbooks/edx-west/stage-certificates-only.yml
+++ b/playbooks/edx-west/stage-certificates-only.yml
@@ -1,0 +1,17 @@
+# run the certificate agent on the first util machine only
+- hosts: ~tag_Name_util10_stage
+  sudo: True
+  vars:
+    secure_dir: '../../../configuration-secure/ansible'
+    migrate_db: "no"
+  vars_files:
+    - "{{ secure_dir }}/vars/edxapp_stage_vars.yml"
+    - "{{ secure_dir }}/vars/certifier_stage_vars.yml"
+  roles:
+    - common
+    - role: virtualenv
+      virtualenv_user: certifier
+      virtualenv_name: certifier
+      virtualenv_user_home: /opt/wwc/certifier
+    - certificates
+

--- a/playbooks/edx-west/stage-worker.yml
+++ b/playbooks/edx-west/stage-worker.yml
@@ -35,3 +35,20 @@
       virtualenv_user_home: "/opt/wwc/notifier"
       virtualenv_name: "notifier"
     - notifier
+
+## run the certificate agent on the first util machine only
+#- hosts: ~tag_Name_util10_stage
+#  sudo: True
+#  vars:
+#    secure_dir: '../../../configuration-secure/ansible'
+#    migrate_db: "no"
+#  vars_files:
+#    - "{{ secure_dir }}/vars/edxapp_stage_vars.yml"
+#    - "{{ secure_dir }}/vars/notifier_stage_vars.yml"
+#  roles:
+#    - role: virtualenv
+#      virtualenv_user: "certifier"
+#      virtualenv_user_home: "/opt/wwc/certifier"
+#      virtualenv_name: "certifier"
+#    - certificates
+#

--- a/playbooks/roles/certificates/files/git_ssh.sh
+++ b/playbooks/roles/certificates/files/git_ssh.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec /usr/bin/ssh -o StrictHostKeyChecking=no -i /{{certs_home}}/git-identity "$@"

--- a/playbooks/roles/certificates/handlers/main.yml
+++ b/playbooks/roles/certificates/handlers/main.yml
@@ -1,0 +1,2 @@
+- name: certifier | restart certificate-agent
+  supervisorctl: name=certifier-certificate-agent state=restarted

--- a/playbooks/roles/certificates/tasks/main.yml
+++ b/playbooks/roles/certificates/tasks/main.yml
@@ -1,0 +1,138 @@
+# requires:
+#  - group_vars/all
+#  - common/tasks/main.yml
+#  - nginx/tasks/main.yml
+---
+
+- name: certificates | create certificates user {{ certs_user }}
+  user:
+    name={{certs_user}} state=present shell=/bin/bash home={{certs_home}} createhome=yes
+  tags:
+  - certificates
+  - install
+  - update
+
+- name: certificates | create location for gpg information
+  file: state=directory path={{certs_home}}/.gpg mode=0700 owner={{certs_user}} 
+  tags:
+  - certificates
+  - install
+  - update
+
+- name: certificates | put gpg information in place
+  copy: src={{secure_dir}}/files/{{item}} dest={{cert_gpg}}/{{item}} mode=0400 owner={{certs_user}} 
+  with_items:
+  - gpg.conf
+  - pubring.gpg
+  - secring.gpg
+  tags:
+  - certificates
+  - install
+  - update
+
+- name: certificates | create certificates log location
+  file: state=directory path={{certs_logs_dir}} mode=0770 owner={{certs_user}} group=adm
+  tags:
+  - certificates
+  - install
+  - update
+
+- name: certificates | upload ssh script
+  copy: src=git_ssh.sh dest=/tmp/git_ssh.sh force=yes owner=root group=adm mode=750
+  tags:
+  - certificates
+  - install
+  - update
+
+- name: certificates | install read-only ssh key for the certs repo
+  copy: src={{secure_dir}}/files/git-identity dest=/{{certs_home}}/git-identity force=yes owner={{certs_user}} group=adm mode=600
+  tags:
+  - certificates
+  - install
+  - update
+
+- name: certificates | checkout certificate code
+  git: dest={{certs_home}}/src repo={{certs_repo}} version={{certs_ver}}
+  environment:
+    GIT_SSH: /tmp/git_ssh.sh
+  tags:
+  - certificates
+  - install
+  - deploy
+
+- name: certificates | fixup permissions on repo
+  # TODO: after remote_user is available in ansible dist, use that in the above task instead of manual perms fixup
+  file: path={{certs_home}}/src state=directory recurse=yes owner={{certs_user}} group=adm mode=755
+  tags:
+  - certificates
+  - install
+  - deploy
+  
+- name: certificates | install prerequisites
+  pip: requirements={{certs_home}}/src/requirements.txt virtualenv={{certs_venv_dir}} state=present
+  tags:
+  - certificates
+  - install
+  - update
+
+- name: certificates | install env
+  template: src=certificates.env.json.j2 dest={{certs_home}}/env.json mode=640 owner={{certs_user}} group=adm
+  tags:
+  - certificates
+  - install
+  - update
+  - deploy
+
+- name: certificates | install auth
+  template: src=certificates.auth.json.j2 dest={{certs_home}}/auth.json mode=640 owner={{certs_user}} group=adm
+  tags:
+  - certificates
+  - install
+  - update
+  - deploy
+
+- name: certifier | install bash_profile
+  copy: src=../../common/files/bash_profile dest={{certs_home}}/.bash_profile owner={{certs_user}} group={{certs_user}}
+  tags:
+  - certificates
+  - install
+  - update
+  - deploy
+
+- name: certifier | setup certifier shell environment
+  template: src=certifier_shell_env.j2 dest={{certs_home}}/certifier_env owner={{certs_user}} group={{certs_user}}
+  tags:
+  - certificates
+  - install
+  - update
+
+- name: certifier | ensure .bashrc exists and sources shell environment
+  lineinfile: 
+    dest={{certs_home}}/.bashrc create=yes state=present insertbefore=BOF
+    regexp='source {{certs_home}}/certifier_env' line='source {{certs_home}}/certifier_env' 
+    mode=640 owner={{certs_user}} group=adm
+  tags:
+  - certificates
+  - install
+  - update
+
+- name: certifier | add source venv to .bashrc
+  lineinfile:
+    dest={{certs_home}}/.bashrc create=yes state=present insertafter=EOF
+    regexp='source {{certs_venv_dir}}/bin/activate' line='source {{certs_venv_dir}}/bin/activate' 
+    mode=640 owner={{certs_user}} group=adm
+  tags:
+  - certifier
+  - install
+  - update
+
+- name: certifier | supervisord config for certificate-agent
+  template: src=certifier-cert-agent-supervisor.j2 dest=/etc/supervisor/conf.d/certifier-cert-agent.conf
+  notify: certifier | restart certificate-agent
+  tags:
+  - notifier
+  - install
+  - update
+
+### TODO: still have to do all the startup and gunicorn things (below)
+

--- a/playbooks/roles/certificates/templates/certificates.auth.json.j2
+++ b/playbooks/roles/certificates/templates/certificates.auth.json.j2
@@ -1,0 +1,1 @@
+{{ certs_auth_config | to_nice_json }}

--- a/playbooks/roles/certificates/templates/certificates.env.json.j2
+++ b/playbooks/roles/certificates/templates/certificates.env.json.j2
@@ -1,0 +1,1 @@
+{{ certs_env_config | to_nice_json }}

--- a/playbooks/roles/certificates/templates/certifier-cert-agent-supervisor.j2
+++ b/playbooks/roles/certificates/templates/certifier-cert-agent-supervisor.j2
@@ -1,0 +1,23 @@
+;
+;  {{ ansible_managed }}
+;
+[program:certificate-agent]
+
+command={{ certs_venv_dir }}/bin/python {{certs_home}}/src/certificate_agent.py
+
+priority=999
+user={{ certs_user }}
+stdout_logfile={{certs_logs_dir}}/certifier-certificate-agent-stdout.log
+stderr_logfile={{certs_logs_dir}}/certifier-certificate-agent-stderr.log
+environment=PID='/var/tmp/certifier-certificate-agent.pid',LANG=en_US.UTF-8,
+killasgroup=true
+stopasgroup=true
+startsecs=10
+autostart=true
+autorestart=true
+directory={{certs_home}}/src
+
+environment=PID='/var/tmp/certifier-certificate-agent.pid',LANG=en_US.UTF-8,
+{%- for name,value in certs_shell_env_vars.items() -%}
+{{name}}="{{value}}"{%- if not loop.last -%},{%- endif -%}
+{%- endfor -%}

--- a/playbooks/roles/certificates/templates/certifier_shell_env.j2
+++ b/playbooks/roles/certificates/templates/certifier_shell_env.j2
@@ -1,0 +1,7 @@
+# {{ ansible_managed }}
+
+{% for name,value in certs_shell_env_vars.items() %}
+{% if value %}
+export {{ name }}="{{ value }}"
+{% endif %}		 
+{% endfor %}

--- a/playbooks/roles/certificates/templates/notifier_env.j2
+++ b/playbooks/roles/certificates/templates/notifier_env.j2
@@ -1,0 +1,7 @@
+# {{ ansible_managed }}
+
+{% for name,value in notifier_env_vars.items() %}
+{% if value %}
+export {{ name }}="{{ value }}"
+{% endif %}		 
+{% endfor %}

--- a/playbooks/roles/datadog/tasks/main.yml
+++ b/playbooks/roles/datadog/tasks/main.yml
@@ -90,9 +90,10 @@
     - logging
     - datadog
 
-# quoting intentional, missing space after line=api_key: also
+################# Datadog config file lines
+# quoting intentional, missing spaces also
 # ansible wasn't handling the double quoted yaml properly 
-# otherwise.
+# without some weirdness.
 - name: datadog | set hostname if unset
   lineinfile:
     dest="/etc/dd-agent/datadog.conf" 
@@ -104,9 +105,17 @@
   tags:
     - datadog
 
-# quoting intentional, missing space after line=api_key: also
-# ansible wasn't handling the double quoted yaml properly 
-# otherwise.
+- name: datadog | set dogstats update interval
+  lineinfile:
+    dest="/etc/dd-agent/datadog.conf" 
+    "line=dogstatsd_interval:10"
+    state=present 
+    "regexp=^\#?\s*dogstatsd_interval:.+$"
+  notify:
+    - datadog | restart the datadog service
+  tags:
+    - datadog
+
 - name: datadog | update dogstreams
   lineinfile:
     dest="/etc/dd-agent/datadog.conf" 
@@ -120,9 +129,6 @@
   tags:
     - datadog
 
-# quoting intentional, missing space after line=api_key: also
-# ansible wasn't handling the double quoted yaml properly 
-# otherwise.
 - name: datadog | update api-key
   lineinfile: 
     dest="/etc/dd-agent/datadog.conf" 
@@ -133,3 +139,4 @@
   tags:
     - datadog
 
+################# END Datadog config file lines

--- a/playbooks/roles/nginx/templates/edx_logrotate_nginx_access.j2
+++ b/playbooks/roles/nginx/templates/edx_logrotate_nginx_access.j2
@@ -9,10 +9,8 @@
   notifempty
   daily
   rotate 90
-  size 1M
-  sharedscripts
   postrotate
-	[ ! -f /var/run/nginx.pid ] || kill -HUP `cat /var/run/nginx.pid`
+	[ -f /var/run/nginx.pid ] && kill -HUP `cat /var/run/nginx.pid`
   endscript
 }
 

--- a/playbooks/roles/nginx/templates/edx_logrotate_nginx_error.j2
+++ b/playbooks/roles/nginx/templates/edx_logrotate_nginx_error.j2
@@ -10,8 +10,7 @@
   daily
   rotate 90
   size 1M
-  sharedscripts
   postrotate
-	[ ! -f /var/run/nginx.pid ] || kill -HUP `cat /var/run/nginx.pid`
+	[ -f /var/run/nginx.pid ] && kill -HUP `cat /var/run/nginx.pid`
   endscript
 }


### PR DESCRIPTION
Substantially similar to the certs role developed (in paralell) that
exists on master, but this one uses pre-Croissant directory structure
and variable conventions. Modeled on the croissant-era notifier role.
Useful as a bridge to midterms, when Stanford can afford to port to the
new ways of doing things.

Includes updates to logging-related tasks for ansible and datadog. These
are ongoing problems for us at the moment.
