### PR TITLE
Create default mongo users.

### DIFF
--- a/playbooks/roles/mongo/defaults/main.yml
+++ b/playbooks/roles/mongo/defaults/main.yml
@@ -32,7 +32,7 @@ mongo_dbpath: "{{ mongo_data_dir }}/mongodb"
 
 # Have to use this conditional instead of ignore errors
 # because the mongo_user module fails and doesn't ignore errors.
-mongo_create_users: !!null
+mongo_create_users: true
 
 # If the system is running out of an Amazon Web Services
 # cloudformation stack, this group name can used to pull out


### PR DESCRIPTION
Because the application expects the users to exist and tries to use them for auth.  In 2.6.4 if you provide auth and the mongo database has no auth setup, it will fail to authenticate.  This is a change in behaviour.
