### PR TITLE
Turn off basic auth for all endpoints below '/api'.

### DIFF
--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
@@ -84,10 +84,10 @@ error_page {{ k }} {{ v }};
     try_files $uri @proxy_to_lms_app;
   }
 
-  # The VAL api is accessed using OAUTH2 which
+  # The api is accessed using OAUTH2 which
   # uses the authorization header so we can't have
   # basic auth on it as well.
-  location /api/val {
+  location /api {
     try_files $uri @proxy_to_lms_app;
   }
 


### PR DESCRIPTION
Both basic auth and OAUTH2 use the same authorization header so a client can't auth both ways.
