### PR TITLE
update port forward for comments service and add 9200 for elasticsearch

### DIFF
--- a/vagrant/base/devstack/Vagrantfile
+++ b/vagrant/base/devstack/Vagrantfile
@@ -27,7 +27,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.network :private_network, ip: "192.168.33.10"
   config.vm.network :forwarded_port, guest: 8000, host: 8000
   config.vm.network :forwarded_port, guest: 8001, host: 8001
-  config.vm.network :forwarded_port, guest: 4567, host: 4567
+  config.vm.network :forwarded_port, guest: 18080, host: 18080
+  config.vm.network :forwarded_port, guest: 8765, host: 8765
+  config.vm.network :forwarded_port, guest: 9200, host: 9200
   config.ssh.insert_key = true
 
   config.vm.synced_folder  ".", "/vagrant", disabled: true

--- a/vagrant/release/devstack/Vagrantfile
+++ b/vagrant/release/devstack/Vagrantfile
@@ -50,8 +50,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.network :private_network, ip: "192.168.33.10"
   config.vm.network :forwarded_port, guest: 8000, host: 8000
   config.vm.network :forwarded_port, guest: 8001, host: 8001
-  config.vm.network :forwarded_port, guest: 4567, host: 4567
+  config.vm.network :forwarded_port, guest: 18080, host: 18080
   config.vm.network :forwarded_port, guest: 8765, host: 8765
+  config.vm.network :forwarded_port, guest: 9200, host: 9200
   config.ssh.insert_key = true
 
   # Enable X11 forwarding so we can interact with GUI applications


### PR DESCRIPTION
devstack needs comments service running on 18080, so updated the port forward to make it directly accessible from the host.  in addition, made elasticsearch accessible from the host as well.

I know there are several other Vagrantfiles where these directives exist, let me know which of these would need the same changes applied and I'll add.
