### PR TITLE
adding libfreetype6-dev

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -734,6 +734,8 @@ edxapp_debian_pkgs:
   # Needed by the CMS to manipulate images.
   - libjpeg8-dev
   - libpng12-dev
+  # matplotlib needs libfreetype6-dev
+  - libfreetype6-dev
 
 # Ruby Specific Vars
 edxapp_ruby_version: "1.9.3-p374"


### PR DESCRIPTION
matplotlib is a new requirement in the sandbox, and it needs libfreetype6-dev before it complies properly
