### PR TITLE
Hadoop configuration proof of concept (DO NOT MERGE)

### DIFF
--- a/playbooks/authorize-user.yml
+++ b/playbooks/authorize-user.yml
@@ -1,0 +1,20 @@
+---
+
+- hosts: kerberos_server
+  sudo: True
+  vars:
+    - username: ubuntu
+  tasks:
+    - name: principal created
+      kerberos_principal: name={{ username }}
+
+    - name: keytab created
+      command: /usr/sbin/kadmin.local -q 'xst -norandkey -k /home/{{ username }}/credentials.keytab {{ username }}'
+
+    - name: keytab permissions
+      file: path=/home/{{ username }}/credentials.keytab mode=0400 owner={{ username }} group={{ username }}
+
+    - name: credentials cached
+      command: /usr/bin/kinit -k -t /home/{{ username }}/credentials.keytab {{ username }}
+      sudo: True
+      sudo_user: "{{ username }}"

--- a/playbooks/credentials.yml
+++ b/playbooks/credentials.yml
@@ -1,0 +1,148 @@
+---
+
+- hosts: kerberos_server
+  sudo: True
+  vars:
+    - cdh_credentials_staging_path: /var/lib/ansible/hadoop/staging/credentials
+  tasks:
+
+    - name: cdh-secure | local temp directory created
+      local_action: file path=/tmp/ansible-hadoop state=directory
+      sudo: False
+      tags:
+        - cdh-secure
+        - credentials
+
+    - name: cdh-secure | staged credentials removed
+      file: path={{ cdh_credentials_staging_path }}/hadoop.truststore state=absent
+      tags:
+        - cdh-secure
+        - credentials
+        - unsafe
+
+- hosts: cdh_all
+  sudo: True
+  vars:
+    - cdh_credentials_staging_path: /var/lib/ansible/hadoop/staging/credentials
+  serial: 1
+  tasks:
+
+    - name: cdh-secure | principals created
+      kerberos_principal: name={{ item }}/{{ ansible_fqdn }}
+      delegate_to: "{{ groups.kerberos_server[0] }}"
+      with_items:
+        - mapred
+        - hdfs
+        - HTTP
+      register: principals_created
+      tags:
+        - cdh-secure
+        - credentials
+
+    - name: cdh-secure | staged credentials removed
+      file: path={{ cdh_credentials_staging_path }}/{{ inventory_hostname }}/{{ item }} state=absent
+      delegate_to: "{{ groups.kerberos_server[0] }}"
+      with_items:
+        - mapred.keytab
+        - hdfs.keytab
+      when: principals_created.changed
+      tags:
+        - cdh-secure
+        - credentials
+        - unsafe
+
+    - name: cdh-secure | credential staging directory
+      file: path={{ cdh_credentials_staging_path }}/{{ inventory_hostname }} state=directory
+      delegate_to: "{{ groups.kerberos_server[0] }}"
+      tags:
+        - cdh-secure
+        - credentials
+
+    - name: cdh-secure | keytabs created
+      command: /usr/sbin/kadmin.local -q 'xst -norandkey -k {{ cdh_credentials_staging_path }}/{{ inventory_hostname }}/{{ item }}.keytab {{ item }}/{{ ansible_fqdn }} HTTP/{{ ansible_fqdn }}' creates={{ cdh_credentials_staging_path }}/{{ inventory_hostname }}/{{ item }}.keytab
+      delegate_to: "{{ groups.kerberos_server[0] }}"
+      with_items:
+        - mapred
+        - hdfs
+      tags:
+        - cdh-secure
+        - credentials
+
+    - name: cdh-secure | keystores created
+      command: /usr/bin/keytool -genkey -keystore {{ cdh_credentials_staging_path }}/{{ inventory_hostname }}/https.keystore -keyalg RSA -alias {{ ansible_hostname }} -dname "CN={{ ansible_fqdn }},O=Hadoop" -keypass hadoop -storepass hadoop creates={{ cdh_credentials_staging_path }}/{{ inventory_hostname }}/https.keystore
+      delegate_to: "{{ groups.kerberos_server[0] }}"
+      tags:
+        - cdh-secure
+        - credentials
+
+    - name: cdh-secure | certs exported
+      command: /usr/bin/keytool -exportcert -keystore {{ cdh_credentials_staging_path }}/{{ inventory_hostname }}/https.keystore -alias {{ ansible_hostname }} -file {{ cdh_credentials_staging_path }}/{{ inventory_hostname }}/https.cert -storepass hadoop creates={{ cdh_credentials_staging_path }}/{{ inventory_hostname }}/https.cert
+      delegate_to: "{{ groups.kerberos_server[0] }}"
+      tags:
+        - cdh-secure
+        - credentials
+
+    - name: cdh-secure | credentials downloaded
+      fetch: src={{ cdh_credentials_staging_path }}/{{ inventory_hostname }}/{{ item }} dest=/tmp/ansible-hadoop/{{ inventory_hostname }}/ flat=yes
+      delegate_to: "{{ groups.kerberos_server[0] }}"
+      with_items:
+        - https.keystore
+        - hdfs.keytab
+        - mapred.keytab
+      tags:
+        - cdh-secure
+        - credentials
+
+    - name: cdh-secure | certs added to trust store
+      command: /usr/bin/keytool -import -keystore {{ cdh_credentials_staging_path }}/hadoop.truststore -alias {{ ansible_hostname }} -file {{ cdh_credentials_staging_path }}/{{ inventory_hostname }}/https.cert -noprompt -storepass hadoop
+      delegate_to: "{{ groups.kerberos_server[0] }}"
+      tags:
+        - cdh-secure
+        - credentials
+
+- hosts: cdh_all
+  sudo: True
+  vars:
+    - cdh_credentials_staging_path: /var/lib/ansible/hadoop/staging/credentials
+  tasks:
+
+    - name: cdh-secure | trust store downloaded
+      fetch: src={{ cdh_credentials_staging_path }}/hadoop.truststore dest=/tmp/ansible-hadoop/{{ inventory_hostname }}/ flat=yes
+      delegate_to: "{{ groups.kerberos_server[0] }}"
+      tags:
+        - cdh-secure
+        - credentials
+
+- hosts: cdh_all
+  sudo: True
+  vars:
+    - cdh_credentials_path: /var/lib/ansible/hadoop/credentials
+  tasks:
+
+    - name: cdh-secure | credentials directory
+      file: path={{ cdh_credentials_path }} state=directory mode=0777
+      tags:
+        - cdh-secure
+        - credentials
+
+    - name: cdh-secure | credentials uploaded
+      copy: src=/tmp/ansible-hadoop/{{ inventory_hostname }}/{{ item.name }} dest={{ cdh_credentials_path }}/{{ item.name }} owner={{ item.owner }} group=hadoop mode={{ item.mode }}
+      with_items:
+        - { name: mapred.keytab, owner: mapred, mode: '0400' }
+        - { name: hdfs.keytab, owner: hdfs, mode: '0400' }
+        - { name: hadoop.truststore, owner: root, mode: '0444' }
+        - { name: https.keystore, owner: root, mode: '0440' }
+      tags:
+        - cdh-secure
+        - credentials
+
+    - name: cdh-secure | credential links created
+      file: src={{ cdh_credentials_path }}/{{ item }} dest=/etc/hadoop/conf/{{ item }} state=link
+      with_items:
+        - mapred.keytab
+        - hdfs.keytab
+        - hadoop.truststore
+        - https.keystore
+      tags:
+        - cdh-secure
+        - credentials

--- a/playbooks/distribute-keys.yml
+++ b/playbooks/distribute-keys.yml
@@ -1,0 +1,16 @@
+---
+
+- hosts: master
+  sudo: True
+  tasks:
+    - name: Key generated
+      command: /usr/bin/ssh-keygen -t rsa -P '' -f /home/root/.ssh/id_rsa creates=/home/root/.ssh/id_rsa
+
+    - name: Key downloaded
+      fetch: src=/home/root/.ssh/id_rsa.pub dest=/tmp/{{ ansible_fqdn }}.pub flat=yes
+
+- hosts: all
+  sudo: True
+  tasks:
+    - name: Key authorized
+      authorized_key: user=root key="{{ lookup('file', '/tmp/{}.pub'.format(groups.master[0])) }}"

--- a/playbooks/group_vars/cdh_all
+++ b/playbooks/group_vars/cdh_all
@@ -1,0 +1,6 @@
+---
+cdh_hadoop_conf_path: /etc/hadoop/conf.ansible
+cdh_job_tracker_port: 8021
+cdh_hdfs_namenode_dir: /mnt/hdfs/meta/
+cdh_hdfs_datanode_dir: /mnt/hdfs/data/
+cdh_mapred_local_dir: /mnt/mapred/

--- a/playbooks/group_vars/ec2_all
+++ b/playbooks/group_vars/ec2_all
@@ -1,0 +1,3 @@
+---
+
+kerberos_realm: ANALYTICS.EDX.ORG

--- a/playbooks/group_vars/type_m1_large
+++ b/playbooks/group_vars/type_m1_large
@@ -1,0 +1,3 @@
+---
+
+cdh_task_jvm_heap: '2048M'

--- a/playbooks/group_vars/type_m1_small
+++ b/playbooks/group_vars/type_m1_small
@@ -1,0 +1,3 @@
+---
+
+cdh_task_jvm_heap: '512M'

--- a/playbooks/group_vars/vagrant_all
+++ b/playbooks/group_vars/vagrant_all
@@ -1,0 +1,4 @@
+---
+
+cdh_task_jvm_heap: '256M'
+kerberos_realm: 'CDH.VAGRANT.LOCAL'

--- a/playbooks/library/alternatives
+++ b/playbooks/library/alternatives
@@ -1,0 +1,53 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+import subprocess
+
+UPDATE_ALTERNATIVES = '/usr/sbin/update-alternatives'
+
+def main():
+
+    module = AnsibleModule(
+        argument_spec = dict(
+            name = dict(required=True),
+            path  = dict(required=True),
+            link = dict(required=False),
+            priority = dict(required=False, default=50),
+        )
+    )
+
+    params = module.params
+    name = params['name']
+    path = params['path']
+    link = params['link']
+    priority = params['priority']
+
+    current_path = None
+    all_alternatives = []
+    try:
+        query_output = subprocess.check_output([UPDATE_ALTERNATIVES, '--query', name])
+        for line in query_output.splitlines():
+            split_line = line.split(':')
+            if len(split_line) == 2:
+                key = split_line[0]
+                value = split_line[1].strip()
+                if key == 'Value':
+                    current_path = value
+                elif key == 'Alternative':
+                    all_alternatives.append(value)
+    except subprocess.CalledProcessError:
+        pass
+
+    if current_path != path:
+        if path not in all_alternatives:
+            subprocess.check_call([UPDATE_ALTERNATIVES, '--install', link, name, path, str(priority)])
+
+        subprocess.check_call([UPDATE_ALTERNATIVES, '--set', name, path])
+        module.exit_json(changed=True)
+    else:
+        module.exit_json(changed=False)
+
+# this is magic, see lib/ansible/module_common.py
+#<<INCLUDE_ANSIBLE_MODULE_COMMON>>
+main()
+

--- a/playbooks/library/hadoop_configuration
+++ b/playbooks/library/hadoop_configuration
@@ -1,0 +1,54 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+import xml.etree.ElementTree as et
+
+def main():
+
+    module = AnsibleModule(
+        argument_spec = dict(
+            property = dict(required=True),
+            value  = dict(required=True),
+            path = dict(required=True),
+        )
+    )
+
+    params = module.params
+    property_name = params['property']
+    value = params['value']
+    path = params['path']
+
+    try:
+        tree = et.parse(path)
+        root = tree.getroot()
+    except:
+        root = et.Element('configuration')
+        tree = et.ElementTree(root)
+
+    found_property = False
+    for property_element in root.findall('property'):
+        name_element = property_element.find('name')
+        value_element = property_element.find('value')
+        if name_element is not None and property_name == name_element.text:
+            found_property = True
+            if value_element is not None:
+                if value_element.text == value:
+                    module.exit_json(changed=False)
+                else:
+                    value_element.text = value
+                    break
+
+    if not found_property:
+        property_element = et.SubElement(root, 'property')
+        name_element = et.SubElement(property_element, 'name')
+        name_element.text = property_name
+        value_element = et.SubElement(property_element, 'value')
+        value_element.text = value
+
+    tree.write(path, xml_declaration=True, encoding='utf-8')
+    module.exit_json(changed=True)
+
+
+# this is magic, see lib/ansible/module_common.py
+#<<INCLUDE_ANSIBLE_MODULE_COMMON>>
+main()

--- a/playbooks/library/hdfs_directory
+++ b/playbooks/library/hdfs_directory
@@ -1,0 +1,75 @@
+#!/usr/bin/env groovy -cp `hadoop classpath`
+
+import java.io.FileNotFoundException
+
+import groovy.json.JsonBuilder
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.FileStatus
+import org.apache.hadoop.fs.FileSystem
+import org.apache.hadoop.fs.permission.FsPermission
+import org.apache.hadoop.fs.Path
+
+String argumentsFileContents = new File(args[0]).text
+
+String[] argKeyValues = argumentsFileContents.split(' ')
+def arguments = [:]
+argKeyValues.each { String keyValuePair ->
+    String[] keyValue = keyValuePair.split('=')
+    arguments[keyValue[0]] = keyValue[1]
+}
+
+def state = arguments.get('state', 'present')
+def mode = arguments.get('mode', null)
+def owner = arguments.get('owner', null)
+def group = arguments.get('group', null)
+
+Path filePath = new Path(arguments['path'])
+FileSystem fs = filePath.getFileSystem(new Configuration())
+
+boolean hasChanged = false
+FileStatus status = null
+try {
+    status = fs.getFileStatus(filePath)
+    if (state == 'absent') {
+        fs.delete(filePath, true)
+        hasChanged = true
+    }
+} catch(FileNotFoundException fnf) {
+    if (state == 'present') {
+        fs.mkdirs(filePath)
+        status = fs.getFileStatus(filePath)
+        hasChanged = true
+    }
+}
+
+if (state == 'present') {
+    if (mode != null) {
+        Short parsedPerms = Short.valueOf(mode, 8)
+        FsPermission requestedPermissions = new FsPermission(parsedPerms)
+        if (status.permission != requestedPermissions) {
+            fs.setPermission(filePath, requestedPermissions)
+            hasChanged = true
+        }
+    }
+
+    if (owner == null) {
+        owner = status.owner
+    }
+
+    if (group == null) {
+        group = status.group
+    }
+
+    if (owner != status.owner || group != status.group) {
+        fs.setOwner(filePath, owner, group)
+        hasChanged = true
+    }
+}
+
+
+def json = new groovy.json.JsonBuilder()
+json {
+    changed hasChanged
+}
+println(json.toString())

--- a/playbooks/library/kerberos_principal
+++ b/playbooks/library/kerberos_principal
@@ -1,0 +1,32 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+import subprocess
+
+KADMIN = '/usr/sbin/kadmin.local'
+
+def kadmin(query):
+    return subprocess.check_output([KADMIN, '-q', query], stderr=subprocess.STDOUT)
+
+def main():
+
+    module = AnsibleModule(
+        argument_spec = dict(
+            name = dict(required=True),
+        )
+    )
+
+    name = module.params['name']
+
+    query_output = kadmin('get_principal {}'.format(name))
+    if 'get_principal: Principal does not exist' in query_output:
+        kadmin('add_principal -randkey {}'.format(name))
+        module.exit_json(changed=True)
+    else:
+        module.exit_json(changed=False)
+        
+
+# this is magic, see lib/ansible/module_common.py
+#<<INCLUDE_ANSIBLE_MODULE_COMMON>>
+main()
+

--- a/playbooks/roles/cdh-common/files/configuration.xsl
+++ b/playbooks/roles/cdh-common/files/configuration.xsl
@@ -1,0 +1,40 @@
+<?xml version="1.0"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+<xsl:output method="html"/>
+<xsl:template match="configuration">
+<html>
+<body>
+<table border="1">
+<tr>
+ <td>name</td>
+ <td>value</td>
+ <td>description</td>
+</tr>
+<xsl:for-each select="property">
+<tr>
+  <td><a name="{name}"><xsl:value-of select="name"/></a></td>
+  <td><xsl:value-of select="value"/></td>
+  <td><xsl:value-of select="description"/></td>
+</tr>
+</xsl:for-each>
+</table>
+</body>
+</html>
+</xsl:template>
+</xsl:stylesheet>

--- a/playbooks/roles/cdh-common/files/hadoop-env.sh
+++ b/playbooks/roles/cdh-common/files/hadoop-env.sh
@@ -1,0 +1,1 @@
+export HADOOP_MAPRED_HOME=/usr/lib/hadoop-0.20-mapreduce

--- a/playbooks/roles/cdh-common/files/hadoop-hdfs-datanode
+++ b/playbooks/roles/cdh-common/files/hadoop-hdfs-datanode
@@ -1,0 +1,4 @@
+export HADOOP_SECURE_DN_USER=hdfs
+export HADOOP_SECURE_DN_PID_DIR=/var/run/hadoop-hdfs
+export HADOOP_SECURE_DN_LOG_DIR=/var/log/hadoop-hdfs
+export JSVC_HOME=/usr/lib/bigtop-utils/

--- a/playbooks/roles/cdh-common/files/hadoop-policy.xml
+++ b/playbooks/roles/cdh-common/files/hadoop-policy.xml
@@ -1,0 +1,219 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<!--
+
+ Copyright 2011 The Apache Software Foundation
+ 
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+-->
+
+<!-- Put site-specific property overrides in this file. -->
+
+<configuration>
+  <property>
+    <name>security.client.protocol.acl</name>
+    <value>*</value>
+    <description>ACL for ClientProtocol, which is used by user code
+    via the DistributedFileSystem.
+    The ACL is a comma-separated list of user and group names. The user and
+    group list is separated by a blank. For e.g. "alice,bob users,wheel".
+    A special value of "*" means all users are allowed.</description>
+  </property>
+
+  <property>
+    <name>security.client.datanode.protocol.acl</name>
+    <value>*</value>
+    <description>ACL for ClientDatanodeProtocol, the client-to-datanode protocol
+    for block recovery.
+    The ACL is a comma-separated list of user and group names. The user and
+    group list is separated by a blank. For e.g. "alice,bob users,wheel".
+    A special value of "*" means all users are allowed.</description>
+  </property>
+
+  <property>
+    <name>security.datanode.protocol.acl</name>
+    <value>*</value>
+    <description>ACL for DatanodeProtocol, which is used by datanodes to
+    communicate with the namenode.
+    The ACL is a comma-separated list of user and group names. The user and
+    group list is separated by a blank. For e.g. "alice,bob users,wheel".
+    A special value of "*" means all users are allowed.</description>
+  </property>
+
+  <property>
+    <name>security.inter.datanode.protocol.acl</name>
+    <value>*</value>
+    <description>ACL for InterDatanodeProtocol, the inter-datanode protocol
+    for updating generation timestamp.
+    The ACL is a comma-separated list of user and group names. The user and
+    group list is separated by a blank. For e.g. "alice,bob users,wheel".
+    A special value of "*" means all users are allowed.</description>
+  </property>
+
+  <property>
+    <name>security.namenode.protocol.acl</name>
+    <value>*</value>
+    <description>ACL for NamenodeProtocol, the protocol used by the secondary
+    namenode to communicate with the namenode.
+    The ACL is a comma-separated list of user and group names. The user and
+    group list is separated by a blank. For e.g. "alice,bob users,wheel".
+    A special value of "*" means all users are allowed.</description>
+  </property>
+
+ <property>
+    <name>security.admin.operations.protocol.acl</name>
+    <value>*</value>
+    <description>ACL for AdminOperationsProtocol. Used for admin commands.
+    The ACL is a comma-separated list of user and group names. The user and
+    group list is separated by a blank. For e.g. "alice,bob users,wheel".
+    A special value of "*" means all users are allowed.</description>
+  </property>
+
+  <property>
+    <name>security.refresh.usertogroups.mappings.protocol.acl</name>
+    <value>*</value>
+    <description>ACL for RefreshUserMappingsProtocol. Used to refresh
+    users mappings. The ACL is a comma-separated list of user and
+    group names. The user and group list is separated by a blank. For
+    e.g. "alice,bob users,wheel".  A special value of "*" means all
+    users are allowed.</description>
+  </property>
+
+  <property>
+    <name>security.refresh.policy.protocol.acl</name>
+    <value>*</value>
+    <description>ACL for RefreshAuthorizationPolicyProtocol, used by the
+    dfsadmin and mradmin commands to refresh the security policy in-effect.
+    The ACL is a comma-separated list of user and group names. The user and
+    group list is separated by a blank. For e.g. "alice,bob users,wheel".
+    A special value of "*" means all users are allowed.</description>
+  </property>
+
+  <property>
+    <name>security.ha.service.protocol.acl</name>
+    <value>*</value>
+    <description>ACL for HAService protocol used by HAAdmin to manage the
+      active and stand-by states of namenode.</description>
+  </property>
+
+  <property>
+    <name>security.zkfc.protocol.acl</name>
+    <value>*</value>
+    <description>ACL for access to the ZK Failover Controller
+    </description>
+  </property>
+
+  <property>
+    <name>security.qjournal.service.protocol.acl</name>
+    <value>*</value>
+    <description>ACL for QJournalProtocol, used by the NN to communicate with
+    JNs when using the QuorumJournalManager for edit logs.</description>
+  </property>
+
+  <property>
+    <name>security.mrhs.client.protocol.acl</name>
+    <value>*</value>
+    <description>ACL for HSClientProtocol, used by job clients to
+    communciate with the MR History Server job status etc. 
+    The ACL is a comma-separated list of user and group names. The user and
+    group list is separated by a blank. For e.g. "alice,bob users,wheel".
+    A special value of "*" means all users are allowed.</description>
+  </property>
+
+  <!-- YARN Protocols -->
+
+  <property>
+    <name>security.resourcetracker.protocol.acl</name>
+    <value>*</value>
+    <description>ACL for ResourceTracker protocol, used by the
+    ResourceManager and NodeManager to communicate with each other.
+    The ACL is a comma-separated list of user and group names. The user and
+    group list is separated by a blank. For e.g. "alice,bob users,wheel".
+    A special value of "*" means all users are allowed.</description>
+  </property>
+
+  <property>
+    <name>security.admin.protocol.acl</name>
+    <value>*</value>
+    <description>ACL for RMAdminProtocol, for admin commands. 
+    The ACL is a comma-separated list of user and group names. The user and
+    group list is separated by a blank. For e.g. "alice,bob users,wheel".
+    A special value of "*" means all users are allowed.</description>
+  </property>
+
+  <property>
+    <name>security.client.resourcemanager.protocol.acl</name>
+    <value>*</value>
+    <description>ACL for ClientRMProtocol, used by the ResourceManager 
+    and applications submission clients to communicate with each other.
+    The ACL is a comma-separated list of user and group names. The user and
+    group list is separated by a blank. For e.g. "alice,bob users,wheel".
+    A special value of "*" means all users are allowed.</description>
+  </property>
+
+  <property>
+    <name>security.applicationmaster.resourcemanager.protocol.acl</name>
+    <value>*</value>
+    <description>ACL for AMRMProtocol, used by the ResourceManager 
+    and ApplicationMasters to communicate with each other.
+    The ACL is a comma-separated list of user and group names. The user and
+    group list is separated by a blank. For e.g. "alice,bob users,wheel".
+    A special value of "*" means all users are allowed.</description>
+  </property>
+
+  <property>
+    <name>security.containermanager.protocol.acl</name>
+    <value>*</value>
+    <description>ACL for ContainerManager protocol, used by the NodeManager 
+    and ApplicationMasters to communicate with each other.
+    The ACL is a comma-separated list of user and group names. The user and
+    group list is separated by a blank. For e.g. "alice,bob users,wheel".
+    A special value of "*" means all users are allowed.</description>
+  </property>
+
+  <property>
+    <name>security.resourcelocalizer.protocol.acl</name>
+    <value>*</value>
+    <description>ACL for ResourceLocalizer protocol, used by the NodeManager 
+    and ResourceLocalizer to communicate with each other.
+    The ACL is a comma-separated list of user and group names. The user and
+    group list is separated by a blank. For e.g. "alice,bob users,wheel".
+    A special value of "*" means all users are allowed.</description>
+  </property>
+
+  <property>
+    <name>security.job.task.protocol.acl</name>
+    <value>*</value>
+    <description>ACL for TaskUmbilicalProtocol, used by the map and reduce
+    tasks to communicate with the parent tasktracker.
+    The ACL is a comma-separated list of user and group names. The user and
+    group list is separated by a blank. For e.g. "alice,bob users,wheel".
+    A special value of "*" means all users are allowed.</description>
+  </property>
+
+  <property>
+    <name>security.job.client.protocol.acl</name>
+    <value>*</value>
+    <description>ACL for MRClientProtocol, used by job clients to
+    communciate with the MR ApplicationMaster to query job status etc. 
+    The ACL is a comma-separated list of user and group names. The user and
+    group list is separated by a blank. For e.g. "alice,bob users,wheel".
+    A special value of "*" means all users are allowed.</description>
+  </property>
+
+</configuration>

--- a/playbooks/roles/cdh-common/files/log4j.properties
+++ b/playbooks/roles/cdh-common/files/log4j.properties
@@ -1,0 +1,219 @@
+# Copyright 2011 The Apache Software Foundation
+# 
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Define some default values that can be overridden by system properties
+hadoop.root.logger=INFO,console
+hadoop.log.dir=.
+hadoop.log.file=hadoop.log
+
+# Define the root logger to the system property "hadoop.root.logger".
+log4j.rootLogger=${hadoop.root.logger}, EventCounter
+
+# Logging Threshold
+log4j.threshold=ALL
+
+# Null Appender
+log4j.appender.NullAppender=org.apache.log4j.varia.NullAppender
+
+#
+# Rolling File Appender - cap space usage at 5gb.
+#
+hadoop.log.maxfilesize=256MB
+hadoop.log.maxbackupindex=20
+log4j.appender.RFA=org.apache.log4j.RollingFileAppender
+log4j.appender.RFA.File=${hadoop.log.dir}/${hadoop.log.file}
+
+log4j.appender.RFA.MaxFileSize=${hadoop.log.maxfilesize}
+log4j.appender.RFA.MaxBackupIndex=${hadoop.log.maxbackupindex}
+
+log4j.appender.RFA.layout=org.apache.log4j.PatternLayout
+
+# Pattern format: Date LogLevel LoggerName LogMessage
+log4j.appender.RFA.layout.ConversionPattern=%d{ISO8601} %p %c: %m%n
+# Debugging Pattern format
+#log4j.appender.RFA.layout.ConversionPattern=%d{ISO8601} %-5p %c{2} (%F:%M(%L)) - %m%n
+
+
+#
+# Daily Rolling File Appender
+#
+
+log4j.appender.DRFA=org.apache.log4j.DailyRollingFileAppender
+log4j.appender.DRFA.File=${hadoop.log.dir}/${hadoop.log.file}
+
+# Rollver at midnight
+log4j.appender.DRFA.DatePattern=.yyyy-MM-dd
+
+# 30-day backup
+#log4j.appender.DRFA.MaxBackupIndex=30
+log4j.appender.DRFA.layout=org.apache.log4j.PatternLayout
+
+# Pattern format: Date LogLevel LoggerName LogMessage
+log4j.appender.DRFA.layout.ConversionPattern=%d{ISO8601} %p %c: %m%n
+# Debugging Pattern format
+#log4j.appender.DRFA.layout.ConversionPattern=%d{ISO8601} %-5p %c{2} (%F:%M(%L)) - %m%n
+
+
+#
+# console
+# Add "console" to rootlogger above if you want to use this 
+#
+
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.target=System.err
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss} %p %c{2}: %m%n
+
+#
+# TaskLog Appender
+#
+
+#Default values
+hadoop.tasklog.taskid=null
+hadoop.tasklog.iscleanup=false
+hadoop.tasklog.noKeepSplits=4
+hadoop.tasklog.totalLogFileSize=100
+hadoop.tasklog.purgeLogSplits=true
+hadoop.tasklog.logsRetainHours=12
+
+log4j.appender.TLA=org.apache.hadoop.mapred.TaskLogAppender
+log4j.appender.TLA.taskId=${hadoop.tasklog.taskid}
+log4j.appender.TLA.isCleanup=${hadoop.tasklog.iscleanup}
+log4j.appender.TLA.totalLogFileSize=${hadoop.tasklog.totalLogFileSize}
+
+log4j.appender.TLA.layout=org.apache.log4j.PatternLayout
+log4j.appender.TLA.layout.ConversionPattern=%d{ISO8601} %p %c: %m%n
+
+#
+# HDFS block state change log from block manager
+#
+# Uncomment the following to suppress normal block state change
+# messages from BlockManager in NameNode.
+#log4j.logger.BlockStateChange=WARN
+
+#
+#Security appender
+#
+hadoop.security.logger=INFO,NullAppender
+hadoop.security.log.maxfilesize=256MB
+hadoop.security.log.maxbackupindex=20
+log4j.category.SecurityLogger=${hadoop.security.logger}
+hadoop.security.log.file=SecurityAuth-${user.name}.audit
+log4j.appender.RFAS=org.apache.log4j.RollingFileAppender 
+log4j.appender.RFAS.File=${hadoop.log.dir}/${hadoop.security.log.file}
+log4j.appender.RFAS.layout=org.apache.log4j.PatternLayout
+log4j.appender.RFAS.layout.ConversionPattern=%d{ISO8601} %p %c: %m%n
+log4j.appender.RFAS.MaxFileSize=${hadoop.security.log.maxfilesize}
+log4j.appender.RFAS.MaxBackupIndex=${hadoop.security.log.maxbackupindex}
+
+#
+# Daily Rolling Security appender
+#
+log4j.appender.DRFAS=org.apache.log4j.DailyRollingFileAppender 
+log4j.appender.DRFAS.File=${hadoop.log.dir}/${hadoop.security.log.file}
+log4j.appender.DRFAS.layout=org.apache.log4j.PatternLayout
+log4j.appender.DRFAS.layout.ConversionPattern=%d{ISO8601} %p %c: %m%n
+log4j.appender.DRFAS.DatePattern=.yyyy-MM-dd
+
+#
+# hdfs audit logging
+#
+hdfs.audit.logger=INFO,NullAppender
+hdfs.audit.log.maxfilesize=256MB
+hdfs.audit.log.maxbackupindex=20
+log4j.logger.org.apache.hadoop.hdfs.server.namenode.FSNamesystem.audit=${hdfs.audit.logger}
+log4j.additivity.org.apache.hadoop.hdfs.server.namenode.FSNamesystem.audit=false
+log4j.appender.RFAAUDIT=org.apache.log4j.RollingFileAppender
+log4j.appender.RFAAUDIT.File=${hadoop.log.dir}/hdfs-audit.log
+log4j.appender.RFAAUDIT.layout=org.apache.log4j.PatternLayout
+log4j.appender.RFAAUDIT.layout.ConversionPattern=%d{ISO8601} %p %c{2}: %m%n
+log4j.appender.RFAAUDIT.MaxFileSize=${hdfs.audit.log.maxfilesize}
+log4j.appender.RFAAUDIT.MaxBackupIndex=${hdfs.audit.log.maxbackupindex}
+
+#
+# mapred audit logging
+#
+mapred.audit.logger=INFO,NullAppender
+mapred.audit.log.maxfilesize=256MB
+mapred.audit.log.maxbackupindex=20
+log4j.logger.org.apache.hadoop.mapred.AuditLogger=${mapred.audit.logger}
+log4j.additivity.org.apache.hadoop.mapred.AuditLogger=false
+log4j.appender.MRAUDIT=org.apache.log4j.RollingFileAppender
+log4j.appender.MRAUDIT.File=${hadoop.log.dir}/mapred-audit.log
+log4j.appender.MRAUDIT.layout=org.apache.log4j.PatternLayout
+log4j.appender.MRAUDIT.layout.ConversionPattern=%d{ISO8601} %p %c{2}: %m%n
+log4j.appender.MRAUDIT.MaxFileSize=${mapred.audit.log.maxfilesize}
+log4j.appender.MRAUDIT.MaxBackupIndex=${mapred.audit.log.maxbackupindex}
+
+# Custom Logging levels
+
+#log4j.logger.org.apache.hadoop.mapred.JobTracker=DEBUG
+#log4j.logger.org.apache.hadoop.mapred.TaskTracker=DEBUG
+#log4j.logger.org.apache.hadoop.hdfs.server.namenode.FSNamesystem.audit=DEBUG
+
+# Jets3t library
+log4j.logger.org.jets3t.service.impl.rest.httpclient.RestS3Service=ERROR
+
+#
+# Event Counter Appender
+# Sends counts of logging messages at different severity levels to Hadoop Metrics.
+#
+log4j.appender.EventCounter=org.apache.hadoop.log.metrics.EventCounter
+
+#
+# Job Summary Appender 
+#
+# Use following logger to send summary to separate file defined by 
+# hadoop.mapreduce.jobsummary.log.file :
+# hadoop.mapreduce.jobsummary.logger=INFO,JSA
+# 
+hadoop.mapreduce.jobsummary.logger=${hadoop.root.logger}
+hadoop.mapreduce.jobsummary.log.file=hadoop-mapreduce.jobsummary.log
+hadoop.mapreduce.jobsummary.log.maxfilesize=256MB
+hadoop.mapreduce.jobsummary.log.maxbackupindex=20
+log4j.appender.JSA=org.apache.log4j.RollingFileAppender
+log4j.appender.JSA.File=${hadoop.log.dir}/${hadoop.mapreduce.jobsummary.log.file}
+log4j.appender.JSA.MaxFileSize=${hadoop.mapreduce.jobsummary.log.maxfilesize}
+log4j.appender.JSA.MaxBackupIndex=${hadoop.mapreduce.jobsummary.log.maxbackupindex}
+log4j.appender.JSA.layout=org.apache.log4j.PatternLayout
+log4j.appender.JSA.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss} %p %c{2}: %m%n
+log4j.logger.org.apache.hadoop.mapred.JobInProgress$JobSummary=${hadoop.mapreduce.jobsummary.logger}
+log4j.additivity.org.apache.hadoop.mapred.JobInProgress$JobSummary=false
+
+#
+# Yarn ResourceManager Application Summary Log 
+#
+# Set the ResourceManager summary log filename
+#yarn.server.resourcemanager.appsummary.log.file=rm-appsummary.log
+# Set the ResourceManager summary log level and appender
+#yarn.server.resourcemanager.appsummary.logger=INFO,RMSUMMARY
+
+# Appender for ResourceManager Application Summary Log
+# Requires the following properties to be set
+#    - hadoop.log.dir (Hadoop Log directory)
+#    - yarn.server.resourcemanager.appsummary.log.file (resource manager app summary log filename)
+#    - yarn.server.resourcemanager.appsummary.logger (resource manager app summary log level and appender)
+
+#log4j.logger.org.apache.hadoop.yarn.server.resourcemanager.RMAppManager$ApplicationSummary=${yarn.server.resourcemanager.appsummary.logger}
+#log4j.additivity.org.apache.hadoop.yarn.server.resourcemanager.RMAppManager$ApplicationSummary=false
+#log4j.appender.RMSUMMARY=org.apache.log4j.RollingFileAppender
+#log4j.appender.RMSUMMARY.File=${hadoop.log.dir}/${yarn.server.resourcemanager.appsummary.log.file}
+#log4j.appender.RMSUMMARY.MaxFileSize=256MB
+#log4j.appender.RMSUMMARY.MaxBackupIndex=20
+#log4j.appender.RMSUMMARY.layout=org.apache.log4j.PatternLayout
+#log4j.appender.RMSUMMARY.layout.ConversionPattern=%d{ISO8601} %p %c{2}: %m%n

--- a/playbooks/roles/cdh-common/tasks/main.yml
+++ b/playbooks/roles/cdh-common/tasks/main.yml
@@ -1,0 +1,189 @@
+---
+
+- name: cdh-common | playbook requirements
+  apt: pkg={{ item }}
+  with_items:
+    - curl
+    - python-pycurl
+    - groovy
+  tags:
+    - cdh-common
+
+- name: cdh-common | cloudera repository key
+  apt_key: url=http://archive.cloudera.com/cdh4/ubuntu/precise/amd64/cdh/archive.key state=present
+  tags:
+    - cdh-common
+
+- name: cdh-common | cloudera repository
+  apt_repository: repo='deb [arch=amd64] http://archive.cloudera.com/cdh4/ubuntu/precise/amd64/cdh precise-cdh4 contrib' state=present
+  tags:
+    - cdh-common
+
+- name: cdh-common | cloudera src repository
+  apt_repository: repo='deb-src http://archive.cloudera.com/cdh4/ubuntu/precise/amd64/cdh precise-cdh4 contrib' state=present
+  tags:
+    - cdh-common
+
+- name: cdh-common | update apt cache
+  apt: update_cache=yes
+  tags:
+    - cdh-common
+
+- name: cdh-common | hadoop groups
+  group: name={{ item }} system=yes state=present
+  with_items:
+    - hadoop
+    - hdfs
+    - mapred
+  tags:
+    - cdh-common
+
+- name: cdh-common | users
+  user: name={{ item.name }} group={{ item.name }} groups=hadoop home={{ item.home }} shell=/bin/bash createhome=no system=yes state=present
+  with_items:
+    - { name: hdfs,   home: /var/lib/hadoop-hdfs }
+    - { name: mapred, home: /usr/lib/hadoop-0.20-mapreduce }
+  tags:
+    - cdh-common
+
+- name: cdh-common | configuration directory
+  file: path={{ cdh_hadoop_conf_path }} state=directory owner=root group=root mode=0755
+  tags:
+    - cdh-common
+
+- name: cdh-common | configuration files
+  copy: src={{ item }} dest={{ cdh_hadoop_conf_path }} owner=root group=root mode=0644
+  with_items:
+    - configuration.xsl
+    - hadoop-env.sh
+    - hadoop-policy.xml
+    - log4j.properties
+    - hadoop-hdfs-datanode
+  tags:
+    - cdh-common
+
+- name: cdh-common | datanode default files
+  copy: src=hadoop-hdfs-datanode dest=/etc/default/hadoop-hdfs-datanode owner=root group=root mode=0644
+  tags:
+    - cdh-common
+
+- name: cdh-common | templated configuration files
+  template: src={{ item }}.j2 dest={{ cdh_hadoop_conf_path }}/{{ item }} owner=root group=root mode=0644
+  with_items:
+    - hadoop-metrics.properties
+    - hadoop-metrics2.properties
+    - taskcontroller.cfg
+    - mapred.exclude
+    - hdfs.exclude
+  tags:
+    - cdh-common
+
+- name: cdh-common | core configured
+  hadoop_configuration: path={{ cdh_hadoop_conf_path }}/core-site.xml property={{ item.key }} value={{ item.value }}
+  with_items:
+    - { key: fs.defaultFS, value: "hdfs://{{ groups['cdh_namenode'][0] }}/" }
+    - { key: mapred.hosts.exclude, value: "{{ cdh_hadoop_conf_path }}/mapred.exclude" }
+    - { key: dfs.hosts.exclude, value: "{{ cdh_hadoop_conf_path }}/hdfs.exclude" }
+    - { key: hadoop.security.authentication, value: kerberos }
+    - { key: hadoop.security.authorization, value: true }
+    - { key: hadoop.rpc.protection, value: privacy }
+    - { key: hadoop.ssl.enabled, value: true }
+  tags:
+    - cdh-common
+
+- name: cdh-common | job tracker address configured
+  hadoop_configuration: path={{ cdh_hadoop_conf_path }}/mapred-site.xml property=mapred.job.tracker value={{ groups['cdh_jobtracker'][0] }}:{{ cdh_job_tracker_port }}
+  tags:
+    - cdh-common
+
+- name: cdh-common | S3 access key id configured
+  hadoop_configuration: path={{ cdh_hadoop_conf_path }}/core-site.xml property=fs.s3n.awsAccessKeyId value={{ cdh_s3_access_key_id }}
+  when: cdh_s3_access_key_id is defined
+  tags:
+    - cdh-common
+
+- name: cdh-common | S3 secret access key configured
+  hadoop_configuration: path={{ cdh_hadoop_conf_path }}/core-site.xml property=fs.s3n.awsSecretAccessKey value={{ cdh_s3_secret_access_key }}
+  when: cdh_s3_secret_access_key is defined
+  tags:
+    - cdh-common
+
+- name: cdh-common | hdfs security configured
+  hadoop_configuration: path={{ cdh_hadoop_conf_path }}/hdfs-site.xml property={{ item.key }} value={{ item.value }}
+  with_items:
+    - { key: dfs.block.access.token.enable, value: true }
+    - { key: dfs.namenode.keytab.file, value: /etc/hadoop/conf/hdfs.keytab }
+    - { key: dfs.namenode.kerberos.principal, value: "hdfs/_HOST@{{ kerberos_realm }}" }
+    - { key: dfs.namenode.kerberos.internal.spnego.principal, value: "HTTP/_HOST@{{ kerberos_realm }}" }
+    - { key: dfs.datanode.data.dir.perm, value: 700 }
+    - { key: dfs.datanode.address, value: '0.0.0.0:1004' }
+    - { key: dfs.datanode.http.address, value: '0.0.0.0:1006' }
+    - { key: dfs.datanode.keytab.file, value: /etc/hadoop/conf/hdfs.keytab }
+    - { key: dfs.datanode.kerberos.principal, value: "hdfs/_HOST@{{ kerberos_realm }}" }
+    - { key: dfs.web.authentication.kerberos.keytab, value: /etc/hadoop/conf/hdfs.keytab }
+    - { key: dfs.web.authentication.kerberos.principal, value: "hdfs/_HOST@{{ kerberos_realm }}" }
+    - { key: dfs.encrypt.data.transfer, value: 'true' }
+  tags:
+    - cdh-common
+    - cdh-secure
+
+- name: cdh-common | local mapred directories created
+  file: path={{ item }} state=directory owner=mapred group=mapred mode=0777
+  with_items: cdh_mapred_local_dir.split(',')
+  tags:
+    - cdh-common
+
+- name: cdh-common | mapred config file modified
+  hadoop_configuration: path={{ cdh_hadoop_conf_path }}/mapred-site.xml property={{ item.key }} value={{ item.value }}
+  with_items:
+    - { key: mapreduce.jobtracker.kerberos.principal, value: "mapred/_HOST@{{ kerberos_realm }}" }
+    - { key: mapreduce.jobtracker.keytab.file, value: /etc/hadoop/conf/mapred.keytab }
+    - { key: mapreduce.tasktracker.kerberos.principal, value: "mapred/_HOST@{{ kerberos_realm }}" }
+    - { key: mapreduce.tasktracker.keytab.file, value: /etc/hadoop/conf/mapred.keytab }
+    - { key: mapreduce.tasktracker.group, value: mapred }
+    - { key: mapred.task.tracker.task-controller, value: org.apache.hadoop.mapred.LinuxTaskController }
+    - { key: mapred.local.dir, value: "{{ cdh_mapred_local_dir }}" }
+    - { key: mapred.child.java.opts, value: "-Xmx{{ cdh_task_jvm_heap }}" }
+  tags:
+    - cdh-common
+    - cdh-secure
+
+- name: cdh-common | ssl client config file modified
+  hadoop_configuration: path={{ cdh_hadoop_conf_path }}/ssl-client.xml property={{ item.key }} value={{ item.value }}
+  with_items:
+    - { key: ssl.client.keystore.type, value: jks }
+    - { key: ssl.client.keystore.location, value: "/etc/hadoop/conf/https.keystore" }
+    - { key: ssl.client.keystore.password, value: hadoop }
+    - { key: ssl.client.truststore.type, value: jks }
+    - { key: ssl.client.truststore.location, value: "/etc/hadoop/conf/hadoop.truststore" }
+    - { key: ssl.client.truststore.password, value: hadoop }
+  tags:
+    - cdh-common
+    - cdh-secure
+
+- name: cdh-common | ssl server config file modified
+  hadoop_configuration: path={{ cdh_hadoop_conf_path }}/ssl-server.xml property={{ item.key }} value={{ item.value }}
+  with_items:
+    - { key: ssl.server.keystore.type, value: jks }
+    - { key: ssl.server.keystore.location, value: "/etc/hadoop/conf/https.keystore" }
+    - { key: ssl.server.keystore.password, value: hadoop }
+    - { key: ssl.server.truststore.type, value: jks }
+    - { key: ssl.server.truststore.location, value: "/etc/hadoop/conf/hadoop.truststore" }
+    - { key: ssl.server.truststore.password, value: hadoop }
+  tags:
+    - cdh-common
+    - cdh-secure
+
+- name: cdh-common | permissions
+  file: path={{ cdh_hadoop_conf_path }}/{{ item.name }} owner=mapred group=hadoop mode={{ item.mode }}
+  with_items:
+    - { name: ssl-client.xml, mode: '0444' }
+    - { name: ssl-server.xml, mode: '0440' }
+  tags:
+    - cdh-common
+    - cdh-secure
+
+- name: cdh-common | alternatives link
+  alternatives: name=hadoop-conf link=/etc/hadoop/conf path={{ cdh_hadoop_conf_path }}
+  tags:
+    - cdh-common

--- a/playbooks/roles/cdh-common/templates/hadoop-metrics.properties.j2
+++ b/playbooks/roles/cdh-common/templates/hadoop-metrics.properties.j2
@@ -1,0 +1,26 @@
+{% if 'ganglia_monitored' in groups and inventory_hostname in groups.ganglia_monitored %}
+dfs.class=org.apache.hadoop.metrics.ganglia.GangliaContext31
+dfs.period=10
+dfs.servers={{ groups.ganglia_collector[0] }}:8649
+
+mapred.class=org.apache.hadoop.metrics.ganglia.GangliaContext31
+mapred.period=10
+mapred.servers={{ groups.ganglia_collector[0] }}:8649
+
+jvm.class=org.apache.hadoop.metrics.ganglia.GangliaContext31
+jvm.period=10
+jvm.servers={{ groups.ganglia_collector[0] }}:8649
+
+rpc.class=org.apache.hadoop.metrics.ganglia.GangliaContext31
+rpc.period=10
+rpc.servers={{ groups.ganglia_collector[0] }}:8649
+
+ugi.class=org.apache.hadoop.metrics.ganglia.GangliaContext31
+ugi.period=10
+ugi.servers={{ groups.ganglia_collector[0] }}:8649
+{% else %}
+dfs.class=org.apache.hadoop.metrics.spi.NullContext
+mapred.class=org.apache.hadoop.metrics.spi.NullContext
+rpc.class=org.apache.hadoop.metrics.spi.NullContext
+ugi.class=org.apache.hadoop.metrics.spi.NullContext
+{% endif %}

--- a/playbooks/roles/cdh-common/templates/hadoop-metrics2.properties.j2
+++ b/playbooks/roles/cdh-common/templates/hadoop-metrics2.properties.j2
@@ -1,0 +1,11 @@
+*.period=10
+
+{% if 'ganglia_monitored' in groups and inventory_hostname in groups.ganglia_monitored %}
+*.sink.ganglia.class=org.apache.hadoop.metrics2.sink.ganglia.GangliaSink31
+*.sink.ganglia.servers={{ groups.ganglia_collector[0] }}:8649
+*.sink.ganglia.supportsparse=true
+*.sink.ganglia.slope=jvm.metrics.gcCount=zero,jvm.metrics.memHeapUsedM=both
+*.sink.ganglia.dmax=jvm.metrics.threadsBlocked=70,jvm.metrics.memHeapUsedM=40
+{% else %}
+*.sink.file.class=org.apache.hadoop.metrics2.sink.FileSink
+{% endif %}

--- a/playbooks/roles/cdh-common/templates/hdfs.exclude.j2
+++ b/playbooks/roles/cdh-common/templates/hdfs.exclude.j2
@@ -1,0 +1,5 @@
+{% if 'cdh_hdfs_excluded' in groups %}
+{% for host in groups.cdh_hdfs_excluded %}
+{{ host }}
+{% endfor %}
+{% endif %}

--- a/playbooks/roles/cdh-common/templates/mapred.exclude.j2
+++ b/playbooks/roles/cdh-common/templates/mapred.exclude.j2
@@ -1,0 +1,5 @@
+{% if 'cdh_mapred_excluded' in groups %}
+{% for host in groups.cdh_mapred_excluded %}
+{{ host }}
+{% endfor %}
+{% endif %}

--- a/playbooks/roles/cdh-common/templates/taskcontroller.cfg.j2
+++ b/playbooks/roles/cdh-common/templates/taskcontroller.cfg.j2
@@ -1,0 +1,5 @@
+hadoop.log.dir=/var/log/hadoop-0.20-mapreduce
+mapreduce.tasktracker.group=mapred
+banned.users=mapred,hdfs,bin
+mapred.local.dir={{ cdh_mapred_local_dir }}
+min.user.id=0

--- a/playbooks/roles/cdh-datanode/tasks/main.yml
+++ b/playbooks/roles/cdh-datanode/tasks/main.yml
@@ -1,0 +1,35 @@
+---
+
+- name: cdh-datanode | packages
+  apt: pkg=hadoop-hdfs-datanode
+  tags:
+    - cdh-datanode
+
+- name: cdh-datanode | data directory configured
+  hadoop_configuration: path={{ cdh_hadoop_conf_path }}/hdfs-site.xml property=dfs.datanode.data.dir value={{ cdh_hdfs_datanode_dir }}
+  tags:
+    - cdh-datanode
+
+- name: cdh-datanode | remove data directory
+  file: path={{ item }} owner=hdfs group=hadoop state=absent
+  with_items: cdh_hdfs_datanode_dir.split(',')
+  when: hdfs_format is defined
+  tags:
+    - cdh-datanode
+    - unsafe
+
+- name: cdh-datanode | data directory
+  file: path={{ item }} owner=hdfs group=hdfs mode=0700 state=directory
+  with_items: cdh_hdfs_datanode_dir.split(',')
+  tags:
+    - cdh-datanode
+
+- name: cdh-datanode | log directory permissions
+  file: path=/var/log/hadoop-hdfs owner=hdfs group=hdfs mode=0775 state=directory
+  tags:
+    - cdh-datanode
+
+- name: cdh-datanode | data node started
+  service: name=hadoop-hdfs-datanode state=started enabled=yes
+  tags:
+    - cdh-datanode

--- a/playbooks/roles/cdh-jobtracker/tasks/main.yml
+++ b/playbooks/roles/cdh-jobtracker/tasks/main.yml
@@ -1,0 +1,42 @@
+---
+
+- name: cdh-jobtracker | packages
+  apt: pkg=hadoop-0.20-mapreduce-jobtracker
+  tags:
+    - cdh-jobtracker
+
+- name: cdh-jobtracker | log directory permissions
+  file: path=/var/log/hadoop-0.20-mapreduce owner=mapred group=mapred mode=0775 state=directory
+  tags:
+    - cdh-jobtracker
+
+- name: cdh-jobtracker | root credential cache
+  command: /usr/bin/kinit -k -t /etc/hadoop/conf/hdfs.keytab hdfs/{{ ansible_fqdn }}
+  sudo: True
+  tags:
+    - cdh-jobtracker
+    - cdh-secure
+    - unsafe
+
+- name: cdh-jobtracker | hdfs temporary directories
+  hdfs_directory: path={{ item }} owner=mapred group=hadoop mode=0777
+  with_items:
+    - /tmp/mapred
+    - /tmp/hadoop-mapred
+    - /tmp/hadoop-mapred/mapred
+    - /tmp/hadoop-mapred/mapred/staging
+  tags:
+    - cdh-jobtracker
+
+- name: cdh-jobtracker | hdfs system directories
+  hdfs_directory: path={{ item }} owner=mapred group=hadoop mode=0700
+  with_items:
+    - /tmp/mapred/system
+    - /tmp/hadoop-mapred/mapred/system
+  tags:
+    - cdh-jobtracker
+
+- name: cdh-jobtracker | start the job tracker
+  service: name=hadoop-0.20-mapreduce-jobtracker state=started enabled=yes
+  tags:
+    - cdh-jobtracker

--- a/playbooks/roles/cdh-namenode/tasks/main.yml
+++ b/playbooks/roles/cdh-namenode/tasks/main.yml
@@ -1,0 +1,78 @@
+---
+
+- name: cdh-namenode | package
+  apt: pkg=hadoop-hdfs-namenode
+  tags:
+    - cdh-namenode
+
+- name: cdh-namenode | data directory configured
+  hadoop_configuration: path={{ cdh_hadoop_conf_path }}/hdfs-site.xml property=dfs.namenode.name.dir value={{ cdh_hdfs_namenode_dir }}
+  tags:
+    - cdh-namenode
+
+- name: cdh-namenode | supergroup
+  group: name=supergroup
+  tags:
+    - cdh-namenode
+
+- name: cdh-namenode | root in supergroup
+  user: name=root groups=supergroup append=true
+  tags:
+    - cdh-namenode
+
+- name: cdh-namenode | data directory exists
+  file: path={{ item }} owner=hdfs group=hdfs mode=0700 state=directory
+  tags:
+    - cdh-namenode
+  with_items: cdh_hdfs_namenode_dir.split(',')
+
+- name: cdh-namenode | log directory permissions
+  file: path=/var/log/hadoop-hdfs owner=hdfs group=hdfs mode=0775 state=directory
+  tags:
+    - cdh-namenode
+
+- name: cdh-namenode | stopped
+  service: name=hadoop-hdfs-namenode state=stopped
+  when: hdfs_format is defined
+  tags:
+    - cdh-namenode
+    - unsafe
+
+- name: cdh-namenode | formatted
+  command: hdfs namenode -format -force
+  sudo: True
+  sudo_user: hdfs
+  when: hdfs_format is defined
+  tags:
+    - cdh-namenode
+    - unsafe
+
+- name: cdh-namenode | started
+  service: name=hadoop-hdfs-namenode state=started enabled=yes
+  tags:
+    - cdh-namenode
+
+- name: cdh-namenode | root credential cache
+  command: /usr/bin/kinit -k -t /etc/hadoop/conf/hdfs.keytab hdfs/{{ ansible_fqdn }}
+  sudo: True
+  tags:
+    - cdh-namenode
+    - cdh-secure
+    - unsafe
+
+- name: cdh-namenode | root hdfs directory
+  hdfs_directory: path=/ mode=0755 owner=hdfs group=hadoop
+  tags:
+    - cdh-namenode
+
+- name: cdh-namenode | hdfs directories
+  hdfs_directory: path={{ item }} mode=1777 owner=hdfs group=hadoop
+  with_items:
+    - /tmp
+    - /user
+    - /var
+    - /var/lib
+    - /var/lib/hadoop-hdfs
+    - /var/lib/hadoop-hdfs/cache
+  tags:
+    - cdh-namenode

--- a/playbooks/roles/cdh-tasktracker/tasks/main.yml
+++ b/playbooks/roles/cdh-tasktracker/tasks/main.yml
@@ -1,0 +1,17 @@
+---
+
+- name: cdh-tasktracker | packages
+  apt: pkg=hadoop-0.20-mapreduce-tasktracker
+  tags:
+    - cdh-tasktracker
+
+- name: cdh-tasktracker | log directory permissions
+  file: path=/var/log/hadoop-0.20-mapreduce owner=mapred group=mapred mode=0775 state=directory
+  tags:
+    - cdh-tasktracker
+
+- name: cdh-tasktracker | task tracker started
+  service: name=hadoop-0.20-mapreduce-tasktracker state=started enabled=yes
+  tags:
+    - cdh-tasktracker
+

--- a/playbooks/roles/cdh-zookeeper/defaults/main.yml
+++ b/playbooks/roles/cdh-zookeeper/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+
+cdh_zookeeper_conf_path: /etc/zookeeper/conf.ansible

--- a/playbooks/roles/cdh-zookeeper/files/configuration.xsl
+++ b/playbooks/roles/cdh-zookeeper/files/configuration.xsl
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+<xsl:output method="html"/>
+<xsl:template match="configuration">
+<html>
+<body>
+<table border="1">
+<tr>
+ <td>name</td>
+ <td>value</td>
+ <td>description</td>
+</tr>
+<xsl:for-each select="property">
+<tr>
+  <td><a name="{name}"><xsl:value-of select="name"/></a></td>
+  <td><xsl:value-of select="value"/></td>
+  <td><xsl:value-of select="description"/></td>
+</tr>
+</xsl:for-each>
+</table>
+</body>
+</html>
+</xsl:template>
+</xsl:stylesheet>

--- a/playbooks/roles/cdh-zookeeper/files/log4j.properties
+++ b/playbooks/roles/cdh-zookeeper/files/log4j.properties
@@ -1,0 +1,65 @@
+# Copyright 2012 The Apache Software Foundation
+# 
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Define some default values that can be overridden by system properties
+zookeeper.root.logger=INFO, CONSOLE
+
+zookeeper.console.threshold=INFO
+
+zookeeper.log.dir=.
+zookeeper.log.file=zookeeper.log
+zookeeper.log.threshold=INFO
+zookeeper.log.maxfilesize=256MB
+zookeeper.log.maxbackupindex=20
+
+zookeeper.tracelog.dir=.
+zookeeper.tracelog.file=zookeeper_trace.log
+
+log4j.rootLogger=${zookeeper.root.logger}
+
+#
+# console
+# Add "console" to rootlogger above if you want to use this 
+#
+log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
+log4j.appender.CONSOLE.Threshold=${zookeeper.console.threshold}
+log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout
+log4j.appender.CONSOLE.layout.ConversionPattern=%d{ISO8601} [myid:%X{myid}] - %-5p [%t:%C{1}@%L] - %m%n
+
+#
+# Add ROLLINGFILE to rootLogger to get log file output
+#
+log4j.appender.ROLLINGFILE=org.apache.log4j.RollingFileAppender
+log4j.appender.ROLLINGFILE.Threshold=${zookeeper.log.threshold}
+log4j.appender.ROLLINGFILE.File=${zookeeper.log.dir}/${zookeeper.log.file}
+log4j.appender.ROLLINGFILE.MaxFileSize=${zookeeper.log.maxfilesize}
+log4j.appender.ROLLINGFILE.MaxBackupIndex=${zookeeper.log.maxbackupindex}
+log4j.appender.ROLLINGFILE.layout=org.apache.log4j.PatternLayout
+log4j.appender.ROLLINGFILE.layout.ConversionPattern=%d{ISO8601} [myid:%X{myid}] - %-5p [%t:%C{1}@%L] - %m%n
+
+#
+# Add TRACEFILE to rootLogger to get log file output
+#    Log TRACE level and above messages to a log file
+#
+log4j.appender.TRACEFILE=org.apache.log4j.FileAppender
+log4j.appender.TRACEFILE.Threshold=TRACE
+log4j.appender.TRACEFILE.File=${zookeeper.tracelog.dir}/${zookeeper.tracelog.file}
+
+log4j.appender.TRACEFILE.layout=org.apache.log4j.PatternLayout
+### Notice we are including log4j's NDC here (%x)
+log4j.appender.TRACEFILE.layout.ConversionPattern=%d{ISO8601} [myid:%X{myid}] - %-5p [%t:%C{1}@%L][%x] - %m%n

--- a/playbooks/roles/cdh-zookeeper/tasks/main.yml
+++ b/playbooks/roles/cdh-zookeeper/tasks/main.yml
@@ -1,0 +1,48 @@
+---
+
+- name: cdh-zookeeper | package
+  apt: pkg=zookeeper-server
+  tags:
+    - cdh-zookeeper
+
+- name: cdh-zookeeper | configuration directory
+  file: path={{ cdh_zookeeper_conf_path }} state=directory owner=root group=root mode=755
+  tags:
+    - cdh-zookeeper
+
+- name: cdh-zookeeper | configured static files
+  copy: src={{ item }} dest={{ cdh_zookeeper_conf_path }} owner=root group=root mode=644
+  with_items:
+    - configuration.xsl
+    - log4j.properties
+  tags:
+    - cdh-zookeeper
+
+- name: cdh-zookeeper | configured zoo.cfg
+  template: src=zoo.cfg.j2 dest={{ cdh_zookeeper_conf_path }}/zoo.cfg owner=root group=root mode=644
+  tags:
+    - cdh-zookeeper
+
+- name: cdh-zookeeper | alternatives link
+  alternatives: name=zookeeper-conf link=/etc/zookeeper/conf path={{ cdh_zookeeper_conf_path }}
+  tags:
+    - cdh-zookeeper
+
+- name: cdh-zookeeper | service stopped
+  service: name=zookeeper-server state=stopped
+  when: zookeeper_format is defined
+  tags:
+    - cdh-zookeeper
+    - unsafe
+
+- name: cdh-zookeeper | service initialized
+  command: service zookeeper-server init --myid={{ zk_id }} --force
+  when: zookeeper_format is defined
+  tags:
+    - cdh-zookeeper
+    - unsafe
+
+- name: cdh-zookeeper | service started
+  service: name=zookeeper-server state=started enabled=yes
+  tags:
+    - cdh-zookeeper

--- a/playbooks/roles/cdh-zookeeper/templates/zoo.cfg.j2
+++ b/playbooks/roles/cdh-zookeeper/templates/zoo.cfg.j2
@@ -1,0 +1,32 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+maxClientCnxns=50
+# The number of milliseconds of each tick
+tickTime=2000
+# The number of ticks that the initial 
+# synchronization phase can take
+initLimit=10
+# The number of ticks that can pass between 
+# sending a request and getting an acknowledgement
+syncLimit=5
+# the directory where the snapshot is stored.
+dataDir=/var/lib/zookeeper
+# the port at which the clients will connect
+clientPort=2181
+
+{% for host in groups['cdh_zookeeper'] %}
+server.{{hostvars[host].zk_id}}={{host}}:2888:3888
+{% endfor %}

--- a/playbooks/roles/inventory-hosts/tasks/main.yml
+++ b/playbooks/roles/inventory-hosts/tasks/main.yml
@@ -1,0 +1,17 @@
+---
+- name: inventory-hosts | /etc/hostname
+  template: src=hostname.j2 dest=/etc/hostname
+  register: hostname_file
+  tags:
+    - inventory-hosts
+
+- name: inventory-hosts | hostname set
+  command: /bin/hostname -F /etc/hostname
+  when: hostname_file.changed
+  tags:
+    - inventory-hosts
+
+- name: inventory-hosts | /etc/hosts
+  template: src=hosts.j2 dest=/etc/hosts
+  tags:
+    - inventory-hosts

--- a/playbooks/roles/inventory-hosts/templates/hostname.j2
+++ b/playbooks/roles/inventory-hosts/templates/hostname.j2
@@ -1,0 +1,1 @@
+{{ inventory_hostname }}

--- a/playbooks/roles/inventory-hosts/templates/hosts.j2
+++ b/playbooks/roles/inventory-hosts/templates/hosts.j2
@@ -1,0 +1,7 @@
+127.0.0.1 localhost
+{% for host in groups.all %}
+{% if 'ansible_default_ipv4' in hostvars.get(host, {}) %}
+{{ hostvars[host].ansible_default_ipv4.address }} {{ hostvars[host].inventory_hostname }}
+{% endif %}
+{% endfor %}
+

--- a/playbooks/roles/kerberos-client/defaults/main.yml
+++ b/playbooks/roles/kerberos-client/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+
+kerberos_realm: EXAMPLE.COM

--- a/playbooks/roles/kerberos-client/tasks/main.yml
+++ b/playbooks/roles/kerberos-client/tasks/main.yml
@@ -1,0 +1,11 @@
+---
+
+- name: kerberos-client | package
+  apt: pkg=krb5-user
+  tags:
+    - kerberos-client
+
+- name: kerberos-client | configuration files
+  template: src=krb5.conf.j2 dest=/etc/krb5.conf
+  tags:
+    - kerberos-client

--- a/playbooks/roles/kerberos-client/templates/krb5.conf.j2
+++ b/playbooks/roles/kerberos-client/templates/krb5.conf.j2
@@ -1,0 +1,15 @@
+[libdefaults]
+	default_realm = {{ kerberos_realm }}
+
+[realms]
+	{{ kerberos_realm }} = {
+{% for host in groups.kerberos_server %}
+		kdc = {{ hostvars[host]['ansible_fqdn'] }}
+{% endfor %}
+		admin_server = {{ groups.kerberos_server[0] }}
+		default_domain = {{ kerberos_realm.lower() }}
+	}
+
+[domain_realm]
+	.{{ kerberos_realm.lower() }} = {{ kerberos_realm }}
+	{{ kerberos_realm.lower() }} = {{ kerberos_realm }}

--- a/playbooks/roles/kerberos-server/defaults/main.yml
+++ b/playbooks/roles/kerberos-server/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+
+kerberos_master_password: 897jsdflkj8967cuysh
+kerberos_realm: EXAMPLE.COM

--- a/playbooks/roles/kerberos-server/tasks/main.yml
+++ b/playbooks/roles/kerberos-server/tasks/main.yml
@@ -1,0 +1,41 @@
+---
+
+- name: kerberos-server | package
+  apt: pkg={{ item }}
+  with_items:
+    - krb5-kdc
+    - krb5-admin-server
+  tags:
+    - kerberos-server
+
+- name: kerberos-server | configuration files
+  template: src={{ item | basename }}.j2 dest={{ item }}
+  with_items:
+    - /etc/krb5kdc/kadm5.acl
+    - /etc/krb5kdc/kdc.conf
+  tags:
+    - kerberos-server
+
+- name: kerberos-server | destroy existing database
+  shell: kdb5_util destroy -f || true
+  when: kdc_format is defined
+  tags:
+    - kerberos-server
+    - unsafe
+
+- name: kerberos-server | database created
+  shell: kdb5_util -P {{ kerberos_master_password }} create -s
+  when: kdc_format is defined
+  tags:
+    - kerberos-server
+    - unsafe
+
+- name: kerberos-server | service started
+  service: name=krb5-kdc state=started enabled=yes
+  tags:
+    - kerberos-server
+
+- name: kerberos-server | admin service started
+  service: name=krb5-admin-server state=started enabled=yes
+  tags:
+    - kerberos-server

--- a/playbooks/roles/kerberos-server/templates/kadm5.acl.j2
+++ b/playbooks/roles/kerberos-server/templates/kadm5.acl.j2
@@ -1,0 +1,1 @@
+*/admin@{{ kerberos_realm }} *

--- a/playbooks/roles/kerberos-server/templates/kdc.conf.j2
+++ b/playbooks/roles/kerberos-server/templates/kdc.conf.j2
@@ -1,0 +1,16 @@
+[kdcdefaults]
+    kdc_ports = 750,88
+
+[realms]
+    {{ kerberos_realm }} = {
+        database_name = /var/lib/krb5kdc/principal
+        admin_keytab = FILE:/etc/krb5kdc/kadm5.keytab
+        acl_file = /etc/krb5kdc/kadm5.acl
+        key_stash_file = /etc/krb5kdc/stash
+        kdc_ports = 750,88
+        max_life = 10h 0m 0s
+        max_renewable_life = 7d 0h 0m 0s
+        master_key_type = des3-hmac-sha1
+        supported_enctypes = arcfour-hmac:normal des3-hmac-sha1:normal des-cbc-crc:normal des:normal des:v4 des:norealm des:onlyrealm des:afs3
+        default_principal_flags = +preauth
+    }

--- a/playbooks/roles/ntp/tasks/main.yml
+++ b/playbooks/roles/ntp/tasks/main.yml
@@ -1,0 +1,11 @@
+---
+
+- name: ntp | package
+  apt: pkg=ntp
+  tags:
+    - ntp
+
+- name: ntp | daemon started
+  service: name=ntp state=started enabled=yes
+  tags:
+    - ntp

--- a/playbooks/roles/openjdk/tasks/main.yml
+++ b/playbooks/roles/openjdk/tasks/main.yml
@@ -1,0 +1,6 @@
+---
+
+- name: openjdk | package
+  apt: pkg=openjdk-6-jdk
+  tags:
+    - openjdk

--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -1,0 +1,59 @@
+---
+
+- hosts: cdh_all
+  sudo: True
+  roles:
+    - inventory-hosts
+  tasks:
+    - name: update facts
+      action: setup
+
+- hosts: cdh_all
+  sudo: True
+  roles:
+    - openjdk
+    - ntp
+    - kerberos-client
+    - cdh-common
+
+- hosts: kerberos_server
+  sudo: True
+  vars:
+    - kdc_format: yes
+  roles:
+    - kerberos-server
+
+- include: credentials.yml
+
+- hosts: cdh_zookeeper
+  sudo: True
+  vars:
+    - zookeeper_format: yes
+  roles:
+    - cdh-zookeeper
+
+- hosts: cdh_namenode
+  sudo: True
+  vars:
+    - hdfs_format: yes
+  roles:
+    - cdh-namenode
+
+- hosts: cdh_datanode
+  sudo: True
+  vars:
+    - hdfs_format: yes
+  roles:
+    - cdh-datanode
+
+- hosts: cdh_jobtracker
+  sudo: True
+  roles:
+    - cdh-jobtracker
+    - cdh-mrjob
+    - cdh-edx-hadoop
+
+- hosts: cdh_tasktracker
+  sudo: True
+  roles:
+    - cdh-tasktracker

--- a/playbooks/start.yml
+++ b/playbooks/start.yml
@@ -1,0 +1,29 @@
+---
+
+- hosts: cdh_namenode
+  sudo: True
+  tasks:
+    - name: start name node
+      service: name=hadoop-hdfs-namenode state=started
+      sudo: True
+
+- hosts: cdh_datanode
+  sudo: True
+  tasks:
+    - name: start data node
+      service: name=hadoop-hdfs-datanode state=started
+      sudo: True
+
+- hosts: cdh_jobtracker
+  sudo: True
+  tasks:
+    - name: start job tracker
+      service: name=hadoop-0.20-mapreduce-jobtracker state=started
+      sudo: True
+
+- hosts: cdh_tasktracker
+  sudo: True
+  tasks:
+    - name: start task tracker
+      service: name=hadoop-0.20-mapreduce-tasktracker state=started
+      sudo: True

--- a/playbooks/stop.yml
+++ b/playbooks/stop.yml
@@ -1,0 +1,29 @@
+---
+
+- hosts: cdh_tasktracker
+  sudo: True
+  tasks:
+    - name: stop task tracker
+      service: name=hadoop-0.20-mapreduce-tasktracker state=stopped
+      sudo: True
+
+- hosts: cdh_jobtracker
+  sudo: True
+  tasks:
+    - name: stop job tracker
+      service: name=hadoop-0.20-mapreduce-jobtracker state=stopped
+      sudo: True
+
+- hosts: cdh_datanode
+  sudo: True
+  tasks:
+    - name: stop data node
+      service: name=hadoop-hdfs-datanode state=stopped
+      sudo: True
+
+- hosts: cdh_namenode
+  sudo: True
+  tasks:
+    - name: stop name node
+      service: name=hadoop-hdfs-namenode state=stopped
+      sudo: True


### PR DESCRIPTION
@e0d here is the ansible code we discussed. I wrote this a long time ago, really helped ramp me up on ansible.

Notable stuff in here:
- I was always testing this on a set of dedicated vagrant VMs. So it does scary stuff like clobber the /etc/hosts file.
- I don't remember what version of ansible I was running this stuff with... I think 1.4.4?
- There are some defaults for variables that look secure. They aren't and are not actually in use anywhere.
- I had half-extracted the security stuff, I don't think this is in a working state right now. It could also be vastly simplified if we removed all of the stuff related to kerberos and the "cdh-secure" tag.
- The "alternatives" module I actually got merged into ansible trunk a while ago, so we wouldn't actually need the custom module in the library.
- The way this is currently setup you can really only deploy a single hadoop cluster. The inventory isn't smart enough to distinguish between clusters.
- I have a bunch of other setup code for Hive etc, but this gives you the general idea.
- This is all using a fairly old version of cloudera hadoop.
