### PR TITLE
Don't restart edxapp after updating edx-platform using script on devstack

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -35,3 +35,4 @@ Matjaz Gregoric <mtyaka@gmail.com>
 Ben Patterson <bpatterson@edx.org>
 Jason Zhu <fmyzjs@gmail.com>
 Rohit Karajgi <rohit.karajgi@gmail.com>
+Brandon DeRosier <bdero@mit.edu>

--- a/playbooks/roles/edx_ansible/templates/update.j2
+++ b/playbooks/roles/edx_ansible/templates/update.j2
@@ -38,6 +38,10 @@ if [[ -f {{ edx_ansible_var_file }} ]]; then
     extra_args="-e@{{ edx_ansible_var_file }}"
 fi
 
+{% if devstack %}
+extra_args="$extra_args -e 'disable_edx_services=true'"
+{% endif %}
+
 declare -A repos_to_cmd
 edx_ansible_cmd="{{ edx_ansible_venv_bin }}/ansible-playbook -i localhost, -c local --tags deploy $extra_args "
 


### PR DESCRIPTION
@carsongee When using `/edx/bin/update edx-platform (branch)`, the "restart edxapp" task isn't skipped on the devstack - this fixes that.
