### PR TITLE
edx-west: use local temp dir for sockets and ansible cache

### DIFF
--- a/playbooks/edx-west/ansible.cfg
+++ b/playbooks/edx-west/ansible.cfg
@@ -1,1 +1,0 @@
-../ansible.cfg

--- a/playbooks/edx-west/ec2_cache/.gitignore
+++ b/playbooks/edx-west/ec2_cache/.gitignore
@@ -1,0 +1,6 @@
+*
+
+!prod
+!stage
+!data
+!.gitignore

--- a/playbooks/edx-west/ec2_cache/README
+++ b/playbooks/edx-west/ec2_cache/README
@@ -1,0 +1,3 @@
+This temp directory created here so that we can make sure it doesn't
+collide with other users doing ansible operations on the same machine;
+or concurrent installs to different environments, say to prod and stage.

--- a/playbooks/edx-west/ec2_cache/data/.gitignore
+++ b/playbooks/edx-west/ec2_cache/data/.gitignore
@@ -1,0 +1,3 @@
+*
+
+!.gitignore

--- a/playbooks/edx-west/ec2_cache/prod/.gitignore
+++ b/playbooks/edx-west/ec2_cache/prod/.gitignore
@@ -1,0 +1,3 @@
+*
+
+!.gitignore

--- a/playbooks/edx-west/ec2_cache/stage/.gitignore
+++ b/playbooks/edx-west/ec2_cache/stage/.gitignore
@@ -1,0 +1,3 @@
+*
+
+!.gitignore

--- a/playbooks/edx-west/prod-ansible.cfg
+++ b/playbooks/edx-west/prod-ansible.cfg
@@ -1,0 +1,22 @@
+# config file for ansible -- http://ansible.github.com
+# nearly all parameters can be overridden in ansible-playbook or with command line flags
+# ansible will read ~/.ansible.cfg or /etc/ansible/ansible.cfg, whichever it finds first
+
+[defaults]
+
+jinja2_extensions=jinja2.ext.do
+hash_behaviour=merge
+host_key_checking = False
+
+# These are environment-specific defaults
+forks=10
+transport=ssh
+hostfile=./ec2.py
+extra_vars='key=deployment region=us-west-1'
+user=ubuntu
+
+
+[ssh_connection]
+# example from https://github.com/ansible/ansible/blob/devel/examples/ansible.cfg
+ssh_args= -o ControlMaster=auto -o ControlPersist=60s -o ControlPath=/tmp/ansible-ssh-%h-%p-%r
+scp_if_ssh=True

--- a/playbooks/edx-west/prod-ec2.ini
+++ b/playbooks/edx-west/prod-ec2.ini
@@ -1,0 +1,8 @@
+[ec2]
+regions=us-west-1
+regions_exclude = us-gov-west-1
+destination_variable=public_dns_name
+vpc_destination_variable=private_dns_name
+cache_path=ec2_cache/prod
+cache_max_age=300
+route53=False

--- a/playbooks/edx-west/stage-ec2.ini
+++ b/playbooks/edx-west/stage-ec2.ini
@@ -3,6 +3,6 @@ regions=us-west-1
 regions_exclude = us-gov-west-1
 destination_variable=public_dns_name
 vpc_destination_variable=private_dns_name
-cache_path=/tmp
+cache_path=ec2_cache/stage
 cache_max_age=300
 route53=False


### PR DESCRIPTION
@feanil -- this is a change that we've been running with for the last few weeks on edx-west/release.  It was pulled into our config branch in #806.  This just gets the same change onto master, anticipating that we'll be picking up master at some point soon.

Given that we're doing this already and only affects our plays should be a quick one.  Thanks for reviewing.  Original commit msg below.

---

I was having problems where concurrent installs could trample on each
other.  The instance that immediately affected me was output caching
from ec2.py: the output of that command is different between staging and
prod, and both were being written to /tmp/ansible_ec2.cache and .index.

Fix here is to write to a local temp directory.  This creates empty temp
dirs to ensure that they are created in all repos.

While less likely, you could have collisions on named ssh sockets.
Those are named with just the instance name, which could be re-used
across VPC's.  Putting those in the ./tmp dir too prevents that.

Note that for consistency I did away with just the plain ec2.ini file,
and instead now there are prod- and stage- variants.  This is clean but
now means that you'll need to change your install command to look
something like this:

```
ANSIBLE_EC2_INI=prod-ec2.ini ANSIBLE_CONFIG=prod-ansible.cfg ansible-playbook -c ssh -u ubuntu -i ./ec2.py prod-app.yml
```

Conflicts:

```
playbooks/edx-west/ansible.cfg
```
