### PR TITLE
Download JSCover from S3

### DIFF
--- a/playbooks/roles/jenkins_worker/defaults/main.yml
+++ b/playbooks/roles/jenkins_worker/defaults/main.yml
@@ -24,7 +24,7 @@ jenkins_rbenv_root: "{{ jenkins_home }}/.rbenv"
 jenkins_ruby_version: "1.9.3-p374"
 
 # JSCover direct download URL
-jscover_url: "http://superb-dca2.dl.sourceforge.net/project/jscover/JSCover-1.0.2.zip"
+jscover_url: "http://files.edx.org/testeng/JSCover-1.0.2.zip"
 jscover_version: "1.0.2"
 
 # Python


### PR DESCRIPTION
Use an S3 URL for JSCover instead of downloading from a SourceForge mirror.  This should be more reliable, as SourceForge download URLs can change.

@feanil 
