### PR TITLE
Added pyexpat to whitelisted shared objects, and flipped apparmor mode to enforce.

### DIFF
--- a/playbooks/roles/edxapp/templates/code.sandbox.j2
+++ b/playbooks/roles/edxapp/templates/code.sandbox.j2
@@ -1,6 +1,6 @@
 #include <tunables/global>
 
-{{ edxapp_sandbox_venv_dir }}/bin/python flags=(complain) {
+{{ edxapp_sandbox_venv_dir }}/bin/python {
     #include <abstractions/base>
 
     {{ edxapp_sandbox_venv_dir }}/** mr,
@@ -19,6 +19,7 @@
     /usr/lib/python2.7/lib-dynload/_csv.so mr,
     /usr/lib/python2.7/lib-dynload/datetime.so mr,
     /usr/lib/python2.7/lib-dynload/_elementtree.so mr,
+    /usr/lib/python2.7/lib-dynload/pyexpat.so mr,
 
     #
     # Allow access to selections from /proc

--- a/playbooks/roles/edxapp/templates/code.sandbox.j2
+++ b/playbooks/roles/edxapp/templates/code.sandbox.j2
@@ -25,5 +25,8 @@
     # Allow access to selections from /proc
     #
     /proc/*/mounts r,
+    
+    /tmp/codejail-*/ rix,
+    /tmp/codejail-*/** wrix,
 
 }


### PR DESCRIPTION
@e0d 
