### PR TITLE
The jenkins_worker roles needs to include the role defaults.

### DIFF
--- a/playbooks/edx-east/jenkins_worker.yml
+++ b/playbooks/edx-east/jenkins_worker.yml
@@ -8,6 +8,12 @@
   gather_facts: True
   vars:
     mongo_enable_journal: False
+  vars_files:
+    - roles/edxapp/defaults/main.yml
+    - roles/ora/defaults/main.yml
+    - roles/xqueue/defaults/main.yml
+    - roles/xserver/defaults/main.yml
+    - roles/forum/defaults/main.yml
   roles:
     - common
     - edxlocal


### PR DESCRIPTION
These roles now set various default passwords that the edxlocal role
needs.
