### PR TITLE
Explicitly set ssh to insecure private key.  It is default but sometimes...

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -28,3 +28,4 @@ Valera Rozuvan <valera.rozuvan@gmail.com>
 Ker Ruben Ramos <xdiscent@gmail.com>
 Fred Smith <derf@edx.org>
 Wang Peifeng <pku9104038@hotmail.com>
+Ray Hooker <ray.hooker@gmail.com>

--- a/vagrant/base/devstack/Vagrantfile
+++ b/vagrant/base/devstack/Vagrantfile
@@ -26,6 +26,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.network :forwarded_port, guest: 8000, host: 8000
   config.vm.network :forwarded_port, guest: 8001, host: 8001
   config.vm.network :forwarded_port, guest: 4567, host: 4567
+  config.ssh.insert_key = true
 
   config.vm.synced_folder "#{edx_platform_mount_dir}", "/edx/app/edxapp/edx-platform", :create => true, nfs: true
   config.vm.synced_folder "#{forum_mount_dir}", "/edx/app/forum/cs_comments_service", :create => true, nfs: true

--- a/vagrant/base/fullstack/Vagrantfile
+++ b/vagrant/base/fullstack/Vagrantfile
@@ -6,6 +6,7 @@ CPU_COUNT = 2
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box     = "precise64"
   config.vm.box_url = "http://files.vagrantup.com/precise64.box"
+  config.ssh.insert_key = true
 
   config.vm.network :private_network, ip: "192.168.33.10"
 

--- a/vagrant/release/devstack/Vagrantfile
+++ b/vagrant/release/devstack/Vagrantfile
@@ -44,6 +44,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.network :forwarded_port, guest: 8001, host: 8001
   config.vm.network :forwarded_port, guest: 4567, host: 4567
   config.vm.network :forwarded_port, guest: 8765, host: 8765
+  config.ssh.insert_key = true
 
   # Enable X11 forwarding so we can interact with GUI applications
   if ENV['VAGRANT_X11']

--- a/vagrant/release/fullstack/Vagrantfile
+++ b/vagrant/release/fullstack/Vagrantfile
@@ -8,6 +8,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # Creates an edX fullstack VM from an official release
   config.vm.box     = "himbasha-fullstack"
   config.vm.box_url = "http://files.edx.org/vagrant-images/20140325-himbasha-fullstack.box"
+  config.ssh.insert_key = true
 
   config.vm.network :private_network, ip: "192.168.33.10"
   config.hostsupdater.aliases = ["preview.localhost"]


### PR DESCRIPTION
There are a number of people having problems accessing the guest machine that vagrant creates.  The message indicates that Permission denied (publickey).  The solution is to explicitly set:

config.ssh.insert_key = true

Now it comes up correctly.  Of course if the installation choses to change to a secure public keys, they can change the Vagrantfile locally or in their own fork to reflect that change. 
