### PR TITLE
Add "unset NO_PREREQ_INSTALL" call to lms and cms scripts

### DIFF
--- a/playbooks/roles/datajam/files/edx-cms-devserver
+++ b/playbooks/roles/datajam/files/edx-cms-devserver
@@ -1,4 +1,5 @@
 #!/bin/bash
 
+unset NO_PREREQ_INSTALL
 cd /edx/app/edxapp/edx-platform
 rake cms[devstack,0.0.0.0:8001]

--- a/playbooks/roles/datajam/files/edx-lms-devserver
+++ b/playbooks/roles/datajam/files/edx-lms-devserver
@@ -1,4 +1,5 @@
 #!/bin/bash
 
+unset NO_PREREQ_INSTALL
 cd /edx/app/edxapp/edx-platform
 rake lms[datajam,0.0.0.0:8000]


### PR DESCRIPTION
...so that missing prereqs are installed by rake calls.

@mulby @rocha 
