### PR TITLE
Make devpi optional

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -209,6 +209,8 @@ edxapp_upload_dir: "{{ edxapp_data_dir }}/uploads"
 edxapp_theme_dir: "{{ edxapp_data_dir }}/themes"
 edxapp_git_identity: "{{ edxapp_app_dir }}/edxapp-git-identity"
 edxapp_git_ssh: "/tmp/edxapp_git_ssh.sh"
+edxapp_devpi_enabled: false
+
 edxapp_workers:
   - queue: low
     service_variant: cms

--- a/playbooks/roles/edxapp/meta/main.yml
+++ b/playbooks/roles/edxapp/meta/main.yml
@@ -5,7 +5,8 @@ dependencies:
     rbenv_user: "{{ edxapp_user }}"
     rbenv_dir: "{{ edxapp_app_dir }}"
     rbenv_ruby_version: "{{ edxapp_ruby_version }}"
-  - devpi
+  - role: devpi
+    when: edxapp_devpi_enabled
   - role: user
     user_info:
       - name: "{{ EDXAPP_AUTOMATOR_NAME }}"


### PR DESCRIPTION
To enable, set the `devpi_enabled` variable to `"yes"`.
The vagrant devstack installs devpi by default.
