### PR TITLE
Handle resolution failures for sqs.

### DIFF
--- a/playbooks/callback_plugins/sqs.py
+++ b/playbooks/callback_plugins/sqs.py
@@ -20,6 +20,7 @@ import os
 import sys
 import time
 import json
+import socket
 try:
     import boto.sqs
     from boto.exception import NoAuthHandlerFound
@@ -132,4 +133,10 @@ class CallbackModule(object):
                     # only keep the last 20 or so lines to avoid payload size errors
                     if len(payload[msg_type]['stdout_lines']) > 20:
                         payload[msg_type]['stdout_lines'] = ['(clipping) ... '] + payload[msg_type]['stdout_lines'][-20:]
-            self.sqs.send_message(self.queue, json.dumps(payload))
+            while True:
+                try:
+                    self.sqs.send_message(self.queue, json.dumps(payload))
+                    break
+                except socket.gaierror as e:
+                    print 'socket.gaierror will retry: ' + e
+                    time.sleep(1)

--- a/playbooks/callback_plugins/sqs.py
+++ b/playbooks/callback_plugins/sqs.py
@@ -140,3 +140,5 @@ class CallbackModule(object):
                 except socket.gaierror as e:
                     print 'socket.gaierror will retry: ' + e
                     time.sleep(1)
+                except Exception as e:
+                    raise e


### PR DESCRIPTION
@e0d @jarv ran into this while building AMIs with abbey.

```
fatal: [localhost] => Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/ansible/runner/__init__.py", line 532, in _executor
    exec_rc = self._executor_internal(host, new_stdin)
  File "/usr/local/lib/python2.7/dist-packages/ansible/runner/__init__.py", line 660, in _executor_internal
    complex_args=complex_args
  File "/usr/local/lib/python2.7/dist-packages/ansible/runner/__init__.py", line 890, in _executor_internal_inner
    self.callbacks.on_ok(host, data)
  File "/usr/local/lib/python2.7/dist-packages/ansible/callbacks.py", line 529, in on_ok
    super(PlaybookRunnerCallbacks, self).on_ok(host, host_result)
  File "/usr/local/lib/python2.7/dist-packages/ansible/callbacks.py", line 338, in on_ok
    call_callback_module('runner_on_ok', host, res)
  File "/usr/local/lib/python2.7/dist-packages/ansible/callbacks.py", line 170, in call_callback_module
    method(*args, **kwargs)
  File "/var/tmp/edx-cfg/configuration/playbooks/edx-east/callback_plugins/sqs.py", line 89, in runner_on_ok
    self._send_queue_message(res, 'OK')
  File "/var/tmp/edx-cfg/configuration/playbooks/edx-east/callback_plugins/sqs.py", line 135, in _send_queue_message
    self.sqs.send_message(self.queue, json.dumps(payload))
  File "/usr/local/lib/python2.7/dist-packages/boto/sqs/connection.py", line 311, in send_message
    params['MessageAttribute.%s.Value.StringListValue' % i] = \
  File "/usr/local/lib/python2.7/dist-packages/boto/connection.py", line 1163, in get_object
    body = body.encode('utf-8')
  File "/usr/local/lib/python2.7/dist-packages/boto/connection.py", line 1089, in make_request
    return boto.utils.get_utf8_value(value)
  File "/usr/local/lib/python2.7/dist-packages/boto/connection.py", line 922, in _mexe
    boto.log.debug('Final headers: %s' % request.headers)
  File "/usr/lib/python2.7/httplib.py", line 958, in request
    self._send_request(method, url, body, headers)
  File "/usr/lib/python2.7/httplib.py", line 992, in _send_request
    self.endheaders(body)
  File "/usr/lib/python2.7/httplib.py", line 954, in endheaders
    self._send_output(message_body)
  File "/usr/lib/python2.7/httplib.py", line 814, in _send_output
    self.send(msg)
  File "/usr/lib/python2.7/httplib.py", line 776, in send
    self.connect()
  File "/usr/local/lib/python2.7/dist-packages/boto/https_connection.py", line 111, in connect
    self.ca_certs = ca_certs
  File "/usr/lib/python2.7/socket.py", line 224, in meth
    return getattr(self._sock,name)(*args)
gaierror: [Errno -3] Temporary failure in name resolution
```
