### PR TITLE
Remove vagrant version requirement

### DIFF
--- a/vagrant/base/devstack/Vagrantfile
+++ b/vagrant/base/devstack/Vagrantfile
@@ -1,5 +1,4 @@
 VAGRANTFILE_API_VERSION = "2"
-Vagrant.require_version ">= 1.4"
 
 MEMORY = 2048
 CPU_COUNT = 2

--- a/vagrant/base/fullstack/Vagrantfile
+++ b/vagrant/base/fullstack/Vagrantfile
@@ -1,5 +1,4 @@
 VAGRANTFILE_API_VERSION = "2"
-Vagrant.require_version ">= 1.4"
 
 MEMORY = 2048
 CPU_COUNT = 2

--- a/vagrant/release/devstack/Vagrantfile
+++ b/vagrant/release/devstack/Vagrantfile
@@ -1,5 +1,4 @@
 VAGRANTFILE_API_VERSION = "2"
-Vagrant.require_version ">= 1.4"
 
 MEMORY = 2048
 CPU_COUNT = 2
@@ -49,7 +48,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   if ENV['VAGRANT_X11']
       config.ssh.forward_x11 = true
   end
-  
+
   config.vm.synced_folder "#{edx_platform_mount_dir}", "/edx/app/edxapp/edx-platform", :create => true, nfs: true
   config.vm.synced_folder "#{forum_mount_dir}", "/edx/app/forum/cs_comments_service", :create => true, nfs: true
   config.vm.synced_folder "#{ora_mount_dir}", "/edx/app/ora/ora", :create => true, nfs: true

--- a/vagrant/release/fullstack/Vagrantfile
+++ b/vagrant/release/fullstack/Vagrantfile
@@ -1,5 +1,4 @@
 VAGRANTFILE_API_VERSION = "2"
-Vagrant.require_version ">= 1.4"
 
 MEMORY = 2048
 CPU_COUNT = 2


### PR DESCRIPTION
**Description**

Many people have complained that the 1.4 version of Vagrant is not necessary. We can use a lower version of Vagrant. However, the `Vagrant.require_version` is only available starting with Vagrant 1.4. So, for now this requirement should be removed.

**Reviewers**
- @hkim823 
