### PR TITLE
Replace ORA XQueue vars

### DIFF
--- a/playbooks/roles/ora/defaults/main.yml
+++ b/playbooks/roles/ora/defaults/main.yml
@@ -54,6 +54,10 @@ ORA_USERS:
   "lms": "password"
 
 ORA_XQUEUE_URL: "http://localhost:18040"
+ORA_XQUEUE_DJANGO_USER: "lms"
+ORA_XQUEUE_DJANGO_PASSWORD: "password"
+ORA_XQUEUE_BASIC_AUTH_USER: "edx"
+ORA_XQUEUE_BASIC_AUTH_PASSWORD: "edx"
 
 ORA_DJANGO_USER: "lms"
 ORA_DJANGO_PASSWORD: "password"
@@ -111,9 +115,9 @@ ora_auth_config:
   USERS: $ORA_USERS
   XQUEUE_INTERFACE:
     django_auth:
-      username: $XQUEUE_DJANGO_USER
-      password: $XQUEUE_DJANGO_PASSWORD
-    basic_auth: [$XQUEUE_BASIC_AUTH_USER, $XQUEUE_BASIC_AUTH_PASSWORD]
+      username: $ORA_XQUEUE_DJANGO_USER
+      password: $ORA_XQUEUE_DJANGO_PASSWORD
+    basic_auth: [ $ORA_XQUEUE_BASIC_AUTH_USER, $ORA_XQUEUE_BASIC_AUTH_PASSWORD ]
     url: $ORA_XQUEUE_URL
   GRADING_CONTROLLER_INTERFACE:
     django_auth:


### PR DESCRIPTION
The ORA role depends on variables defined in XQueue, which aren't available when deploying ORA independently of XQueue.  This change replaces the XQueue-defined variables with ORA-specific equivalents.

I tested ORA was able to pick up submissions off the XQueue in a sandbox, which was not the case before.

@feanil 
