### PR TITLE
Remove ORA1 role from devstack, in preparation for deprecation

### DIFF
--- a/playbooks/roles/local_dev/tasks/main.yml
+++ b/playbooks/roles/local_dev/tasks/main.yml
@@ -27,6 +27,7 @@
     src=app_bashrc.j2 dest={{ item.home }}/.bashrc
     owner={{ item.user }} mode=755
   with_items: localdev_accounts
+  ignore_errors: yes
 
 # Default to the correct git config
 # No more accidentally force pushing to master! :)
@@ -35,6 +36,7 @@
     src=gitconfig dest={{ item.home }}/.gitconfig
     owner={{ item.user }} mode=700
   with_items: localdev_accounts
+  ignore_errors: yes
 
 # Configure X11 for application users
 - name: preserve DISPLAY for sudo
@@ -59,4 +61,5 @@
   template:
     src=paver_autocomplete dest={{ item.home }}/.paver_autocomplete
     owner={{ item.user }} mode=755
-  with_items: localdev_accounts    
+  with_items: localdev_accounts
+  ignore_errors: yes

--- a/playbooks/vagrant-devstack.yml
+++ b/playbooks/vagrant-devstack.yml
@@ -12,6 +12,7 @@
     EDXAPP_NO_PREREQ_INSTALL: 0
     COMMON_MOTD_TEMPLATE: 'devstack_motd.tail.j2'
     COMMON_SSH_PASSWORD_AUTH: "yes"
+    ENABLE_LEGACY_ORA: !!null
   vars_files:
     - "group_vars/all"
   roles:
@@ -22,7 +23,8 @@
     - oraclejdk
     - elasticsearch
     - forum
-    - ora
+    - role: ora
+      when: ENABLE_LEGACY_ORA
     - browsers
     - local_dev
     - demo

--- a/vagrant/base/devstack/Vagrantfile
+++ b/vagrant/base/devstack/Vagrantfile
@@ -50,8 +50,11 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       create: true, owner: "edxapp", group: "www-data"
     config.vm.synced_folder "#{forum_mount_dir}", "/edx/app/forum/cs_comments_service",
       create: true, owner: "forum", group: "www-data"
-    config.vm.synced_folder "#{ora_mount_dir}", "/edx/app/ora/ora",
-      create: true, owner: "ora", group: "www-data"
+
+    if ENV['ENABLE_LEGACY_ORA']
+        config.vm.synced_folder "#{ora_mount_dir}", "/edx/app/ora/ora",
+          create: true, owner: "ora", group: "www-data"
+    end
   else
     config.vm.synced_folder "#{edx_platform_mount_dir}", "/edx/app/edxapp/edx-platform",
       create: true, nfs: true
@@ -59,8 +62,11 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       create: true, nfs: true
     config.vm.synced_folder "#{forum_mount_dir}", "/edx/app/forum/cs_comments_service",
       create: true, nfs: true
-    config.vm.synced_folder "#{ora_mount_dir}", "/edx/app/ora/ora",
-      create: true, nfs: true
+
+    if ENV['ENABLE_LEGACY_ORA']
+        config.vm.synced_folder "#{ora_mount_dir}", "/edx/app/ora/ora",
+          create: true, nfs: true
+    end
   end
 
 
@@ -95,5 +101,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.provision :ansible do |ansible|
     ansible.playbook = "../../../playbooks/vagrant-devstack.yml"
     ansible.verbose = "vvvv"
+
+    if ENV['ENABLE_LEGACY_ORA']
+        ansible.extra_vars = { ENABLE_LEGACY_ORA: true }
+    end
   end
 end


### PR DESCRIPTION
[ORA-696](https://openedx.atlassian.net/browse/ORA-696): Update DevStack to not have ORA1 by default

This PR removes ORA1 from the devstack base image.  It does NOT remove it from the sandbox, vagrant-fullstack, or the release version of devstack (which assumes ORA1 folder sharing).

@feanil Please review.  When the next configuration release goes out, someone will need to update `vagrant/release/devstack/Vagrantfile` as well.
