### PR TITLE
parameterize machine names in edx-west playbooks -- to edx-west/release

### DIFF
--- a/playbooks/edx-west/README.md
+++ b/playbooks/edx-west/README.md
@@ -31,13 +31,19 @@ sure that the stanford-deploy-20130415 ssh key is in your ssh agent.
 
 Some specifics:
 
-* To hit multiple machines the -e parameter would look like this: ```"machine=app(1|2|4)"```.
+* To do database migrations, include this: ```-e "migrate_db=yes"```.  The default
+  behavior is to not do migrations.
+
+* To hit multiple machines the use this: ```-e "machine=app(1|2|4)"```.
+  Use multiple separate "-e" options to specify multiple vars on the
+  command line.
 
 * Usually I do with the ```--list-hosts``` option first to verify that I'm
   doing something sane before actually running.
 
-* To do the utility machines, use ```prod-worker.yml```.  Those also
-  take the machine variable.
+* To install the utility machines, substitute ```prod-worker.yml```.  Those
+  are also parameterized on the take the machine variable (util1, util(1|2),
+  and so forth).
 
 
 ## Ansible Commands - Stage

--- a/playbooks/edx-west/README.md
+++ b/playbooks/edx-west/README.md
@@ -1,0 +1,49 @@
+# Stanford Ansible Configuration Files
+
+This directory has the live playbooks that we use here at Stanford to
+maintain our instance of OpenEdX at [class.stanford.edu][c].  We check
+it in to this public repo since we think that others might benefit from
+seeing how we are configured.
+
+  [c]: https://class.stanford.edu/
+
+That said, we haven't documented things in here well, so we have no
+expectation that others will be able to make enough sense of this to
+give us useful contributions back.  Generally a PR affecting files in
+here will be ignored / rejected.
+
+This README is a useful proximate place to keep commands.  But it is 
+a public repo so we shouldn't store anything confidential in here.
+
+Other install docs:
+
+- Giulio's install doc [here][1].
+
+  [1]: https://docs.google.com/document/d/1ZDx51Jxa-zffyeKvHmTp_tIskLW9D9NRg9NytPTbnrA/edit#heading=h.iggugvghbcpf
+
+
+## Ansible Commands - Prod
+
+Generally we do installs as the "ubuntu" user.  You want to make
+sure that the stanford-deploy-20130415 ssh key is in your ssh agent.
+
+    ANSIBLE_CONFIG=prod-ansible.cfg ANSIBLE_EC2_INI=prod-ec2.ini ansible-playbook prod-app.yml -e "machine=app4" -u ubuntu -c ssh -i ./ec2.py
+
+Some specifics:
+
+* To hit multiple machines the -e parameter would look like this: ```"machine=app(1|2|4)"```.
+
+* Usually I do with the ```--list-hosts``` option first to verify that I'm
+  doing something sane before actually running.
+
+* To do the utility machines, use ```prod-worker.yml```.  Those also
+  take the machine variable.
+
+
+## Ansible Commands - Stage
+
+Command is:
+
+    ANSIBLE_CONFIG=stage-ansible.cfg ANSIBLE_EC2_INI=stage-ec2.ini ansible-playbook stage-app.yml -e "machine=app1" -u ubuntu -c ssh -i ./ec2.py
+
+

--- a/playbooks/edx-west/carnegie-prod-app.yml
+++ b/playbooks/edx-west/carnegie-prod-app.yml
@@ -1,13 +1,10 @@
-#- hosts: ~tag_Name_app(1|2)_carn
-- hosts: ~tag_Name_app1_carn
-#- hosts: ~tag_Name_app2_carn
-#- hosts: ~tag_Name_app1_carn_test
+# This uses variable expansion so you can select machine(s) from the command line
+# using the -e flag.  See README for instructions on how to use.
+- hosts: ~tag_Name_{{machine}}_carn
+  pre_tasks:
+  - fail: msg="This playbook only runnable on 'app' machines"
+    when: "'app' not in machine"
   sudo: True
-  vars_prompt:
-    - name: "migrate_db"
-      prompt: "Should this playbook run database migrations? (Type 'yes' to run, anything else to skip migrations)"
-      default: "no"
-      private: no
   vars:
     secure_dir: '../../../configuration-secure/ansible'
     # this indicates the path to site-specific (with precedence)

--- a/playbooks/edx-west/carnegie-prod-worker.yml
+++ b/playbooks/edx-west/carnegie-prod-worker.yml
@@ -1,11 +1,12 @@
 - name: Basic util setup on carnegie workers
-# this gets all running prod webservers
-# hosts: tag_environment_prod_carn:&tag_function_util
-# or we can get subsets of them by name
-# hosts: ~tag_Name_util(10)_carn
-  hosts: ~tag_Name_util(1)_carn
-  gather_facts: True
+  # This uses variable expansion so you can select machine(s) from the command line
+  # using the -e flag.  See README for instructions on how to use.
+  hosts: ~tag_Name_{{machine}}_carn
+  pre_tasks:
+  - fail: msg="This playbook only runnable on 'util' machines"
+    when: "'util' not in machine"
   sudo: True
+  gather_facts: True
   vars:
     secure_dir: '../../../edx-secret/ansible'
     # this indicates the path to site-specific (with precedence)

--- a/playbooks/edx-west/cme-prod-app.yml
+++ b/playbooks/edx-west/cme-prod-app.yml
@@ -9,20 +9,13 @@
 #      - apt: pkg=libzmq-dev,python-zmq state=present
 #      - action: fireball
 
-
-# this gets all running prod webservers
-#- hosts: tag_environment_prod:&tag_function_webserver
-# or we can get subsets of them by name
-#- hosts: ~tag_Name_app(1|2)_cme
-- hosts: ~tag_Name_app1_cme
-#- hosts: ~tag_Name_app2_cme
-#- hosts: ~tag_Name_app(1|2)_cme
+# This uses variable expansion so you can select machine(s) from the command line
+# using the -e flag.  See README for instructions on how to use.
+- hosts: ~tag_Name_{{machine}}_cme
+  pre_tasks:
+  - fail: msg="This playbook only runnable on 'app' machines"
+    when: "'app' not in machine"
   sudo: True
-  vars_prompt:
-    - name: "migrate_db"
-      prompt: "Should this playbook run database migrations? (Type 'yes' to run, anything else to skip migrations)"
-      default: "no"
-      private: no
   vars:
     secure_dir: '../../../edx-secret/ansible'
     # this indicates the path to site-specific (with precedence)

--- a/playbooks/edx-west/cme-prod-worker.yml
+++ b/playbooks/edx-west/cme-prod-worker.yml
@@ -1,8 +1,10 @@
 - name: Basic util setup on cme hosts
-# this gets all running prod webservers
-# hosts: tag_environment_prod_cme:&tag_function_util
-# or we can get subsets of them by name
-  hosts: ~tag_Name_util(1)_cme
+  # This uses variable expansion so you can select machine(s) from the command line
+  # using the -e flag.  See README for instructions on how to use.
+  hosts: ~tag_Name_{{machine}}_cme
+  pre_tasks:
+  - fail: msg="This playbook only runnable on 'util' machines"
+    when: "'util' not in machine"
   sudo: True
   gather_facts: True
   vars:

--- a/playbooks/edx-west/prod-app.yml
+++ b/playbooks/edx-west/prod-app.yml
@@ -1,13 +1,9 @@
-# this gets all running prod webservers
+# This uses variable expansion so you can select machine(s) from the command line
+# using the -e flag.  See README for instructions on how to use.
+- hosts: ~tag_Name_{{machine}}_prod
+#
+# This alternative hits all running prod webservers.  Left here as an example.
 #- hosts: tag_environment_prod:&tag_function_webserver
-# or we can get subsets of them by name
-#- hosts: ~tag_Name_app1_prod
-#- hosts: ~tag_Name_app2_prod
-## this is the test box
-- hosts: ~tag_Name_app4_prod
-#- hosts: ~tag_Name_app(4|1|2)_prod
-## you can also do security group, but don't do that
-#- hosts: security_group_edx-prod-EdxappServerSecurityGroup-NSKCQTMZIPQB
   sudo: True
   vars_prompt:
     - name: "migrate_db"

--- a/playbooks/edx-west/prod-app.yml
+++ b/playbooks/edx-west/prod-app.yml
@@ -1,15 +1,10 @@
 # This uses variable expansion so you can select machine(s) from the command line
 # using the -e flag.  See README for instructions on how to use.
 - hosts: ~tag_Name_{{machine}}_prod
-#
-# This alternative hits all running prod webservers.  Left here as an example.
-#- hosts: tag_environment_prod:&tag_function_webserver
+  pre_tasks:
+  - fail: msg="This playbook only runnable on 'app' machines"
+    when: "'app' not in machine"
   sudo: True
-  vars_prompt:
-    - name: "migrate_db"
-      prompt: "Should this playbook run database migrations? (Type 'yes' to run, anything else to skip migrations)"
-      default: "no"
-      private: no
   vars:
     secure_dir: '../../../configuration-secure/ansible'
     # this indicates the path to site-specific (with precedence)

--- a/playbooks/edx-west/prod-worker.yml
+++ b/playbooks/edx-west/prod-worker.yml
@@ -1,10 +1,10 @@
 - name: Basic util setup on all hosts
-# This uses variable expansion so you can select machine(s) from the command line
-# using the -e flag.  See README for instructions on how to use.
+  # This uses variable expansion so you can select machine(s) from the command line
+  # using the -e flag.  See README for instructions on how to use.
   hosts: ~tag_Name_{{machine}}_prod
-#
-# This alternative hits all running prod webservers.  Left here as an example.
-#  hosts: tag_environment_prod:&tag_function_util
+  pre_tasks:
+  - fail: msg="This playbook only runnable on 'util' machines"
+    when: "'util' not in machine"
   sudo: True
   gather_facts: True
   vars:

--- a/playbooks/edx-west/prod-worker.yml
+++ b/playbooks/edx-west/prod-worker.yml
@@ -1,8 +1,10 @@
 - name: Basic util setup on all hosts
-# For all util machines
+# This uses variable expansion so you can select machine(s) from the command line
+# using the -e flag.  See README for instructions on how to use.
+  hosts: ~tag_Name_{{machine}}_prod
+#
+# This alternative hits all running prod webservers.  Left here as an example.
 #  hosts: tag_environment_prod:&tag_function_util
-# or we can get subsets of them by name
-  hosts: ~tag_Name_util(1|2)_prod
   sudo: True
   gather_facts: True
   vars:

--- a/playbooks/edx-west/stage-app.yml
+++ b/playbooks/edx-west/stage-app.yml
@@ -1,15 +1,10 @@
 # This uses variable expansion so you can select machine(s) from the command line
 # using the -e flag.  See README for instructions on how to use.
-- hosts: ~tag_Name_{{machine}}_stage
-#
-# This alternative hits all running prod webservers.  Left here as an example.
-#- hosts: tag_environment_stage:&tag_function_webserver
+- hosts: ~tag_Name_{{ machine }}_stage
+  pre_tasks:
+  - fail: msg="This playbook only runnable on 'app' machines"
+    when: "'app' not in machine"
   sudo: True
-  vars_prompt:
-    - name: "migrate_db"
-      prompt: "Should this playbook run database migrations? (Type 'yes' to run, anything else to skip migrations)"
-      default: "no"
-      private: no
   vars:
     not_prod: true
     secure_dir: "../../../edx-secret/ansible"
@@ -52,4 +47,3 @@
     #- datadog
     #- splunkforwarder
 
-    

--- a/playbooks/edx-west/stage-app.yml
+++ b/playbooks/edx-west/stage-app.yml
@@ -1,6 +1,9 @@
+# This uses variable expansion so you can select machine(s) from the command line
+# using the -e flag.  See README for instructions on how to use.
+- hosts: ~tag_Name_{{machine}}_stage
+#
+# This alternative hits all running prod webservers.  Left here as an example.
 #- hosts: tag_environment_stage:&tag_function_webserver
-#- hosts: ~tag_Name_app10_stage
-- hosts: ~tag_Name_app1_stage
   sudo: True
   vars_prompt:
     - name: "migrate_db"

--- a/playbooks/edx-west/stage-worker.yml
+++ b/playbooks/edx-west/stage-worker.yml
@@ -1,7 +1,11 @@
 ---
 - name: Basic util setup on all hosts
-#- hosts: tag_environment_stage:&tag_function_util
-  hosts: ~tag_Name_util1_stage
+# This uses variable expansion so you can select machine(s) from the command line
+# using the -e flag.  See README for instructions on how to use.
+  hosts: ~tag_Name_{{machine}}_stage
+#
+# This alternative hits all running prod webservers.  Left here as an example.
+#  hosts: tag_environment_stage:&tag_function_util
   sudo: True
   gather_facts: True
   vars:

--- a/playbooks/edx-west/stage-worker.yml
+++ b/playbooks/edx-west/stage-worker.yml
@@ -1,11 +1,11 @@
 ---
 - name: Basic util setup on all hosts
-# This uses variable expansion so you can select machine(s) from the command line
-# using the -e flag.  See README for instructions on how to use.
+  # This uses variable expansion so you can select machine(s) from the command line
+  # using the -e flag.  See README for instructions on how to use.
   hosts: ~tag_Name_{{machine}}_stage
-#
-# This alternative hits all running prod webservers.  Left here as an example.
-#  hosts: tag_environment_stage:&tag_function_util
+  pre_tasks:
+  - fail: msg="This playbook only runnable on 'util' machines"
+    when: "'util' not in machine"
   sudo: True
   gather_facts: True
   vars:


### PR DESCRIPTION
@jbau and @jrbl -- this is the new way I recommend running ansible plays, using the "-e machine=foo" option.  this is a pull request to our release branch.  If it lands then I'll do the same to master just for cleanliness sake (I've already put our README up there).
