### PR TITLE
Making profile explicit

### DIFF
--- a/util/vpc-tools/asg_lifcycle_watcher.py
+++ b/util/vpc-tools/asg_lifcycle_watcher.py
@@ -97,7 +97,7 @@ class LifecycleHandler:
                 raise NotImplemented("Encountered message, {message_id}, of unexpected type.".format(
                     message_id=as_message['MessageId']))
 
-    def get_base_command(self):
+    def get_base_cli_command(self):
         return "{python_bin} {aws_bin} --profile {profile} ".format(
             python_bin=self.python_bin,
             aws_bin=self.aws_bin,
@@ -105,7 +105,7 @@ class LifecycleHandler:
 
     def record_lifecycle_action_heartbeat(self, asg, token, hook):
 
-        command = self.get_base_command() + "autoscaling record-lifecycle-action-heartbeat " \
+        command = self.get_base_cli_command() + "autoscaling record-lifecycle-action-heartbeat " \
                   "--lifecycle-hook-name {hook} " \
                   "--auto-scaling-group-name {asg} " \
                   "--lifecycle-action-token {token}".format(
@@ -114,7 +114,7 @@ class LifecycleHandler:
         self.run_subprocess_command(command, self.dry_run)
 
     def continue_lifecycle(self, asg, token, hook):
-        command = self.get_base_command() + "autoscaling complete-lifecycle-action --lifecycle-hook-name {hook} " \
+        command = self.get_base_cli_command() + "autoscaling complete-lifecycle-action --lifecycle-hook-name {hook} " \
                   "--auto-scaling-group-name {asg} --lifecycle-action-token {token} --lifecycle-action-result " \
                   "CONTINUE".format(
                 hook=hook, asg=asg, token=token)

--- a/util/vpc-tools/asg_lifcycle_watcher.py
+++ b/util/vpc-tools/asg_lifcycle_watcher.py
@@ -43,6 +43,11 @@ class LifecycleHandler:
         self.aws_bin = spawn.find_executable('aws')
         self.python_bin = spawn.find_executable('python')
 
+        self.base_cli_command ="{python_bin} {aws_bin} --profile {profile} ".format(
+            python_bin=self.python_bin,
+            aws_bin=self.aws_bin,
+            profile=self.profile)
+
         self.dry_run = dry_run
         self.ec2_con = boto.connect_ec2()
         self.sqs_con = boto.connect_sqs()
@@ -97,15 +102,9 @@ class LifecycleHandler:
                 raise NotImplemented("Encountered message, {message_id}, of unexpected type.".format(
                     message_id=as_message['MessageId']))
 
-    def get_base_cli_command(self):
-        return "{python_bin} {aws_bin} --profile {profile} ".format(
-            python_bin=self.python_bin,
-            aws_bin=self.aws_bin,
-            profile=self.profile)
-
     def record_lifecycle_action_heartbeat(self, asg, token, hook):
 
-        command = self.get_base_cli_command() + "autoscaling record-lifecycle-action-heartbeat " \
+        command = self.get_base_cli_command + "autoscaling record-lifecycle-action-heartbeat " \
                   "--lifecycle-hook-name {hook} " \
                   "--auto-scaling-group-name {asg} " \
                   "--lifecycle-action-token {token}".format(
@@ -114,7 +113,7 @@ class LifecycleHandler:
         self.run_subprocess_command(command, self.dry_run)
 
     def continue_lifecycle(self, asg, token, hook):
-        command = self.get_base_cli_command() + "autoscaling complete-lifecycle-action --lifecycle-hook-name {hook} " \
+        command = self.get_base_cli_command + "autoscaling complete-lifecycle-action --lifecycle-hook-name {hook} " \
                   "--auto-scaling-group-name {asg} --lifecycle-action-token {token} --lifecycle-action-result " \
                   "CONTINUE".format(
                 hook=hook, asg=asg, token=token)


### PR DESCRIPTION
This changes the AWS shell outs to use an explicit profile.  I think the indirection of the env var is confusing and it also seem to not work.

```
15:33:14 A client error (ValidationError) occurred when calling the CompleteLifecycleAction operation: No Lifecycle Hook found with name 'e-d-GetTrackingLogs' for group 'e-d-EdxappServerASGroup-Q9BAAVZLU6K7-v011'
```

This hook does exist, but is not being found because the profile isn't being used for CLI commands.
