### PR TITLE
allow ansible to be pulled from a private repo

### DIFF
--- a/playbooks/roles/edx_ansible/defaults/main.yml
+++ b/playbooks/roles/edx_ansible/defaults/main.yml
@@ -41,4 +41,9 @@ edx_ansible_source_repo: https://github.com/edx/configuration.git
 edx_ansible_requirements_file: "{{ edx_ansible_code_dir }}/requirements.txt"
 # edX configuration repo
 configuration_version: release
+EDX_ANSIBLE_USE_GIT_IDENTITY: false
+# Example: "{{ secure_dir }}/files/ansible-git-identity"
+EDX_ANSIBLE_LOCAL_GIT_IDENTITY: !!null
+edx_ansible_git_ssh: "/tmp/edx_ansible_git_ssh.sh"
+edx_ansible_git_identity: "{{ edx_ansible_app_dir }}/{{ EDX_ANSIBLE_LOCAL_GIT_IDENTITY|basename }}"
 edx_ansible_var_file: "{{ edx_ansible_app_dir }}/server-vars.yml"

--- a/playbooks/roles/edx_ansible/tasks/deploy.yml
+++ b/playbooks/roles/edx_ansible/tasks/deploy.yml
@@ -1,9 +1,35 @@
 ---
+
+# Optional auth for git
+- name: create ssh script for git (not authenticated)
+  template: >
+    src=git_ssh_noauth.sh.j2 dest={{ edx_ansible_git_ssh }}
+    owner={{ edx_ansible_user }} mode=750
+  when: not EDX_ANSIBLE_USE_GIT_IDENTITY
+
+- name: create ssh script for git (authenticated)
+  template: >
+    src=git_ssh_auth.sh.j2 dest={{ edx_ansible_git_ssh }}
+    owner={{ edx_ansible_user }} mode=750
+  when: EDX_ANSIBLE_USE_GIT_IDENTITY
+
+- name: install read-only ssh key
+  copy: >
+    src={{ EDX_ANSIBLE_LOCAL_GIT_IDENTITY }} dest={{ edx_ansible_git_identity }}
+    force=yes owner={{ edx_ansible_user }} mode=0600
+  when: EDX_ANSIBLE_USE_GIT_IDENTITY
+
 - name: git checkout edx_ansible repo into edx_ansible_code_dir
   git: >
     dest={{ edx_ansible_code_dir }} repo={{ edx_ansible_source_repo }} version={{ configuration_version }}
     accept_hostkey=yes
   sudo_user: "{{ edx_ansible_user }}"
+  environment:
+    GIT_SSH: "{{ edx_ansible_git_ssh }}"
+
+- name: remove read-only ssh key
+  file: path={{ edx_ansible_git_identity }} state=absent
+  when: EDX_ANSIBLE_USE_GIT_IDENTITY
 
 - name : install edx_ansible venv requirements
   pip: >

--- a/playbooks/roles/edx_ansible/templates/git_ssh_auth.sh.j2
+++ b/playbooks/roles/edx_ansible/templates/git_ssh_auth.sh.j2
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec /usr/bin/ssh -o StrictHostKeyChecking=no -i {{ edx_ansible_git_identity }} "$@"

--- a/playbooks/roles/edx_ansible/templates/git_ssh_noauth.sh.j2
+++ b/playbooks/roles/edx_ansible/templates/git_ssh_noauth.sh.j2
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec /usr/bin/ssh -o StrictHostKeyChecking=no "$@"


### PR DESCRIPTION
original pull request: https://github.com/edx/configuration/pull/1211

Background: Currently, it is not possible to pull from a private ansible repo when provisioning a new Edx server. This PR will allow Ansible to pull from a private repo using a private SSH key.

Studio Updates: None.

LMS Updates: None

Configuration Updates: Yes. Added the option to pull the Ansible configuration from a private git repo.

Testing: By default, the Ansible script should continue to use the public repo. In order to download the provisioning script from the private repo then we need to minimally set these two variables.

```
EDX_ANSIBLE_USE_GIT_IDENTITY: True
EDX_ANSIBLE_LOCAL_GIT_IDENTITY: "/path/to/the/git/ssh/key/file"
```
