### PR TITLE
Changes to update dhclient search domain.

### DIFF
--- a/playbooks/roles/common/defaults/main.yml
+++ b/playbooks/roles/common/defaults/main.yml
@@ -21,6 +21,11 @@ COMMON_GIT_MIRROR: 'github.com'
 # override this var to set a different hostname
 COMMON_HOSTNAME: !!null
 
+# Set to true to customize DNS search domains
+COMMON_CUSTOM_DHCLIENT_CONFIG: false
+# uncomment and specifity your domains.
+# COMMON_DHCLIENT_DNS_SEARCH: ["ec2.internal","example.com"]
+  
 common_debian_pkgs:
   - ntp
   - ack-grep

--- a/playbooks/roles/common/tasks/main.yml
+++ b/playbooks/roles/common/tasks/main.yml
@@ -70,3 +70,7 @@
   shell: >
     hostname -F /etc/hostname
   when: COMMON_HOSTNAME and (etc_hosts.changed or etc_hostname.changed)
+
+- name: update /etc/dhcp/dhclient.conf
+  template: src=etc/dhcp/dhclient.conf.j2 dest=/etc/dhcp/dhclient.conf
+  when: COMMON_CUSTOM_DHCLIENT_CONFIG

--- a/playbooks/roles/common/templates/etc/dhcp/dhclient.conf.j2
+++ b/playbooks/roles/common/templates/etc/dhcp/dhclient.conf.j2
@@ -1,0 +1,62 @@
+# {{ ansible_managed }}
+
+# Configuration file for /sbin/dhclient, which is included in Debian's
+#	dhcp3-client package.
+#
+# This is a sample configuration file for dhclient. See dhclient.conf's
+#	man page for more information about the syntax of this file
+#	and a more comprehensive list of the parameters understood by
+#	dhclient.
+#
+# Normally, if the DHCP server provides reasonable information and does
+#	not leave anything out (like the domain name, for example), then
+#	few changes must be made to this file, if any.
+#
+
+option rfc3442-classless-static-routes code 121 = array of unsigned integer 8;
+
+send host-name "<hostname>";
+#send dhcp-client-identifier 1:0:a0:24:ab:fb:9c;
+#send dhcp-lease-time 3600;
+#supersede domain-name "fugue.com home.vix.com";
+#prepend domain-name-servers 127.0.0.1;
+request subnet-mask, broadcast-address, time-offset, routers,
+	domain-name, domain-name-servers, domain-search, host-name,
+	netbios-name-servers, netbios-scope, interface-mtu,
+	rfc3442-classless-static-routes, ntp-servers,
+	dhcp6.domain-search, dhcp6.fqdn,
+	dhcp6.name-servers, dhcp6.sntp-servers;
+#require subnet-mask, domain-name-servers;
+#timeout 60;
+#retry 60;
+#reboot 10;
+#select-timeout 5;
+#initial-interval 2;
+#script "/etc/dhcp3/dhclient-script";
+#media "-link0 -link1 -link2", "link0 link1";
+#reject 192.33.137.209;
+
+#alias {
+#  interface "eth0";
+#  fixed-address 192.5.5.213;
+#  option subnet-mask 255.255.255.255;
+#}
+
+#lease {
+#  interface "eth0";
+#  fixed-address 192.33.137.200;
+#  medium "link0 link1";
+#  option host-name "andare.swiftmedia.com";
+#  option subnet-mask 255.255.255.0;
+#  option broadcast-address 192.33.137.255;
+#  option routers 192.33.137.250;
+#  option domain-name-servers 127.0.0.1;
+#  renew 2 2000/1/12 00:00:01;
+#  rebind 2 2000/1/12 00:00:01;
+#  expire 2 2000/1/12 00:00:01;
+#}
+
+interface "eth0" {
+    prepend domain-search {%- for search in COMMON_DHCLIENT_DNS_SEARCH -%}"{{search}}"{%- if not loop.last -%},{%- endif -%}
+{%- endfor -%};
+}


### PR DESCRIPTION
Allows updating domain-search in /etc/dhcp/dhclient.conf.

Generally useful for AWS internal domain resolution.  Best solution for rabbitmq clustering.
