### PR TITLE
Will/performance test sandbox

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -67,6 +67,7 @@ EDXAPP_FEATURES:
   PREVIEW_LMS_BASE: $EDXAPP_PREVIEW_LMS_BASE
   ENABLE_S3_GRADE_DOWNLOADS: true
   USE_CUSTOM_THEME: $edxapp_use_custom_theme
+  AUTOMATIC_AUTH_FOR_TESTING: $edxapp_enable_auto_auth
 
 EDXAPP_BOOK_URL: ''
 # This needs to be set to localhost
@@ -523,3 +524,7 @@ worker_django_settings_module: 'aws'
 # the automator user.
 edxapp_automated_rbash_links:
   - /usr/bin/sudo
+
+# Enable an end-point that creates a user and logs them in
+# Used for performance testing
+edxapp_enable_auto_auth: false


### PR DESCRIPTION
- Add feature flag for enabling auto_auth, which is required for JMeter load tests.
- Add `extra_vars` env variable to Jenkins provision script, which allows other Jenkins jobs to override arbitrary Ansible variables.  I use this to (a) enable auto auth, and (b) change the settings to `load_test.py`

@e0d 
