### PR TITLE
Turn off hash merge, add gh_user_no_sudo

### DIFF
--- a/playbooks/edx-west/prod-jumpbox.yml
+++ b/playbooks/edx-west/prod-jumpbox.yml
@@ -17,7 +17,10 @@
         - ali123
         - caesar2164
         - dcadams
+        - nparlante
+      gh_users_no_sudo:
         - jinpa
         - gbruhns
-        - nparlante
+        - paepcke
+        - akshayak
       tags: users

--- a/playbooks/edx-west/stage-ansible.cfg
+++ b/playbooks/edx-west/stage-ansible.cfg
@@ -3,7 +3,6 @@
 [defaults]
 # Always have these for using the configuration repo
 jinja2_extensions=jinja2.ext.do
-hash_behaviour=merge
 
 # These are environment-specific defaults
 forks=10

--- a/playbooks/roles/gh_users/defaults/main.yml
+++ b/playbooks/roles/gh_users/defaults/main.yml
@@ -3,3 +3,4 @@
 # update the system bashrc default
 GH_USERS_PROMPT: ""
 gh_users: []
+gh_users_no_sudo: []

--- a/playbooks/roles/gh_users/tasks/main.yml
+++ b/playbooks/roles/gh_users/tasks/main.yml
@@ -10,6 +10,8 @@
 #     gh_users:
 #      - joe
 #      - mark
+#     gh_users_no_sudo:
+#      - tourist_dave
 
 
 - name: gh_users | creating default .bashrc
@@ -27,22 +29,28 @@
     dest=/etc/sudoers.d/gh owner=root group=root
     mode=0440 validate='visudo -cf %s'
 
-- name: gh_users | create github users
+- name: gh_users | create sudo github users
   user:
     name={{ item }} groups=gh
     shell=/bin/bash
   with_items: gh_users
 
+- name: gh_users | create non-sudo github users
+  user:
+    name={{ item }}
+    shell=/bin/bash
+  with_items: gh_users_no_sudo
+
 - name: gh_users | create .ssh directory
   file:
     path=/home/{{ item }}/.ssh state=directory mode=0700
     owner={{ item }}
-  with_items: gh_users
+  with_items: gh_users + gh_users_no_sudo
 
 - name: gh_users | copy github key[s] to .ssh/authorized_keys
   get_url:
     url=https://github.com/{{ item }}.keys
     dest=/home/{{ item }}/.ssh/authorized_keys mode=0600
     owner={{ item }}
-  with_items: gh_users
+  with_items: gh_users + gh_users_no_sudo
 


### PR DESCRIPTION
add users without sudo (gh_user_no_sudo)

It's handy to be able to create users that _don't_ have sudo rights. Here at Stanford we use this to add users to our VPC bastion box (ssh proxy) so these users can use this machine for ssh tunneling, but I don't want to give those users the keys to the kingdom.

This let's me configure a playbook like this.

```
   roles:
     - common
     - supervisor
     - role: gh_users
       gh_users:
         - su1
         - su2
         - su3
       gh_users_no_sudo:
         - normal1
         - normal2
```

The new gh_users_no_sudo list can be empty.

@jbau or @jrbl.  
