### PR TITLE
New Relic : Adding some logic for Amazon Linux

### DIFF
--- a/playbooks/roles/newrelic/defaults/main.yml
+++ b/playbooks/roles/newrelic/defaults/main.yml
@@ -16,9 +16,9 @@
 #
 newrelic_role_name: newrelic
 
-NEWRELIC_REPO: 'deb http://apt.newrelic.com/debian/ newrelic non-free'
-NEWRELIC_KEY_ID: '548C16BF'
-NEWRELIC_KEY_URL: 'https://download.newrelic.com/{{ NEWRELIC_KEY_ID }}.gpg'
+NEWRELIC_DEBIAN_REPO: 'deb http://apt.newrelic.com/debian/ newrelic non-free'
+NEWRELIC_DEBIAN_KEY_ID: '548C16BF'
+NEWRELIC_DEBIAN_KEY_URL: 'https://download.newrelic.com/{{ NEWRELIC_DEBIAN_KEY_ID }}.gpg'
 NEWRELIC_LICENSE_KEY: "SPECIFY_KEY_HERE"
 
 #
@@ -28,4 +28,5 @@ NEWRELIC_LICENSE_KEY: "SPECIFY_KEY_HERE"
 newrelic_debian_pkgs:
   - newrelic-sysmond
 
-newrelic_redhat_pkgs: []
+newrelic_redhat_pkgs:
+  - newrelic-sysmond

--- a/playbooks/roles/newrelic/tasks/main.yml
+++ b/playbooks/roles/newrelic/tasks/main.yml
@@ -27,18 +27,33 @@
 
 - name: add apt key
   apt_key: >
-    id="{{ NEWRELIC_KEY_ID }}" url="{{ NEWRELIC_KEY_URL }}"
+    id="{{ NEWRELIC_DEBIAN_KEY_ID }}" url="{{ NEWRELIC_DEBIAN_KEY_URL }}"
     state=present
+  when: ansible_distribution == 'Ubuntu'
+
+- name: Configure the New Relic Servers yum repository
+  shell: >
+    rpm -Uvh https://yum.newrelic.com/pub/newrelic/el5/x86_64/newrelic-repo-5-3.noarch.rpm
+    creates=/etc/yum.repos.d/newrelic.repo
+  when: ansible_distribution == 'Amazon'
 
 - name: install apt repository
-  apt_repository: repo="{{ NEWRELIC_REPO }}" update_cache=yes
+  apt_repository: repo="{{ NEWRELIC_DEBIAN_REPO }}" update_cache=yes
+  when: ansible_distribution == 'Ubuntu'
 
-- name: install newrelic agent
+- name: install newrelic agent (apt)
   apt: pkg="newrelic-sysmond"
+  when: ansible_distribution == 'Ubuntu'
 
-- name: Install newrelic related system packages.
+- name: Install newrelic related system packages for Ubuntu
   apt: pkg={{ item }} install_recommends=yes state=present
   with_items: newrelic_debian_pkgs
+  when: ansible_distribution == 'Ubuntu'
+
+- name: Install newrelic related system packages for Amazon
+  yum: pkg={{ item }} state=present
+  with_items: newrelic_redhat_pkgs
+  when: ansible_distribution == 'Amazon'
 
 - name: configure the agent with the license key
   shell: >


### PR DESCRIPTION
Adding some logic for Amazon Linux so we can install New Relic on those machines based on that AMI
