### PR TITLE
changing source_type

### DIFF
--- a/playbooks/roles/splunkforwarder/defaults/main.yml
+++ b/playbooks/roles/splunkforwarder/defaults/main.yml
@@ -23,6 +23,14 @@ SPLUNKFORWARDER_DEB: !!null
 SPLUNKFORWARDER_PASSWORD: !!null
 
 SPLUNKFORWARDER_LOG_ITEMS:
+  - directory: '{{ COMMON_LOG_DIR }}/lms'
+    recursive: true
+    index: '{{COMMON_ENVIRONMENT}}-{{COMMON_DEPLOYMENT}}'
+    sourcetype: 'edx'
+  - directory: '{{ COMMON_LOG_DIR }}/cms'
+    recursive: true
+    index: '{{COMMON_ENVIRONMENT}}-{{COMMON_DEPLOYMENT}}'
+    sourcetype: 'edx'    
   - directory: '{{ COMMON_LOG_DIR }}'
     recursive: true
     index: '{{COMMON_ENVIRONMENT}}-{{COMMON_DEPLOYMENT}}'

--- a/playbooks/roles/splunkforwarder/defaults/main.yml
+++ b/playbooks/roles/splunkforwarder/defaults/main.yml
@@ -26,7 +26,7 @@ SPLUNKFORWARDER_LOG_ITEMS:
   - directory: '{{ COMMON_LOG_DIR }}'
     recursive: true
     index: '{{COMMON_ENVIRONMENT}}-{{COMMON_DEPLOYMENT}}'
-    sourcetype: 'edx'
+    sourcetype: 'syslog'
   - directory: '/var/log'
     recursive: true
     index: '{{COMMON_ENVIRONMENT}}-{{COMMON_DEPLOYMENT}}'


### PR DESCRIPTION
The edx source type doesn't work properly with supervisor generated logs.  We should default to syslog until we can do something better here.
