### PR TITLE
forum-nginx-sites-playbook: Add missing forum config in nginx_sites

### DIFF
--- a/playbooks/edx_sandbox.yml
+++ b/playbooks/edx_sandbox.yml
@@ -18,6 +18,7 @@
       nginx_sites:
       - cms
       - lms
+      - forum
       - ora
       - xqueue
       nginx_default_sites:

--- a/playbooks/vagrant-fullstack.yml
+++ b/playbooks/vagrant-fullstack.yml
@@ -17,6 +17,7 @@
       - cms
       - lms
       - ora
+      - forum
       - xqueue
       nginx_default_sites:
       - lms


### PR DESCRIPTION
Some playbooks are missing the new forum nginx reverse proxy configuration
file, which prevents the LMS to access the forum service.
