### PR TITLE
Added gettext to jenkins worker

### DIFF
--- a/playbooks/roles/jenkins_worker/defaults/main.yml
+++ b/playbooks/roles/jenkins_worker/defaults/main.yml
@@ -17,6 +17,7 @@ jenkins_debian_pkgs:
     - libxslt1-dev
     - npm
     - pkg-config
+    - gettext
 
 # Ruby Specific Vars
 jenkins_rbenv_root: "{{ jenkins_home }}/.rbenv"


### PR DESCRIPTION
We need `gettext` installed to run i18n tests in Jenkins: https://github.com/edx/edx-platform/pull/2253

@feanil 
