### PR TITLE
Brian/add workbench

### DIFF
--- a/playbooks/roles/datajam/files/edx-workbench-devserver
+++ b/playbooks/roles/datajam/files/edx-workbench-devserver
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# assume the current user is already 'edxapp', so the right virtualenv is set up.
+python /edx/app/edxapp/venvs/edxapp/src/xblock/manage.py runserver 0.0.0.0:8003

--- a/playbooks/roles/datajam/tasks/main.yml
+++ b/playbooks/roles/datajam/tasks/main.yml
@@ -21,5 +21,6 @@
     - edx-insights-devserver
     - edx-lms-devserver
     - edx-forum-devserver
+    - edx-workbench-devserver
   tags:
     - deploy

--- a/vagrant/release/datajam/Vagrantfile
+++ b/vagrant/release/datajam/Vagrantfile
@@ -21,6 +21,7 @@ Vagrant.configure("2") do |config|
   config.vm.network :forwarded_port, guest: 8000, host: 8000
   config.vm.network :forwarded_port, guest: 8001, host: 8001
   config.vm.network :forwarded_port, guest: 8002, host: 8002
+  config.vm.network :forwarded_port, guest: 8003, host: 8003
   config.vm.network :forwarded_port, guest: 4567, host: 4567
 
   config.vm.synced_folder "#{edx_platform_mount_dir}", "/edx/app/edxapp/edx-platform", :create => true, nfs: true


### PR DESCRIPTION
This adds a script and a port for running XBlock workbench.  Doesn't deal with thumb dependency in workbench, which needs to be installed.  @mulby 
