### PR TITLE
whitelisting /oath2

### DIFF
--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
@@ -71,6 +71,11 @@ server {
     try_files $uri @proxy_to_lms_app;
   }
 
+  # No basic auth security on oath2 endpoint
+  location /oauth2 {
+    try_files $uri @proxy_to_lms_app;
+  }
+
   # No basic auth security on the heartbeat url, so that ELB can use it
   location /heartbeat {
     try_files $uri @proxy_to_lms_app;


### PR DESCRIPTION
@jarv @feanil 

The initlal strategy won't work because of our proxy configurtion.  This covers the oauth2 case.
