### PR TITLE
Remove update ssh config tasks

### DIFF
--- a/playbooks/roles/common/tasks/main.yml
+++ b/playbooks/roles/common/tasks/main.yml
@@ -117,9 +117,4 @@
   template: >
     dest=/etc/motd.tail
     src={{ COMMON_MOTD_TEMPLATE }} mode=0755 owner=root group=root
-
-- name: update ssh config
-  template: >
-    dest=/etc/ssh/sshd_config
-    src=sshd_config.j2 mode=0644 owner=root group=root
   notify: restart ssh


### PR DESCRIPTION
Although AWS EC-2 always use key to loggin, but in local deployment, use password to loggin ssh is common. Update the system sshd_config without any warning might cause people can not loggin to their host any more, and that should be a disaster for host manager. It should be more safe to give people manage their sshd_config.
