### PR TITLE
datajam: remove virtualenv requirement

### DIFF
--- a/util/datajam
+++ b/util/datajam
@@ -14,16 +14,27 @@ VENV_WRAPPER_SETUP_PATHS = [
 
 Dependency = namedtuple('Dependency', ['name', 'command'])
 DEPENDENCIES = [
-    Dependency('virtualenvwrapper', 'declare -f -F workon'),
     Dependency('vagrant', 'vagrant --version'),
     Dependency('git', 'git --version')
+]
+PROVISION_DEPENDENCIES = [
+    Dependency('virtualenvwrapper', 'declare -f -F workon'),
 ]
 TESTED_WITH_VERSIONS = [
     'virtualbox 4.2.18',
     'vagrant 1.3.4',
     'git 1.7.10.4',
     'virtualenv 1.7.1.2',
-    'virtualenvwrapper 3.4'
+    'python 2.7.3',
+    'virtualenvwrapper 3.4 (only required for provisioning)',
+]
+Repository = namedtuple('Repository', ['name', 'branch'])
+REPOSITORIES = [
+    Repository('configuration', 'datajam'),
+    Repository('cs_comments_service', 'master'),
+    Repository('datajam', 'master'),
+    Repository('edx-platform', 'datajam'),
+    Repository('insights', 'datajam1'),
 ]
 
 DEFAULT_ACTION = 'create'
@@ -34,31 +45,41 @@ class DatajamExecutor(object):
     def main(self):
         self.parser = argparse.ArgumentParser()
         self.parser.add_argument('--root', action='store', default='.', help='Root directory for your virtual environment.  Will be created along with any missing parent directories if it does not exist. Defaults to "."')
+        self.parser.add_argument('--bare', action='store_true', default=False, help="Use a bare OS base image. For advanced usage only.")
 
         self.subparsers = self.parser.add_subparsers()
 
-        self.add_action('create', self.create, 'Create a datajam virtual environment.')
+        create_parser = self.add_action('create', self.create, 'Create a datajam virtual environment.')
+        create_parser.add_argument('--provision', action='store_true', default=False, help="Run the ansible provisioner. For advanced usage only.")
         self.add_action('ssh', self.ssh, 'Login to the datajam virtual environment')
         self.add_action('halt', self.halt, 'Shutdown an existing datajam virtual environment')
         self.add_action('start', self.start, 'Start up an existing datajam virtual environment')
         self.add_action('destroy', self.destroy, 'Remove a datajam virtual environment.  This will remove everything, use with care!')
+        self.add_action('freeze', self.freeze, 'Generate a vagrant box from the current virtual environment state.')
 
         if len(sys.argv) == 1:
             args = self.parser.parse_args([DEFAULT_ACTION])
         else:
             args = self.parser.parse_args()
 
-        self.root = os.path.abspath(args.root)
+        if 'provision' not in args:
+            args.provision = False
 
-        self.venv_setup_path = VENV_WRAPPER_SETUP_PATHS[0]
-        for venv_setup_path in VENV_WRAPPER_SETUP_PATHS:
-            if os.path.exists(venv_setup_path):
-                self.venv_setup_path = venv_setup_path
+        self.root = os.path.abspath(args.root)
+        self.args = args
+
+        if args.provision:
+            self.venv_setup_path = VENV_WRAPPER_SETUP_PATHS[0]
+            for venv_setup_path in VENV_WRAPPER_SETUP_PATHS:
+                if os.path.exists(venv_setup_path):
+                    self.venv_setup_path = venv_setup_path
 
         self.check_environment()
 
         self.configuration_root = os.path.join(self.root, 'configuration')
         self.datajam_root = os.path.join(self.configuration_root, 'vagrant', 'release', 'datajam')
+        if args.bare:
+            self.datajam_root = os.path.join(self.configuration_root, 'vagrant', 'datajam')
 
         if os.path.exists(self.datajam_root):
             os.chdir(self.datajam_root)
@@ -69,6 +90,7 @@ class DatajamExecutor(object):
     def add_action(self, action_name, func, help=None):
         parser = self.subparsers.add_parser(action_name, help=help)
         parser.set_defaults(action=func)
+        return parser
 
     def check_environment(self):
         self.environment = os.environ.copy()
@@ -77,7 +99,11 @@ class DatajamExecutor(object):
         if not os.path.exists(self.root):
             os.makedirs(self.root)
 
-        for dep in DEPENDENCIES:
+        all_deps = DEPENDENCIES
+        if self.args.provision:
+            all_deps.extend(PROVISION_DEPENDENCIES)
+
+        for dep in all_deps:
             try:
                 self.execute(dep.command + ' 2>/dev/null >/dev/null')
             except subprocess.CalledProcessError:
@@ -86,31 +112,39 @@ class DatajamExecutor(object):
                 sys.exit(1)
 
     def execute(self, command):
-        return subprocess.check_call(['/bin/bash', '-c', 'source {venv_path} && {cmd}'.format(venv_path=self.venv_setup_path, cmd=command)], env=self.environment)
+        if self.args.provision:
+            command = 'source {venv_path} && {cmd}'.format(venv_path=self.venv_setup_path, cmd=command)
+
+        return subprocess.check_call(['/bin/bash', '-c', command], env=self.environment)
 
     def create(self):
-        os.chdir(self.root)
-        if not os.path.exists(self.configuration_root):
-            self.execute('git clone git@github.com:edx/configuration.git')
+        for repository in REPOSITORIES:
+            repo_dir = os.path.join(self.root, repository.name)
+            if not os.path.exists(repo_dir):
+                os.chdir(self.root)
+                self.execute('git clone https://github.com/edx/{name}.git'.format(name=repository.name))
+                os.chdir(repo_dir)
+                self.execute('git checkout {branch} && git pull --ff-only'.format(branch=repository.branch))
 
-        os.chdir(self.configuration_root)
-        self.execute('git fetch --all')
-        self.execute('git checkout datajam')
-        self.execute('git merge --ff-only origin/datajam')
+        if self.args.provision:
+            os.chdir(self.configuration_root)
+            try:
+                self.execute('workon edx-configuration')
+            except subprocess.CalledProcessError:
+                self.execute('mkvirtualenv edx-configuration')
 
-        try:
-            self.execute('workon edx-configuration')
-        except subprocess.CalledProcessError:
-            self.execute('mkvirtualenv edx-configuration')
+            self.execute('workon edx-configuration && pip install -r requirements.txt')
+            os.chdir(self.datajam_root)
+            self.execute('workon edx-configuration && vagrant up')
+        else:
+            os.chdir(self.datajam_root)
+            self.execute('vagrant up --no-provision')
 
-        self.execute('workon edx-configuration && pip install -r requirements.txt')
-        os.chdir(self.datajam_root)
-        self.execute('workon edx-configuration && vagrant up')
-
+    def freeze(self):
+        self.execute('vagrant package')
 
     def destroy(self):
         self.execute('vagrant destroy')
-        self.execute('rmvirtualenv edx-configuration')
 
     def ssh(self):
         self.execute('vagrant ssh')

--- a/vagrant/release/datajam/Vagrantfile
+++ b/vagrant/release/datajam/Vagrantfile
@@ -16,8 +16,8 @@ end
 
 Vagrant.configure("2") do |config|
 
-  config.vm.box    = "edx-datajam"
-  config.vm.box_url = "https://s3.amazonaws.com/edx-analytics-public/vagrant/201311211446-edx-datajam.box"
+  config.vm.box    = "edx-datajam-201312031505"
+  config.vm.box_url = "https://s3.amazonaws.com/edx-analytics-public/vagrant/201312031505-edx-datajam.box"
 
   config.vm.network :private_network, ip: "192.168.33.10"
   config.vm.network :forwarded_port, guest: 8000, host: 8000


### PR DESCRIPTION
This change has two major implications:

1) Users will no longer have to install all of the configuration repo deps, and will not need to run ansible to start up the image.
2) If we change any of the ansible stuff, we will have to generate a new image (which is a multi-hour somewhat manual process).

@brianhw, @rocha
