### PR TITLE
Allow users to be removed from systems

### DIFF
--- a/playbooks/roles/user/defaults/main.yml
+++ b/playbooks/roles/user/defaults/main.yml
@@ -18,7 +18,7 @@
 user_role_name: user
 
 # override this var to add a prefix to the prompt
-# also need to set commont_update_bashrc for to
+# also need to set comment_update_bashrc for to
 # update the system bashrc default
 USER_CMD_PROMPT: ""
 

--- a/playbooks/roles/user/tasks/main.yml
+++ b/playbooks/roles/user/tasks/main.yml
@@ -66,13 +66,20 @@
 #
 # By default for restricted users we only allow sudo, if you
 # want to provide more binaries add them to user_rbash_links
-# which can be passed in as a paramter to the role.
+# which can be passed in as a parameter to the role.
 #
 
 - debug: var=user_info
 
 - name: create the edxadmin group
   group: name=edxadmin state=present
+
+# some AMIs (such as EMR master nodes) don't read the config files out of /etc/sudoers.d by default
+- name: ensure sudoers.d is read
+  lineinfile: >
+    dest=/etc/sudoers state=present
+    regexp='^#includedir /etc/sudoers.d' line='#includedir /etc/sudoers.d'
+    validate='visudo -cf %s'
 
 # give full sudo admin access to the edxadmin group
 - name: grant full sudo access to the edxadmin group
@@ -82,45 +89,47 @@
     mode=0440 validate='visudo -cf %s'
 
 - name: create the users
-  user:
+  user: >
     name={{ item.name }}
     shell=/bin/bash
+    state={{ item.state | default('present') }}
   with_items: user_info
 
 - name: create .ssh directory
-  file:
+  file: >
     path=/home/{{ item.name }}/.ssh state=directory mode=0750
     owner={{ item.name }}
+  when: item.get('state', 'present') == 'present'
   with_items: user_info
 
 - name: assign admin role to admin users
-  user:
+  user: >
     name={{ item.name }}
     groups=edxadmin
-  when: item.type is defined and item.type == 'admin'
+  when: item.type is defined and item.type == 'admin' and item.get('state', 'present') == 'present'
   with_items: user_info
 
 # authorized_keys2 used here so that personal
 # keys can be copied to authorized_keys
 # force is set to yes here, otherwise the keys
-# won't update if they haven't changed on teh github
+# won't update if they haven't changed on the github
 # side
 - name: copy github key[s] to .ssh/authorized_keys2
-  get_url:
+  get_url: >
     url=https://github.com/{{ item.name }}.keys
     force=yes
     dest=/home/{{ item.name }}/.ssh/authorized_keys2 mode=0640
     owner={{ item.name }}
-  when: item.github is defined
+  when: item.github is defined and item.get('state', 'present') == 'present'
   with_items: user_info
 
 - name: copy additional authorized keys
   copy: >
-    content="{{ "\n".join(item.authorized_keys) }}"
+    content="{{ '\n'.join(item.authorized_keys) }}"
     dest=/home/{{ item.name }}/.ssh/authorized_keys mode=0640
     owner={{ item.name }}
     mode=0440
-  when: item.authorized_keys is defined
+  when: item.authorized_keys is defined and item.get('state', 'present') == 'present'
   with_items: user_info
 
 - name: create bashrc file for normal users
@@ -128,7 +137,7 @@
     src=default.bashrc.j2
     dest=/home/{{ item.name }}/.bashrc mode=0640
     owner={{ item.name }}
-  when: not (item.type is defined and item.type == 'restricted')
+  when: not (item.type is defined and item.type == 'restricted') and item.get('state', 'present') == 'present'
   with_items: user_info
 
 - name: create .profile for all users
@@ -136,16 +145,17 @@
     src=default.profile.j2
     dest=/home/{{ item.name }}/.profile mode=0640
     owner={{ item.name }}
+  when: item.get('state', 'present') == 'present'
   with_items: user_info
 
 ########################################################
 # All tasks below this line are for restricted users
 
 - name: modify shell for restricted users
-  user:
+  user: >
     name={{ item.name }}
     shell=/bin/rbash
-  when: item.type is defined and item.type == 'restricted'
+  when: item.type is defined and item.type == 'restricted' and item.get('state', 'present') == 'present'
   with_items: user_info
 
 - name: create bashrc file for restricted users
@@ -153,11 +163,11 @@
     src=restricted.bashrc.j2
     dest=/home/{{ item.name }}/.bashrc mode=0640
     owner={{ item.name }}
-  when: item.type is defined and item.type == 'restricted'
+  when: item.type is defined and item.type == 'restricted' and item.get('state', 'present') == 'present'
   with_items: user_info
 
 - name: create sudoers file from template
-  template:
+  template: >
     dest=/etc/sudoers.d/99-restricted
     src=restricted.sudoers.conf.j2 owner="root"
     group="root" mode=0440 validate='visudo -cf %s'
@@ -167,14 +177,14 @@
 
 - name: change home directory ownership to root for restricted users
   shell: "chown -R root:{{ item.name }} /home/{{ item.name }}"
-  when: item.type is defined and item.type == 'restricted'
+  when: item.type is defined and item.type == 'restricted' and item.get('state', 'present') == 'present'
   with_items: user_info
 
 - name: create ~/bin directory
-  file:
+  file: >
     path=/home/{{ item.name }}/bin state=directory mode=0750
     owner="root" group={{ item.name }}
-  when: item.type is defined and item.type == 'restricted'
+  when: item.type is defined and item.type == 'restricted' and item.get('state', 'present') == 'present'
   with_items: user_info
 
 - name: create allowed command links
@@ -182,7 +192,7 @@
     src: "{{ item[1] }}"
     dest: "/home/{{ item[0].name }}/bin/{{ item[1]|basename }}"
     state: link
-  when: item[0].type is defined and item[0].type == 'restricted'
+  when: item[0].type is defined and item[0].type == 'restricted' and item[0].get('state', 'present') == 'present'
   with_nested:
     - user_info
     - user_rbash_links


### PR DESCRIPTION
This will allow us to keep a list of users that are allowed explicitly not
allowed to access systems.

```
user_info:
 - name: someonewholeft
   state: absent
 - name: activeaccount
   type: admin
   github: true
```

The above settings would ensure that the user named "someonewholeft" is not
able to access the system and "activeaccount" is.
