### PR TITLE
Updated devstack role to include ORA

### DIFF
--- a/playbooks/roles/local_dev/defaults/main.yml
+++ b/playbooks/roles/local_dev/defaults/main.yml
@@ -3,6 +3,7 @@
 localdev_accounts:
     - { user: "{{ edxapp_user}}", home: "{{ edxapp_app_dir }}" }
     - { user: "{{ forum_user }}", home: "{{ forum_app_dir }}" }
+    - { user: "{{ ora_user }}", home: "{{ ora_app_dir }}" }
 
 localdev_env:
     DISPLAY: "{{ browser_xvfb_display }}"

--- a/playbooks/roles/local_dev/templates/ora_bashrc.j2
+++ b/playbooks/roles/local_dev/templates/ora_bashrc.j2
@@ -1,0 +1,6 @@
+#! /usr/bin/env bash
+
+# {{ ansible_managed }}
+
+source "{{ ora_app_dir }}/ora_env"
+cd {{ ora_code_dir }}

--- a/playbooks/roles/ora/defaults/main.yml
+++ b/playbooks/roles/ora/defaults/main.yml
@@ -9,6 +9,7 @@ ora_venvs_dir: "{{ ora_app_dir }}/venvs"
 ora_venv_dir: "{{ ora_venvs_dir }}/ora"
 ora_venv_bin: "{{ ora_venv_dir }}/bin"
 ora_user: "ora"
+ora_deploy_path: "{{ ora_venv_bin }}:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 ora_nltk_data_dir: "{{ ora_data_dir}}/nltk_data"
 
 ora_source_repo: https://github.com/edx/edx-ora.git
@@ -134,6 +135,12 @@ ora_auth_config:
       PORT: $ORA_MYSQL_PORT
   AWS_ACCESS_KEY_ID: $ORA_AWS_ACCESS_KEY_ID
   AWS_SECRET_ACCESS_KEY: $ORA_AWS_SECRET_ACCESS_KEY
+
+ora_environment:
+  SERVICE_VARIANT: ora
+  NLTK_DATA: $ora_nltk_data_dir
+  LANG: $ORA_LANG
+  PATH: $ora_deploy_path
 
 ora_debian_pkgs:
   - python-software-properties

--- a/playbooks/roles/ora/handlers/main.yml
+++ b/playbooks/roles/ora/handlers/main.yml
@@ -5,6 +5,7 @@
     supervisorctl_path={{ supervisor_ctl }}
     config={{ supervisor_cfg }}
     state=restarted
+  when: not devstack
   tags: deploy
 
 - name: ora | restart ora_celery
@@ -13,4 +14,5 @@
     supervisorctl_path={{ supervisor_ctl }}
     config={{ supervisor_cfg }}
     state=restarted
+  when: not devstack
   tags: deploy

--- a/playbooks/roles/ora/tasks/deploy.yml
+++ b/playbooks/roles/ora/tasks/deploy.yml
@@ -6,6 +6,7 @@
     - ora | restart ora
     - ora | restart ora_celery
   with_items: ['ora', 'ora_celery']
+  when: not devstack
   tags:
   - deploy
 
@@ -22,6 +23,17 @@
   sudo_user: "{{ ora_user }}"
   tags:
   - deploy
+
+- name: ora | setup the ora env
+  notify:
+  - "ora | restart ora"
+  - "ora | restart ora_celery"
+  template: >
+    src=ora_env.j2 dest={{ ora_app_dir }}/ora_env
+    owner={{ ora_user }} group={{ common_web_user }}
+    mode=0644
+  tags:
+    - deploy
 
 # Do A Checkout
 - name: ora | git checkout ora repo into {{ ora_app_dir }}
@@ -94,6 +106,7 @@
 - name: ora | update supervisor configuration
   shell:  "{{ supervisor_ctl }} -c {{ supervisor_cfg }} update"
   register: supervisor_update
+  when: not devstack
   changed_when: supervisor_update.stdout != ""
   tags: deploy
 
@@ -103,6 +116,7 @@
     supervisorctl_path={{ supervisor_ctl }}
     config={{ supervisor_cfg }}
     state=started
+  when: not devstack
   tags: deploy
 
 - name: ora | ensure ora_celery is started
@@ -111,4 +125,5 @@
     supervisorctl_path={{ supervisor_ctl }}
     config={{ supervisor_cfg }}
     state=started
+  when: not devstack
   tags: deploy

--- a/playbooks/roles/ora/tasks/main.yml
+++ b/playbooks/roles/ora/tasks/main.yml
@@ -56,5 +56,3 @@
   with_items:
   - python
   - pip
-
-

--- a/playbooks/roles/ora/templates/ora_env.j2
+++ b/playbooks/roles/ora/templates/ora_env.j2
@@ -1,0 +1,7 @@
+# {{ ansible_managed }}
+{% for name,value in ora_environment.items() %}
+{%- if value %}
+export {{ name }}="{{ value }}"
+
+{% endif %}
+{% endfor %}

--- a/playbooks/vagrant-devstack.yml
+++ b/playbooks/vagrant-devstack.yml
@@ -17,5 +17,6 @@
     - oraclejdk
     - elasticsearch
     - forum
+    - ora
     - browsers
     - local_dev

--- a/vagrant/devstack/Vagrantfile
+++ b/vagrant/devstack/Vagrantfile
@@ -3,11 +3,13 @@ CPU_COUNT = 2
 
 edx_platform_mount_dir = "edx-platform"
 forum_mount_dir = "cs_comments_service"
+ora_mount_dir = "ora"
 
 if ENV['VAGRANT_MOUNT_BASE']
 
   edx_platform_mount_dir = ENV['VAGRANT_MOUNT_BASE'] + "/" + edx_platform_mount_dir
   forum_mount_dir = ENV['VAGRANT_MOUNT_BASE'] + "/" + forum_mount_dir
+  ora_mount_dir = ENV['VAGRANT_MOUNT_BASE'] + "/" + ora_mount_dir
 
 end
 
@@ -25,6 +27,7 @@ Vagrant.configure("2") do |config|
 
   config.vm.synced_folder "#{edx_platform_mount_dir}", "/edx/app/edxapp/edx-platform", :create => true, nfs: true
   config.vm.synced_folder "#{forum_mount_dir}", "/edx/app/forum/cs_comments_service", :create => true, nfs: true
+  config.vm.synced_folder "#{ora_mount_dir}", "/edx/app/ora/ora", :create => true, nfs: true
 
   config.hostsupdater.aliases = ["preview.localhost"]
 


### PR DESCRIPTION
1) Adds the ORA role to devstack
2) Creates an ora_env script that activates the virtualenv and sets up other useful environment variables (such as `NLTK_DATA`)

Unfortunately, this will break the Dosa release of devstack because the Dosa Vagrantfile runs only the deploy plays.  Until the next release, you'll need to create the VM from the base Ubuntu image using `configuration/vagrant/devstack`.  You can speed this up by manually updating `configuration/vagrant/devstack` to use the Dosa base image.

I verified that all the tests ran when logged in as `ora`, but I didn't verify that ORA/LMS communicate correctly.

Suggested reviewers: @feanil @stephensanchez 
