### PR TITLE
Enable X11 forwarding for devstack

### DIFF
--- a/playbooks/roles/local_dev/app_bashrc.j2
+++ b/playbooks/roles/local_dev/app_bashrc.j2
@@ -1,0 +1,18 @@
+#! /usr/bin/env bash
+
+# {{ ansible_managed }}
+
+source "{{ item.home }}/{{ item.env }}"
+
+# If X11 forwarding is enabled, then use the DISPLAY value
+# already set and use the X11 session cookie
+if [ -n "$DISPLAY" ]; then
+    export XAUTHORITY="{{ localdev_xauthority }}"
+
+# Otherwise, configure the display to use the virtual frame buffer
+else
+    export DISPLAY="{{ localdev_xvfb_display }}"
+fi
+
+# Default to the code repository
+cd "{{ item.home }}/{{ item.repo }}"

--- a/playbooks/roles/local_dev/defaults/main.yml
+++ b/playbooks/roles/local_dev/defaults/main.yml
@@ -1,14 +1,24 @@
 ---
 
-localdev_accounts:
-    - { user: "{{ edxapp_user}}", home: "{{ edxapp_app_dir }}" }
-    - { user: "{{ forum_user }}", home: "{{ forum_app_dir }}" }
-    - { user: "{{ ora_user }}", home: "{{ ora_app_dir }}" }
+localdev_user: "vagrant"
+localdev_home: "/home/vagrant"
+localdev_xauthority: "{{ localdev_home }}/.Xauthority"
+localdev_xvfb_display: ":1"
 
-localdev_env:
-    DISPLAY: "{{ browser_xvfb_display }}"
+localdev_accounts:
+    - { user: "{{ edxapp_user}}", home: "{{ edxapp_app_dir }}",
+        env: "edxapp_env", repo: "edx-platform" }
+
+    - { user: "{{ forum_user }}",home: "{{ forum_app_dir }}",
+        env: "forum_env", repo: "cs_comments_service" }
+
+    - { user: "{{ ora_user }}", home: "{{ ora_app_dir }}",
+        env: "ora_env", repo: "ora" }
+
 
 # Helpful system packages for local dev
 local_dev_pkgs:
     - vim
     - emacs
+    - xorg
+    - openbox

--- a/playbooks/roles/local_dev/files/x11_display
+++ b/playbooks/roles/local_dev/files/x11_display
@@ -1,0 +1,1 @@
+Defaults        env_keep+=DISPLAY

--- a/playbooks/roles/local_dev/tasks/main.yml
+++ b/playbooks/roles/local_dev/tasks/main.yml
@@ -27,7 +27,7 @@
 # Create scripts to configure environment
 - name: local_dev | create login scripts
   template:
-    src={{ item.user }}_bashrc.j2 dest={{ item.home }}/.bashrc
+    src=app_bashrc.j2 dest={{ item.home }}/.bashrc
     owner={{ item.user }} mode=755
   with_items: "{{ localdev_accounts }}"
 
@@ -38,3 +38,21 @@
     src=gitconfig dest={{ item.home }}/.gitconfig
     owner={{ item.user }} mode=700
   with_items: "{{ localdev_accounts }}"
+
+# Configure X11 for application users
+- name: local_dev | preserve DISPLAY for sudo
+  copy:
+    src=x11_display dest=/etc/sudoers.d/x11_display
+    owner=root group=root mode=0440
+
+- name: local_dev | login share X11 auth to app users
+  template:
+    src=share_x11.j2 dest={{ localdev_home }}/share_x11
+    owner={{ localdev_user }} mode=0700
+
+- name: local_dev | update bashrc with X11 share script
+  lineinfile:
+    dest={{ localdev_home }}/.bashrc
+    regexp=". {{ localdev_home }}/share_x11"
+    line=". {{ localdev_home }}/share_x11"
+    state=present

--- a/playbooks/roles/local_dev/templates/app_bashrc.j2
+++ b/playbooks/roles/local_dev/templates/app_bashrc.j2
@@ -1,0 +1,17 @@
+#! /usr/bin/env bash
+
+# {{ ansible_managed }}
+
+source "{{ item.home }}/{{ item.env }}"
+
+# If X11 forwarding is enabled, then use the DISPLAY value
+# already set and use the X11 session cookie
+if [ -n "$DISPLAY" ]; then
+    export XAUTHORITY="{{ localdev_xauthority }}"
+
+# Otherwise, configure the display to use the virtual frame buffer
+else
+    export DISPLAY="{{ localdev_xvfb_display }}"
+fi
+
+cd "{{ item.home }}/{{ item.repo }}"

--- a/playbooks/roles/local_dev/templates/edxapp_bashrc.j2
+++ b/playbooks/roles/local_dev/templates/edxapp_bashrc.j2
@@ -1,8 +1,0 @@
-#! /usr/bin/env bash
-
-# {{ ansible_managed }}
-
-source "{{ edxapp_app_dir }}/edxapp_env"
-export DISPLAY="{{ browser_xvfb_display }}"
-
-cd $HOME/edx-platform

--- a/playbooks/roles/local_dev/templates/forum_bashrc.j2
+++ b/playbooks/roles/local_dev/templates/forum_bashrc.j2
@@ -1,8 +1,0 @@
-#! /usr/bin/env bash
-
-# {{ ansible_managed }}
-
-source "{{ forum_app_dir }}/forum_env"
-export DISPLAY="{{ browser_xvfb_display }}"
-
-cd $HOME/cs_comments_service

--- a/playbooks/roles/local_dev/templates/ora_bashrc.j2
+++ b/playbooks/roles/local_dev/templates/ora_bashrc.j2
@@ -1,6 +1,0 @@
-#! /usr/bin/env bash
-
-# {{ ansible_managed }}
-
-source "{{ ora_app_dir }}/ora_env"
-cd {{ ora_code_dir }}

--- a/playbooks/roles/local_dev/templates/share_x11.j2
+++ b/playbooks/roles/local_dev/templates/share_x11.j2
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# Change permissions on the X11 session cookie
+# so application users can use the same X11 session.
+# This is very insecure and should *only* be used for local VMs.
+if [ -f {{ localdev_xauthority }} ]; then
+    chmod og+r {{ localdev_xauthority }}
+fi

--- a/vagrant/base/devstack/Vagrantfile
+++ b/vagrant/base/devstack/Vagrantfile
@@ -16,7 +16,7 @@ end
 
 Vagrant.configure("2") do |config|
 
-# Creates a devstack from a base Ubuntu 12.04 image
+  # Creates a devstack from a base Ubuntu 12.04 image
   config.vm.box     = "precise64"
   config.vm.box_url = "http://files.vagrantup.com/precise64.box"
 
@@ -30,6 +30,11 @@ Vagrant.configure("2") do |config|
   config.vm.synced_folder "#{ora_mount_dir}", "/edx/app/ora/ora", :create => true, nfs: true
 
   config.hostsupdater.aliases = ["preview.localhost"]
+
+  # Enable X11 forwarding so we can interact with GUI applications
+  if ENV['VAGRANT_X11']
+      config.ssh.forward_x11 = true
+  end
 
   config.vm.provider :virtualbox do |vb|
     vb.customize ["modifyvm", :id, "--memory", MEMORY.to_s]


### PR DESCRIPTION
This PR enables X11 forwarding for the devstack Vagrant image.  This should make it _much_ easier to develop and debug acceptance tests.

When enabled, GUI applications started on the Vagrant instance appear in a window on the host machine:
![image](https://f.cloud.github.com/assets/2948394/1783713/3d8c936a-68c7-11e3-9cd5-ad87e48335e6.png)

To enable it on Mac OS X:
1) Install [XQuartz](http://xquartz.macosforge.org/landing/)
2) `export VAGRANT_X11=1`
3) `vagrant up` (if not started) or `vagrant reload` (if already running).  If using an existing instance, use `vagrant provision` to update the configuration.
4) `vagrant ssh` into the instance, then start a GUI application such as `xclock` or `firefox`

Suggested reviewers: @feanil @jzoldak 
