### PR TITLE
Jarv/migration config

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -134,6 +134,14 @@ EDXAPP_AUTOMATOR_AUTHORIZED_KEYS: []
 EDXAPP_USE_GIT_IDENTITY: false
 # Example: "{{ secure_dir }}/files/git-identity"
 EDXAPP_LOCAL_GIT_IDENTITY: !!null
+# Configuration for database migration
+
+EDXAPP_MIGRATE_ENGINE: django.db.backends.mysql
+EDXAPP_MIGRATE_NAME: "{{ EDXAPP_MYSQL_DB_NAME }}"
+EDXAPP_MIGRATE_USER: "{{ EDXAPP_MYSQL_USER }}"
+EDXAPP_MIGRATE_PASSWORD: "{{ EDXAPP_MYSQL_PASSWORD }}"
+EDXAPP_MIGRATE_HOST: "{{ EDXAPP_MYSQL_HOST }}"
+EDXAPP_MIGRATE_PORT: "{{ EDXAPP_MYSQL_PORT }}"
 
 #-------- Everything below this line is internal to the role ------------
 
@@ -158,8 +166,6 @@ edxapp_staticfile_dir: "{{ edxapp_data_dir }}/staticfiles"
 edxapp_course_data_dir: "{{ edxapp_data_dir }}/data"
 edxapp_upload_dir: "{{ edxapp_data_dir }}/uploads"
 edxapp_theme_dir: "{{ edxapp_data_dir }}/themes"
-edxapp_git_identity: "{{ edxapp_app_dir }}/{{ EDXAPP_LOCAL_GIT_IDENTITY|basename }}"
-edxapp_git_ssh: "/tmp/edxapp_git_ssh.sh"
 edxapp_pypi_local_mirror: "http://localhost:{{ devpi_port }}/root/pypi/+simple"
 edxapp_workers:
   - queue: low

--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -166,6 +166,8 @@ edxapp_staticfile_dir: "{{ edxapp_data_dir }}/staticfiles"
 edxapp_course_data_dir: "{{ edxapp_data_dir }}/data"
 edxapp_upload_dir: "{{ edxapp_data_dir }}/uploads"
 edxapp_theme_dir: "{{ edxapp_data_dir }}/themes"
+edxapp_git_identity: "{{ edxapp_app_dir }}/{{ EDXAPP_LOCAL_GIT_IDENTITY|basename }}"
+edxapp_git_ssh: "/tmp/edxapp_git_ssh.sh"
 edxapp_pypi_local_mirror: "http://localhost:{{ devpi_port }}/root/pypi/+simple"
 edxapp_workers:
   - queue: low

--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -134,14 +134,9 @@ EDXAPP_AUTOMATOR_AUTHORIZED_KEYS: []
 EDXAPP_USE_GIT_IDENTITY: false
 # Example: "{{ secure_dir }}/files/git-identity"
 EDXAPP_LOCAL_GIT_IDENTITY: !!null
-# Configuration for database migration
 
-EDXAPP_MIGRATE_ENGINE: django.db.backends.mysql
-EDXAPP_MIGRATE_NAME: "{{ EDXAPP_MYSQL_DB_NAME }}"
-EDXAPP_MIGRATE_USER: "{{ EDXAPP_MYSQL_USER }}"
-EDXAPP_MIGRATE_PASSWORD: "{{ EDXAPP_MYSQL_PASSWORD }}"
-EDXAPP_MIGRATE_HOST: "{{ EDXAPP_MYSQL_HOST }}"
-EDXAPP_MIGRATE_PORT: "{{ EDXAPP_MYSQL_PORT }}"
+# Configuration for database migration
+EDXAPP_TEST_MIGRATE_DB_NAME: "{{ COMMON_ENVIRONMENT }}_{{ COMMON_DEPLOYMENT }}_test_{{ EDXAPP_MYSQL_DB_NAME }}"
 
 #-------- Everything below this line is internal to the role ------------
 

--- a/playbooks/roles/edxapp/tasks/service_variant_config.yml
+++ b/playbooks/roles/edxapp/tasks/service_variant_config.yml
@@ -56,7 +56,7 @@
   - "restart edxapp_workers"
 
 - name: db migrate
-  shell:
+  shell: >
     chdir={{ edxapp_code_dir }}
     {{ edxapp_venv_bin}}/python manage.py lms migrate --noinput --settings=aws_migrate
   when: migrate_only is defined and migrate_only|lower == "yes"

--- a/playbooks/roles/edxapp/tasks/service_variant_config.yml
+++ b/playbooks/roles/edxapp/tasks/service_variant_config.yml
@@ -44,23 +44,59 @@
   when: celery_worker is defined and not devstack
   sudo_user: "{{ supervisor_user }}"
 
+# Fake migrations, only when fake_migrations is defined
+# This overrides the database name to be the test database which
+# the default application user has full write access to
 - name: syncdb and migrate
   shell: >
     chdir={{ edxapp_code_dir }}
     {{ edxapp_venv_bin}}/python manage.py lms syncdb --migrate --noinput --settings=aws_migrate
-  when: migrate_db is defined and migrate_db|lower == "yes"
+  when: fake_migrations is defined and migrate_db is defined and migrate_db|lower == "yes"
   sudo_user: "{{ edxapp_user }}"
-  environment: "{{ edxapp_migrate_environment }}"
+  environment:
+    DB_MIGRATION_NAME: "{{ EDXAPP_TEST_MIGRATE_DB_NAME }}"
   notify:
   - "restart edxapp"
   - "restart edxapp_workers"
 
+# Regular migrations
+- name: syncdb and migrate
+  shell: >
+    chdir={{ edxapp_code_dir }}
+    {{ edxapp_venv_bin}}/python manage.py lms syncdb --migrate --noinput --settings=aws_migrate
+  when: fake_migrations is not defined and migrate_db is defined and migrate_db|lower == "yes"
+  sudo_user: "{{ edxapp_user }}"
+  notify:
+  - "restart edxapp"
+  - "restart edxapp_workers"
+
+# Fake migrations, only when fake_migrations is defined
+# This overrides the database name to be the test database which
+# the default application user has full write access to
+- name: syncdb and migrate
+  shell: >
+    chdir={{ edxapp_code_dir }}
+    {{ edxapp_venv_bin}}/python manage.py lms syncdb --migrate --noinput --settings=aws_migrate
+  when: fake_migrations is defined and migrate_db is defined and migrate_db|lower == "yes"
+  sudo_user: "{{ edxapp_user }}"
+  environment:
+    DB_MIGRATION_NAME: "{{ EDXAPP_TEST_MIGRATE_DB_NAME }}"
+  notify:
+  - "restart edxapp"
+  - "restart edxapp_workers"
+
+
+# Regular migrations
 - name: db migrate
   shell: >
     chdir={{ edxapp_code_dir }}
     {{ edxapp_venv_bin}}/python manage.py lms migrate --noinput --settings=aws_migrate
-  when: migrate_only is defined and migrate_only|lower == "yes"
+  when: fake_migrations is not defined and migrate_only is defined and migrate_only|lower == "yes"
   sudo_user: "{{ edxapp_user }}"
+  notify:
+  - "restart edxapp"
+  - "restart edxapp_workers"
+
 
 # Gather assets using rake if possible
 

--- a/playbooks/roles/edxapp/tasks/service_variant_config.yml
+++ b/playbooks/roles/edxapp/tasks/service_variant_config.yml
@@ -60,9 +60,6 @@
     chdir={{ edxapp_code_dir }}
     {{ edxapp_venv_bin}}/python manage.py lms migrate --noinput --settings=aws_migrate
   when: migrate_only is defined and migrate_only|lower == "yes"
-  notify:
-  - "restart edxapp"
-  - "restart edxapp_workers"
   sudo_user: "{{ edxapp_user }}"
 
 # Gather assets using rake if possible

--- a/playbooks/roles/edxapp/tasks/service_variant_config.yml
+++ b/playbooks/roles/edxapp/tasks/service_variant_config.yml
@@ -44,7 +44,7 @@
   when: celery_worker is defined and not devstack
   sudo_user: "{{ supervisor_user }}"
 
-# Fake migrations, only when fake_migrations is defined
+# Fake syncdb with migrate, only when fake_migrations is defined
 # This overrides the database name to be the test database which
 # the default application user has full write access to
 - name: syncdb and migrate
@@ -59,7 +59,7 @@
   - "restart edxapp"
   - "restart edxapp_workers"
 
-# Regular migrations
+# Regular syncdb with migrate
 - name: syncdb and migrate
   shell: >
     chdir={{ edxapp_code_dir }}
@@ -70,20 +70,19 @@
   - "restart edxapp"
   - "restart edxapp_workers"
 
-# Fake migrations, only when fake_migrations is defined
+# Fake migrate, only when fake_migrations is defined
 # This overrides the database name to be the test database which
 # the default application user has full write access to
-- name: syncdb and migrate
+- name: db migrate
   shell: >
     chdir={{ edxapp_code_dir }}
-    {{ edxapp_venv_bin}}/python manage.py lms syncdb --migrate --noinput --settings=aws_migrate
-  when: fake_migrations is defined and migrate_db is defined and migrate_db|lower == "yes"
+    {{ edxapp_venv_bin}}/python manage.py lms migrate --noinput --settings=aws_migrate
+  when: fake_migrations is defined and migrate_only is defined and migrate_only|lower == "yes"
   sudo_user: "{{ edxapp_user }}"
-  environment:
-    DB_MIGRATION_NAME: "{{ EDXAPP_TEST_MIGRATE_DB_NAME }}"
   notify:
   - "restart edxapp"
   - "restart edxapp_workers"
+
 
 
 # Regular migrations

--- a/playbooks/roles/edxapp/tasks/service_variant_config.yml
+++ b/playbooks/roles/edxapp/tasks/service_variant_config.yml
@@ -79,6 +79,8 @@
     {{ edxapp_venv_bin}}/python manage.py lms migrate --noinput --settings=aws_migrate
   when: fake_migrations is defined and migrate_only is defined and migrate_only|lower == "yes"
   sudo_user: "{{ edxapp_user }}"
+  environment:
+    DB_MIGRATION_NAME: "{{ EDXAPP_TEST_MIGRATE_DB_NAME }}"
   notify:
   - "restart edxapp"
   - "restart edxapp_workers"

--- a/playbooks/roles/edxapp/tasks/service_variant_config.yml
+++ b/playbooks/roles/edxapp/tasks/service_variant_config.yml
@@ -45,15 +45,20 @@
   sudo_user: "{{ supervisor_user }}"
 
 - name: syncdb and migrate
-  shell: SERVICE_VARIANT=lms {{ edxapp_venv_bin}}/django-admin.py syncdb --migrate --noinput --settings=lms.envs.aws --pythonpath={{ edxapp_code_dir }}
+  shell: >
+    chdir={{ edxapp_code_dir }}
+    {{ edxapp_venv_bin}}/python manage.py lms syncdb --migrate --noinput --settings=aws_migrate
   when: migrate_db is defined and migrate_db|lower == "yes"
   sudo_user: "{{ edxapp_user }}"
+  environment: "{{ edxapp_migrate_environment }}"
   notify:
   - "restart edxapp"
   - "restart edxapp_workers"
 
 - name: db migrate
-  shell: SERVICE_VARIANT=lms {{ edxapp_venv_bin }}/django-admin.py migrate --noinput --settings=lms.envs.aws --pythonpath={{ edxapp_code_dir }}
+  shell:
+    chdir={{ edxapp_code_dir }}
+    {{ edxapp_venv_bin}}/python manage.py lms migrate --noinput --settings=aws_migrate
   when: migrate_only is defined and migrate_only|lower == "yes"
   notify:
   - "restart edxapp"
@@ -74,5 +79,4 @@
   - "restart edxapp"
   - "restart edxapp_workers"
   environment: "{{ edxapp_environment }}"
-
 

--- a/util/vpc-tools/abbey.py
+++ b/util/vpc-tools/abbey.py
@@ -336,6 +336,11 @@ secure_vars: $secure_vars_file
 # to true in the extra vars for this
 # variable to be used.
 EDXAPP_LOCAL_GIT_IDENTITY: $secure_identity
+
+# abbey will always run fake migrations
+# this is so that the application can come
+# up healthy
+fake_migrations: true
 EOF
 
 chmod 400 $secure_identity


### PR DESCRIPTION
This will have no impact on existing deployments since the defaults for the new migration vars are the default mysql db settings.  
This also changes the migrate commands so that they use manage.py instead of django-admin.py
