### PR TITLE
devstack vagrantfile: mount "themes" from host

### DIFF
--- a/vagrant/release/devstack/Vagrantfile
+++ b/vagrant/release/devstack/Vagrantfile
@@ -22,12 +22,14 @@ ansible-playbook -i localhost, -c local vagrant-devstack.yml --tags=deploy
 SCRIPT
 
 edx_platform_mount_dir = "edx-platform"
+themes_mount_dir = "themes"
 forum_mount_dir = "cs_comments_service"
 ora_mount_dir = "ora"
 
 if ENV['VAGRANT_MOUNT_BASE']
 
   edx_platform_mount_dir = ENV['VAGRANT_MOUNT_BASE'] + "/" + edx_platform_mount_dir
+  themes_mount_dir = ENV['VAGRANT_MOUNT_BASE'] + "/" + themes_mount_dir
   forum_mount_dir = ENV['VAGRANT_MOUNT_BASE'] + "/" + forum_mount_dir
   ora_mount_dir = ENV['VAGRANT_MOUNT_BASE'] + "/" + ora_mount_dir
 
@@ -50,6 +52,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   end
 
   config.vm.synced_folder "#{edx_platform_mount_dir}", "/edx/app/edxapp/edx-platform", :create => true, nfs: true
+  config.vm.synced_folder "#{themes_mount_dir}", "/edx/app/edxapp/themes", :create => true, nfs: true
   config.vm.synced_folder "#{forum_mount_dir}", "/edx/app/forum/cs_comments_service", :create => true, nfs: true
   config.vm.synced_folder "#{ora_mount_dir}", "/edx/app/ora/ora", :create => true, nfs: true
 


### PR DESCRIPTION
This mounts the "themes" directory on the host.  This will enable people
who have configured "stanford-style" themes to check out their themes on
the host and have it useable in the devstack.

Two things are a bit odd about this that are worth highlighting.
1. For people not using Stanford-style theming, which are most
   developers and certainly everyone at edX.org, this is a wasted
   export.  It doesn't do any harm, but would it be confusing?  I
   think that's OK.
2. The provision steps checks out the other repos that you need
   (edx-platform, cs_comment_service, etc.).  We're not checking out
   the theme repo ourselves here, counting on the user to do so
   yourself later.  I know this isn't consistent, but I couldn't
   plumb through the theming stuff into the rest of devstack
   provision, at least not right now.
