### PR TITLE
datajam: remove dependency on hostsupdater

### DIFF
--- a/vagrant/release/datajam/Vagrantfile
+++ b/vagrant/release/datajam/Vagrantfile
@@ -31,8 +31,6 @@ Vagrant.configure("2") do |config|
   config.vm.synced_folder "#{insights_mount_dir}", "/edx/app/insights/insights", :create => true, nfs: true
   config.vm.synced_folder "#{datajam_mount_dir}", "/edx/app/datajam", :create => true, nfs: true
 
-  config.hostsupdater.aliases = ["preview.localhost"]
-
   config.vm.provider :virtualbox do |vb|
     vb.customize ["modifyvm", :id, "--memory", MEMORY.to_s]
     vb.customize ["modifyvm", :id, "--cpus", CPU_COUNT.to_s]


### PR DESCRIPTION
Note that now users will have to manually include the following line in their /etc/hosts file:

192.168.33.10  preview.localhost

We will have to update the readme accordingly.

@brianhw, @rocha
