### PR TITLE
Upgrade setuptools with pip upgrade to prevent pkg_resources errors

### DIFF
--- a/playbooks/roles/common/defaults/main.yml
+++ b/playbooks/roles/common/defaults/main.yml
@@ -68,6 +68,7 @@ common_debian_pkgs:
 
 common_pip_pkgs:
   - pip==1.5.4
+  - setuptools=3.6
   - virtualenv==1.11.4
   - virtualenvwrapper
 


### PR DESCRIPTION
These two packages need to roughly sync up or newly installed package dependencies aren't found by the system's crusty setuptools.
