### PR TITLE
Bump ansible to latest stable release 1.7.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-ansible==1.5.5
+ansible==1.7.0
 PyYAML==3.11
 Jinja2==2.7.2
 MarkupSafe==0.23


### PR DESCRIPTION
This patch fixes issue/1382 https://github.com/edx/configuration/issues/1382.
Ansible version 1.5.5 is very old now and many important fixes have gone in since then.
