### PR TITLE
change default of COMMON_ENABLE_BASIC_AUTH to False

### DIFF
--- a/playbooks/roles/common/defaults/main.yml
+++ b/playbooks/roles/common/defaults/main.yml
@@ -4,7 +4,7 @@
 # where edX is installed
 
 # Set global htpasswd credentials
-COMMON_ENABLE_BASIC_AUTH: True
+COMMON_ENABLE_BASIC_AUTH: False
 COMMON_HTPASSWD_USER: edx
 COMMON_HTPASSWD_PASS: edx
 

--- a/util/jenkins/ansible-provision.sh
+++ b/util/jenkins/ansible-provision.sh
@@ -131,7 +131,7 @@ EOF
 if [[ $basic_auth == "true" ]]; then
     # vars specific to provisioning added to $extra-vars
     cat << EOF_AUTH >> $extra_vars_file
-COMMON_ENABLE_BASIC_AUTH: True
+COMMON_ENABLE_BASIC_AUTH: False
 COMMON_HTPASSWD_USER: $auth_user
 COMMON_HTPASSWD_PASS: $auth_pass
 XQUEUE_BASIC_AUTH_USER: $auth_user


### PR DESCRIPTION
I changed the default behavior of basic authorization to false.  I found the default behavior unintuitive.  Upon installation of the default image via vagrant, going to the server from a remote host (including the vagrant host computer) prompts the user for a username/password.  The default behavior should be that the edx lms/cms "just work" without a username/password, right?  Furthermore, the documentation does not mention that the username/password is edx/edx, and one can only find this information by going into the source files.  Finally, I didn't see a great reason to use basic auth at all, and thus if someone wants to use it, they probably should explicitly enable it, instead of this being the default behavior.
