### PR TITLE
Adds ability to have multiple named access logs be rotated

### DIFF
--- a/playbooks/roles/nginx/templates/edx_logrotate_nginx_access.j2
+++ b/playbooks/roles/nginx/templates/edx_logrotate_nginx_access.j2
@@ -1,6 +1,6 @@
 # Put in place by ansible
 
-{{ nginx_log_dir }}/access.log {
+{{ nginx_log_dir }}/*access.log {
   create 0640 www-data adm
   compress
   delaycompress

--- a/playbooks/roles/nginx/templates/edx_logrotate_nginx_error.j2
+++ b/playbooks/roles/nginx/templates/edx_logrotate_nginx_error.j2
@@ -1,6 +1,6 @@
 # Put in place by ansible
 
-{{ nginx_log_dir }}/error.log {
+{{ nginx_log_dir }}/*error.log {
   create 0640 www-data adm
   compress
   delaycompress


### PR DESCRIPTION
This should still rotate the old logs, but I've split the log files by name, so the named ones weren't getting rotated, and thus adding a wildcard.
