### PR TITLE
Disable basic auth for 127.0.0.1

### DIFF
--- a/playbooks/roles/nginx/templates/basic-auth.j2
+++ b/playbooks/roles/nginx/templates/basic-auth.j2
@@ -1,6 +1,12 @@
 {% if  NGINX_HTPASSWD_USER and NGINX_HTPASSWD_PASS %}
+     satisfy any;
+
+     allow 127.0.0.1;
+     deny all;
+
      auth_basic            "Restricted";
      auth_basic_user_file  {{ nginx_htpasswd_file }};
+
      index index.html
      proxy_set_header X-Forwarded-Proto https;
 {% endif %}


### PR DESCRIPTION
This change disables basic auth for 127.0.0.1 so that services within a sandbox can communicate.  Basic auth is still enabled for external requests.

I tested this change in my sandbox, verifying that:
- Basic auth is still enabled for external requests
- ORA/LMS communication works with basic auth enabled (not the case before this change)

@feanil This isn't quite the change we discussed, but I think it's a lot simpler than duplicating basic auth credentials across all the roles that communicate by HTTP.
