### PR TITLE
Create log directories after rsyslog is installed

### DIFF
--- a/playbooks/roles/common/tasks/main.yml
+++ b/playbooks/roles/common/tasks/main.yml
@@ -15,11 +15,6 @@
     - "{{ COMMON_BIN_DIR }}"
     - "{{ COMMON_CFG_DIR }}"
 
-- name: common | Create common log directory
-  file: >
-    path={{ COMMON_LOG_DIR }} state=directory owner=syslog
-    group=syslog mode=0755
-
 # Need to install python-pycurl to use Ansible's apt_repository module
 - name: common | Install python-pycurl
   apt: pkg=python-pycurl state=present update_cache=yes
@@ -35,6 +30,11 @@
   apt: >
     pkg={{','.join(common_debian_pkgs)}} install_recommends=yes
     state=present update_cache=yes
+
+- name: common | Create common log directory
+  file: >
+    path={{ COMMON_LOG_DIR }} state=directory owner=syslog
+    group=syslog mode=0755
 
 - name: common | upload sudo config for key forwarding as root
   copy: >


### PR DESCRIPTION
Those directories are created with 'syslog' as owner, if rsyslog is not
installed yet, the user does not exist.
