### PR TITLE
Update the course ID for the demo course

### DIFF
--- a/playbooks/roles/demo/defaults/main.yml
+++ b/playbooks/roles/demo/defaults/main.yml
@@ -14,7 +14,7 @@
 demo_app_dir: "{{ COMMON_APP_DIR }}/demo"
 demo_code_dir: "{{ demo_app_dir }}/edx-demo-course"
 demo_repo: "https://{{ COMMON_GIT_MIRROR }}/edx/edx-demo-course.git"
-demo_course_id: 'edX/Open_DemoX/edx_demo_course'
+demo_course_id: 'edX/DemoX/Demo_Course'
 demo_version: "master"
 demo_test_users:
   - email: 'honor@example.com'


### PR DESCRIPTION
A few weeks ago, we updated the demo course repository by exporting the course from Studio.  In production, the course ID is `edX/DemoX/Demo_Course`, so that's also the ID of the exported course.

This PR updates the configuration scripts so they install users for the course with the new ID.

@jarv
