### PR TITLE
Increase how long supervisor waits for workers to stop.

### DIFF
--- a/playbooks/roles/edxapp/templates/workers.conf.j2
+++ b/playbooks/roles/edxapp/templates/workers.conf.j2
@@ -10,6 +10,7 @@ stderr_logfile={{ supervisor_log_dir }}/%(program_name)-stderr.log
 command={{ edxapp_venv_bin}}/python {{ edxapp_code_dir }}/manage.py {{ w.service_variant }} --settings=aws celery worker --loglevel=info --queues=edx.{{ w.service_variant }}.core.{{ w.queue }} --hostname=edx.{{ w.service_variant }}.core.{{ w.queue }}.{{ ansible_hostname }} --concurrency={{ w.concurrency }}
 killasgroup=true
 stopasgroup=true
+stopwaitsecs=432000
 
 {% endfor %}
 


### PR DESCRIPTION
This is set as 5 days for now because we have seen "grade_course" tasks that
take about 4 days to complete for large classes and if we shutdown before
they are done we end up in a bad state in the database.
