### PR TITLE
Allow override of edx-ora2 version installed

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -184,6 +184,13 @@ EDXAPP_UPDATE_STATIC_FILES_KEY: false
 # set to true
 
 EDXAPP_INSTALL_PRIVATE_REQUIREMENTS: false
+
+# ORA2 (from the edx/edx-ora2 repo) is currently installed
+# from edx-platform requirements.  If this variable is set
+# to a branch/tag, then the version of ora2 in the edx-platform
+# requirements will be overridden by this version.
+EDXAPP_ORA2_VERSION: ''
+
 #-------- Everything below this line is internal to the role ------------
 
 #Use YAML references (& and *) and hash merge <<: to factor out shared settings
@@ -570,3 +577,6 @@ edxapp_cms_variant: cms
 
 # Worker Settings
 worker_django_settings_module: 'aws'
+
+# edx-ora2 repo for pip installs
+edxapp_ora2_pip_req: "git+https://github.com/edx/edx-ora2.git@{{ EDXAPP_ORA2_VERSION }}#egg=edx-ora2"

--- a/playbooks/roles/edxapp/tasks/deploy.yml
+++ b/playbooks/roles/edxapp/tasks/deploy.yml
@@ -215,6 +215,16 @@
   - "restart edxapp"
   - "restart edxapp_workers"
 
+# Override the version of edx-ora2 specified in the edx-platform requirements
+- name: install edx-ora2 (overwrite version in edx-platform)
+  shell: >
+    {{ edxapp_venv_dir }}/bin/pip install -e {{ edxapp_ora2_pip_req }}
+    chdir={{ edxapp_code_dir }}
+  sudo_user: "{{ edxapp_user }}"
+  notify:
+    - "restart edxapp"
+    - "restart edxapp_workers"
+  when: EDXAPP_ORA2_VERSION != ""
 
 # If using CAS and you have a function for mapping attributes, install
 # the module here.  The next few tasks set up the python code sandbox


### PR DESCRIPTION
I'd like to create an integration sandbox that gets updated each night with the latest version of edx-ora2, even if edx-platform has an older version in its requirements.

This PR adds a variable to the `edxapp` role that allows users to `pip install` a version of `edx-ora2` after other edx-platform requirements are installed, but before database migrations are run.

@e0d Does this seem like a reasonable approach?
