### PR TITLE
set startsecs param in xqueue supervisor conf

### DIFF
--- a/playbooks/roles/xqueue/templates/xqueue_consumer.conf.j2
+++ b/playbooks/roles/xqueue/templates/xqueue_consumer.conf.j2
@@ -11,3 +11,5 @@ stdout_logfile={{ supervisor_log_dir }}/%(program_name)-stdout.log
 stderr_logfile={{ supervisor_log_dir }}/%(program_name)-stderr.log
 killasgroup=true
 stopasgroup=true
+startsecs=0
+


### PR DESCRIPTION
@jarv 

quite simple, really.  when there are no push queues the `xqueue_consumer` will exit right away.  this might fall under the 1 second threshold for supervisor to consider a start to be healthy.  (see http://supervisord.org/configuration.html#program-x-section-values)

so set it to 0 instead.
