### PR TITLE
upgrading boto

### DIFF
--- a/playbooks/ec2.ini
+++ b/playbooks/ec2.ini
@@ -11,7 +11,7 @@
 # AWS regions to make calls to. Set this to 'all' to make request to all regions
 # in AWS and merge the results together. Alternatively, set this to a comma
 # separated list of regions. E.g. 'us-east-1,us-west-1,us-west-2'
-regions = all
+regions = us-east-1
 regions_exclude = us-gov-west-1
 
 # When generating inventory, Ansible needs to know how to address a server.

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ PyYAML==3.11
 Jinja2==2.7.2
 MarkupSafe==0.21
 argparse==1.2.1
-boto==2.20.1
+boto==2.28.0
 ecdsa==0.11
 paramiko==1.13.0
 pycrypto==2.6.1


### PR DESCRIPTION
The new version of boto doesn't except 'all' as a region, defaulting our
ini to use us-east-1
