### PR TITLE
Nginx X-Forwarded-For header configuration.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -31,3 +31,4 @@ Wang Peifeng <pku9104038@hotmail.com>
 Ray Hooker <ray.hooker@gmail.com>
 David Pollack <david@sologourmand.com>
 Rodolphe Quiedeville <rodolphe@quiedeville.org>
+Matjaz Gregoric <mtyaka@gmail.com>

--- a/playbooks/edx_sandbox.yml
+++ b/playbooks/edx_sandbox.yml
@@ -13,6 +13,8 @@
     openid_workaround: True
     EDXAPP_LMS_NGINX_PORT: '80'
     edx_platform_version: 'master'
+    # Set to false if deployed behind another proxy/load balancer.
+    NGINX_SET_X_FORWARDED_HEADERS: True
     # These should stay false for the public AMI
     COMMON_ENABLE_DATADOG: False
     COMMON_ENABLE_SPLUNKFORWARDER: False

--- a/playbooks/roles/nginx/defaults/main.yml
+++ b/playbooks/roles/nginx/defaults/main.yml
@@ -13,6 +13,15 @@ NGINX_ENABLE_SSL: False
 NGINX_SSL_CERTIFICATE: 'ssl-cert-snakeoil.pem'
 NGINX_SSL_KEY: 'ssl-cert-snakeoil.key'
 
+# When set to False, nginx will pass X-Forwarded-For, X-Forwarded-Port,
+# and X-Forwarded-Proto headers through to the backend unmodified.
+# This is desired when nginx is deployed behind another load balancer
+# which takes care of properly setting the X-Forwarded-* headers.
+# When there is no other load balancer in front of nginx, set this
+# variable to True to force nginx to set the values of the X-Forwarded-*
+# headers to reflect the properties of the incoming request.
+NGINX_SET_X_FORWARDED_HEADERS: False
+
 nginx_app_dir: "{{ COMMON_APP_DIR }}/nginx"
 nginx_data_dir: "{{ COMMON_DATA_DIR }}/nginx"
 nginx_conf_dir: "{{ nginx_app_dir }}/conf.d"

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/cms.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/cms.j2
@@ -41,9 +41,15 @@ server {
 
 
   location @proxy_to_cms_app {
+    {% if NGINX_SET_X_FORWARDED_HEADERS %}
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-Port $server_port;
+    proxy_set_header X-Forwarded-For $remote_addr;
+    {% else %}
     proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
     proxy_set_header X-Forwarded-Port $http_x_forwarded_port;
     proxy_set_header X-Forwarded-For $http_x_forwarded_for;
+    {% endif %}
     proxy_set_header Host $http_host;
 
     proxy_redirect off;

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/forum.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/forum.j2
@@ -43,9 +43,15 @@ server {
   {% include "robots.j2" %}
 
 location @proxy_to_app {
+    {% if NGINX_SET_X_FORWARDED_HEADERS %}
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-Port $server_port;
+    proxy_set_header X-Forwarded-For $remote_addr;
+    {% else %}
     proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
     proxy_set_header X-Forwarded-Port $http_x_forwarded_port;
     proxy_set_header X-Forwarded-For $http_x_forwarded_for;
+    {% endif %}
     proxy_set_header Host $http_host;
 
     proxy_redirect off;

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms-preview.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms-preview.j2
@@ -21,9 +21,15 @@ server {
   rewrite ^(.*)/favicon.ico$ /static/images/favicon.ico last;
 
   location @proxy_to_lms-preview_app {
+    {% if NGINX_SET_X_FORWARDED_HEADERS %}
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-Port $server_port;
+    proxy_set_header X-Forwarded-For $remote_addr;
+    {% else %}
     proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
     proxy_set_header X-Forwarded-Port $http_x_forwarded_port;
     proxy_set_header X-Forwarded-For $http_x_forwarded_for;
+    {% endif %}
     proxy_set_header Host $http_host;
 
     proxy_redirect off;

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
@@ -38,9 +38,15 @@ server {
   rewrite ^(.*)/favicon.ico$ /static/images/favicon.ico last;
 
   location @proxy_to_lms_app {
+    {% if NGINX_SET_X_FORWARDED_HEADERS %}
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-Port $server_port;
+    proxy_set_header X-Forwarded-For $remote_addr;
+    {% else %}
     proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
     proxy_set_header X-Forwarded-Port $http_x_forwarded_port;
     proxy_set_header X-Forwarded-For $http_x_forwarded_for;
+    {% endif %}
     proxy_set_header Host $http_host;
 
     proxy_redirect off;


### PR DESCRIPTION
The nginx configuration was set to pass `X-Forwarded-For` and related headers
unmodified to backend services.
This works fine when nginx is deployed behind another load balancer
(for example ELB), which already properly sets the `X-Forwarded-*` for headers.

But in simpler deployment scenarios, where nginx is directly facing the end user,
nginx should discard any existing `X-Forwarded-For` header and set it to remote IP of the request,
the `X-Forwarded-Port` header to the nginx server port, and the `X-Forwarded-Proto`
to the scheme of the current request.

The behavior is controlled by the `nginx_set_x_forwarded_headers` configuration variable.
When set to False, nginx will forward existing X-Forwarded-\* unmodified.
When set to True, nginx will discard any existing `X-Forwarded-*` headers and set them itself.

`nginx_set_x_forwarded_headers` is set to `False` by default, but set to `True` in the `edx_sandbox` playbook, where nginx is usually not deployed behind another load balancer.

The variable name is probably not ideal and I would welcome any better suggestions.
