### PR TITLE
install tmux debian package in common role

### DIFF
--- a/playbooks/roles/common/defaults/main.yml
+++ b/playbooks/roles/common/defaults/main.yml
@@ -75,6 +75,7 @@ common_debian_pkgs:
   - mosh
   - rsyslog
   - screen
+  - tmux
   - tree
   - git
   - unzip


### PR DESCRIPTION
TMUX is a terminal multiplexer similar to GNU screen but with many improvements. See their FAQ for differences/improvements:

http://sourceforge.net/p/tmux/tmux-code/ci/master/tree/FAQ

also:

http://www.techrepublic.com/blog/linux-and-open-source/is-tmux-the-gnu-screen-killer/
