### PR TITLE
Adds upstream address and request time to ssl logging

### DIFF
--- a/playbooks/roles/nginx/templates/nginx.conf.j2
+++ b/playbooks/roles/nginx/templates/nginx.conf.j2
@@ -37,8 +37,8 @@ http {
                             '"$request" $status $body_bytes_sent $request_time '
                             '"$http_referer" "$http_user_agent"';
 
-        log_format ssl_combined '$remote_addr - $ssl_client_s_dn [$time_local]  '
-                                '"$request" $status $body_bytes_sent '
+        log_format ssl_combined '$remote_addr - $ssl_client_s_dn - "$upstream_addr" [$time_local]  '
+                                '"$request" $status $body_bytes_sent $request_time '
                                 '"$http_referer" "$http_user_agent"';
 
         access_log {{ nginx_log_dir }}/access.log p_combined;


### PR DESCRIPTION
It turns out when using nginx as a load balancer it is handy to know which app server it is sending requests too. Go figure.
