### PR TITLE
Allow future_builtins map module to memory map in xqwatcher apparmor profile

### DIFF
--- a/playbooks/roles/xqwatcher/templates/etc/apparmor.d/code.jail.j2
+++ b/playbooks/roles/xqwatcher/templates/etc/apparmor.d/code.jail.j2
@@ -21,7 +21,7 @@
     /usr/lib/python2.7/lib-dynload/datetime.so mr,
     /usr/lib/python2.7/lib-dynload/_elementtree.so mr,
     /usr/lib/python2.7/lib-dynload/pyexpat.so mr,
-
+    /usr/lib/python2.7/lib-dynload/future_builtins.so mr,
     #
     # Allow access to selections from /proc
     #


### PR DESCRIPTION
numpy, for example, uses `map` from future_builtins so adding it to allowed memory map locations.  I was curious if we just wanted to allow all the system python .so libraries to memory map and read to avoid this type of one off change, but I'm ok with one off if we prefer to continue to whitelist.
