### PR TITLE
Update README.md

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -29,3 +29,4 @@ Ker Ruben Ramos <xdiscent@gmail.com>
 Fred Smith <derf@edx.org>
 Wang Peifeng <pku9104038@hotmail.com>
 Ray Hooker <ray.hooker@gmail.com>
+David Pollack <david@sologourmand.com>

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Private Cloud with hosts for the core edX services.  This template
 will build quite a number of AWS resources that cost money, so please
 consider this before you start.
 
-The configuration phase is managed by [Ansible](http://ansible.cc/).
+The configuration phase is managed by [Ansible](http://ansible.com/).
 We have provided a number of playbooks that will configure each of
 the edX services.
 


### PR DESCRIPTION
the ansible link was dead, so it's been changed from ansible.cc to ansible.com.

In pull #1118, I had some miscellaneous pulls accidently.  This corrects those.
