### PR TITLE
Devstack enables prereq install by default

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -113,6 +113,9 @@ EDXAPP_GRADE_STORAGE_TYPE: 'localfs'
 EDXAPP_GRADE_BUCKET: 'edx-grades'
 EDXAPP_GRADE_ROOT_PATH: '/tmp/edx-s3/grades'
 
+# Configure rake tasks in edx-platform to skip Python/Ruby/Node installation
+EDXAPP_NO_PREREQ_INSTALL: 1
+
 #-------- Everything below this line is internal to the role ------------
 
 #Use YAML references (& and *) and hash merge <<: to factor out shared settings
@@ -187,7 +190,7 @@ edxapp_all_req_files:
 
 edxapp_environment:
   LANG: $EDXAPP_LANG
-  NO_PREREQ_INSTALL: 1
+  NO_PREREQ_INSTALL: $EDXAPP_NO_PREREQ_INSTALL
   SKIP_WS_MIGRATIONS: 1
   RBENV_ROOT: $edxapp_rbenv_root
   GEM_HOME: $edxapp_gem_root

--- a/playbooks/roles/edxapp/tasks/deploy.yml
+++ b/playbooks/roles/edxapp/tasks/deploy.yml
@@ -1,3 +1,13 @@
+- name: edxapp | setup the edxapp env
+  notify:
+  - "edxapp | restart edxapp"
+  - "edxapp | restart edxapp_workers"
+  template: >
+    src=edxapp_env.j2 dest={{ edxapp_app_dir }}/edxapp_env
+    owner={{ edxapp_user }}  group={{ common_web_user }}
+    mode=0644
+  tags: deploy
+
 # Do A Checkout
 - name: edxapp | checkout edx-platform repo into {{edxapp_code_dir}}
   git: dest={{edxapp_code_dir}} repo={{edx_platform_repo}} version={{edx_platform_commit}}

--- a/playbooks/roles/edxapp/tasks/main.yml
+++ b/playbooks/roles/edxapp/tasks/main.yml
@@ -68,15 +68,6 @@
     mode=0750
   with_items: service_variants_enabled
 
-- name: edxapp | setup the edxapp env
-  notify:
-  - "edxapp | restart edxapp"
-  - "edxapp | restart edxapp_workers"
-  template: >
-    src=edxapp_env.j2 dest={{ edxapp_app_dir }}/edxapp_env
-    owner={{ edxapp_user }}  group={{ common_web_user }}
-    mode=0644
-
 - include: deploy.yml
 
 - name: edxapp | create a symlink for venv python

--- a/playbooks/vagrant-devstack.yml
+++ b/playbooks/vagrant-devstack.yml
@@ -8,6 +8,7 @@
     devstack: True
     edx_platform_commit: 'master'
     mongo_enable_journal: False
+    EDXAPP_NO_PREREQ_INSTALL: 0
   vars_files:
     - "group_vars/all"
   roles:


### PR DESCRIPTION
Default to enabling prereq installation in devstack.
Move `edxapp_env` file creation to the deploy steps to ensure it gets updated.

@feanil 
