### PR TITLE
Add discern_local_pypi_mirror variable for use a local pypi mirror easil...

### DIFF
--- a/playbooks/roles/discern/defaults/main.yml
+++ b/playbooks/roles/discern/defaults/main.yml
@@ -22,6 +22,7 @@ discern_venv_bin: "{{ discern_venv_dir }}/bin"
 discern_pre_requirements_file: "{{ discern_code_dir }}/pre-requirements.txt"
 discern_post_requirements_file: "{{ discern_code_dir }}/requirements.txt"
 discern_user: "discern"
+discern_local_pypi_mirror: "https://pypi.python.org/simple"
 
 discern_ease_venv_dir: "{{ discern_venv_dir }}"
 discern_ease_code_dir: "{{ discern_app_dir }}/ease"

--- a/playbooks/roles/discern/tasks/deploy.yml
+++ b/playbooks/roles/discern/tasks/deploy.yml
@@ -46,7 +46,7 @@
 
 #Numpy has to be a pre-requirement in order for scipy to build
 - name : install python pre-requirements for discern and ease
-  pip: requirements={{item}} virtualenv={{ discern_venv_dir }} state=present
+  pip: requirements={{item}} virtualenv={{ discern_venv_dir }} state=present extra_args="-i {{ discern_local_pypi_mirror }}"  
   sudo_user: "{{ discern_user }}"
   notify:
     - restart discern
@@ -55,7 +55,7 @@
     - "{{ discern_ease_pre_requirements_file }}"
 
 - name : install python requirements for discern and ease
-  pip: requirements={{item}} virtualenv={{ discern_venv_dir }} state=present
+  pip: requirements={{item}} virtualenv={{ discern_venv_dir }} state=present extra_args="-i {{ discern_local_pypi_mirror }}"
   sudo_user: "{{ discern_user }}"
   notify:
     - restart discern


### PR DESCRIPTION
Add a variable discern_local_pypi_mirror as the extra_args for pip install python requirmente, and define the default value as pypi official site. This will help to make it easy if someone want to use a local pypi mirror to speed up the deployment.
