### PR TITLE
Fix xqwatcher sudoers

### DIFF
--- a/playbooks/roles/xqwatcher/tasks/code_jail.yml
+++ b/playbooks/roles/xqwatcher/tasks/code_jail.yml
@@ -18,17 +18,10 @@
     mode=0644 owner=root group=root
   with_items: XQWATCHER_COURSES
 
-- name: write out sudoers config jail user
-  template: >
-    src=etc/sudoers.d/95-jailed-user.j2
-    dest=/etc/sudoers.d/95-{{ item.QUEUE_CONFIG.HANDLERS[0].CODEJAIL.user }}
-    mode=0440 owner=root group=root validate='visudo -c -f %s'
-  with_items: XQWATCHER_COURSES
-
 - name: write out sudoers for watcher
   template: >
     src=etc/sudoers.d/95-xqwatcher.j2
-    dest=/etc/sudoers.d/95-xqwatcher-{{ item.QUEUE_CONFIG.HANDLERS[0].CODEJAIL.user }}
+    dest=/etc/sudoers.d/95-xqwatcher-{{ item.QUEUE_CONFIG.HANDLERS[0].CODEJAIL.user|replace('.', '') }}
     mode=0440 owner=root group=root validate='visudo -c -f %s'
   with_items: XQWATCHER_COURSES
 

--- a/playbooks/roles/xqwatcher/templates/etc/sudoers.d/95-jailed-user.j2
+++ b/playbooks/roles/xqwatcher/templates/etc/sudoers.d/95-jailed-user.j2
@@ -1,3 +1,0 @@
-{{ item.QUEUE_CONFIG.HANDLERS[0].CODEJAIL.user }} ALL=({{ item.QUEUE_CONFIG.HANDLERS[0].CODEJAIL.user }})  SETENV:NOPASSWD:{{ xqwatcher_venv_base }}/{{ item.QUEUE_CONFIG.HANDLERS[0].CODEJAIL.name }}/bin/python
-{{ item.QUEUE_CONFIG.HANDLERS[0].CODEJAIL.user }} ALL=(ALL) NOPASSWD:/bin/kill
-{{ item.QUEUE_CONFIG.HANDLERS[0].CODEJAIL.user }} ALL=(ALL) NOPASSWD:/usr/bin/pkill

--- a/playbooks/roles/xqwatcher/templates/etc/sudoers.d/95-xqwatcher.j2
+++ b/playbooks/roles/xqwatcher/templates/etc/sudoers.d/95-xqwatcher.j2
@@ -1,3 +1,3 @@
 {{ xqwatcher_user }} ALL=({{ item.QUEUE_CONFIG.HANDLERS[0].CODEJAIL.user }})  SETENV:NOPASSWD:{{ xqwatcher_venv_base }}/{{ item.QUEUE_CONFIG.HANDLERS[0].CODEJAIL.name }}/bin/python
-{{ xqwatcher_user }} ALL=(ALL) NOPASSWD:/bin/kill
-{{ xqwatcher_user }} ALL=(ALL) NOPASSWD:/usr/bin/pkill
+{{ xqwatcher_user }} ALL=({{ item.QUEUE_CONFIG.HANDLERS[0].CODEJAIL.user }}) NOPASSWD:/bin/kill
+{{ xqwatcher_user }} ALL=({{ item.QUEUE_CONFIG.HANDLERS[0].CODEJAIL.user }}) NOPASSWD:/usr/bin/pkill


### PR DESCRIPTION
@e0d and @itsbenweeks I created jails for course numbers and those have dots.  It turns out sudoers.d ignores any file with a dot in it and doesn't give a warning of any kind so it wasn't an apparmor problem.  I also removed the sudoers files for the jail users since they don't need a password to execute any command as themselves.  I am also fairly certain we don't want xqwatcher or the codejail users to be able to execute kill and pkill as root.
