### PR TITLE
Custom requirements installation fix on vanillas

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -37,3 +37,4 @@ Jason Zhu <fmyzjs@gmail.com>
 Rohit Karajgi <rohit.karajgi@gmail.com>
 Brandon DeRosier <bdero@mit.edu>
 Arbab Nazar <arbab@edx.org>
+Dmitry Ivanyushin <defance@gmail.com>

--- a/playbooks/roles/edxapp/tasks/deploy.yml
+++ b/playbooks/roles/edxapp/tasks/deploy.yml
@@ -223,7 +223,7 @@
   notify:
   - "restart edxapp"
   - "restart edxapp_workers"
-  when: custom_requirements.stat.exists and new.stat.md5 != inst.stat.md5
+  when: not inst.stat.exists or custom_requirements.stat.exists and new.stat.md5 != inst.stat.md5
 
 # Install the final python modules into {{ edxapp_venv_dir }}
 - name : install python post-post requirements


### PR DESCRIPTION
There is a heavy bug that makes installation fail on vanillas when using `custom_requirements_file`.

I supposes this mistake was made by just copying-paste some snippets.

The main idea: on vanilla versions there is no `inst.stat.md5`-file and it is created much latter. So overall process fails on calclulating `when`-condition. 

There are some other tasks that are successfully executed on these cases (like `install post-requirements`). So I suppose that this is the condition supposed to be when installing custom requirements. :)
