### PR TITLE
Set rbenv tar target to .rbenv instead of /home/jenkins

### DIFF
--- a/playbooks/roles/jenkins_worker/tasks/ruby.yml
+++ b/playbooks/roles/jenkins_worker/tasks/ruby.yml
@@ -6,7 +6,7 @@
 # cleanly from the archive by the jenkins build scripts.
 - name: Create a clean rbenv archive
   command: >
-    tar -cpzf edx-rbenv_clean.tar.gz {{ jenkins_rbenv_root }}
+    tar -cpzf edx-rbenv_clean.tar.gz .rbenv
     chdir={{ jenkins_home }}
     creates={{ jenkins_home }}/edx-rbenv_clean.tar.gz
   sudo_user: "{{ jenkins_user }}"


### PR DESCRIPTION
This will make it consistent with how we pack and unpack the
virtualenv (in terms of directory structure).

CC @singingwolfboy @jzoldak For additional info on unpacking, see edx-platform/jenkins/all-tests.sh
