### PR TITLE
Allow anonymous access to gerrit

### DIFF
--- a/playbooks/roles/gerrit/templates/gerrit.config.j2
+++ b/playbooks/roles/gerrit/templates/gerrit.config.j2
@@ -13,6 +13,7 @@
 [auth]
     type = HTTP
     httpHeader = GITHUB_USER
+    loginUrl = /login
     logoutUrl = /oauth/reset
 [sendemail]
     enable = {{ gerrit_smtp_enabled }}


### PR DESCRIPTION
Without the loginUrl setting, gerrit assumes the user is logged in; if
that is not the case, it then automatically attempts to start the OAuth
process and redirects to GitHub.

@mulby 

See https://groups.google.com/forum/#!topic/repo-discuss/fCYf4it4vsc
