### PR TITLE
moving sites-enabled to /etc/nginx/sites-enabled

### DIFF
--- a/playbooks/roles/nginx/defaults/main.yml
+++ b/playbooks/roles/nginx/defaults/main.yml
@@ -54,7 +54,7 @@ nginx_server_static_dir: "{{ nginx_data_dir }}/server-static"
 nginx_conf_dir: "{{ nginx_app_dir }}/conf.d"
 nginx_log_dir: "{{ COMMON_LOG_DIR }}/nginx"
 nginx_sites_available_dir: "{{ nginx_app_dir }}/sites-available"
-nginx_sites_enabled_dir: "{{ nginx_app_dir }}/sites-enabled"
+nginx_sites_enabled_dir: "/etc/nginx/sites-enabled"
 nginx_user: root
 nginx_htpasswd_file: "{{ nginx_app_dir }}/nginx.htpasswd"
 nginx_default_sites: []
@@ -66,9 +66,9 @@ NGINX_EDXAPP_ENABLE_S3_MAINTENANCE: False
 nginx_default_error_page: "/server/server-error.html"
 NGINX_EDXAPP_ERROR_PAGES:
   "500": "{{ nginx_default_error_page}}"
-  "502": "{{ nginx_default_error_page}}"  
+  "502": "{{ nginx_default_error_page}}"
   "504": "{{ nginx_default_error_page}}"
-  
+
 CMS_HOSTNAME: '~^((stage|prod)-)?studio.*'
 
 nginx_template_dir: "edx/app/nginx/sites-available"

--- a/playbooks/roles/nginx/defaults/main.yml
+++ b/playbooks/roles/nginx/defaults/main.yml
@@ -65,9 +65,9 @@ nginx_debian_pkgs:
 NGINX_EDXAPP_ENABLE_S3_MAINTENANCE: False
 nginx_default_error_page: "/server/server-error.html"
 NGINX_EDXAPP_ERROR_PAGES:
-  "500": "{{ nginx_default_error_page}}"
-  "502": "{{ nginx_default_error_page}}"
-  "504": "{{ nginx_default_error_page}}"
+  "500": "{{ nginx_default_error_page }}"
+  "502": "{{ nginx_default_error_page }}"
+  "504": "{{ nginx_default_error_page }}"
 
 CMS_HOSTNAME: '~^((stage|prod)-)?studio.*'
 

--- a/playbooks/roles/nginx/tasks/main.yml
+++ b/playbooks/roles/nginx/tasks/main.yml
@@ -31,11 +31,17 @@
   apt: pkg={{','.join(nginx_debian_pkgs)}} state=present
   notify: restart nginx
 
+- name: Remove the default site
+  file: >
+    path=/etc/nginx/sites-enabled/default
+    state=absent
+  notify: reload nginx
+
 - name: Server configuration file
   template: >
     src=etc/nginx/nginx.conf.j2 dest=/etc/nginx/nginx.conf
     owner=root group={{ common_web_user }} mode=0644
-  notify: reload nginx
+  notify: restart nginx
 
 - name: Creating common nginx configuration
   template: >

--- a/playbooks/roles/nginx/templates/etc/nginx/nginx.conf.j2
+++ b/playbooks/roles/nginx/templates/etc/nginx/nginx.conf.j2
@@ -62,7 +62,7 @@ http {
         # Virtual Host Configs
         ##
 
-        include {{ nginx_sites_enabled_dir }}/*;
         include {{ nginx_conf_dir }}/*.conf;
+        include /etc/nginx/sites-enabled/*;
 }
 

--- a/playbooks/roles/nginx/templates/etc/nginx/nginx.conf.j2
+++ b/playbooks/roles/nginx/templates/etc/nginx/nginx.conf.j2
@@ -63,6 +63,6 @@ http {
         ##
 
         include {{ nginx_conf_dir }}/*.conf;
-        include /etc/nginx/sites-enabled/*;
+        include {{ nginx_sites_enabled_dir }}/*;
 }
 


### PR DESCRIPTION
This is a small change that moves our sites-enabled directory to `/etc/nginx/sites-enabled`.

It does not remove the old directory `/edx/app/nginx/sites-enabled` which will no longer be used, it also keeps the sources in `/edx/app/nginx/sites-available`
