### PR TITLE
jenkins_worker: Add pre-populated .nmprc file to jenkins home dir.

### DIFF
--- a/playbooks/roles/jenkins_worker/tasks/system.yml
+++ b/playbooks/roles/jenkins_worker/tasks/system.yml
@@ -49,3 +49,11 @@
 - name: add preview.localhost to /etc/hosts
   shell: sed -i -r 's/^127.0.0.1\s+.*$/127.0.0.1 localhost preview.localhost/' /etc/hosts
   sudo: yes
+
+# Npm registry must be pre-loaded or else setting it
+# with the Jenkins user will fail
+# See https://github.com/npm/npm/issues/3565
+- name: Set npm registry
+  template:
+    src=.npmrc.j2 dest={{ jenkins_home }}/.npmrc
+    owner={{ jenkins_user }} group={{ jenkins_group }} mode=0664

--- a/playbooks/roles/jenkins_worker/templates/.npmrc.j2
+++ b/playbooks/roles/jenkins_worker/templates/.npmrc.j2
@@ -1,0 +1,1 @@
+registry=http://registry.npmjs.org/

--- a/playbooks/roles/jenkins_worker/templates/.npmrc.j2
+++ b/playbooks/roles/jenkins_worker/templates/.npmrc.j2
@@ -1,1 +1,1 @@
-registry=http://registry.npmjs.org/
+registry={{ COMMON_NPM_MIRROR_URL }}


### PR DESCRIPTION
@jzoldak @hkim823 @clytwynec 

This is the companion piece to https://github.com/edx/edx-platform/pull/4828. The npm profile should be on the worker already, and when the get registry call is made, the set registry call (which would result in errno 50) is unnecessary and therefore avoided.
