### PR TITLE
Add curl to rbenv’s debian packages

### DIFF
--- a/playbooks/roles/rbenv/defaults/main.yml
+++ b/playbooks/roles/rbenv/defaults/main.yml
@@ -10,6 +10,7 @@ rbenv_bin: "{{ rbenv_dir }}/.rbenv/bin"
 rbenv_shims: "{{ rbenv_root }}/shims"
 rbenv_path: "{{ rbenv_bin }}:{{ rbenv_shims }}:{{ rbenv_gem_bin }}:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 rbenv_debian_pkgs:
+  - curl
   - build-essential
   - libcurl4-openssl-dev
   - libreadline-dev


### PR DESCRIPTION
rbenv install requires curl or wget, if none of them is installed, the
role fails.

See https://github.com/sstephenson/ruby-build/blob/master/bin/ruby-build#L203
