### PR TITLE
Update the ORA2 deploy script to restart workers

### DIFF
--- a/playbooks/edx-east/ora2.yml
+++ b/playbooks/edx-east/ora2.yml
@@ -28,6 +28,7 @@
       sudo_user: "{{ edxapp_user }}"
       notify:
         - "restart edxapp"
+        - "restart workers"
 
     - name: syncdb and migrate
       shell: >
@@ -38,10 +39,11 @@
         DB_MIGRATION_PASS: "{{ edxapp_mysql_password }}"
       notify:
         - "restart edxapp"
+        - "restart workers"
 
   handlers:
     - name: restart edxapp
-      shell: "{{ supervisorctl_path }} restart edxapp:{{ item }}"
-      with_items:
-        - lms
-        - cms
+      shell: "{{ supervisorctl_path }} restart edxapp:"
+
+    - name: restart workers
+      shell: "{{ supervisorctl_path }} restart edxapp_worker:"


### PR DESCRIPTION
This is an update to the ORA2 one-off deployment script.  We've been using this to update our ORA2 sandbox, but it isn't used anywhere else.

Now that we're using Celery workers, we need to restart them once we update ORA2.

@feanil 
