### PR TITLE
pip installs are hanging for xqueue

### DIFF
--- a/playbooks/roles/xqueue/tasks/deploy.yml
+++ b/playbooks/roles/xqueue/tasks/deploy.yml
@@ -41,7 +41,7 @@
 - name : install python pre-requirements
   pip: >
     requirements="{{ xqueue_pre_requirements_file }}" virtualenv="{{ xqueue_venv_dir }}" state=present
-    extra_args="-i {{ COMMON_PYPI_MIRROR_URL }}"
+    extra_args="-i {{ COMMON_PYPI_MIRROR_URL }} --exists-action w"
   sudo_user: "{{ xqueue_user }}"
   notify:
     - restart xqueue
@@ -50,7 +50,7 @@
 - name : install python post-requirements
   pip: >
     requirements="{{ xqueue_post_requirements_file }}" virtualenv="{{ xqueue_venv_dir }}" state=present
-    extra_args="-i {{ COMMON_PYPI_MIRROR_URL }}"
+    extra_args="-i {{ COMMON_PYPI_MIRROR_URL }} --exists-action w"
   sudo_user: "{{ xqueue_user }}"
   notify:
     - restart xqueue


### PR DESCRIPTION
We were hanging on this:

```
Obtaining pika from
git+https://github.com/pika/pika.git@a731347fc0#egg=pika (from -r
/edx/app/xqueue/xqueue/requirements.txt (line 14))
  git clone in /edx/app/xqueue/venvs/xqueue/src/pika exists with URL
git://github.com/pika/pika.git
  The plan is to install the git repository
https://github.com/pika/pika.git
What to do?  (s)witch, (i)gnore, (w)ipe, (b)ackup
```
