### PR TITLE
Addition of production tcp socket configuration

### DIFF
--- a/playbooks/roles/forum/defaults/main.yml
+++ b/playbooks/roles/forum/defaults/main.yml
@@ -29,6 +29,9 @@ FORUM_ELASTICSEARCH_URL: "http://{{ FORUM_ELASTICSEARCH_HOST }}:{{ FORUM_ELASTIC
 FORUM_NEW_RELIC_LICENSE_KEY: "new-relic-license-key"
 FORUM_NEW_RELIC_APP_NAME: "forum-newrelic-app"
 FORUM_WORKER_PROCESSES: "4"
+FORUM_LISTEN_HOST: "0.0.0.0"
+FORUM_LISTEN_PORT: "4567"
+FORUM_USE_TCP: false
 
 forum_environment:
   RBENV_ROOT: "{{ forum_rbenv_root }}"
@@ -45,20 +48,13 @@ forum_environment:
   NEW_RELIC_LICENSE_KEY: "{{ FORUM_NEW_RELIC_LICENSE_KEY }}"
   WORKER_PROCESSES: "{{ FORUM_WORKER_PROCESSES }}"
   DATA_DIR: "{{ forum_data_dir }}"
+  FORUM_LISTEN_HOST: "{{ FORUM_LISTEN_HOST }}"
+  FORUM_LISTEN_PORT: "{{ FORUM_LISTEN_PORT }}"
 
 forum_user: "forum"
 forum_ruby_version: "1.9.3-p448"
 forum_source_repo: "https://github.com/edx/cs_comments_service.git"
-# Currently we are installing a branch of the comments service
-# that configures unicorn to listen on a unix socket and get the
-# worker count configuration from the environment.  We are not
-# merging to master of the comments service yet as this will have
-# some incompatibilities with our Heroku deployments.
-#
-# https://github.com/edx/cs_comments_service/pull/83
-#
 forum_version: "master"
-forum_unicorn_port: "4567"
 
 #
 # test config

--- a/playbooks/roles/forum/templates/forum-supervisor.sh.j2
+++ b/playbooks/roles/forum/templates/forum-supervisor.sh.j2
@@ -5,6 +5,8 @@ cd {{ forum_code_dir }}
 
 {% if devstack %}
 {{ forum_rbenv_shims }}/ruby app.rb
+{% elif FORUM_USE_TCP %}
+{{ forum_gem_bin }}/unicorn -c config/unicorn_tcp.rb
 {% else %}
 {{ forum_gem_bin }}/unicorn -c config/unicorn.rb
 {% endif %}

--- a/playbooks/roles/forum/templates/forum.conf.j2
+++ b/playbooks/roles/forum/templates/forum.conf.j2
@@ -6,3 +6,4 @@ stdout_logfile={{ supervisor_log_dir }}/%(program_name)-stdout.log
 stderr_logfile={{ supervisor_log_dir }}/%(program_name)-stderr.log
 killasgroup=true
 stopasgroup=true
+stopsignal=QUIT


### PR DESCRIPTION
This adds an option to listen on a TCP socket and control host and port with ansible.  See https://github.com/edx/cs_comments_service/pull/90 for related pull to that repo.
