### PR TITLE
Print error message if edx_ansible not installed in base box

### DIFF
--- a/vagrant/release/devstack/Vagrantfile
+++ b/vagrant/release/devstack/Vagrantfile
@@ -2,6 +2,10 @@ MEMORY = 2048
 CPU_COUNT = 2
 
 $script = <<SCRIPT
+if [ ! -d /edx/app/edx_ansible ]; then
+    echo "Error: Base box is missing provisioning scripts." 1>&2
+    exit 1
+fi
 source /edx/app/edx_ansible/venvs/edx_ansible/bin/activate
 cd /edx/app/edx_ansible/edx_ansible/playbooks
 ansible-playbook -i localhost, -c local vagrant-devstack.yml


### PR DESCRIPTION
In response to @yarko 's suggestion for issue https://github.com/edx/configuration/issues/564:

Added a check for the `edx_ansible` role in the release version of devstack.  If the base box doesn't have `edx_ansible` installed, then fail immediately with an error message.
