### PR TITLE
We have to keep upstart from killing supervisor.

### DIFF
--- a/playbooks/roles/supervisor/templates/etc/init/supervisor-upstart.conf.j2
+++ b/playbooks/roles/supervisor/templates/etc/init/supervisor-upstart.conf.j2
@@ -7,5 +7,7 @@ start on runlevel [2345]
 {% endif %}
 stop on runlevel [!2345]
 
+kill timeout 432000
+
 setuid {{ supervisor_service_user }}
 exec {{ supervisor_venv_dir }}/bin/supervisord -n --configuration {{ supervisor_cfg }}


### PR DESCRIPTION
Supervisor could wait up to 5 days for workers to finish jobs. So
Upstart needs to wait that long for supervisor to finish.
