### PR TITLE
Include common for jenkins_worker role.

### DIFF
--- a/playbooks/edx-east/jenkins_worker.yml
+++ b/playbooks/edx-east/jenkins_worker.yml
@@ -15,7 +15,6 @@
     - roles/xserver/defaults/main.yml
     - roles/forum/defaults/main.yml
   roles:
-    - common
     - edxlocal
     - mongo
     - browsers

--- a/playbooks/roles/jenkins_worker/meta/main.yml
+++ b/playbooks/roles/jenkins_worker/meta/main.yml
@@ -1,5 +1,6 @@
 ---
 dependencies:
+  - common
   - role: rbenv
     rbenv_user: "{{ jenkins_user }}"
     rbenv_dir: "{{ jenkins_home }}"


### PR DESCRIPTION
@hkim823 @jzoldak @clytwynec 

Running the jenkins_worker role via vagrant results in errors because the common_web_user is not set. This takes care of it.
