### PR TITLE
Apache LMS template listen on all ports

### DIFF
--- a/playbooks/roles/apache/templates/lms.j2
+++ b/playbooks/roles/apache/templates/lms.j2
@@ -1,7 +1,7 @@
 WSGIPythonHome {{ edxapp_venv_dir }}
 WSGIRestrictEmbedded On
 
-<VirtualHost *:{{ apache_port }}>
+<VirtualHost *:*>
     ServerName https://{{ lms_env_config.SITE_NAME }}
     ServerAlias *.{{ lms_env_config.SITE_NAME }}
     UseCanonicalName On


### PR DESCRIPTION
@marcore and @jbau This is a workaround for the apache role changes I made earlier.  The original purpose of allowing multiple ports was to support having an 80 and 443, but this would cause the same VirtualHost to respond on all specified ports, so if you wanted to do that you would need to override the template I think.
