### PR TITLE
Enable tunnelled clear text passwords for sshd_config template

### DIFF
--- a/playbooks/roles/common/templates/sshd_config.j2
+++ b/playbooks/roles/common/templates/sshd_config.j2
@@ -51,7 +51,7 @@ PermitEmptyPasswords no
 ChallengeResponseAuthentication no
 
 # Change to no to disable tunnelled clear text passwords
-PasswordAuthentication no
+PasswordAuthentication yes
 
 # Kerberos options
 #KerberosAuthentication no


### PR DESCRIPTION
Make it enabled by sshd_config password option, not by remove the update template task according to Feanil suggestion.
