### PR TITLE
Configure NLTK_DATA environment variable for ORA celery workers

### DIFF
--- a/playbooks/roles/ora/templates/ora_celery.conf.j2
+++ b/playbooks/roles/ora/templates/ora_celery.conf.j2
@@ -5,7 +5,7 @@ command={{ ora_venv_bin }}/python {{ ora_code_dir }}/manage.py celeryd --logleve
 user={{ common_web_user }}
 directory={{ ora_code_dir }}
 
-environment=DJANGO_SETTINGS_MODULE=edx_ora.aws,SERVICE_VARIANT=ora
+environment=DJANGO_SETTINGS_MODULE=edx_ora.aws,SERVICE_VARIANT=ora,NLTK_DATA={{ ora_nltk_data_dir }}
 
 stdout_logfile={{ supervisor_log_dir }}/%(program_name)-stdout.log
 stderr_logfile={{ supervisor_log_dir }}/%(program_name)-stderr.log


### PR DESCRIPTION
The `nltk` library uses the `NLTK_DATA` environment variable to find data, which we store in `/edx/var/ora` instead of the default location.  We had this correctly configured for ORA, but not for the ORA celery workers.  As a result, ML model creation was failing in the sandbox.
