### PR TITLE
runs the worker role before the edxapp role

### DIFF
--- a/playbooks/edx-east/edx_continuous_integration.yml
+++ b/playbooks/edx-east/edx_continuous_integration.yml
@@ -18,11 +18,11 @@
       - lms
     - edxlocal
     - mongo
+    - { role: 'edxapp', celery_worker: True }
     - edxapp
     - role: demo
       tags: ['demo']
     - { role: 'rabbitmq', rabbitmq_ip: '127.0.0.1' }
-    - { role: 'edxapp', celery_worker: True }
     - oraclejdk
     - elasticsearch
     - forum

--- a/playbooks/edx_sandbox.yml
+++ b/playbooks/edx_sandbox.yml
@@ -25,10 +25,10 @@
       - lms
     - edxlocal
     - mongo
+    - { role: 'edxapp', celery_worker: True }
     - edxapp
     - demo
     - { role: 'rabbitmq', rabbitmq_ip: '127.0.0.1' }
-    - { role: 'edxapp', celery_worker: True }
     - oraclejdk
     - elasticsearch
     - forum

--- a/playbooks/vagrant-fullstack.yml
+++ b/playbooks/vagrant-fullstack.yml
@@ -24,10 +24,10 @@
       - cms
     - edxlocal
     - mongo
+    - { role: 'edxapp', celery_worker: True }
     - edxapp
     - demo
     - { role: 'rabbitmq', rabbitmq_ip: '127.0.0.1' }
-    - { role: 'edxapp', celery_worker: True }
     - oraclejdk
     - elasticsearch
     - forum


### PR DESCRIPTION
Because the CMS uses the git hash of the edx-platform for the
static path it can be problematic if you update the edx-platform
repo for the worker AFTER you update the edx-platform repo
for edxapp.  This is because when running the edxapp role in worker mode
rake gather_assets is skipped.

This is a workaround but we may want to consider using separate
repos for worker and edxapp for situations where both are installed
on the same server.
