### PR TITLE
fix handler interaction/add pkill

### DIFF
--- a/playbooks/edx-east/retire_host.yml
+++ b/playbooks/edx-east/retire_host.yml
@@ -33,7 +33,15 @@
       with_items:
         - "tracking.log"
         - "edx-services"
+    - name: Terminate existing s3 log sync
+      command: /usr/bin/pkill send-logs-to-s3
     - name: Send logs to s3
       command: /edx/bin/send-logs-to-s3
+
+- name: Run minos verification
+  hosts: all
+  sudo: True
+  gather_facts: False
+  tasks:
     - name: Run minos
       command: /edx/app/minos/venvs/bin/minos --config /edx/etc/minos/minos.yml --json


### PR DESCRIPTION
- Makes minos a separate play as stop all services users handlers which are run last.
- Defensively kills any existing sync log job

@jarv 
