### PR TITLE
Add thin-backup plugin

### DIFF
--- a/playbooks/roles/jenkins_master/defaults/main.yml
+++ b/playbooks/roles/jenkins_master/defaults/main.yml
@@ -44,6 +44,7 @@ jenkins_plugins:
     - { name: "violations", version: "0.7.11" }
     - { name: "multiple-scms", version: "0.2" }
     - { name: "timestamper", version: "1.5.7" }
+    - { name: "thinBackup", version: "1.7.4"}
 
 jenkins_bundled_plugins:
     - "credentials"


### PR DESCRIPTION
Although this can be used as part of any DR strategy, the immediate intent is
providing an ability to quickly spin up Jenkins master instances for testing
against. (A user would run the ansible script to create a test instance,
then restore a backup .zip which would contain all of the jobs' and master's
configuration.)

ThinBackup plugin doc: https://wiki.jenkins-ci.org/display/JENKINS/thinBackup
