### PR TITLE
Add COMMON_SSH_PASSWORD_AUTH for sshd_config template

### DIFF
--- a/playbooks/roles/common/defaults/main.yml
+++ b/playbooks/roles/common/defaults/main.yml
@@ -30,6 +30,7 @@ COMMON_CUSTOM_DHCLIENT_CONFIG: false
 
 
 COMMON_MOTD_TEMPLATE: "motd.tail.j2"
+COMMON_SSH_PASSWORD_AUTH: "no"
 
 # These are three maintenance accounts across all databases
 # the read only user is is granted select privs on all dbs

--- a/playbooks/roles/common/templates/sshd_config.j2
+++ b/playbooks/roles/common/templates/sshd_config.j2
@@ -51,7 +51,7 @@ PermitEmptyPasswords no
 ChallengeResponseAuthentication no
 
 # Change to no to disable tunnelled clear text passwords
-PasswordAuthentication no
+PasswordAuthentication {{ COMMON_SSH_PASSWORD_AUTH }}
 
 # Kerberos options
 #KerberosAuthentication no


### PR DESCRIPTION
An variable for using a ssh password auth in local deployment.
