### PR TITLE
Jarv/clean ami

### DIFF
--- a/playbooks/edx-east/edx_continuous_integration.yml
+++ b/playbooks/edx-east/edx_continuous_integration.yml
@@ -9,7 +9,7 @@
     ENABLE_DATADOG: True
     ENABLE_SPLUNKFORWARDER: False
     ENABLE_NEWRELIC: False
-    public_ami: True
+    edx_internal: False
   roles:
     - aws
     - role: nginx
@@ -33,7 +33,7 @@
     - elasticsearch
     - forum
     - { role: "xqueue", update_users: True }
-    - { role: xserver, when: not public_ami }
+    - { role: xserver, when: edx_internal }
     - ora
     - discern
     - certs

--- a/playbooks/edx-east/edx_continuous_integration.yml
+++ b/playbooks/edx-east/edx_continuous_integration.yml
@@ -9,6 +9,7 @@
     ENABLE_DATADOG: True
     ENABLE_SPLUNKFORWARDER: False
     ENABLE_NEWRELIC: False
+    public_ami: True
   roles:
     - aws
     - role: nginx
@@ -32,7 +33,7 @@
     - elasticsearch
     - forum
     - { role: "xqueue", update_users: True }
-    - xserver
+    - { role: xserver, when: public_ami }
     - ora
     - discern
     - certs

--- a/playbooks/edx-east/edx_continuous_integration.yml
+++ b/playbooks/edx-east/edx_continuous_integration.yml
@@ -33,7 +33,7 @@
     - elasticsearch
     - forum
     - { role: "xqueue", update_users: True }
-    - { role: xserver, when: public_ami }
+    - { role: xserver, when: not public_ami }
     - ora
     - discern
     - certs

--- a/util/jenkins/ansible-provision.sh
+++ b/util/jenkins/ansible-provision.sh
@@ -115,14 +115,14 @@ if [[ $basic_auth == "true" ]]; then
 
     if [[ $public_ami == "true" ]]; then
         cat << EOF_AUTH >> $extra_vars_file
-    NGINX_HTPASSWD_USER: edx 
-    NGINX_HTPASSWD_PASS: edx
+NGINX_HTPASSWD_USER: edx 
+NGINX_HTPASSWD_PASS: edx
 EOF_AUTH
     else
         # vars specific to provisioning added to $extra-vars
         cat << EOF_AUTH >> $extra_vars_file
-    NGINX_HTPASSWD_USER: $auth_user
-    NGINX_HTPASSWD_PASS: $auth_pass
+NGINX_HTPASSWD_USER: $auth_user
+NGINX_HTPASSWD_PASS: $auth_pass
 EOF_AUTH
     fi
 fi

--- a/util/jenkins/ansible-provision.sh
+++ b/util/jenkins/ansible-provision.sh
@@ -91,12 +91,6 @@ cd playbooks/edx-east
 cat << EOF > $extra_vars_file
 ---
 ansible_ssh_private_key_file: /var/lib/jenkins/${keypair}.pem
-EDXAPP_PREVIEW_LMS_BASE: preview.${deploy_host}
-EDXAPP_LMS_BASE: ${deploy_host}
-EDXAPP_CMS_BASE: studio.${deploy_host}
-EDXAPP_SITE_NAME: ${deploy_host}
-CERTS_DOWNLOAD_URL: "http://${deploy_host}:18090"
-CERTS_VERIFY_URL: "http://${deploy_host}:18090"
 edx_platform_version: $edxapp_version
 forum_version: $forum_version
 xqueue_version: $xqueue_version
@@ -159,6 +153,12 @@ EOF
         # user and set edx_internal to True so that
         # xserver is installed
         cat << EOF >> $extra_vars_file
+EDXAPP_PREVIEW_LMS_BASE: preview.${deploy_host}
+EDXAPP_LMS_BASE: ${deploy_host}
+EDXAPP_CMS_BASE: studio.${deploy_host}
+EDXAPP_SITE_NAME: ${deploy_host}
+CERTS_DOWNLOAD_URL: "http://${deploy_host}:18090"
+CERTS_VERIFY_URL: "http://${deploy_host}:18090"
 edx_internal: True
 COMMON_USER_INFO:
   - name: ${github_username}

--- a/util/jenkins/ansible-provision.sh
+++ b/util/jenkins/ansible-provision.sh
@@ -42,13 +42,12 @@ if [[ ! -f $BOTO_CONFIG ]]; then
 fi
 
 extra_vars_file="/var/tmp/extra-vars-$$.yml"
+extra_var_arg="-e@${extra_vars_file}"
 
 if [[ $edx_internal == "true" ]]; then
-    extra_var_arg="-e@${extra_vars_file} -e@${WORKSPACE}/configuration-secure/ansible/vars/developer-sandbox.yml"
-else
-    # if this is a public server do not include
+    # if this is a an edx server include
     # the secret var file
-    extra_var_arg="-e@${extra_vars_file}"
+    extra_var_arg="-e@${extra_vars_file} -e@${WORKSPACE}/configuration-secure/ansible/vars/developer-sandbox.yml"
 fi
 
 if [[ -z $region ]]; then

--- a/util/jenkins/ansible-provision.sh
+++ b/util/jenkins/ansible-provision.sh
@@ -43,11 +43,11 @@ fi
 
 extra_vars_file="/var/tmp/extra-vars-$$.yml"
 
-if [[ $public_ami == "true" ]]; then
-    # if this is a public server do not include
-    # the secret var file
+if [[ $edx_internal == "true" ]]; then
     extra_var_arg="-e@${extra_vars_file} -e@${WORKSPACE}/configuration-secure/ansible/vars/developer-sandbox.yml"
 else
+    # if this is a public server do not include
+    # the secret var file
     extra_var_arg="-e@${extra_vars_file}"
 fi
 
@@ -113,18 +113,10 @@ EOF
 
 if [[ $basic_auth == "true" ]]; then
 
-    if [[ $public_ami == "true" ]]; then
-        cat << EOF_AUTH >> $extra_vars_file
-NGINX_HTPASSWD_USER: edx 
-NGINX_HTPASSWD_PASS: edx
-EOF_AUTH
-    else
-        # vars specific to provisioning added to $extra-vars
-        cat << EOF_AUTH >> $extra_vars_file
+    cat << EOF_AUTH >> $extra_vars_file
 NGINX_HTPASSWD_USER: $auth_user
 NGINX_HTPASSWD_PASS: $auth_pass
 EOF_AUTH
-    fi
 fi
 
 
@@ -152,11 +144,11 @@ rabbitmq_refresh: True
 elb: $elb
 EOF
 
-    if [[ $public_ami != "true" ]]; then
+    if [[ $edx_internal == "true" ]]; then
         # if this isn't a public server add the github
         # user and set public_ami to false
         cat << EOF >> $extra_vars_file
-public_ami: False
+edx_internal: False
 COMMON_USER_INFO:
   - name: ${github_username}
     github: true

--- a/util/jenkins/ansible-provision.sh
+++ b/util/jenkins/ansible-provision.sh
@@ -43,6 +43,14 @@ fi
 
 extra_vars_file="/var/tmp/extra-vars-$$.yml"
 
+if [[ $public_ami == "true" ]]; then
+    # if this is a public server do not include
+    # the secret var file
+    extra_var_arg="-e@${extra_vars_file} -e@${WORKSPACE}/configuration-secure/ansible/vars/developer-sandbox.yml"
+else
+    extra_var_arg="-e@${extra_vars_file}"
+fi
+
 if [[ -z $region ]]; then
   region="us-east-1"
 fi
@@ -104,11 +112,19 @@ $extra_vars
 EOF
 
 if [[ $basic_auth == "true" ]]; then
-    # vars specific to provisioning added to $extra-vars
-    cat << EOF_AUTH >> $extra_vars_file
-NGINX_HTPASSWD_USER: $auth_user
-NGINX_HTPASSWD_PASS: $auth_pass
+
+    if [[ $public_ami == "true" ]]; then
+        cat << EOF_AUTH >> $extra_vars_file
+    NGINX_HTPASSWD_USER: edx 
+    NGINX_HTPASSWD_PASS: edx
 EOF_AUTH
+    else
+        # vars specific to provisioning added to $extra-vars
+        cat << EOF_AUTH >> $extra_vars_file
+    NGINX_HTPASSWD_USER: $auth_user
+    NGINX_HTPASSWD_PASS: $auth_pass
+EOF_AUTH
+    fi
 fi
 
 
@@ -131,25 +147,34 @@ instance_tags:
     datadog: monitored
 root_ebs_size: $root_ebs_size
 name_tag: $name_tag
+dns_zone: $dns_zone
+rabbitmq_refresh: True
+elb: $elb
+EOF
+
+    if [[ $public_ami != "true" ]]; then
+        # if this isn't a public server add the github
+        # user and set public_ami to false
+        cat << EOF >> $extra_vars_file
+public_ami: False
 COMMON_USER_INFO:
   - name: ${github_username}
     github: true
     type: admin
-dns_zone: $dns_zone
-rabbitmq_refresh: True
 USER_CMD_PROMPT: '[$name_tag] '
-elb: $elb
 EOF
+    fi
+
 
     # run the tasks to launch an ec2 instance from AMI
     cat $extra_vars_file
-    ansible-playbook edx_provision.yml  -i inventory.ini -e@${extra_vars_file} -e@${WORKSPACE}/configuration-secure/ansible/vars/developer-sandbox.yml --user ubuntu  -v
+    ansible-playbook edx_provision.yml  -i inventory.ini $extra_var_arg --user ubuntu  -v
 
     if [[ $server_type == "full_edx_installation" ]]; then
         # additional tasks that need to be run if the
         # entire edx stack is brought up from an AMI
-        ansible-playbook rabbitmq.yml -i "${deploy_host}," -e@${extra_vars_file} -e@${WORKSPACE}/configuration-secure/ansible/vars/developer-sandbox.yml --user ubuntu
-        ansible-playbook restart_supervisor.yml -i "${deploy_host}," -e@${extra_vars_file} -e@${WORKSPACE}/configuration-secure/ansible/vars/developer-sandbox.yml --user ubuntu
+        ansible-playbook rabbitmq.yml -i "${deploy_host}," $extra_var_arg --user ubuntu
+        ansible-playbook restart_supervisor.yml -i "${deploy_host}," $extra_var_arg --user ubuntu
     fi
 fi
 
@@ -163,21 +188,22 @@ done
 # run non-deploy tasks for all roles
 if [[ $reconfigure == "true" || $server_type == "full_edx_installation_from_scratch" ]]; then
     cat $extra_vars_file
-    ansible-playbook edx_continuous_integration.yml -i "${deploy_host}," -e@${extra_vars_file} -e@${WORKSPACE}/configuration-secure/ansible/vars/developer-sandbox.yml --user ubuntu 
+    ansible-playbook edx_continuous_integration.yml -i "${deploy_host}," $extra_var_arg --user ubuntu 
 fi
+
 
 if [[ $server_type == "full_edx_installation" ]]; then
     # Run deploy tasks for the roles selected
     for i in $roles; do
         if [[ ${deploy[$i]} == "true" ]]; then
             cat $extra_vars_file
-            ansible-playbook ${i}.yml -i "${deploy_host}," -e@${extra_vars_file} -e@${WORKSPACE}/configuration-secure/ansible/vars/developer-sandbox.yml --user ubuntu --tags deploy -v
+            ansible-playbook ${i}.yml -i "${deploy_host}," $extra_var_arg --user ubuntu --tags deploy -v
         fi
     done
 fi
 
 # deploy the edx_ansible role
-ansible-playbook edx_ansible.yml -i "${deploy_host}," -e@${extra_vars_file} -e@${WORKSPACE}/configuration-secure/ansible/vars/developer-sandbox.yml --user ubuntu
+ansible-playbook edx_ansible.yml -i "${deploy_host}," $extra_var_arg --user ubuntu
 
 # set the hostname
 ansible-playbook set_hostname.yml -i "${deploy_host}," -e hostname_fqdn=${deploy_host} --user ubuntu

--- a/util/jenkins/ansible-provision.sh
+++ b/util/jenkins/ansible-provision.sh
@@ -106,6 +106,16 @@ ease_version: $ease_version
 certs_version: $certs_version
 discern_version: $discern_version
 EDXAPP_STATIC_URL_BASE: $static_url_base
+EDXAPP_LMS_NGINX_PORT: 80
+EDXAPP_LMS_PREVIEW_NGINX_PORT: 80
+EDX_ANSIBLE_DUMP_VARS: true
+migrate_db: "yes"
+openid_workaround: True
+rabbitmq_ip: "127.0.0.1"
+rabbitmq_refresh: True
+COMMON_HOSTNAME: edx-server
+COMMON_DEPLOYMENT: edx
+COMMON_ENVIRONMENT: sandbox
 
 # User provided extra vars
 $extra_vars
@@ -146,9 +156,10 @@ EOF
 
     if [[ $edx_internal == "true" ]]; then
         # if this isn't a public server add the github
-        # user and set public_ami to false
+        # user and set edx_internal to True so that
+        # xserver is installed
         cat << EOF >> $extra_vars_file
-edx_internal: False
+edx_internal: True
 COMMON_USER_INFO:
   - name: ${github_username}
     github: true


### PR DESCRIPTION
These changes allow for easy creation of a public AMI for when we do configuration releases.
ansible-provision.sh reads a new boolean "edx_internal" that when unchecked will not use the sandbox secret vars or install the xserver.
