### PR TITLE
Add registration extra fields setting to configuration.

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -288,6 +288,17 @@ EDXAPP_SUBDOMAIN_BRANDING: {}
 EDXAPP_WORKERS: !!null
 EDXAPP_ANALYTICS_DATA_TOKEN: ""
 EDXAPP_ANALYTICS_DATA_URL: ""
+
+EDXAPP_REGISTRATION_EXTRA_FIELDS:
+  level_of_education: "optional"
+  gender: "optional"
+  year_of_birth: "optional"
+  mailing_address: "optional"
+  goals: "optional"
+  honor_code: "required"
+  city: "hidden"
+  country: "hidden"
+
 #-------- Everything below this line is internal to the role ------------
 
 #Use YAML references (& and *) and hash merge <<: to factor out shared settings
@@ -566,7 +577,7 @@ generic_env_config:  &edxapp_generic_env
   FILE_UPLOAD_STORAGE_PREFIX: $EDXAPP_FILE_UPLOAD_STORAGE_PREFIX
   VIRTUAL_UNIVERSITIES: $EDXAPP_VIRTUAL_UNIVERSITIES
   SUBDOMAIN_BRANDING: $EDXAPP_SUBDOMAIN_BRANDING
-
+  REGISTRATION_EXTRA_FIELDS: $EDXAPP_REGISTRATION_EXTRA_FIELDS
 
 lms_auth_config:
   <<: *edxapp_generic_auth


### PR DESCRIPTION
This exposes a Django setting to configure the registration form.  The values in this PR are identical to the [current defaults](https://github.com/edx/edx-platform/blob/master/lms/envs/common.py#L1425-L1441)

Eventually, we'll need to override the defaults to set `country` to "optional" for [ECOM-128](https://openedx.atlassian.net/browse/ECOM-128).

@jarv please review.
