### PR TITLE
default to old change screen

### DIFF
--- a/playbooks/roles/gerrit/templates/gerrit.config.j2
+++ b/playbooks/roles/gerrit/templates/gerrit.config.j2
@@ -3,7 +3,6 @@
 [gerrit]
     basePath = {{ gerrit_data_dir }}
     canonicalWebUrl = http://{{ gerrit_hostname }}/
-    changeScreen = CHANGE_SCREEN2
 [database]
     type = MYSQL
     hostname = {{ gerrit_db_hostname }}


### PR DESCRIPTION
The new one lacks many very useful features and is still in beta, we should
be using the old one pretty much exclusively.

Note that users can override this setting in their own preferences if they
really want to use the new change screen.

Reviewers: @gwprice, @e0d
