### PR TITLE
Fixed dead link in README.md (ansible.cc -> ansible.com)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Private Cloud with hosts for the core edX services.  This template
 will build quite a number of AWS resources that cost money, so please
 consider this before you start.
 
-The configuration phase is managed by [Ansible](http://ansible.cc/).
+The configuration phase is managed by [Ansible](http://ansible.com/).
 We have provided a number of playbooks that will configure each of
 the edX services.
 

--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -82,6 +82,7 @@ EDXAPP_FEATURES:
   ENABLE_S3_GRADE_DOWNLOADS: true
   USE_CUSTOM_THEME: $edxapp_use_custom_theme
   AUTOMATIC_AUTH_FOR_TESTING: $EDXAPP_ENABLE_AUTO_AUTH
+  ENABLE_THIRD_PARTY_AUTH: $edxapp_enable_third_party_auth
 
 EDXAPP_BOOK_URL: ''
 # This needs to be set to localhost
@@ -379,6 +380,7 @@ edxapp_generic_auth_config:  &edxapp_generic_auth
   CELERY_BROKER_USER: $EDXAPP_CELERY_USER
   CELERY_BROKER_PASSWORD: $EDXAPP_CELERY_PASSWORD
   GOOGLE_ANALYTICS_ACCOUNT: $EDXAPP_GOOGLE_ANALYTICS_ACCOUNT
+  THIRD_PARTY_AUTH: $edxapp_third_party_auth
 
 generic_env_config:  &edxapp_generic_env
   COURSES_WITH_UNSAFE_CODE: $EDXAPP_COURSES_WITH_UNSAFE_CODE

--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -82,7 +82,6 @@ EDXAPP_FEATURES:
   ENABLE_S3_GRADE_DOWNLOADS: true
   USE_CUSTOM_THEME: $edxapp_use_custom_theme
   AUTOMATIC_AUTH_FOR_TESTING: $EDXAPP_ENABLE_AUTO_AUTH
-  ENABLE_THIRD_PARTY_AUTH: $edxapp_enable_third_party_auth
 
 EDXAPP_BOOK_URL: ''
 # This needs to be set to localhost
@@ -380,7 +379,6 @@ edxapp_generic_auth_config:  &edxapp_generic_auth
   CELERY_BROKER_USER: $EDXAPP_CELERY_USER
   CELERY_BROKER_PASSWORD: $EDXAPP_CELERY_PASSWORD
   GOOGLE_ANALYTICS_ACCOUNT: $EDXAPP_GOOGLE_ANALYTICS_ACCOUNT
-  THIRD_PARTY_AUTH: $edxapp_third_party_auth
 
 generic_env_config:  &edxapp_generic_env
   COURSES_WITH_UNSAFE_CODE: $EDXAPP_COURSES_WITH_UNSAFE_CODE


### PR DESCRIPTION
The ansible link is dead.  I changed it from ansible.cc to ansible.com.
