### PR TITLE
productionalization of forum role

### DIFF
--- a/playbooks/roles/forum/defaults/main.yml
+++ b/playbooks/roles/forum/defaults/main.yml
@@ -28,6 +28,7 @@ FORUM_ELASTICSEARCH_PORT: "9200"
 FORUM_ELASTICSEARCH_URL: "http://{{ FORUM_ELASTICSEARCH_HOST }}:{{ FORUM_ELASTICSEARCH_PORT }}"
 FORUM_NEW_RELIC_LICENSE_KEY: "new-relic-license-key"
 FORUM_NEW_RELIC_APP_NAME: "forum-newrelic-app"
+FORUM_WORKER_PROCESSES: "4"
 
 forum_environment:
   RBENV_ROOT: "{{ forum_rbenv_root }}"
@@ -41,12 +42,14 @@ forum_environment:
   MONGOHQ_URL: "{{ FORUM_MONGO_URL }}"
   HOME: "{{ forum_app_dir }}"
   NEW_RELIC_APP_NAME: "{{ FORUM_NEW_RELIC_APP_NAME }}"
-  NEW_RELIC_LICENSE_KEY: " {{ FORUM_NEW_RELIC_LICENSE_KEY }}"
+  NEW_RELIC_LICENSE_KEY: "{{ FORUM_NEW_RELIC_LICENSE_KEY }}"
+  WORKER_PROCESSES: "{{ FORUM_WORKER_PROCESSES }}"
+  DATA_DIR: "{{ forum_data_dir }}"
 
 forum_user: "forum"
 forum_ruby_version: "1.9.3-p448"
 forum_source_repo: "https://github.com/edx/cs_comments_service.git"
-forum_version: "HEAD"
+forum_version: "e0d/unicorn-config"
 forum_unicorn_port: "4567"
 
 #
@@ -59,5 +62,5 @@ forum_unicorn_port: "4567"
 # connectivity to Mongo is also tested, but separately.
 #
 forum_services:
-  - {service: "sinatra", host: "localhost", port: "{{ forum_unicorn_port }}"}
+#  - {service: "sinatra", host: "localhost", port: "{{ forum_unicorn_port }}"}
   - {service: "elasticsearch", host: "{{ FORUM_ELASTICSEARCH_HOST }}", port: "{{ FORUM_ELASTICSEARCH_PORT }}"}

--- a/playbooks/roles/forum/defaults/main.yml
+++ b/playbooks/roles/forum/defaults/main.yml
@@ -62,5 +62,5 @@ forum_unicorn_port: "4567"
 # connectivity to Mongo is also tested, but separately.
 #
 forum_services:
-#  - {service: "sinatra", host: "localhost", port: "{{ forum_unicorn_port }}"}
   - {service: "elasticsearch", host: "{{ FORUM_ELASTICSEARCH_HOST }}", port: "{{ FORUM_ELASTICSEARCH_PORT }}"}
+

--- a/playbooks/roles/forum/defaults/main.yml
+++ b/playbooks/roles/forum/defaults/main.yml
@@ -49,6 +49,14 @@ forum_environment:
 forum_user: "forum"
 forum_ruby_version: "1.9.3-p448"
 forum_source_repo: "https://github.com/edx/cs_comments_service.git"
+# Currently we are installing a branch of the comments service
+# that configures unicorn to listen on a unix socket and get the
+# worker count configuration from the environment.  We are not
+# merging to master of the comments service yet as this will have
+# some incompatibilities with our Heroku deployments.
+#
+# https://github.com/edx/cs_comments_service/pull/83
+#
 forum_version: "e0d/unicorn-config"
 forum_unicorn_port: "4567"
 

--- a/playbooks/roles/forum/tasks/main.yml
+++ b/playbooks/roles/forum/tasks/main.yml
@@ -38,7 +38,7 @@
   template: >
     src=forum_env.j2 dest={{ forum_app_dir }}/forum_env
     owner={{ forum_user }}  group={{ common_web_user }}
-    mode=0774
+    mode=0644
   notify:
     - restart the forum service
 

--- a/playbooks/roles/forum/tasks/main.yml
+++ b/playbooks/roles/forum/tasks/main.yml
@@ -38,9 +38,14 @@
   template: >
     src=forum_env.j2 dest={{ forum_app_dir }}/forum_env
     owner={{ forum_user }}  group={{ common_web_user }}
-    mode=0644
+    mode=0774
   notify:
     - restart the forum service
 
+- name: create {{ forum_data_dir }}
+  file: >
+    path={{ forum_data_dir }} state=directory
+    owner="{{ common_web_user }}" group="{{ common_web_group }}"
+    mode=0777
+    
 - include: deploy.yml tags=deploy
-

--- a/playbooks/roles/forum/tasks/test.yml
+++ b/playbooks/roles/forum/tasks/test.yml
@@ -9,7 +9,3 @@
   wait_for: port={{ FORUM_MONGO_PORT }} host={{ item }} timeout=30
   with_items: FORUM_MONGO_HOSTS
   when: not devstack
-
-- name: test for the existence of unix socket
-  wait_for: path={{ forum_data_dir }}/forum.sock state=present timeout=30
-  when: not devstack

--- a/playbooks/roles/forum/tasks/test.yml
+++ b/playbooks/roles/forum/tasks/test.yml
@@ -9,3 +9,7 @@
   wait_for: port={{ FORUM_MONGO_PORT }} host={{ item }} timeout=30
   with_items: FORUM_MONGO_HOSTS
   when: not devstack
+
+- name: test for the existence of unix socket
+  wait_for: path={{ forum_data_dir }}/forum.sock state=present timeout=30
+  when: not devstack

--- a/playbooks/roles/forum/templates/forum-supervisor.sh.j2
+++ b/playbooks/roles/forum/templates/forum-supervisor.sh.j2
@@ -1,4 +1,10 @@
 #!/bin/bash
+
 source {{ forum_app_dir }}/forum_env
 cd {{ forum_code_dir }}
+
+{% if devstack %}
 {{ forum_rbenv_shims }}/ruby app.rb
+{% else %}
+{{ forum_gem_bin }}/unicorn -c config/unicorn.rb
+{% endif %}

--- a/playbooks/roles/nginx/templates/forum.j2
+++ b/playbooks/roles/nginx/templates/forum.j2
@@ -1,13 +1,33 @@
+#
+# {{ ansible_managed }}
+#
+{# This prevents the injected comment from eating the server
+   directive.  There's probably a better way of doing this,
+   but I don't know it currently.
+#}
+{% raw %}
+
+{% endraw %}
+
 {%- if "forum" in nginx_default_sites -%}
   {%- set default_site = "default" -%}
 {%- else -%}
   {%- set default_site = "" -%}
 {%- endif -%}
 
-upstream forum_app_server {
+{% if devstack %}
+{# Connects to webbrick on port 4567 typically. Appropriate for development deployments #}
 
-    	 server localhost:{{ forum_unicorn_port }} fail_timeout=0;
+upstream forum_app_server {
+  server localhost:{{ forum_unicorn_port }} fail_timeout=0;
 }
+{% else %}
+{# Connects to unicorn over a unix socket.  Appropriate for production deployments #}
+
+upstream forum_app_server {
+  server unix:{{ forum_data_dir }}/forum.sock fail_timeout=0;
+}
+{% endif %}
 
 server {
 


### PR DESCRIPTION
The PR updates the forum nginx config and the forum role to support running unicorn properly and configuring nginx to talk to unicorn over a unix socket.

This can't be merged yet as it relies on a branch of the forums code the pulls in worker config and paths for the pidfile and sock file from environment variables.
