### PR TITLE
Update edxapp ansible role for third party authorization

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -82,6 +82,7 @@ EDXAPP_FEATURES:
   ENABLE_S3_GRADE_DOWNLOADS: true
   USE_CUSTOM_THEME: $edxapp_use_custom_theme
   AUTOMATIC_AUTH_FOR_TESTING: $EDXAPP_ENABLE_AUTO_AUTH
+  ENABLE_THIRD_PARTY_AUTH: $edxapp_enable_third_party_auth
 
 EDXAPP_BOOK_URL: ''
 # This needs to be set to localhost
@@ -378,6 +379,7 @@ edxapp_generic_auth_config:  &edxapp_generic_auth
   CELERY_BROKER_USER: $EDXAPP_CELERY_USER
   CELERY_BROKER_PASSWORD: $EDXAPP_CELERY_PASSWORD
   GOOGLE_ANALYTICS_ACCOUNT: $EDXAPP_GOOGLE_ANALYTICS_ACCOUNT
+  THIRD_PARTY_AUTH: $edxapp_third_party_auth
 
 generic_env_config:  &edxapp_generic_env
   COURSES_WITH_UNSAFE_CODE: $EDXAPP_COURSES_WITH_UNSAFE_CODE

--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -70,7 +70,10 @@ EDXAPP_CAS_ATTRIBUTE_PACKAGE: ''
 # Enable an end-point that creates a user and logs them in
 # Used for performance testing
 EDXAPP_ENABLE_AUTO_AUTH: false
-
+# Settings for enabling and configuring third party authorization
+EDXAPP_ENABLE_THIRD_PARTY_AUTH: false
+EDXAPP_THIRD_PARTY_AUTH: !!null
+ 
 EDXAPP_FEATURES:
   AUTH_USE_OPENID_PROVIDER: true
   CERTIFICATES_ENABLED: true
@@ -82,7 +85,7 @@ EDXAPP_FEATURES:
   ENABLE_S3_GRADE_DOWNLOADS: true
   USE_CUSTOM_THEME: $edxapp_use_custom_theme
   AUTOMATIC_AUTH_FOR_TESTING: $EDXAPP_ENABLE_AUTO_AUTH
-  ENABLE_THIRD_PARTY_AUTH: $edxapp_enable_third_party_auth
+  ENABLE_THIRD_PARTY_AUTH: $EDXAPP_ENABLE_THIRD_PARTY_AUTH
 
 EDXAPP_BOOK_URL: ''
 # This needs to be set to localhost
@@ -379,7 +382,7 @@ edxapp_generic_auth_config:  &edxapp_generic_auth
   CELERY_BROKER_USER: $EDXAPP_CELERY_USER
   CELERY_BROKER_PASSWORD: $EDXAPP_CELERY_PASSWORD
   GOOGLE_ANALYTICS_ACCOUNT: $EDXAPP_GOOGLE_ANALYTICS_ACCOUNT
-  THIRD_PARTY_AUTH: $edxapp_third_party_auth
+  THIRD_PARTY_AUTH: $EDXAPP_THIRD_PARTY_AUTH
 
 generic_env_config:  &edxapp_generic_env
   COURSES_WITH_UNSAFE_CODE: $EDXAPP_COURSES_WITH_UNSAFE_CODE


### PR DESCRIPTION
I updated edxapp ansible role to include the ability to enable third party authorization via the server-vars.yml file.  A sample of the server-vars.yml file is as follows:

```
# Third Party Auth Additions
EDXAPP_ENABLE_THIRD_PARTY_AUTH: true
EDXAPP_THIRD_PARTY_AUTH: {
  'Google': {
    "SOCIAL_AUTH_GOOGLE_OAUTH2_KEY": "[GOOGLE-KEY]",
    "SOCIAL_AUTH_GOOGLE_OAUTH2_SECRET": "[GOOGLE-SECRET]"
  }
}
```

Where the key ("Client ID" on Google's site) and secret are your own secret and key from [Google's Developer Console](https://console.developers.google.com/).
