### PR TITLE
Add the mongo backup cron only if mongo S3 backup is enabled

### DIFF
--- a/playbooks/roles/mongo/tasks/main.yml
+++ b/playbooks/roles/mongo/tasks/main.yml
@@ -160,3 +160,4 @@
     hour="{{ MONGO_S3_BACKUP_HOUR }}"
     minute="0"
     day="{{ MONGO_S3_BACKUP_DAY }}"
+  when: MONGO_S3_BACKUP


### PR DESCRIPTION
The cron for running the mongo backup script should only be added if MONGO_S3_BACKUP is enabled.
