### PR TITLE
Replace mongodb_user module with javascripts

### DIFF
--- a/playbooks/roles/mongo/defaults/main.yml
+++ b/playbooks/roles/mongo/defaults/main.yml
@@ -1,5 +1,5 @@
 mongo_logappend: true
-mongo_version: 2.6.4
+mongo_version: 2.6.5
 mongo_port: "27017"
 mongo_extra_conf: ''
 mongo_key_file: '/etc/mongodb_key'
@@ -14,13 +14,19 @@ MONGODB_APT_KEY: "http://docs.mongodb.org/10gen-gpg-key.asc"
 MONGODB_REPO: "deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen"
 
 # Vars Meant to be overridden
+MONGO_USER_SUPER: 'admin'
+MONGO_PASSWORD_SUPER: 'password'
 MONGO_USERS:
   - user: cs_comments_service
     password: password
     database: cs_comments_service
+    roles:
+      - dbOwner
   - user: edxapp
     password: password
     database: edxapp
+    roles:
+      - dbOwner
 
 MONGO_CLUSTERED: !!null
 MONGO_BIND_IP: 127.0.0.1
@@ -29,10 +35,6 @@ MONGO_BIND_IP: 127.0.0.1
 
 mongo_logpath: "{{ mongo_log_dir }}/mongodb.log"
 mongo_dbpath: "{{ mongo_data_dir }}/mongodb"
-
-# Have to use this conditional instead of ignore errors
-# because the mongo_user module fails and doesn't ignore errors.
-mongo_create_users: true
 
 # If the system is running out of an Amazon Web Services
 # cloudformation stack, this group name can used to pull out

--- a/playbooks/roles/mongo/tasks/main.yml
+++ b/playbooks/roles/mongo/tasks/main.yml
@@ -8,12 +8,6 @@
   fail: msg="MongoDB 2.4 is currently installed. If on a stand alone host (devstack), apt-get remove mongodb-10gen and re-run ansible. if on a cluster, read http://docs.mongodb.org/manual/release-notes/2.6-upgrade/#upgrade-considerations and upgrade to 2.6."
   when: mongodb_needs_upgrade.stat.exists 
 
-
-- name: install python pymongo for mongo_user ansible module
-  pip: >
-    name=pymongo state=present
-    version=2.6.3 extra_args="-i {{ COMMON_PYPI_MIRROR_URL }}"
-
 - name: add the mongodb signing key
   apt_key: >
     id=7F0CEB10
@@ -68,24 +62,41 @@
 - name: wait for mongo server to start
   wait_for: port=27017 delay=2
 
+- name: drop super user script
+  template: src="create_root.js.j2" dest="/tmp/create_root.js"
+  when: not MONGO_CLUSTERED
+
+- name: create super user with js
+  shell: >
+    /usr/bin/mongo admin /tmp/create_root.js
+  when: not MONGO_CLUSTERED
+
+- name: delete super user script
+  file: path=/tmp/create_root.js state=absent
+  when: not MONGO_CLUSTERED
+
 - name: Create the file to initialize the mongod replica set
-  template: src=repset_init.j2 dest=/tmp/repset_init.js
+  template: src=repset_init.js.j2 dest=/tmp/repset_init.js
   when: MONGO_CLUSTERED
 
 - name: Initialize the replication set
-  shell: /usr/bin/mongo  /tmp/repset_init.js
+  shell: >
+    /usr/bin/mongo /tmp/repset_init.js
   when: MONGO_CLUSTERED
 
-# Ignore errors doesn't work because the module throws an exception
-# it doesn't catch.
-- name: create a mongodb user
-  mongodb_user: >
-    database={{ item.database }}
-    name={{ item.user }}
-    password={{ item.password }}
-    state=present
-  with_items: MONGO_USERS
-  when: mongo_create_users
+- name: delete repset script
+  file: path=/tmp/repset_init.js state=absent
+  when: MONGO_CLUSTERED
+
+- name: drop create users script
+  template: src="create_users.js.j2" dest="/tmp/create_users.js"
+
+- name: create users with js
+  shell: >
+    /usr/bin/mongo /tmp/create_users.js
+
+- name: delete user creation script
+  file: path=/tmp/create_users.js state=absent
 
 - name: install s3cmd
   pip: >

--- a/playbooks/roles/mongo/templates/create_root.js.j2
+++ b/playbooks/roles/mongo/templates/create_root.js.j2
@@ -1,0 +1,23 @@
+// Add super user
+conn = new Mongo();
+db = conn.getDB("admin");
+db.auth( '{{ MONGO_USER_SUPER }}', '{{ MONGO_PASSWORD_SUPER }}');
+
+if(db.getUser('{{ MONGO_USER_SUPER }}') == null) {
+    db.createUser(
+        {
+            "user": "{{ MONGO_USER_SUPER }}",
+            "pwd": "{{ MONGO_PASSWORD_SUPER }}",
+            "roles": ["root"]
+        }
+    );
+} else {
+    db.updateUser(
+        "{{ MONGO_USER_SUPER }}",
+        {
+            "pwd": "{{ MONGO_PASSWORD_SUPER }}",
+            "roles": ["root"]
+        }
+    );
+}
+

--- a/playbooks/roles/mongo/templates/create_users.js.j2
+++ b/playbooks/roles/mongo/templates/create_users.js.j2
@@ -1,0 +1,32 @@
+// Now create the rest of the users
+conn = new Mongo();
+db = conn.getDB("admin");
+db.auth( "{{ MONGO_USER_SUPER }}", "{{ MONGO_PASSWORD_SUPER }}");
+{% if MONGO_CLUSTERED %}
+if(rs.isMaster().ismaster) {
+{% endif %}
+
+    {% for user in MONGO_USERS %}
+    db = conn.getDB("{{ user.database }}");
+    if(db.getUser("{{ user.user }}") == null) {
+        db.createUser(
+            {
+                "user": "{{ user.user }}",
+                "pwd": "{{ user.password }}",
+                "roles": {{ user.roles|to_nice_json }}
+            }
+        );
+    } else {
+        db.updateUser(
+            "{{ user.user }}",
+            {
+                "pwd": "{{ user.password }}",
+                "roles": {{ user.roles|to_nice_json }}
+            }
+        );
+    }
+    {% endfor %}
+
+{% if MONGO_CLUSTERED %}
+}
+{% endif %}

--- a/playbooks/roles/mongo/templates/repset_init.js.j2
+++ b/playbooks/roles/mongo/templates/repset_init.js.j2
@@ -1,3 +1,7 @@
+conn = new Mongo();
+db = conn.getDB("admin");
+db.auth( '{{ MONGO_USER_SUPER }}', '{{ MONGO_PASSWORD_SUPER }}');
+
 {# Generate a list of hosts if no cluster members are give. Otherwise use the
    hosts provided in the variable.
 #}
@@ -20,9 +24,9 @@
 {%- endif -%}
 
 config = {_id: '{{ mongo_repl_set }}', members: [
-	   {%- for host in hosts -%}
-	   {_id: {{ loop.index }}, host: '{{ host }}'}{% if not loop.last %},{% endif %}
-	   {%- endfor -%}
+       {%- for host in hosts -%}
+       {_id: {{ loop.index }}, host: '{{ host }}'}{% if not loop.last %},{% endif %}
+       {%- endfor -%}
            ]};
 rs.initiate(config)
 
@@ -47,4 +51,27 @@ if(rs.isMaster().ismaster) {
             throw 'Could not add all members to cluster'
         }
     }
+    // Now add super user to cluster
+    conn = new Mongo();
+    db = conn.getDB("admin");
+    db.auth( '{{ MONGO_USER_SUPER }}', '{{ MONGO_PASSWORD_SUPER }}');
+
+    if(db.getUser("{{ MONGO_USER_SUPER }}") == null) {
+        db.createUser(
+            {
+                "user": "{{ MONGO_USER_SUPER }}",
+                "pwd": "{{ MONGO_PASSWORD_SUPER }}",
+                "roles": ["root"]
+            }
+        );
+    } else {
+        db.updateUser(
+            "{{ MONGO_USER_SUPER }}",
+            {
+                "pwd": "{{ MONGO_PASSWORD_SUPER }}",
+                "roles": ["root"]
+            }
+        );
+		
+	}
 }

--- a/playbooks/vagrant-cluster.yml
+++ b/playbooks/vagrant-cluster.yml
@@ -10,7 +10,6 @@
       - "cluster3"
     MONGO_CLUSTERED: yes
     MONGO_CLUSTER_KEY: 'password'
-    mongo_create_users: no
     ELASTICSEARCH_CLUSTERED: yes
     MARIADB_CLUSTERED: yes
     MARIADB_CREATE_DBS: no
@@ -41,8 +40,7 @@
   roles:
     - rabbitmq
 
-# Mongo user doesn't handle slave's gracefully when
-# creating users and there are race conditions
+# There are race conditions creating DBs
 # in MariaDB occasionally so this play will work
 # but will also show as failed
 - name: Configure group with tasks that will always fail
@@ -50,19 +48,10 @@
   sudo: True
   gather_facts: True
   vars:
-    mongo_cluster_members:
-      - "cluster1"
-      - "cluster2"
-      - "cluster3"
-    MONGO_CLUSTERED: yes
-    MONGO_CLUSTER_KEY: 'password'
-    mongo_create_users: yes
-    RABBITMQ_CLUSTERED: yes
     MARIADB_CLUSTERED: yes
     MARIADB_CREATE_DBS: yes
   vars_files:
     - "group_vars/all"
     - "roles/analytics-api/defaults/main.yml"
   roles:
-    - mongo
     - mariadb


### PR DESCRIPTION
This add fullsupport of new authentication model in mongodb 2.6.

I know this isn't the most elegant fix, but using the latest module in ansible didn't work, and I was having issues modifying to work properly so I've fallen back to stripping that out and just using mongo javascripts.

I have tested this with the cluster build and devstack (including a "from scratch" on mongodb 2.6 devstack as well as an upgraded version.

One of the upshots is that it will actually work on a cluster and not fail on the slaves since the scripts check if they are master before attempting to modify anything so I removed the "create_users" flag and just run that each time.
