### PR TITLE
Jenkins should save the state of the rbenv

### DIFF
--- a/playbooks/roles/jenkins_worker/tasks/main.yml
+++ b/playbooks/roles/jenkins_worker/tasks/main.yml
@@ -10,4 +10,5 @@
 
 - include: system.yml
 - include: python.yml
+- include: ruby.yml
 - include: jscover.yml

--- a/playbooks/roles/jenkins_worker/tasks/ruby.yml
+++ b/playbooks/roles/jenkins_worker/tasks/ruby.yml
@@ -1,0 +1,12 @@
+---
+
+# Archive the current state of the rbenv
+# as a starting point for new builds.
+# The edx-rbenv directory is deleted and then recreated
+# cleanly from the archive by the jenkins build scripts.
+- name: Create a clean rbenv archive
+  command: >
+    tar -cpzf edx-rbenv_clean.tar.gz {{ jenkins_rbenv_root }}
+    chdir={{ jenkins_home }}
+    creates={{ jenkins_home }}/edx-rbenv_clean.tar.gz
+  sudo_user: "{{ jenkins_user }}"


### PR DESCRIPTION
Companion to #1049, but for Ruby instead of Python. The companion edx-platform pull request is https://github.com/edx/edx-platform/pull/3603. @feanil @jzoldak, can you two review?
