### PR TITLE
COMMON_ENABLE_BASIC_AUTH to False in ansible/comment/defaults/main.yml

### DIFF
--- a/playbooks/roles/common/defaults/main.yml
+++ b/playbooks/roles/common/defaults/main.yml
@@ -4,7 +4,7 @@
 # where edX is installed
 
 # Set global htpasswd credentials
-COMMON_ENABLE_BASIC_AUTH: True
+COMMON_ENABLE_BASIC_AUTH: False
 COMMON_HTPASSWD_USER: edx
 COMMON_HTPASSWD_PASS: edx
 


### PR DESCRIPTION
See [this pull](https://github.com/edx/configuration/pull/1279) for more comments.

I changed the default behavior of basic authorization to false. I found the default behavior unintuitive. Upon installation of the default image via vagrant, going to the server from a remote host (including the vagrant host computer) prompts the user for a username/password. The default behavior should be that the edx lms/cms "just work" without a username/password, right? Furthermore, the documentation does not mention that the username/password is edx/edx, and one can only find this information by going into the source files. Finally, I didn't see a great reason to use basic auth at all, and thus if someone wants to use it, they probably should explicitly enable it, instead of this being the default behavior.
