### PR TITLE
Changing pip packages

### DIFF
--- a/playbooks/roles/common/defaults/main.yml
+++ b/playbooks/roles/common/defaults/main.yml
@@ -71,9 +71,9 @@ common_debian_pkgs:
   - curl
 
 common_pip_pkgs:
-  - pip==1.5.4
+  - pip==1.5.6
   - setuptools==3.6
-  - virtualenv==1.11.4
+  - virtualenv==1.11.6
   - virtualenvwrapper
 
 common_web_user: www-data


### PR DESCRIPTION
Using https://pypi.python.org/pypi/virtualenv as a guide on what versions that and pip should be if setuptools = 3.6 (and vice versa)
