### PR TITLE
Deploy default theme, by default, not Stanford

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -623,7 +623,7 @@ worker_core_mult:
 # TODO: change variables to ALL-CAPS, since they are meant to be externally overridden
 edxapp_use_custom_theme: false
 edxapp_theme_name: ""
-edxapp_theme_source_repo: 'https://{{ COMMON_GIT_MIRROR }}/Stanford-Online/edx-theme.git'
+edxapp_theme_source_repo: "https://{{ COMMON_GIT_MIRROR }}/Stanford-Online/edx-default-theme.git"
 edxapp_theme_version: 'master'
 
 # make this the public URL instead of writable


### PR DESCRIPTION
We would like the community to adopt the "default" theme, as the
starting point for theme development, as opposed to the "Stanford"
theme, which carries our branding.
