### PR TITLE
Add new task to set a boto config file

### DIFF
--- a/playbooks/roles/jenkins_admin/defaults/main.yml
+++ b/playbooks/roles/jenkins_admin/defaults/main.yml
@@ -10,6 +10,10 @@
 ##
 # Defaults for role jenkins_admin
 #
+#
+# JENKINS_ADMIN_USE_BOTO_CFG is not defined by default
+# is set a .boto config file will be create from template
+# templates/edx/var/jenkins/boto.j2
 
 #
 # vars are namespace with the module name.

--- a/playbooks/roles/jenkins_admin/tasks/main.yml
+++ b/playbooks/roles/jenkins_admin/tasks/main.yml
@@ -120,6 +120,15 @@
     mode=0644
   with_items: jenkins_admin_jobs
 
+- name: create boto config file
+  template: >
+    src="./{{ jenkins_home }}/boto.j2"
+    dest="{{ jenkins_home }}/.boto"
+    owner={{ jenkins_user }}
+    group={{ jenkins_group }}
+    mode=0644
+  when: JENKINS_ADMIN_USE_BOTO_CFG is defined
+
 - name: install system packages for edxapp virtualenvs
   apt: pkg={{ item }} state=present
   with_items: jenkins_admin_debian_pkgs

--- a/playbooks/roles/jenkins_admin/templates/edx/var/jenkins/boto.j2
+++ b/playbooks/roles/jenkins_admin/templates/edx/var/jenkins/boto.j2
@@ -1,0 +1,3 @@
+[Credentials]
+aws_access_key_id = {{ JENKINS_ADMIN_S3_PROFILE.access_key }}
+aws_secret_access_key = {{ JENKINS_ADMIN_S3_PROFILE.secret_key }}


### PR DESCRIPTION
The .boto config file will only be created if the  JENKINS_ADMIN_USE_BOTO_CFG var is defined, by default it is not.
