### PR TITLE
packer jenkins_worker: use ansible 1.7.1 for testing build server.

### DIFF
--- a/playbooks/roles/test_build_server/files/test-development-environment.sh
+++ b/playbooks/roles/test_build_server/files/test-development-environment.sh
@@ -38,8 +38,8 @@ paver test_js_run -s xmodule
 paver test_bokchoy -t test_lms.py:RegistrationTest
 
 # Run some of the lettuce acceptance tests
-# paver test_acceptance -s lms --extra_args="lms/djangoapps/courseware/features/problems.feature"
-# paver test_acceptance -s cms --extra_args="cms/djangoapps/contentstore/features/html-editor.feature"
+paver test_acceptance -s lms --extra_args="lms/djangoapps/courseware/features/problems.feature -s 1"
+paver test_acceptance -s cms --extra_args="cms/djangoapps/contentstore/features/html-editor.feature -s 1"
 
 # Generate quality reports
 paver run_quality

--- a/util/packer/jenkins_worker.json
+++ b/util/packer/jenkins_worker.json
@@ -40,6 +40,7 @@
     "type": "shell",
     "inline": ["cd {{user `playbook_remote_dir`}}",
       ". packer-venv/bin/activate",
+      "pip install -q -U ansible==1.7.1",
       "ansible-playbook run_role.yml -i inventory.ini -c local -e role=test_build_server -vvvv"]
   }]
 }


### PR DESCRIPTION
The test_build_server role was failing on acceptance tests because of unicode
static assets being gathered in collectstatic for django. This was because of
this issue https://github.com/ansible/ansible/issues/6655, which has been
resolved in recent ansible versions. We must override the version that is
being used by this repo, and upgrade ansible at provisioning time for
running the test_build_server role.
