### PR TITLE
Skip validating cert :(

### DIFF
--- a/playbooks/roles/jenkins_worker/tasks/packer.yml
+++ b/playbooks/roles/jenkins_worker/tasks/packer.yml
@@ -1,6 +1,6 @@
 ---
 - name: Download packer
-  get_url: url={{ packer_url }} dest=/var/tmp/packer.zip
+  shell: "curl -L {{ packer_url }} -o /var/tmp/packer.zip"
 
 - name: Unzip packer
   unarchive: src=/var/tmp/packer.zip dest=/usr/local/bin copy=no

--- a/playbooks/roles/test_build_server/files/test-development-environment.sh
+++ b/playbooks/roles/test_build_server/files/test-development-environment.sh
@@ -35,10 +35,10 @@ paver test_system -t cms/djangoapps/course_creators/tests/test_views.py
 paver test_js_run -s xmodule
 
 # Run some of the bok-choy tests
-paver test_bokchoy -t test_lms.py:RegistrationTest
+paver test_bokchoy -t lms/test_lms.py:RegistrationTest
 paver test_bokchoy -t discussion/test_discussion.py:DiscussionTabSingleThreadTest --fasttest
 paver test_bokchoy -t studio/test_studio_with_ora_component.py:ORAComponentTest --fasttest
-paver test_bokchoy -t test_matlab_problem.py:MatlabProblemTest --fasttest
+paver test_bokchoy -t lms/test_lms_matlab_problem.py:MatlabProblemTest --fasttest
 
 # Run some of the lettuce acceptance tests
 paver test_acceptance -s lms --extra_args="lms/djangoapps/courseware/features/problems.feature -s 1"


### PR DESCRIPTION
This seems to be necessary to get our jenkins-workers building again. I don't entirely understand since this worked a month ago and we were running it with ansible 1.7.1 anyway.

@fredsmith I don't suppose you could suggest a different solution? 

CC @singingwolfboy 
