### PR TITLE
added ansible task to add chris-lea ppas for current version nodejs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: python
 python:
   - "2.7"
 install:
-  - "sudo apt-get install -y npm python-demjson"
+  - "sudo apt-get install -y nodejs python-demjson"
   - "pip install --allow-all-external -r requirements.txt"
   - "pip install --allow-all-external demjson"
 script:

--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -634,8 +634,9 @@ sandbox_base_requirements:  "{{ edxapp_code_dir }}/requirements/edx-sandbox/base
 sandbox_local_requirements: "{{ edxapp_code_dir }}/requirements/edx-sandbox/local.txt"
 sandbox_post_requirements:  "{{ edxapp_code_dir }}/requirements/edx-sandbox/post.txt"
 
+edxapp_chrislea_ppa: "ppa:chris-lea/node.js"
+
 edxapp_debian_pkgs:
-  - npm
   # for compiling the virtualenv
   # (only needed if wheel files aren't available)
   - build-essential
@@ -657,7 +658,7 @@ edxapp_debian_pkgs:
   # misc
   - curl
   - ipython
-  - npm
+  - nodejs
   - ntp
   # for shapely
   - libgeos-dev

--- a/playbooks/roles/edxapp/tasks/main.yml
+++ b/playbooks/roles/edxapp/tasks/main.yml
@@ -47,8 +47,12 @@
     - "{{ edxapp_course_data_dir }}"
     - "{{ edxapp_upload_dir }}"
 
+# adding chris-lea nodejs repo
+- name: add ppas for current versions of nodejs
+  apt_repository: repo="{{ edxapp_chrislea_ppa }}"
+
 - name: install system packages on which LMS and CMS rely
-  apt: pkg={{','.join(edxapp_debian_pkgs)}} state=present
+  apt: pkg={{','.join(edxapp_debian_pkgs)}} state=present update_cache=yes
   notify:
   - "restart edxapp"
   - "restart edxapp_workers"

--- a/playbooks/roles/jenkins_admin/defaults/main.yml
+++ b/playbooks/roles/jenkins_admin/defaults/main.yml
@@ -27,6 +27,8 @@ JENKINS_ADMIN_AWS_CREDENTIALS: !!null
 
 jenkins_admin_role_name: jenkins_admin
 
+# repo for nodejs
+jenkins_chrislea_ppa: "ppa:chris-lea/node.js"
 #
 # OS packages
 #
@@ -38,7 +40,6 @@ jenkins_admin_debian_pkgs:
   # These are copied from the edxapp
   # role so that we can create virtualenvs
   # on the jenkins server for edxapp
-  - npm
   # for compiling the virtualenv
   # (only needed if wheel files aren't available)
   - build-essential
@@ -61,7 +62,7 @@ jenkins_admin_debian_pkgs:
   # misc
   - curl
   - ipython
-  - npm
+  - nodejs
   - ntp
   # for shapely
   - libgeos-dev

--- a/playbooks/roles/jenkins_admin/tasks/main.yml
+++ b/playbooks/roles/jenkins_admin/tasks/main.yml
@@ -112,9 +112,12 @@
     mode=0644
   with_items: jenkins_admin_jobs
 
+# adding chris-lea nodejs repo
+- name: add ppas for current versions of nodejs
+  apt_repository: repo="{{ jenkins_chrislea_ppa }}"
+
 - name: install system packages for edxapp virtualenvs
-  apt: pkg={{ item }} state=present
-  with_items: jenkins_admin_debian_pkgs
+  apt: pkg={{','.join(jenkins_admin_debian_pkgs)}} state=present update_cache=yes
 
 # This is necessary so that ansible can run with
 # sudo set to True (as the jenkins user) on jenkins

--- a/playbooks/roles/jenkins_worker/defaults/main.yml
+++ b/playbooks/roles/jenkins_worker/defaults/main.yml
@@ -3,6 +3,9 @@ jenkins_user: "jenkins"
 jenkins_group: "jenkins"
 jenkins_home: /home/jenkins
 
+# repo for nodejs
+jenkins_chrislea_ppa: "ppa:chris-lea/node.js"
+
 # System packages
 jenkins_debian_pkgs:
     - build-essential
@@ -15,7 +18,7 @@ jenkins_debian_pkgs:
     - libxml2-dev
     - libgeos-dev
     - libxslt1-dev
-    - npm
+    - nodejs
     - pkg-config
     - gettext
 

--- a/playbooks/roles/jenkins_worker/tasks/system.yml
+++ b/playbooks/roles/jenkins_worker/tasks/system.yml
@@ -26,6 +26,10 @@
     owner={{ jenkins_user }} group={{ jenkins_group }} mode=400
   ignore_errors: yes
 
+# adding chris-lea nodejs repo
+- name: add ppas for current versions of nodejs
+  apt_repository: repo="{{ jenkins_chrislea_ppa }}"
+
 - name: Install system packages
   apt: pkg={{','.join(jenkins_debian_pkgs)}}
        state=present update_cache=yes

--- a/playbooks/roles/xqueue/defaults/main.yml
+++ b/playbooks/roles/xqueue/defaults/main.yml
@@ -84,7 +84,6 @@ xqueue_version: 'HEAD'
 xqueue_pre_requirements_file:    "{{ xqueue_code_dir }}/pre-requirements.txt"
 xqueue_post_requirements_file:   "{{ xqueue_code_dir }}/requirements.txt"
 
-
 # These packages are required for the xqueue server,
 # copied from the LMS role for now since there is a lot
 # of overlap
@@ -102,7 +101,6 @@ xqueue_debian_pkgs:
   # misc
   - curl
   - ipython
-  - npm
   - ntp
   # for shapely
   - libgeos-dev


### PR DESCRIPTION
I added a task to use chris-lea's repos for nodejs.  In other parts of the program, it seems like these repos are preferred to the default ubuntu repos ([see this](https://github.com/edx/edx-platform/blob/master/requirements/system/ubuntu/apt-repos.txt)).  This will keep the nodejs version current as well.

Separately, I fixed a typo where "npm" was listed twice.  Although "nodejs" does not need to be explicitly listed because it is a dependency of npm, I added it for people that may not be familiar with npm.
