### PR TITLE
allow abbey to use additional repos and customizable playbook locations.

### DIFF
--- a/util/jenkins/build-ami.sh
+++ b/util/jenkins/build-ami.sh
@@ -83,6 +83,19 @@ if [[ "$use_blessed" == "true" ]]; then
   blessed_params="--blessed"
 fi
 
+playbookdir_params=""
+if [[ ! -z "$playbook_dir" ]]; then
+  playbookdir_params="--playbook-dir $playbook_dir"
+fi
+
+configurationprivate_params=""
+if [[ ! -z "$configurationprivate-repo" ]]; then
+  configurationprivate_params="--configuration-private-repo $configurationprivate-repo"
+  if [[ ! -z "$configurationprivate-version" ]]; then
+    configurationprivate_params="$configurationprivate_params --configuration-private-version $configurationprivate-version"
+  fi
+fi
+
 cd configuration
 pip install -r requirements.txt
 
@@ -94,4 +107,4 @@ cat /var/tmp/$BUILD_ID-refs.yml
 echo "$vars" > /var/tmp/$BUILD_ID-extra-vars.yml
 cat /var/tmp/$BUILD_ID-extra-vars.yml
 
-python -u abbey.py -p $play -t c1.medium  -d $deployment -e $environment -i /edx/var/jenkins/.ssh/id_rsa $base_params $blessed_params --vars /var/tmp/$BUILD_ID-extra-vars.yml --refs /var/tmp/$BUILD_ID-refs.yml -c $BUILD_NUMBER --configuration-version $configuration --configuration-secure-version $configuration_secure -k $jenkins_admin_ec2_key --configuration-secure-repo $jenkins_admin_configuration_secure_repo
+python -u abbey.py -p $play -t c1.medium  -d $deployment -e $environment -i /edx/var/jenkins/.ssh/id_rsa $base_params $blessed_params $playbookdir_params --vars /var/tmp/$BUILD_ID-extra-vars.yml --refs /var/tmp/$BUILD_ID-refs.yml -c $BUILD_NUMBER --configuration-version $configuration --configuration-secure-version $configuration_secure -k $jenkins_admin_ec2_key --configuration-secure-repo $jenkins_admin_configuration_secure_repo $configurationprivate_params

--- a/util/vpc-tools/abbey.py
+++ b/util/vpc-tools/abbey.py
@@ -213,7 +213,7 @@ git_repo="https://github.com/edx/$git_repo_name"
 git_repo_secure="{configuration_secure_repo}"
 git_repo_secure_name="{configuration_secure_repo_basename}"
 git_repo_private="{configuration_private_repo}"
-git_repo_private_name="{configuration_private_repo_basename}"
+git_repo_private_basename=$(basename $git_repo_private)
 secure_vars_file="$base_dir/$git_repo_secure_name/{secure_vars}"
 instance_id=\\
 $(curl http://169.254.169.254/latest/meta-data/instance-id 2>/dev/null)
@@ -299,7 +299,7 @@ if $config_secure; then
     cd $base_dir
 fi
 
-if $config_private; then
+if [[ ! -z $git_repo_private ]]; then
     $git_cmd clone $git_repo_private $git_repo_private_name
     cd $git_repo_private_name
     $git_cmd checkout $configuration_private_version

--- a/util/vpc-tools/abbey.py
+++ b/util/vpc-tools/abbey.py
@@ -59,6 +59,10 @@ def parse_args():
     parser.add_argument('-p', '--play',
                         help='play name without the yml extension',
                         metavar="PLAY", required=True)
+    parser.add_argument('--playbook-dir',
+                        help='directory to find playbooks in',
+                        default='configuration/playbooks/edx-east'
+                        metavar="PLAYBOOKDIR", required=False)
     parser.add_argument('-d', '--deployment', metavar="DEPLOYMENT",
                         required=True)
     parser.add_argument('-e', '--environment', metavar="ENVIRONMENT",
@@ -80,6 +84,12 @@ def parse_args():
     parser.add_argument('--configuration-secure-repo', required=False,
                         default="git@github.com:edx-ops/prod-secure",
                         help="repo to use for the secure files")
+    parser.add_argument('--configuration-private-version', required=False,
+                        help="configuration-private repo branch(no hashes)",
+                        default="master")
+    parser.add_argument('--configuration-private-repo', required=False,
+                        default="git@github.com:edx-ops/ansible-private",
+                        help="repo to use for private playbooks")
     parser.add_argument('-c', '--cache-id', required=True,
                         help="unique id to use as part of cache prefix")
     parser.add_argument('-i', '--identity', required=False,
@@ -193,6 +203,7 @@ secure_identity="$base_dir/secure-identity"
 git_ssh="$base_dir/git_ssh.sh"
 configuration_version="{configuration_version}"
 configuration_secure_version="{configuration_secure_version}"
+configuration_private_version="{configuration_private_version}"
 environment="{environment}"
 deployment="{deployment}"
 play="{play}"
@@ -201,6 +212,8 @@ git_repo_name="configuration"
 git_repo="https://github.com/edx/$git_repo_name"
 git_repo_secure="{configuration_secure_repo}"
 git_repo_secure_name="{configuration_secure_repo_basename}"
+git_repo_private="{configuration_private_repo}"
+git_repo_private_name="{configuration_private_repo_basename}"
 secure_vars_file="$base_dir/$git_repo_secure_name/{secure_vars}"
 instance_id=\\
 $(curl http://169.254.169.254/latest/meta-data/instance-id 2>/dev/null)
@@ -208,7 +221,7 @@ instance_ip=\\
 $(curl http://169.254.169.254/latest/meta-data/local-ipv4 2>/dev/null)
 instance_type=\\
 $(curl http://169.254.169.254/latest/meta-data/instance-type 2>/dev/null)
-playbook_dir="$base_dir/configuration/playbooks/edx-east"
+playbook_dir="$base_dir/{playbook-dir}"
 
 if $config_secure; then
     git_cmd="env GIT_SSH=$git_ssh git"
@@ -285,6 +298,14 @@ if $config_secure; then
     $git_cmd checkout $configuration_secure_version
     cd $base_dir
 fi
+
+if $config_private; then
+    $git_cmd clone $git_repo_private $git_repo_private_name
+    cd $git_repo_private_name
+    $git_cmd checkout $configuration_private_version
+    cd $base_dir
+fi
+
 
 cd $base_dir/$git_repo_name
 sudo pip install -r requirements.txt


### PR DESCRIPTION
This PR will allow abbey and build-ami to:
- check out a third repo, ansible-private, which contains private playbooks and roles.  
- run playbooks out of a configurable directory, not hard coded to configuration/playbooks/edx-east
