### PR TITLE
Modify jenkins worker task to run the wheel script 

### DIFF
--- a/playbooks/roles/jenkins_worker/tasks/python.yml
+++ b/playbooks/roles/jenkins_worker/tasks/python.yml
@@ -45,11 +45,26 @@
     src=wheel_venv.sh.j2 dest={{ jenkins_home }}/wheel_venv.sh
     owner={{ jenkins_user }} group={{ jenkins_group }} mode=700
 
+# Run the wheel_venv.sh script for the first time
+# This was previously done in the Jenkins global
+# configuration as part of the AMI Init script.
+# Moving here so that we can archive a clean snapshot
+# of the virtualenv with only the defined packages
+# from jenkins_wheels.
+- name: Run the wheel_venv.sh script
+  command: >
+    ./wheel_venv.sh edx-venv
+    chdir={{ jenkins_home }}
+    creates={{ jenkins_home }}/edx-venv
+  sudo_user: "{{ jenkins_user }}"
+
 # Archive the current state of the virtualenv
-# as a starting point for new builds
+# as a starting point for new builds.
+# The edx-venv directory is deleted and then recreated
+# cleanly from the archive by the jenkins build scripts.
 - name: Create a clean virtualenv archive
   command: >
-    tar -cpzWf {{ jenkins_venv }}_clean.tar.gz {{ jenkins_venv }}
+    tar -cpzf edx-venv_clean.tar.gz edx-venv
     chdir={{ jenkins_home }}
-    creates={{ jenkins_home }}/{{ jenkins_venv }}_clean.tar.gz
+    creates={{ jenkins_home }}/edx-venv_clean.tar.gz
   sudo_user: "{{ jenkins_user }}"


### PR DESCRIPTION
to populate the python virtualenv.

I didn't realize this was being done by the Jenkins master config, and needs to be moved here when I submitted #1049.

Needed to get [edx-platform/pull/3498](https://github.com/edx/edx-platform/pull/3498) working, though it can be merged independently.
