### PR TITLE
Jenkins-datadog configuration

### DIFF
--- a/playbooks/roles/jenkins_master/meta/main.yml
+++ b/playbooks/roles/jenkins_master/meta/main.yml
@@ -1,3 +1,5 @@
 ---
 dependencies:
   - common
+  - role: datadog
+    COMMON_ENABLE_DATADOG: True

--- a/playbooks/roles/jenkins_master/tasks/datadog.yml
+++ b/playbooks/roles/jenkins_master/tasks/datadog.yml
@@ -1,0 +1,3 @@
+- name: enable jenkins datadog
+  shell: cp /etc/dd-agent/conf.d/jenkins.yaml.example /etc/dd-agent/conf.d/jenkins.yaml creates=/etc/dd-agent/conf.d/jenkins.yaml
+  notify: restart the datadog service

--- a/playbooks/roles/jenkins_master/tasks/main.yml
+++ b/playbooks/roles/jenkins_master/tasks/main.yml
@@ -126,3 +126,5 @@
     dest=/etc/nginx/sites-enabled/jenkins
     state=link
   notify: start nginx
+
+- include: datadog.yml tags=datadog


### PR DESCRIPTION
When using datadog on Jenkins, it should include datadog's provided Jenkins capabilities.
