### PR TITLE
Remove hash_behaviour=merge

### DIFF
--- a/playbooks/ansible.cfg
+++ b/playbooks/ansible.cfg
@@ -5,5 +5,4 @@
 [defaults]
 
 jinja2_extensions=jinja2.ext.do
-hash_behaviour=merge
 host_key_checking = False

--- a/playbooks/edx-east/ansible.cfg
+++ b/playbooks/edx-east/ansible.cfg
@@ -5,6 +5,5 @@
 [defaults]
 
 jinja2_extensions=jinja2.ext.do
-hash_behaviour=merge
 host_key_checking=False
 roles_path=../../../ansible-roles


### PR DESCRIPTION
I did some light testing and I don't think this is needed.  Switching the behavior on and off at least for edxapp with the deploy tag creates the same json configuration files, and I didn't think it was used anywhere else.  Having this  in has resulted in me being unable to replace the MixedModuleStore with just the MongoModuleStore in LMS since I can't get rid of the `stores` key which causes exceptions in the platform.
