### PR TITLE
change the repo for certificates and fix checkout

### DIFF
--- a/playbooks/roles/certs/defaults/main.yml
+++ b/playbooks/roles/certs/defaults/main.yml
@@ -35,7 +35,7 @@ CERTS_LOCAL_PRIVATE_KEY: "example-private-key.txt"
 
 # This defaults to the public certificates repo which is
 # used for open-edx
-CERTS_REPO: "https://github.com/edx/read-only-certificate-code"
+CERTS_REPO: "https://github.com/edx/edx-certificates"
 CERTS_NGINX_PORT: 18090
 CERTS_WEB_ROOT: "{{ certs_data_dir }}/www-data"
 CERTS_URL: "http://localhost:{{ CERTS_NGINX_PORT }}"

--- a/playbooks/roles/certs/tasks/deploy.yml
+++ b/playbooks/roles/certs/tasks/deploy.yml
@@ -53,6 +53,16 @@
   environment:
     GIT_SSH: "{{ certs_git_ssh }}"
   register: certs_checkout
+  when: CERTS_GIT_IDENTITY != "none"
+  notify: restart certs
+
+- name: checkout certificates repo into {{ certs_code_dir }}
+  git: >
+    dest={{ certs_code_dir }} repo={{ CERTS_REPO }} version={{ certs_version }}
+    accept_hostkey=yes
+  sudo_user: "{{ certs_user }}"
+  register: certs_checkout
+  when: CERTS_GIT_IDENTITY == "none"
   notify: restart certs
 
 - name: remove read-only ssh key for the certs repo


### PR DESCRIPTION
When there isn't an identity file provided we should not use GIT_SSH
