### PR TITLE
Parameterize machine names in edx-west playbooks

### DIFF
--- a/playbooks/edx-west/README.md
+++ b/playbooks/edx-west/README.md
@@ -31,13 +31,19 @@ sure that the stanford-deploy-20130415 ssh key is in your ssh agent.
 
 Some specifics:
 
-* To hit multiple machines the -e parameter would look like this: ```"machine=app(1|2|4)"```.
+* To do database migrations, include this: ```-e "migrate_db=yes"```.  The default
+  behavior is to not do migrations.
+
+* To hit multiple machines the use this: ```-e "machine=app(1|2|4)"```.
+  Use multiple separate "-e" options to specify multiple vars on the
+  command line.
 
 * Usually I do with the ```--list-hosts``` option first to verify that I'm
   doing something sane before actually running.
 
-* To do the utility machines, use ```prod-worker.yml```.  Those also
-  take the machine variable.
+* To install the utility machines, substitute ```prod-worker.yml```.  Those
+  are also parameterized on the take the machine variable (util1, util(1|2),
+  and so forth).
 
 
 ## Ansible Commands - Stage

--- a/playbooks/edx-west/carnegie-prod-app.yml
+++ b/playbooks/edx-west/carnegie-prod-app.yml
@@ -1,10 +1,14 @@
+<<<<<<< HEAD
 - hosts: ~tag_Name_app(10|20)_carn
+=======
+# This uses variable expansion so you can select machine(s) from the command line
+# using the -e flag.  See README for instructions on how to use.
+- hosts: ~tag_Name_{{machine}}_carn
+  pre_tasks:
+  - fail: msg="This playbook only runnable on 'app' machines"
+    when: "'app' not in machine"
+>>>>>>> ddd57c4... validate machine var, remove migrate_db prompt
   sudo: True
-  vars_prompt:
-    - name: "migrate_db"
-      prompt: "Should this playbook run database migrations? (Type 'yes' to run, anything else to skip migrations)"
-      default: "no"
-      private: no
   vars:
     secure_dir: '../../../configuration-secure/ansible'
     # this indicates the path to site-specific (with precedence)

--- a/playbooks/edx-west/carnegie-prod-app.yml
+++ b/playbooks/edx-west/carnegie-prod-app.yml
@@ -1,13 +1,9 @@
-<<<<<<< HEAD
-- hosts: ~tag_Name_app(10|20)_carn
-=======
 # This uses variable expansion so you can select machine(s) from the command line
 # using the -e flag.  See README for instructions on how to use.
 - hosts: ~tag_Name_{{machine}}_carn
   pre_tasks:
   - fail: msg="This playbook only runnable on 'app' machines"
     when: "'app' not in machine"
->>>>>>> ddd57c4... validate machine var, remove migrate_db prompt
   sudo: True
   vars:
     secure_dir: '../../../configuration-secure/ansible'

--- a/playbooks/edx-west/carnegie-prod-worker.yml
+++ b/playbooks/edx-west/carnegie-prod-worker.yml
@@ -1,8 +1,19 @@
+<<<<<<< HEAD
 # this gets all running prod webservers
 - hosts: tag_environment_prod_carn:&tag_function_util
 # or we can get subsets of them by name
 #- hosts: ~tag_Name_util(10)_carn
+=======
+- name: Basic util setup on carnegie workers
+  # This uses variable expansion so you can select machine(s) from the command line
+  # using the -e flag.  See README for instructions on how to use.
+  hosts: ~tag_Name_{{machine}}_carn
+  pre_tasks:
+  - fail: msg="This playbook only runnable on 'util' machines"
+    when: "'util' not in machine"
+>>>>>>> ddd57c4... validate machine var, remove migrate_db prompt
   sudo: True
+  gather_facts: True
   vars:
     secure_dir: '../../../edx-secret/ansible'
     # this indicates the path to site-specific (with precedence)

--- a/playbooks/edx-west/carnegie-prod-worker.yml
+++ b/playbooks/edx-west/carnegie-prod-worker.yml
@@ -1,9 +1,3 @@
-<<<<<<< HEAD
-# this gets all running prod webservers
-- hosts: tag_environment_prod_carn:&tag_function_util
-# or we can get subsets of them by name
-#- hosts: ~tag_Name_util(10)_carn
-=======
 - name: Basic util setup on carnegie workers
   # This uses variable expansion so you can select machine(s) from the command line
   # using the -e flag.  See README for instructions on how to use.
@@ -11,7 +5,6 @@
   pre_tasks:
   - fail: msg="This playbook only runnable on 'util' machines"
     when: "'util' not in machine"
->>>>>>> ddd57c4... validate machine var, remove migrate_db prompt
   sudo: True
   gather_facts: True
   vars:

--- a/playbooks/edx-west/cme-prod-app.yml
+++ b/playbooks/edx-west/cme-prod-app.yml
@@ -9,20 +9,12 @@
 #      - apt: pkg=libzmq-dev,python-zmq state=present
 #      - action: fireball
 
-<<<<<<< HEAD
-
-# this gets all running prod webservers
-#- hosts: tag_environment_prod:&tag_function_webserver
-# or we can get subsets of them by name
-- hosts: ~tag_Name_app(10|20)_cme
-=======
 # This uses variable expansion so you can select machine(s) from the command line
 # using the -e flag.  See README for instructions on how to use.
 - hosts: ~tag_Name_{{machine}}_cme
   pre_tasks:
   - fail: msg="This playbook only runnable on 'app' machines"
     when: "'app' not in machine"
->>>>>>> ddd57c4... validate machine var, remove migrate_db prompt
   sudo: True
   vars:
     secure_dir: '../../../edx-secret/ansible'

--- a/playbooks/edx-west/cme-prod-app.yml
+++ b/playbooks/edx-west/cme-prod-app.yml
@@ -9,17 +9,21 @@
 #      - apt: pkg=libzmq-dev,python-zmq state=present
 #      - action: fireball
 
+<<<<<<< HEAD
 
 # this gets all running prod webservers
 #- hosts: tag_environment_prod:&tag_function_webserver
 # or we can get subsets of them by name
 - hosts: ~tag_Name_app(10|20)_cme
+=======
+# This uses variable expansion so you can select machine(s) from the command line
+# using the -e flag.  See README for instructions on how to use.
+- hosts: ~tag_Name_{{machine}}_cme
+  pre_tasks:
+  - fail: msg="This playbook only runnable on 'app' machines"
+    when: "'app' not in machine"
+>>>>>>> ddd57c4... validate machine var, remove migrate_db prompt
   sudo: True
-  vars_prompt:
-    - name: "migrate_db"
-      prompt: "Should this playbook run database migrations? (Type 'yes' to run, anything else to skip migrations)"
-      default: "no"
-      private: no
   vars:
     secure_dir: '../../../edx-secret/ansible'
     # this indicates the path to site-specific (with precedence)

--- a/playbooks/edx-west/cme-prod-worker.yml
+++ b/playbooks/edx-west/cme-prod-worker.yml
@@ -1,9 +1,3 @@
-<<<<<<< HEAD
-# this gets all running prod webservers
-- hosts: tag_environment_prod_cme:&tag_function_util
-# or we can get subsets of them by name
-#- hosts: ~tag_Name_util(10)_cme
-=======
 - name: Basic util setup on cme hosts
   # This uses variable expansion so you can select machine(s) from the command line
   # using the -e flag.  See README for instructions on how to use.
@@ -11,7 +5,6 @@
   pre_tasks:
   - fail: msg="This playbook only runnable on 'util' machines"
     when: "'util' not in machine"
->>>>>>> ddd57c4... validate machine var, remove migrate_db prompt
   sudo: True
   vars:
     secure_dir: '../../../edx-secret/ansible'

--- a/playbooks/edx-west/cme-prod-worker.yml
+++ b/playbooks/edx-west/cme-prod-worker.yml
@@ -1,7 +1,17 @@
+<<<<<<< HEAD
 # this gets all running prod webservers
 - hosts: tag_environment_prod_cme:&tag_function_util
 # or we can get subsets of them by name
 #- hosts: ~tag_Name_util(10)_cme
+=======
+- name: Basic util setup on cme hosts
+  # This uses variable expansion so you can select machine(s) from the command line
+  # using the -e flag.  See README for instructions on how to use.
+  hosts: ~tag_Name_{{machine}}_cme
+  pre_tasks:
+  - fail: msg="This playbook only runnable on 'util' machines"
+    when: "'util' not in machine"
+>>>>>>> ddd57c4... validate machine var, remove migrate_db prompt
   sudo: True
   vars:
     secure_dir: '../../../edx-secret/ansible'

--- a/playbooks/edx-west/prod-app.yml
+++ b/playbooks/edx-west/prod-app.yml
@@ -1,15 +1,10 @@
 # This uses variable expansion so you can select machine(s) from the command line
 # using the -e flag.  See README for instructions on how to use.
 - hosts: ~tag_Name_{{machine}}_prod
-#
-# This alternative hits all running prod webservers.  Left here as an example.
-#- hosts: tag_environment_prod:&tag_function_webserver
+  pre_tasks:
+  - fail: msg="This playbook only runnable on 'app' machines"
+    when: "'app' not in machine"
   sudo: True
-  vars_prompt:
-    - name: "migrate_db"
-      prompt: "Should this playbook run database migrations? (Type 'yes' to run, anything else to skip migrations)"
-      default: "no"
-      private: no
   vars:
     secure_dir: '../../../configuration-secure/ansible'
     # this indicates the path to site-specific (with precedence)

--- a/playbooks/edx-west/prod-app.yml
+++ b/playbooks/edx-west/prod-app.yml
@@ -1,12 +1,9 @@
-# this gets all running prod webservers
+# This uses variable expansion so you can select machine(s) from the command line
+# using the -e flag.  See README for instructions on how to use.
+- hosts: ~tag_Name_{{machine}}_prod
+#
+# This alternative hits all running prod webservers.  Left here as an example.
 #- hosts: tag_environment_prod:&tag_function_webserver
-# or we can get subsets of them by name
-#- hosts: ~tag_Name_app(10|20)_prod
-- hosts: ~tag_Name_app(11|21)_prod
-## this is the test box
-#- hosts: ~tag_Name_app4_prod
-## you can also do security group, but don't do that
-#- hosts: security_group_edx-prod-EdxappServerSecurityGroup-NSKCQTMZIPQB
   sudo: True
   vars_prompt:
     - name: "migrate_db"

--- a/playbooks/edx-west/prod-worker.yml
+++ b/playbooks/edx-west/prod-worker.yml
@@ -1,10 +1,10 @@
 - name: Basic util setup on all hosts
-# This uses variable expansion so you can select machine(s) from the command line
-# using the -e flag.  See README for instructions on how to use.
+  # This uses variable expansion so you can select machine(s) from the command line
+  # using the -e flag.  See README for instructions on how to use.
   hosts: ~tag_Name_{{machine}}_prod
-#
-# This alternative hits all running prod webservers.  Left here as an example.
-#  hosts: tag_environment_prod:&tag_function_util
+  pre_tasks:
+  - fail: msg="This playbook only runnable on 'util' machines"
+    when: "'util' not in machine"
   sudo: True
   vars:
     secure_dir: '../../../configuration-secure/ansible'

--- a/playbooks/edx-west/prod-worker.yml
+++ b/playbooks/edx-west/prod-worker.yml
@@ -1,7 +1,10 @@
-# For all util machines
-- hosts: tag_environment_prod:&tag_function_util
-# or we can get subsets of them by name
-#- hosts: ~tag_Name_util(1|2)_prod
+- name: Basic util setup on all hosts
+# This uses variable expansion so you can select machine(s) from the command line
+# using the -e flag.  See README for instructions on how to use.
+  hosts: ~tag_Name_{{machine}}_prod
+#
+# This alternative hits all running prod webservers.  Left here as an example.
+#  hosts: tag_environment_prod:&tag_function_util
   sudo: True
   vars:
     secure_dir: '../../../configuration-secure/ansible'

--- a/playbooks/edx-west/stage-app.yml
+++ b/playbooks/edx-west/stage-app.yml
@@ -1,5 +1,9 @@
-- hosts: tag_environment_stage:&tag_function_webserver
-#- hosts: tag_Name_app1_stage
+# This uses variable expansion so you can select machine(s) from the command line
+# using the -e flag.  See README for instructions on how to use.
+- hosts: ~tag_Name_{{machine}}_stage
+#
+# This alternative hits all running prod webservers.  Left here as an example.
+#- hosts: tag_environment_stage:&tag_function_webserver
   sudo: True
   vars_prompt:
     - name: "migrate_db"

--- a/playbooks/edx-west/stage-app.yml
+++ b/playbooks/edx-west/stage-app.yml
@@ -1,15 +1,10 @@
 # This uses variable expansion so you can select machine(s) from the command line
 # using the -e flag.  See README for instructions on how to use.
-- hosts: ~tag_Name_{{machine}}_stage
-#
-# This alternative hits all running prod webservers.  Left here as an example.
-#- hosts: tag_environment_stage:&tag_function_webserver
+- hosts: ~tag_Name_{{ machine }}_stage
+  pre_tasks:
+  - fail: msg="This playbook only runnable on 'app' machines"
+    when: "'app' not in machine"
   sudo: True
-  vars_prompt:
-    - name: "migrate_db"
-      prompt: "Should this playbook run database migrations? (Type 'yes' to run, anything else to skip migrations)"
-      default: "no"
-      private: no
   vars:
     not_prod: true
     secure_dir: ../../../edx-secret/ansible

--- a/playbooks/edx-west/stage-worker.yml
+++ b/playbooks/edx-west/stage-worker.yml
@@ -1,11 +1,11 @@
 ---
 - name: Basic util setup on all hosts
-# This uses variable expansion so you can select machine(s) from the command line
-# using the -e flag.  See README for instructions on how to use.
+  # This uses variable expansion so you can select machine(s) from the command line
+  # using the -e flag.  See README for instructions on how to use.
   hosts: ~tag_Name_{{machine}}_stage
-#
-# This alternative hits all running prod webservers.  Left here as an example.
-#  hosts: tag_environment_stage:&tag_function_util
+  pre_tasks:
+  - fail: msg="This playbook only runnable on 'util' machines"
+    when: "'util' not in machine"
   sudo: True
   vars:
     secure_dir: ../../../edx-secret/ansible

--- a/playbooks/edx-west/stage-worker.yml
+++ b/playbooks/edx-west/stage-worker.yml
@@ -1,7 +1,11 @@
-  # this gets all running stage util machiens
-- hosts: tag_environment_stage:&tag_function_util
-# or we can get subsets of them by name
-#- hosts: ~tag_Name_util(1|2)_stage
+---
+- name: Basic util setup on all hosts
+# This uses variable expansion so you can select machine(s) from the command line
+# using the -e flag.  See README for instructions on how to use.
+  hosts: ~tag_Name_{{machine}}_stage
+#
+# This alternative hits all running prod webservers.  Left here as an example.
+#  hosts: tag_environment_stage:&tag_function_util
   sudo: True
   vars:
     secure_dir: ../../../edx-secret/ansible


### PR DESCRIPTION
This is pulling into master a few changes we've made in the playbooks we use to drive our own Stanford instance.  Mostly want to keep master in sync so others can see what we're doing and our upcoming merges are cleaner.

@feanil -- can you take a look?  Just asking you since you've been looking at other of my changes, but this one isn't very exciting. 

Look at PR #854 for discussion with Joe and Jason about the over all feature.  Thanks.
