### PR TITLE
Remove non-existent 'splunk' group when creating user

### DIFF
--- a/playbooks/roles/splunkforwarder/tasks/main.yml
+++ b/playbooks/roles/splunkforwarder/tasks/main.yml
@@ -41,7 +41,7 @@
 
 # Create splunk user
 - name: splunkforwarder | create splunk user
-  user: name=splunk group=splunk createhome=no state=present append=yes groups=syslog
+  user: name=splunk createhome=no state=present append=yes groups=syslog
   when: download_deb.changed
 
 # Need to start splunk manually so that it can create various files


### PR DESCRIPTION
When 'splunk' group doesn’t exist yet, ansible fails when creating the
user. Leaving it empty will create the group anyway.
