### PR TITLE
datajam: ensure correct mongodb version

### DIFF
--- a/playbooks/roles/insights/defaults/main.yml
+++ b/playbooks/roles/insights/defaults/main.yml
@@ -25,8 +25,6 @@ insights_debian_pkgs:
   - python-pip
   - python-virtualenv
   - redis-server
-  - mongodb
-  - nginx
 
 insights_app_dir: "{{ COMMON_APP_DIR }}/insights"
 insights_venv_dir: "{{ edxapp_venv_dir }}"

--- a/vagrant/release/datajam/Vagrantfile
+++ b/vagrant/release/datajam/Vagrantfile
@@ -16,8 +16,8 @@ end
 
 Vagrant.configure("2") do |config|
 
-  config.vm.box    = "edx-datajam-201312041308"
-  config.vm.box_url = "https://s3.amazonaws.com/edx-analytics-public/vagrant/201312041308-edx-datajam.box"
+  config.vm.box    = "edx-datajam-201312051108"
+  config.vm.box_url = "https://s3.amazonaws.com/edx-analytics-public/vagrant/201312051108-edx-datajam.box"
 
   config.vm.network :private_network, ip: "192.168.33.10"
   config.vm.network :forwarded_port, guest: 8000, host: 8000


### PR DESCRIPTION
The correct version of mongo was being removed automagically by apt-get when installing the insights dependencies.

@wedaly - FYI, note devstack should be fine, this was a problem with our insights role.

@brianhw, @rocha
