### PR TITLE
Allow restart handler to run when updating conf

### DIFF
--- a/playbooks/roles/edxapp/tasks/deploy.yml
+++ b/playbooks/roles/edxapp/tasks/deploy.yml
@@ -418,3 +418,5 @@
   when: EDXAPP_USE_GIT_IDENTITY
 
 - set_fact: edxapp_installed=true
+  tags:
+    - edxapp_cfg


### PR DESCRIPTION
Running the `edxapp` role with `-t edxapp_cfg` requires the app to be restarted.
