### PR TITLE
Using PyPi URL instead of DevPi

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -193,7 +193,6 @@ edxapp_upload_dir: "{{ edxapp_data_dir }}/uploads"
 edxapp_theme_dir: "{{ edxapp_data_dir }}/themes"
 edxapp_git_identity: "{{ edxapp_app_dir }}/edxapp-git-identity"
 edxapp_git_ssh: "/tmp/edxapp_git_ssh.sh"
-edxapp_pypi_local_mirror: "http://localhost:{{ devpi_port }}/root/pypi/+simple"
 edxapp_workers:
   - queue: low
     service_variant: cms

--- a/playbooks/roles/edxapp/tasks/deploy.yml
+++ b/playbooks/roles/edxapp/tasks/deploy.yml
@@ -128,7 +128,7 @@
     requirements="{{pre_requirements_file}}"
     virtualenv="{{edxapp_venv_dir}}"
     state=present
-    extra_args="-i {{ edxapp_pypi_local_mirror }}"
+    extra_args="-i {{ COMMON_PYPI_MIRROR_URL }}"
   sudo_user: "{{ edxapp_user }}"
   environment: "{{ edxapp_environment }}"
   notify:
@@ -142,7 +142,7 @@
   # requirements are pathed relative to the edx-platform repo. Using the pip from inside the virtual environment implicitly
   # installs everything into that virtual environment.
   shell: >
-    {{ edxapp_venv_dir }}/bin/pip install -i {{ edxapp_pypi_local_mirror }} --exists-action w --use-mirrors -r {{ base_requirements_file }}
+    {{ edxapp_venv_dir }}/bin/pip install -i {{ COMMON_PYPI_MIRROR_URL }} --exists-action w --use-mirrors -r {{ base_requirements_file }}
     chdir={{ edxapp_code_dir }}
   environment: "{{ edxapp_environment }}"
   sudo_user: "{{ edxapp_user }}"
@@ -157,7 +157,21 @@
     requirements="{{post_requirements_file}}"
     virtualenv="{{edxapp_venv_dir}}"
     state=present
-    extra_args="-i {{ edxapp_pypi_local_mirror }}"
+    extra_args="-i {{ COMMON_PYPI_MIRROR_URL }}"
+  sudo_user: "{{ edxapp_user }}"
+  environment: "{{ edxapp_environment }}"
+  notify:
+  - "restart edxapp"
+  - "restart edxapp_workers"
+  when: not inst.stat.exists or new.stat.md5 != inst.stat.md5
+
+# Install the python paver requirements into {{ edxapp_venv_dir }}
+- name : install python paver-requirements
+  pip: >
+    requirements="{{paver_requirements_file}}"
+    virtualenv="{{edxapp_venv_dir}}"
+    state=present
+    extra_args="-i {{ COMMON_PYPI_MIRROR_URL }}"
   sudo_user: "{{ edxapp_user }}"
   environment: "{{ edxapp_environment }}"
   notify:
@@ -171,7 +185,7 @@
   # requirements are pathed relative to the edx-platform repo. Using the pip from inside the virtual environment implicitly
   # installs everything into that virtual environment.
   shell: >
-    {{ edxapp_venv_dir }}/bin/pip install -i {{ edxapp_pypi_local_mirror }} --exists-action w --use-mirrors -r {{ item }}
+    {{ edxapp_venv_dir }}/bin/pip install -i {{ COMMON_PYPI_MIRROR_URL }} --exists-action w --use-mirrors -r {{ item }}
     chdir={{ edxapp_code_dir }}
   with_items:
   - "{{ repo_requirements_file }}"
@@ -189,7 +203,7 @@
   # requirements are pathed relative to the edx-platform repo. Using the pip from inside the virtual environment implicitly
   # installs everything into that virtual environment.
   shell: >
-    {{ edxapp_venv_dir }}/bin/pip install -i {{ edxapp_pypi_local_mirror }} --exists-action w --use-mirrors -r {{ item }}
+    {{ edxapp_venv_dir }}/bin/pip install -i {{ COMMON_PYPI_MIRROR_URL }} --exists-action w --use-mirrors -r {{ item }}
     chdir={{ edxapp_code_dir }}
   with_items:
   - "{{ private_requirements_file }}"
@@ -209,7 +223,7 @@
     name="{{ EDXAPP_CAS_ATTRIBUTE_PACKAGE }}"
     virtualenv="{{edxapp_venv_dir}}"
     state=present
-    extra_args="-i {{ edxapp_pypi_local_mirror }} --exists-action w --use-mirrors"
+    extra_args="-i {{ COMMON_PYPI_MIRROR_URL }} --exists-action w --use-mirrors"
   sudo_user: "{{ edxapp_user }}"
   when: EDXAPP_CAS_ATTRIBUTE_PACKAGE|length > 0
   notify: "restart edxapp"
@@ -220,7 +234,7 @@
   # requirements are pathed relative to the edx-platform repo. Using the pip from inside the virtual environment implicitly
   # installs everything into that virtual environment.
   shell: >
-    {{ edxapp_venv_dir }}/bin/pip install -i {{ edxapp_pypi_local_mirror }} --exists-action w --use-mirrors -r {{ item }}
+    {{ edxapp_venv_dir }}/bin/pip install -i {{ COMMON_PYPI_MIRROR_URL }} --exists-action w --use-mirrors -r {{ item }}
     chdir={{ edxapp_code_dir }}
   with_items:
   - "{{ sandbox_base_requirements }}"
@@ -247,7 +261,7 @@
     requirements="{{sandbox_base_requirements}}"
     virtualenv="{{edxapp_sandbox_venv_dir}}"
     state=present
-    extra_args="-i {{ edxapp_pypi_local_mirror }} --exists-action w --use-mirrors"
+    extra_args="-i {{ COMMON_PYPI_MIRROR_URL }} --exists-action w --use-mirrors"
   sudo_user: "{{ edxapp_sandbox_user }}"
   when: EDXAPP_PYTHON_SANDBOX
   notify:
@@ -258,7 +272,7 @@
 
 - name: code sandbox | Install sandbox requirements into sandbox venv
   shell: >
-    {{ edxapp_sandbox_venv_dir }}/bin/pip install -i {{ edxapp_pypi_local_mirror }} --exists-action w --use-mirrors -r {{ item }}
+    {{ edxapp_sandbox_venv_dir }}/bin/pip install -i {{ COMMON_PYPI_MIRROR_URL }} --exists-action w --use-mirrors -r {{ item }}
     chdir={{ edxapp_code_dir }}
   with_items:
   - "{{ sandbox_local_requirements }}"

--- a/playbooks/roles/edxapp/tasks/deploy.yml
+++ b/playbooks/roles/edxapp/tasks/deploy.yml
@@ -165,20 +165,6 @@
   - "restart edxapp_workers"
   when: not inst.stat.exists or new.stat.md5 != inst.stat.md5
 
-# Install the python paver requirements into {{ edxapp_venv_dir }}
-- name : install python paver-requirements
-  pip: >
-    requirements="{{paver_requirements_file}}"
-    virtualenv="{{edxapp_venv_dir}}"
-    state=present
-    extra_args="-i {{ COMMON_PYPI_MIRROR_URL }}"
-  sudo_user: "{{ edxapp_user }}"
-  environment: "{{ edxapp_environment }}"
-  notify:
-  - "restart edxapp"
-  - "restart edxapp_workers"
-  when: not inst.stat.exists or new.stat.md5 != inst.stat.md5
-
 # Install the final python modules into {{ edxapp_venv_dir }}
 - name : install python post-post requirements
   # Need to use shell rather than pip so that we can maintain the context of our current working directory; some

--- a/playbooks/roles/supervisor/templates/etc/init/supervisor-upstart.conf.j2
+++ b/playbooks/roles/supervisor/templates/etc/init/supervisor-upstart.conf.j2
@@ -1,6 +1,6 @@
 description     "supervisord"
 
-{% if disable_edx_services -%}
+{% if disable_edx_services and not devstack -%}
   start on stopped pre_supervisor
 {% else %}
 start on runlevel [2345]


### PR DESCRIPTION
devstack to not use pre_supervisor

typo error

Taking out edxapp_pypi_local_mirror, replacing with COMMON_PYPI_MIRROR_URL

Adding back - for white space

Conflicts:
    playbooks/roles/edxapp/tasks/deploy.yml
