### PR TITLE
Activating nodeenv to use bower

### DIFF
--- a/playbooks/roles/insights/tasks/deploy.yml
+++ b/playbooks/roles/insights/tasks/deploy.yml
@@ -62,7 +62,7 @@
 - name: install bower dependencies
   shell: >
     chdir={{ insights_code_dir }}
-    {{ insights_node_modules_dir }}/.bin/bower install --production
+    . {{ insights_nodeenv_bin }}/activate && {{ insights_node_modules_dir }}/.bin/bower install --production --config.interactive=false
   sudo_user: "{{ insights_user }}"
 
 - name: syncdb and migrate


### PR DESCRIPTION
The nodeenv needs to be active in order to add `node` to the `PATH`. The `bower` command makes calls to `node`.

@e0d @feanil 
