### PR TITLE
Change boxname on fullstack, and remove ansible play from devstack

### DIFF
--- a/vagrant/release/devstack/Vagrantfile
+++ b/vagrant/release/devstack/Vagrantfile
@@ -16,7 +16,7 @@ cd /edx/app/edx_ansible/edx_ansible/playbooks
 # this can cause problems (e.g. looking for templates that no longer exist).
 /edx/bin/update configuration master
 
-ansible-playbook -i localhost, -c local vagrant-devstack.yml
+ansible-playbook -i localhost, -c local vagrant-devstack.yml --tags=deploy
 SCRIPT
 
 edx_platform_mount_dir = "edx-platform"
@@ -57,6 +57,6 @@ Vagrant.configure("2") do |config|
 
   # Assume that the base box has the edx_ansible role installed
   # We can then tell the Vagrant instance to update itself.
-  # config.vm.provision "shell", inline: $script
+  config.vm.provision "shell", inline: $script
 
 end

--- a/vagrant/release/devstack/Vagrantfile
+++ b/vagrant/release/devstack/Vagrantfile
@@ -57,6 +57,6 @@ Vagrant.configure("2") do |config|
 
   # Assume that the base box has the edx_ansible role installed
   # We can then tell the Vagrant instance to update itself.
-  config.vm.provision "shell", inline: $script
+  # config.vm.provision "shell", inline: $script
 
 end

--- a/vagrant/release/fullstack/Vagrantfile
+++ b/vagrant/release/fullstack/Vagrantfile
@@ -4,7 +4,7 @@ CPU_COUNT = 2
 Vagrant.configure("2") do |config|
 
   # Creates an edX fullstack VM from an official release
-  config.vm.box     = "facaccia"
+  config.vm.box     = "gugelhupf"
   config.vm.box_url = "http://files.edx.org/vagrant-images/20140210-gugelhupf-fullstack.box"
 
   config.vm.network :private_network, ip: "192.168.33.10"


### PR DESCRIPTION
I wasn't sure on the devstack "fix", but don't know why you would need to run ansible again on a prebuilt box. The fullstack box isn't downloading a new box if you already have the previous release installed, so I changed the name.
