### PR TITLE
Create ~/.ssh directory when using Git via SSH

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -34,3 +34,5 @@ Rodolphe Quiedeville <rodolphe@quiedeville.org>
 Matjaz Gregoric <mtyaka@gmail.com>
 Ben Patterson <bpatterson@edx.org>
 Jason Zhu <fmyzjs@gmail.com>
+Steven Burch <stv@stanford.edu>
+

--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -287,6 +287,7 @@ edxapp_rbenv_bin: "{{ edxapp_rbenv_root }}/bin"
 edxapp_gem_root: "{{ edxapp_rbenv_dir }}/.gem"
 edxapp_gem_bin: "{{ edxapp_gem_root }}/bin"
 edxapp_user: edxapp
+edxapp_user_home_dir: "{{ edxapp_app_dir }}"
 edxapp_deploy_path: "{{ edxapp_venv_bin }}:{{ edxapp_code_dir }}/bin:{{ edxapp_rbenv_bin }}:{{ edxapp_rbenv_shims }}:{{ edxapp_gem_bin }}:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 edxapp_staticfile_dir: "{{ edxapp_data_dir }}/staticfiles"
 edxapp_course_static_dir: "{{ edxapp_data_dir }}/course_static"

--- a/playbooks/roles/edxapp/tasks/deploy.yml
+++ b/playbooks/roles/edxapp/tasks/deploy.yml
@@ -26,6 +26,16 @@
     force=yes owner={{ edxapp_user }} mode=0600
   when: EDXAPP_USE_GIT_IDENTITY
 
+- name: create directory for hostkey
+  file: >
+    dest="{{ edxapp_user_home_dir }}/.ssh"
+    mode=0700
+    owner={{ edxapp_user }}
+    group={{ edxapp_user }}
+    state=directory
+  sudo_user: "{{ edxapp_user }}"
+  when: EDXAPP_USE_GIT_IDENTITY
+
 # Do A Checkout
 - name: checkout edx-platform repo into {{edxapp_code_dir}}
   git: >


### PR DESCRIPTION
Previously, if the `${HOME}/.ssh` directory did not already exist when
attempting to checkout a Git repository via SSH, the
`checkout edx-platform repo` and `checkout theme` tasks would fail.

This issue doesn't appear when checking out code as the `edxapp` user
(default: presumably this directory is created elsewhere), but will
surface if run as another user who lacks a `${HOME}/.ssh` directory.

The code now looks before it leaps.
