### PR TITLE
Packer: set config to work with any clone name (host machine).

### DIFF
--- a/util/packer/jenkins_worker.json
+++ b/util/packer/jenkins_worker.json
@@ -21,11 +21,11 @@
     "inline": ["rm -rf {{user `playbook_remote_dir`}}"]
   }, {
     "type": "file",
-    "source": "../../../configuration/playbooks",
+    "source": "../../playbooks",
     "destination": "{{user `playbook_remote_dir`}}"
   }, {
     "type": "file",
-    "source": "../../../configuration/requirements.txt",
+    "source": "../../requirements.txt",
     "destination": "{{user `playbook_remote_dir`}}/requirements.txt"
   }, {
     "type": "shell",


### PR DESCRIPTION
@clytwynec @jzoldak 

This will allow us to set up Jenkins jobs to use this process. (The 'configuration' setting was some left over from local development.)
