### PR TITLE
Set none as the default.

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -16,8 +16,8 @@
 # when the edxapp config is written to disk.
 
 # Bucket used for xblock file storage
-EDXAPP_XBLOCK_FS_STORAGE_BUCKET: 'xblock-storage-bucket'
-EDXAPP_XBLOCK_FS_STORAGE_PREFIX: 'xblock-storage-bucket-dir/'
+EDXAPP_XBLOCK_FS_STORAGE_BUCKET: "None"
+EDXAPP_XBLOCK_FS_STORAGE_PREFIX: "None"
 EDXAPP_LMS_BASE: ""
 EDXAPP_PREVIEW_LMS_BASE: ""
 EDXAPP_CMS_BASE: ""


### PR DESCRIPTION
No one will have access to the fake default bucket causing
things to break if it isn't overridden.
