### PR TITLE
Add celery flower role

### DIFF
--- a/playbooks/edx-east/edx_continuous_integration.yml
+++ b/playbooks/edx-east/edx_continuous_integration.yml
@@ -42,3 +42,4 @@
       when: ENABLE_SPLUNKFORWARDER
     - role: newrelic
       when: ENABLE_NEWRELIC
+    - flower

--- a/playbooks/edx-east/flower.yml
+++ b/playbooks/edx-east/flower.yml
@@ -1,0 +1,6 @@
+- name: Deploy celery flower (monitoring tool)
+  hosts: all
+  sudo: True
+  gather_facts: True
+  roles:
+    - flower

--- a/playbooks/roles/flower/defaults/main.yml
+++ b/playbooks/roles/flower/defaults/main.yml
@@ -1,0 +1,27 @@
+---
+
+# By default, point to the RabbitMQ broker running locally
+FLOWER_BROKER_USERNAME: "celery"
+FLOWER_BROKER_PASSWORD: "celery"
+FLOWER_BROKER_HOST: "127.0.0.1"
+FLOWER_BROKER_PORT: 5672
+FLOWER_ADDRESS: "0.0.0.0"
+FLOWER_PORT: "5555"
+
+flower_user: "flower"
+flower_app_dir: "{{ COMMON_APP_DIR }}/flower"
+flower_data_dir: "{{ COMMON_DATA_DIR }}/flower"
+flower_log_dir: "{{ COMMON_LOG_DIR }}/flower"
+
+flower_venv_dir: "{{ flower_app_dir }}/venvs/flower"
+flower_venv_bin: "{{ flower_venv_dir }}/bin"
+
+flower_python_reqs:
+  - "flower==0.7.0"
+
+flower_deploy_path: "{{ flower_venv_bin }}:/usr/local/sbin:/usr/local/bin:/usr/bin:/sbin:/bin"
+
+flower_broker: "amqp://{{ FLOWER_BROKER_USERNAME }}:{{ FLOWER_BROKER_PASSWORD }}@{{ FLOWER_BROKER_HOST }}:{{ FLOWER_BROKER_PORT }}"
+
+flower_environment:
+  PATH: $flower_deploy_path

--- a/playbooks/roles/flower/handlers/main.yml
+++ b/playbooks/roles/flower/handlers/main.yml
@@ -1,0 +1,8 @@
+---
+- name: restart flower
+  supervisorctl_local: >
+    state=restarted
+    supervisorctl_path={{ supervisor_ctl }}
+    config={{ supervisor_cfg }}
+    name="flower"
+  sudo_user: "{{supervisor_service_user }}"

--- a/playbooks/roles/flower/meta/main.yml
+++ b/playbooks/roles/flower/meta/main.yml
@@ -1,0 +1,4 @@
+---
+dependencies:
+  - supervisor
+  - devpi

--- a/playbooks/roles/flower/tasks/main.yml
+++ b/playbooks/roles/flower/tasks/main.yml
@@ -1,0 +1,67 @@
+---
+
+- name: create application user
+  user: >
+    name="{{ flower_user }}" home="{{ flower_app_dir }}"
+    createhome=no shell=/bin/false
+  notify:
+    - "restart flower"
+
+- name: create flower user dirs
+  file: >
+    path="{{ item }}" state=directory
+    owner="{{ flower_user }}" group="{{ common_web_group }}"
+  notify:
+    - "restart flower"
+  with_items:
+    - "{{ flower_app_dir }}"
+    - "{{ flower_data_dir }}"
+    - "{{ flower_venv_dir }}"
+    - "{{ flower_log_dir }}"
+
+- name: create flower environment script
+  template: >
+    src=flower_env.j2 dest={{ flower_app_dir }}/flower_env
+    owner={{ flower_user }} group={{ common_web_group }}
+    mode=0644
+  notify:
+    - "restart flower"
+
+- name: create virtualenv and install Python requirements
+  pip: >
+    name="{{ item }}"
+    virtualenv="{{ flower_venv_dir }}"
+    state=present
+    extra_args="-i {{ COMMON_PYPI_MIRROR_URL }}"
+  sudo_user: "{{ flower_user }}"
+  environment: "{{ flower_environment }}"
+  with_items: "flower_python_reqs"
+  notify:
+    - "restart flower"
+
+- name: create supervisor configuration
+  template: >
+    src=flower.conf.j2 dest={{ supervisor_available_dir }}/flower.conf
+    owner={{ supervisor_user }}
+    group={{ supervisor_user }}
+  sudo_user: "{{ supervisor_user }}"
+  notify:
+    - "restart flower"
+
+- name: enable supervisor configuration
+  file: >
+    src={{ supervisor_available_dir }}/flower.conf
+    dest={{ supervisor_cfg_dir }}/flower.conf
+    state=link
+    force=yes
+  sudo_user: "{{ supervisor_user }}"
+  notify:
+    - "restart flower"
+
+- name: update supervisor configuration
+  shell:  "{{ supervisor_ctl }} -c {{ supervisor_cfg }} update"
+  register: supervisor_update
+  sudo_user: "{{ supervisor_service_user }}"
+  changed_when: supervisor_update.stdout != ""
+  notify:
+    - "restart flower"

--- a/playbooks/roles/flower/templates/flower.conf.j2
+++ b/playbooks/roles/flower/templates/flower.conf.j2
@@ -1,0 +1,7 @@
+[program:flower]
+
+environment=PATH="{{ flower_deploy_path }}"
+user={{ common_web_user }}
+command={{ flower_venv_bin }}/celery flower --broker {{ flower_broker }} --address={{ FLOWER_ADDRESS }} --port={{ FLOWER_PORT }}
+stdout_logfile={{ supervisor_log_dir }}/flower-stdout.log
+stderr_logfile={{ supervisor_log_dir }}/flower-stderr.log

--- a/playbooks/roles/flower/templates/flower_env.j2
+++ b/playbooks/roles/flower/templates/flower_env.j2
@@ -1,0 +1,6 @@
+# {{ ansible_managed }}
+{% for name,value in flower_environment.items() %}
+{%- if value %}
+export {{ name }}="{{ value }}"
+{%- endif %}
+{% endfor %}


### PR DESCRIPTION
This PR adds a role to run [Celery Flower](http://flower.readthedocs.org/en/latest/), a monitoring tool for Celery tasks.

Initially, I hope to deploy this on single-instance sandboxes for testing.  I've tested it on my sandbox and verified that it connects successfully to rabbitmq and serves HTTP over port 5555.

@feanil please review.
