### PR TITLE
If you have a branch name with .py in it, compileall will fail with bad syntax

### DIFF
--- a/playbooks/roles/edxapp/tasks/deploy.yml
+++ b/playbooks/roles/edxapp/tasks/deploy.yml
@@ -253,7 +253,7 @@
   - edxapp-sandbox
 
 - name: compiling all py files in the edx-platform repo
-  shell: "{{ edxapp_venv_bin }}/python -m compileall {{ edxapp_code_dir }}"
+  shell: "{{ edxapp_venv_bin }}/python -m compileall -x .git.* {{ edxapp_code_dir }}"
   sudo_user: "{{ edxapp_user }}"
   notify:
   - "restart edxapp"

--- a/playbooks/roles/edxapp/tasks/deploy.yml
+++ b/playbooks/roles/edxapp/tasks/deploy.yml
@@ -253,7 +253,7 @@
   - edxapp-sandbox
 
 - name: compiling all py files in the edx-platform repo
-  shell: "{{ edxapp_venv_bin }}/python -m compileall -x .git.* {{ edxapp_code_dir }}"
+  shell: "{{ edxapp_venv_bin }}/python -m compileall -x .git/.* {{ edxapp_code_dir }}"
   sudo_user: "{{ edxapp_user }}"
   notify:
   - "restart edxapp"


### PR DESCRIPTION
This was one of the fun ones to track down:

```
SyntaxError: ('invalid syntax', ('/edx/app/edxapp/edx-platform/.git/refs/remotes/origin/oliviermarquez/update-tabs.py', 1, 40, '925133409b1d81997e04e9c6d9ff58f01e309f46\n'))
```

Turns out python will try and compile everything, even git branches, and it isn't so good at git branches.
