### PR TITLE
make backup of previous server-vars.yml

### DIFF
--- a/playbooks/roles/edx_ansible/tasks/deploy.yml
+++ b/playbooks/roles/edx_ansible/tasks/deploy.yml
@@ -34,6 +34,12 @@
     dest={{ COMMON_CFG_DIR }}/playbooks
     state=link
 
+- name: create backup of server vars
+  copy: >
+    src={{ edx_ansible_var_file }}
+    dest={{ edx_ansible_var_file }}.old
+  when: EDX_ANSIBLE_DUMP_VARS
+
 - name: dump all vars to yaml
   template: src=dumpall.yml.j2 dest={{ edx_ansible_var_file }} mode=0600
   when: EDX_ANSIBLE_DUMP_VARS


### PR DESCRIPTION
Added some code so the previous server-vars.yml is backed up when /edx/bin/update is run.  Previously only the variables in all caps were preserved.
