### PR TITLE
Update vagrant images to support vmware providers

### DIFF
--- a/vagrant/base/devstack/Vagrantfile
+++ b/vagrant/base/devstack/Vagrantfile
@@ -20,7 +20,7 @@ end
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
-  # Creates a devstack from a base Ubuntu 12.04 image
+  # Creates a devstack from a base Ubuntu 12.04 image for virtualbox
   config.vm.box     = "precise64"
   config.vm.box_url = "http://files.vagrantup.com/precise64.box"
 
@@ -50,6 +50,17 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     # http://askubuntu.com/questions/238040/how-do-i-fix-name-service-for-vagrant-client
     vb.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
   end
+
+  ["vmware_fusion", "vmware_workstation"].each do |vmware_provider|
+    config.vm.provider vmware_provider do |v, override|
+      # Override box url to get vmware one
+      override.vm.box     = "precise64_vmware"
+      override.vm.box_url = "http://files.vagrantup.com/precise64_vmware.box"
+      v.vmx["memsize"] = MEMORY.to_s
+      v.vmx["numvcpus"] = CPU_COUNT.to_s
+    end
+  end
+
 
   # Make LC_ALL default to en_US.UTF-8 instead of en_US.
   # See: https://github.com/mitchellh/vagrant/issues/1188

--- a/vagrant/base/fullstack/Vagrantfile
+++ b/vagrant/base/fullstack/Vagrantfile
@@ -22,6 +22,15 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     # http://askubuntu.com/questions/238040/how-do-i-fix-name-service-for-vagrant-client
     vb.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
   end
+ 
+  ["vmware_fusion", "vmware_workstation"].each do |vmware_provider|
+    config.vm.provider vmware_provider do |v, override|
+      override.vm.box     = "precise64_vmware"
+      override.vm.box_url = "http://files.vagrantup.com/precise64_vmware.box"
+      v.vmx["memsize"] = MEMORY.to_s
+      v.vmx["numvcpus"] = CPU_COUNT.to_s
+    end
+  end
 
   # Make LC_ALL default to en_US.UTF-8 instead of en_US.
   # See: https://github.com/mitchellh/vagrant/issues/1188

--- a/vagrant/base/test_role/Vagrantfile
+++ b/vagrant/base/test_role/Vagrantfile
@@ -2,6 +2,7 @@ MEMORY = 2048
 CPU_COUNT = 2
 
 Vagrant.configure("2") do |config|
+
   config.vm.box     = "precise64"
   config.vm.box_url = "http://files.vagrantup.com/precise64.box"
 
@@ -17,6 +18,15 @@ Vagrant.configure("2") do |config|
     # Allow DNS to work for Ubuntu 12.10 host
     # http://askubuntu.com/questions/238040/how-do-i-fix-name-service-for-vagrant-client
     vb.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
+  end
+
+  ["vmware_fusion", "vmware_workstation"].each do |vmware_provider|
+    config.vm.provider vmware_provider do |v, override|
+      override.vm.box     = "precise64_vmware"
+      override.vm.box_url = "http://files.vagrantup.com/precise64_vmware.box"
+      v.vmx["memsize"] = MEMORY.to_s
+      v.vmx["numvcpus"] = CPU_COUNT.to_s
+    end
   end
 
   config.vm.provision :ansible do |ansible|

--- a/vagrant/release/devstack/Vagrantfile
+++ b/vagrant/release/devstack/Vagrantfile
@@ -74,6 +74,15 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     vb.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
   end
 
+  ["vmware_fusion", "vmware_workstation"].each do |vmware_provider|
+    config.vm.provider vmware_provider do |v, override|
+      override.vm.box     = "injera-devstack-vmware"
+      override.vm.box_url = "http://files.edx.org/vagrant-images/20140418-injera-devstack-vmware.box"
+      v.vmx["memsize"] = MEMORY.to_s
+      v.vmx["numvcpus"] = CPU_COUNT.to_s
+    end
+  end
+
   # Use vagrant-vbguest plugin to make sure Guest Additions are in sync
   config.vbguest.auto_reboot = true
   config.vbguest.auto_update = true

--- a/vagrant/release/fullstack/Vagrantfile
+++ b/vagrant/release/fullstack/Vagrantfile
@@ -10,6 +10,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # Creates an edX fullstack VM from an official release
   config.vm.box     = "injera-fullstack"
   config.vm.box_url = "http://files.edx.org/vagrant-images/20140418-injera-fullstack.box"
+
   config.vm.synced_folder  ".", "/vagrant", disabled: true
   config.ssh.insert_key = true
 
@@ -24,5 +25,13 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     # http://askubuntu.com/questions/238040/how-do-i-fix-name-service-for-vagrant-client
     vb.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
   end
-
+ 
+  ["vmware_fusion", "vmware_workstation"].each do |vmware_provider|
+    config.vm.provider vmware_provider do |v, override|
+      override.vm.box     = "injera-fullstack-vmware"
+      override.vm.box_url = "http://files.edx.org/vagrant-images/20140418-injera-fullstack-vmware.box"
+      v.vmx["memsize"] = MEMORY.to_s
+      v.vmx["numvcpus"] = CPU_COUNT.to_s
+    end
+  end
 end


### PR DESCRIPTION
Adds support for VMWare fusion/workstation providers in vagrant.  I changed the release files even though those images don't exist to show the changes, but if you don't want to make those until the next release I can pull those changes out. I did gen some off of master to verify you could build them from base. 
