### PR TITLE
 Disable dynamic scripting when not  ELASTICSEARCH_CLUSTERED

### DIFF
--- a/playbooks/roles/elasticsearch/tasks/main.yml
+++ b/playbooks/roles/elasticsearch/tasks/main.yml
@@ -41,6 +41,11 @@
     dpkg -i  --force-confold /var/tmp/elasticsearch-{{ elasticsearch_version }}.deb
     executable=/bin/bash
   when: elasticsearch_reinstall.changed
+  
+- name: Disable dynamic scripting
+  lineinfile: "dest=/etc/elasticsearch/elasticsearch.yml line='script.disable_dynamic: true'"
+  sudo: True
+  when: not ELASTICSEARCH_CLUSTERED
 
 - name: create directories
   file: >


### PR DESCRIPTION
ticket :  [OSPR-191](https://openedx.atlassian.net/browse/OSPR-191)

Disable dynamic scripting on elasticsearch as it is insecure  when not ELASTICSEARCH_CLUSTERED
@feanil has disabled this but only work when ELASTICSEARCH_CLUSTERED is True.

So  people who install with the default conf (production/devstack vagrant included )will still contain the eval code !It is important to fix , our edx server was hacked by hacker due to this bug.

See: http://bouk.co/blog/elasticsearch-rce/
CVE: CVE-2014-3120
