### PR TITLE
Make LC_ALL default to 'en_US.UTF-8'.

### DIFF
--- a/vagrant/base/devstack/Vagrantfile
+++ b/vagrant/base/devstack/Vagrantfile
@@ -45,6 +45,10 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     vb.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
   end
 
+  # Make LC_ALL default to en_US.UTF-8 instead of en_US.
+  # See: https://github.com/mitchellh/vagrant/issues/1188
+  config.vm.provision "shell", inline: 'echo \'LC_ALL="en_US.UTF-8"\' > /etc/default/locale'
+
   config.vm.provision :ansible do |ansible|
     ansible.playbook = "../../../playbooks/vagrant-devstack.yml"
     ansible.inventory_path = "../../../playbooks/vagrant/inventory.ini"

--- a/vagrant/base/fullstack/Vagrantfile
+++ b/vagrant/base/fullstack/Vagrantfile
@@ -20,6 +20,10 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     vb.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
   end
 
+  # Make LC_ALL default to en_US.UTF-8 instead of en_US.
+  # See: https://github.com/mitchellh/vagrant/issues/1188
+  config.vm.provision "shell", inline: 'echo \'LC_ALL="en_US.UTF-8"\' > /etc/default/locale'
+
   config.vm.provision :ansible do |ansible|
     # point Vagrant at the location of your playbook you want to run
     ansible.playbook = "../../../playbooks/vagrant-fullstack.yml"


### PR DESCRIPTION
The `LC_ALL` environment variable is set to `en_US` in `/etc/default/locale`
in the precise32 vagrant box, see:

https://github.com/mitchellh/vagrant/issues/1188

When running the python unit tests in the devstack machine, several of the
tests fail with a `UnicodeEncodeError` when trying to create folders with names
that contain non-ascii characters.

Explicitly setting `LC_ALL`to `en_US.UTF-8` before running the tests fixes this issue,
but it would be nice if the box was set up with the `en_US.UTF-8` locale by default.
