### PR TITLE
Add libjpeg-dev to edxlocal play

### DIFF
--- a/playbooks/roles/edxlocal/defaults/main.yml
+++ b/playbooks/roles/edxlocal/defaults/main.yml
@@ -3,3 +3,4 @@ edxlocal_debian_pkgs:
   - python-mysqldb
   - mysql-server-5.5
   - postfix
+  - libjpeg-dev


### PR DESCRIPTION
Because running the tests for thumbnail manipulation requires it: see https://github.com/edx/edx-platform/pull/5685
