### PR TITLE
Optionally add arguments to service calls.

### DIFF
--- a/playbooks/roles/stop_all_edx_services/defaults/main.yml
+++ b/playbooks/roles/stop_all_edx_services/defaults/main.yml
@@ -15,3 +15,8 @@
 # vars are namespace with the module name.
 #
 stop_all_edx_services_role_name: stop_all_edx_services
+
+# set this to "--no-wait" if you want to not wait for all
+# superviser jobs to finish.  Useful when used in conjunction
+# with minos.
+STOP_ALL_EDX_SERVICES_EXTRA_ARGS: ""

--- a/playbooks/roles/stop_all_edx_services/handlers/main.yml
+++ b/playbooks/roles/stop_all_edx_services/handlers/main.yml
@@ -19,34 +19,34 @@
 #
 #
 - name: stop supervisor
-  service: name=supervisor state=stopped
+  service: name=supervisor state=stopped arguments="{{ STOP_ALL_EDX_SERVICES_EXTRA_ARGS }}"
 
 - name: stop supervisor.devpi
-  service: name=supervisor.devpi state=stopped
+  service: name=supervisor.devpi state=stopped arguments="{{ STOP_ALL_EDX_SERVICES_EXTRA_ARGS }}"
 
 - name: stop nginx
-  service: name=nginx state=stopped
+  service: name=nginx state=stopped arguments="{{ STOP_ALL_EDX_SERVICES_EXTRA_ARGS }}"
 
 - name: stop rabbitmq-server
-  service: name=rabbitmq-server state=stopped
+  service: name=rabbitmq-server state=stopped arguments="{{ STOP_ALL_EDX_SERVICES_EXTRA_ARGS }}"
 
 - name: stop mysql
-  service: name=mysql state=stopped
+  service: name=mysql state=stopped arguments="{{ STOP_ALL_EDX_SERVICES_EXTRA_ARGS }}"
 
 - name: stop memcached
-  service: name=memcached state=stopped
+  service: name=memcached state=stopped arguments="{{ STOP_ALL_EDX_SERVICES_EXTRA_ARGS }}"
 
 - name: stop supervisor.devpi
-  service: name=supervisor.devpi state=stopped
+  service: name=supervisor.devpi state=stopped arguments="{{ STOP_ALL_EDX_SERVICES_EXTRA_ARGS }}"
 
 - name: stop nginx
-  service: name=nginx state=stopped
+  service: name=nginx state=stopped arguments="{{ STOP_ALL_EDX_SERVICES_EXTRA_ARGS }}"
 
 - name: stop rabbitmq-server
-  service: name=rabbitmq-server state=stopped
+  service: name=rabbitmq-server state=stopped arguments="{{ STOP_ALL_EDX_SERVICES_EXTRA_ARGS }}"
 
 - name: stop mongodb
-  service: name=mongodb state=stopped
+  service: name=mongodb state=stopped arguments="{{ STOP_ALL_EDX_SERVICES_EXTRA_ARGS }}"
 
 - name: kill processes by user
   shell: pkill -u {{ item }} || true


### PR DESCRIPTION
Adding this so we can do a non-blocking call to stop services
which will be useful when we call this as a part of the ansible
run that kicks off Minos.

@e0d @jarv 
