### PR TITLE
Updates to Make Insights Configuration Sandbox-Friendly

### DIFF
--- a/playbooks/edx-east/insights.yml
+++ b/playbooks/edx-east/insights.yml
@@ -1,4 +1,4 @@
-- name: Deploy Analytics API
+- name: Deploy Insights
   hosts: all
   sudo: True
   gather_facts: True

--- a/playbooks/roles/analytics-api/tasks/main.yml
+++ b/playbooks/roles/analytics-api/tasks/main.yml
@@ -32,7 +32,7 @@
 # ansible-playbook -i 'api.example.com,' ./analyticsapi.yml  -e@/ansible/vars/deployment.yml -e@/ansible/vars/env-deployment.yml
 #
 
-- fail: msg="You must provide an private key for the analytics repo"
+- fail: msg="You must provide a private key for the analytics repo"
   when: not ANALYTICS_API_GIT_IDENTITY
 
 - include: deploy.yml tags=deploy

--- a/playbooks/roles/edx_ansible/templates/update.j2
+++ b/playbooks/roles/edx_ansible/templates/update.j2
@@ -51,6 +51,7 @@ repos_to_cmd["configuration"]="$edx_ansible_cmd edx_ansible.yml -e 'configuratio
 repos_to_cmd["read-only-certificate-code"]="$edx_ansible_cmd certs.yml -e 'certs_version=$2'"
 repos_to_cmd["edx-analytics-data-api"]="$edx_ansible_cmd analyticsapi.yml -e 'ANALYTICS_API_VERSION=$2'"
 repos_to_cmd["edx-ora2"]="$edx_ansible_cmd ora2.yml -e 'ora2_version=$2'"
+repos_to_cmd["insights"]="$edx_ansible_cmd insights.yml -e 'INSIGHTS_VERSION=$2'"
 
 
 if [[ -z $1 || -z $2 ]]; then

--- a/playbooks/roles/insights/defaults/main.yml
+++ b/playbooks/roles/insights/defaults/main.yml
@@ -11,6 +11,8 @@
 # Defaults for role insights
 # 
 
+INSIGHTS_GIT_IDENTITY: !!null
+
 INSIGHTS_MEMCACHE: [ 'localhost:11211' ]
 INSIGHTS_FEEDBACK_EMAIL: 'dashboard@example.com'
 INSIGHTS_MKTG_BASE: 'http://example.com'
@@ -132,9 +134,8 @@ insights_wsgi: "analytics_dashboard.wsgi:application"
 
 insights_django_settings: "analytics_dashboard.settings.production"
 insights_source_repo: "git@{{ COMMON_GIT_MIRROR }}:/edx/edx-analytics-dashboard"
-insights_git_ssh_opts: "-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no"
-insights_git_ssh: "/tmp/insights_git_ssh"
-insights_git_identity_file: "{{ insights_home }}/git_identity"
+insights_git_ssh_opts: "-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i {{ insights_git_identity_file }}"
+insights_git_identity_file: "{{ insights_home }}/git-identity"
 insights_manage: "{{ insights_code_dir }}/analytics_dashboard/manage.py"
 
 insights_requirements_base: "{{ insights_code_dir }}/requirements"

--- a/playbooks/roles/insights/defaults/main.yml
+++ b/playbooks/roles/insights/defaults/main.yml
@@ -123,6 +123,7 @@ insights_log_dir: "{{ COMMON_LOG_DIR }}/{{ insights_service_name }}"
 insights_nodeenv_dir: "{{ insights_home }}/nodeenvs/{{ insights_service_name }}"
 insights_nodeenv_bin: "{{ insights_nodeenv_dir }}/bin"
 insights_node_modules_dir: "{{ insights_code_dir }}/node_modules"
+insights_node_bin: "{{ insights_node_modules_dir }}/.bin"
 
 insights_gunicorn_host: "127.0.0.1"
 insights_gunicorn_port: "8110"

--- a/playbooks/roles/insights/tasks/deploy.yml
+++ b/playbooks/roles/insights/tasks/deploy.yml
@@ -1,17 +1,8 @@
 ---
 
-- name: create .ssh directory
-  file:
-    path="{{ insights_home }}/.ssh" mode=2700 state=directory owner={{ insights_user }} group={{ insights_user }}
-
-- name: create ssh script for git (not authenticated)
-  template: >
-    src=tmp/git_ssh_noauth.sh.j2 dest={{ insights_git_ssh }}
-    owner={{ insights_user }} mode=750
-    
 - name: install read-only ssh key
   copy: >
-    content="{{ COMMON_GIT_IDENTITY }}" dest={{ insights_git_identity_file }}
+    content="{{ INSIGHTS_GIT_IDENTITY }}" dest={{ insights_git_identity_file }}
     owner={{ insights_user }} group={{ insights_user }} mode=0600
 
 - name: setup the insights env file
@@ -26,11 +17,10 @@
   git: >
     dest={{ insights_code_dir }} repo={{ insights_source_repo }} version={{ INSIGHTS_VERSION }}
     accept_hostkey=yes
+    ssh_opts="{{ insights_git_ssh_opts }}"
   register: insights_code_checkout
   notify: restart insights
   sudo_user: "{{ insights_user }}"
-  environment:
-    GIT_SSH: "{{ insights_git_ssh }}"
 
 - name: write out app config file
   template: >
@@ -47,8 +37,6 @@
   sudo_user: "{{ insights_user }}"
   notify: restart insights
   with_items: insights_requirements
-  environment:
-    GIT_SSH: "{{ insights_git_ssh }}"
 
 - name: create nodeenv
   shell: >
@@ -91,6 +79,7 @@
   with_items:
     - "collectstatic --noinput"
     - "compress"
+
 - name: write out the supervisior wrapper
   template: >
     src=edx/app/insights/insights.sh.j2

--- a/playbooks/roles/insights/tasks/deploy.yml
+++ b/playbooks/roles/insights/tasks/deploy.yml
@@ -62,7 +62,7 @@
 - name: install bower dependencies
   shell: >
     chdir={{ insights_code_dir }}
-    . {{ insights_nodeenv_bin }}/activate && {{ insights_node_modules_dir }}/.bin/bower install --production --config.interactive=false
+    . {{ insights_nodeenv_bin }}/activate && {{ insights_node_bin }}/bower install --production --config.interactive=false
   sudo_user: "{{ insights_user }}"
 
 - name: syncdb and migrate
@@ -74,6 +74,12 @@
   sudo_user: "{{ insights_user }}"
   environment: "{{ insights_environment }}"
   when: migrate_db is defined and migrate_db|lower == "yes"
+
+- name: run r.js optimizer
+  shell: >
+    chdir={{ insights_code_dir }}
+    . {{ insights_nodeenv_bin }}/activate && {{ insights_node_bin }}/r.js -o build.js
+  sudo_user: "{{ insights_user }}"
 
 - name: run collectstatic
   shell: >

--- a/playbooks/roles/insights/tasks/deploy.yml
+++ b/playbooks/roles/insights/tasks/deploy.yml
@@ -52,6 +52,7 @@
 
 - name: create nodeenv
   shell: >
+    creates={{ insights_nodeenv_dir }}
     {{ insights_venv_bin }}/nodeenv {{ insights_nodeenv_dir }}
   sudo_user: "{{ insights_user }}"
 

--- a/playbooks/roles/insights/tasks/main.yml
+++ b/playbooks/roles/insights/tasks/main.yml
@@ -21,4 +21,7 @@
 #
 #
 
+- fail: msg="You must provide a private key for the Insights repo"
+  when: not INSIGHTS_GIT_IDENTITY
+
 - include: deploy.yml tags=deploy

--- a/playbooks/roles/insights/templates/tmp/git_ssh_noauth.sh.j2
+++ b/playbooks/roles/insights/templates/tmp/git_ssh_noauth.sh.j2
@@ -1,2 +1,0 @@
-#!/bin/sh
-exec /usr/bin/ssh -o StrictHostKeyChecking=no -i {{ insights_git_identity_file }} "$@"


### PR DESCRIPTION
I have copied the behavior of analytics-api. I am unable to fully test this since `/edx/app/edx_ansible/server-vars.yml` is not created with `INSIGHTS_GIT_IDENTITY`. I added it manually and confirmed via curl that the server starts; however, I cannot access it externally (security group block perhaps?).

@e0d @feanil 
