### PR TITLE
Unbuffer output of provisioning scripts for devstack release

### DIFF
--- a/vagrant/release/devstack/Vagrantfile
+++ b/vagrant/release/devstack/Vagrantfile
@@ -6,6 +6,7 @@ if [ ! -d /edx/app/edx_ansible ]; then
     echo "Error: Base box is missing provisioning scripts." 1>&2
     exit 1
 fi
+export PYTHONUNBUFFERED=1
 source /edx/app/edx_ansible/venvs/edx_ansible/bin/activate
 cd /edx/app/edx_ansible/edx_ansible/playbooks
 ansible-playbook -i localhost, -c local vagrant-devstack.yml


### PR DESCRIPTION
A user emailed me thinking that the script was hung because the output was buffered.
