### PR TITLE
Add ability to specify custom python requirements.

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -213,6 +213,17 @@ EDXAPP_UPDATE_STATIC_FILES_KEY: false
 
 EDXAPP_INSTALL_PRIVATE_REQUIREMENTS: false
 
+# List of additional python packages that should be installed into the
+# edxapp virtual environment.
+# `name` (required), `version` (optional), and `extra_args` (optional)
+# are supported and correspond to the options of ansible's pip module.
+# Example:
+# EDXAPP_EXTRA_REQUIREMENTS:
+#   - name: mypackage
+#     version: 1.0.1
+#   - name: git+https://git.myproject.org/MyProject#egg=MyProject
+EDXAPP_EXTRA_REQUIREMENTS: []
+
 EDXAPP_GOOGLE_ANALYTICS_ACCOUNT: "None"
 
 EDXAPP_PEARSON_TEST_PASSWORD: ""

--- a/playbooks/roles/edxapp/tasks/deploy.yml
+++ b/playbooks/roles/edxapp/tasks/deploy.yml
@@ -242,6 +242,20 @@
   - "restart edxapp"
   - "restart edxapp_workers"
 
+# Install any custom extra requirements if defined in EDXAPP_EXTRA_REQUIREMENTS.
+- name: install python extra requirements
+  pip: >
+    name="{{ item.name }}"
+    {% if 'version' in item %}version="{{ item.version }}"{% endif %}
+    extra_args="--exists-action w --use-mirrors {{ item.extra_args|default('') }}"
+    virtualenv="{{ edxapp_venv_dir }}"
+    state=present
+  with_items: EDXAPP_EXTRA_REQUIREMENTS
+  sudo_user: "{{ edxapp_user }}"
+  notify:
+  - "restart edxapp"
+  - "restart edxapp_workers"
+
 # If using CAS and you have a function for mapping attributes, install
 # the module here.  The next few tasks set up the python code sandbox
 - name: install CAS attribute module


### PR DESCRIPTION
This lets you specify additional python packages to be installed
into the edxapp virtual environment.

The `EDXAPP_EXTRA_REQUIREMENTS` should be a list of dict objects
with `name`, `version` (optional) and `extra_args` (optional) keys,
that correspond to the options of ansible's pip module.

Example:

```
EDXAPP_EXTRA_REQUIREMENTS:
  - name: mypackage
    version: 1.0.1
  - name: git+https://git.myproject.org/MyProject#egg=MyProject
```
