### PR TITLE
`hostname` -> {{ansible_hostname}}

### DIFF
--- a/playbooks/roles/edxapp/templates/workers.conf.j2
+++ b/playbooks/roles/edxapp/templates/workers.conf.j2
@@ -7,7 +7,7 @@ directory={{ edxapp_code_dir }}
 stdout_logfile={{ supervisor_log_dir }}/%(program_name)-stdout.log
 stderr_logfile={{ supervisor_log_dir }}/%(program_name)-stderr.log
 
-command={{ edxapp_venv_bin}}/python {{ edxapp_code_dir }}/manage.py {{ w.service_variant }} --settings=aws celery worker --loglevel=info --queues=edx.{{ w.service_variant }}.core.{{ w.queue }} --hostname=edx.{{ w.service_variant }}.core.{{ w.queue }}.`hostname` --concurrency={{ w.concurrency }}
+command={{ edxapp_venv_bin}}/python {{ edxapp_code_dir }}/manage.py {{ w.service_variant }} --settings=aws celery worker --loglevel=info --queues=edx.{{ w.service_variant }}.core.{{ w.queue }} --hostname=edx.{{ w.service_variant }}.core.{{ w.queue }}.{{ ansible_hostname }} --concurrency={{ w.concurrency }}
 killasgroup=true
 stopasgroup=true
 


### PR DESCRIPTION
@jarv Another small one: possibly for discussion:

getting errors like this in celery worker config:

```
2014-01-09 17:24:46,913 WARNING 797 [celery.redirected] log.py:246 - /edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/kombu/pidbox.py:74: UserWarning: A node named u'edx.lms.core.high_mem.`hostname`' is already using this process mailbox!

Maybe you forgot to shutdown the other node or did not do so properly?
Or if you meant to start multiple nodes on the same host please make sure
you give each node a unique node name!

  warnings.warn(W_PIDBOX_IN_USE % {'hostname': self.hostname})
```

So changed "`hostname`" to {{ansible_hostname}}.  Is that unique enough for your usage?
