### PR TITLE
Allow s3sync log dir to be seen by Splunk.

### DIFF
--- a/playbooks/roles/aws/defaults/main.yml
+++ b/playbooks/roles/aws/defaults/main.yml
@@ -39,7 +39,7 @@ aws_dirs:
     path: "{{ COMMON_LOG_DIR }}/{{ aws_role_name }}"
     owner: "syslog"
     group: "syslog"
-    mode: "0700"
+    mode: "0650"
   data:
     path: "{{ COMMON_DATA_DIR }}/{{ aws_role_name }}"
     owner: "root"


### PR DESCRIPTION
This will match perms for things like rabbitmq's logs, which are being indexed successfully.

@e0d @mulby @brianhw 

If you open a sandbox and look at the dirs, you can also see the perms difference.
