### PR TITLE
Have elastic search start, but not restart each time

### DIFF
--- a/playbooks/roles/elasticsearch/tasks/main.yml
+++ b/playbooks/roles/elasticsearch/tasks/main.yml
@@ -84,3 +84,7 @@
   
 - name: Ensure elasticsearch is enabled and started
   service: name=elasticsearch state=started enabled=yes
+
+- name: Restart elastic when there has been an upgrade
+  service: name=elasticsearch state=restarted enabled=yes
+  when: elasticsearch_reinstall.changed

--- a/playbooks/roles/elasticsearch/tasks/main.yml
+++ b/playbooks/roles/elasticsearch/tasks/main.yml
@@ -83,4 +83,4 @@
   when: bigdesk.stat.isdir is not defined
   
 - name: Ensure elasticsearch is enabled and started
-  service: name=elasticsearch state=restarted enabled=yes
+  service: name=elasticsearch state=started enabled=yes


### PR DESCRIPTION
With a large index on a poorly resourced instance, restarting the service causes me to lose logs and have tasks further down fail (logstash stuff particularly that needs elastic search to be fully running to install a template).  If this needs to be this way I can always work around it, but thought started should be sufficient.
