### PR TITLE
Remove NLTK_DATA environment var from ORA celery

### DIFF
--- a/playbooks/roles/ora/templates/ora_celery.conf.j2
+++ b/playbooks/roles/ora/templates/ora_celery.conf.j2
@@ -5,7 +5,7 @@ command={{ ora_venv_bin }}/python {{ ora_code_dir }}/manage.py celeryd --logleve
 user={{ common_web_user }}
 directory={{ ora_code_dir }}
 
-environment=DJANGO_SETTINGS_MODULE=edx_ora.aws,SERVICE_VARIANT=ora,NLTK_DATA={{ ora_nltk_data_dir }}
+environment=DJANGO_SETTINGS_MODULE=edx_ora.aws,SERVICE_VARIANT=ora
 
 stdout_logfile={{ supervisor_log_dir }}/%(program_name)-stdout.log
 stderr_logfile={{ supervisor_log_dir }}/%(program_name)-stderr.log


### PR DESCRIPTION
This is the issue that's breaking the CI build.  In a PR yesterday I moved the NLTK data to /usr/local/share, so there's no need to define the `NLTK_DATA` environment variable.  I removed this from the ORA supervisor config, but forgot to remove it from the worker config.

@feanil 
