### PR TITLE
Add edxapp_custom_debian_pkgs field to install extra packages

### DIFF
--- a/playbooks/roles/edxapp/tasks/main.yml
+++ b/playbooks/roles/edxapp/tasks/main.yml
@@ -70,6 +70,13 @@
   - "restart edxapp"
   - "restart edxapp_workers"
 
+- name: install extra custom system packages on which LMS and CMS rely
+  apt: pkg={{','.join(edxapp_custom_debian_pkgs)}} state=present update_cache=yes
+  when: edxapp_custom_debian_pkgs
+  notify:
+  - "restart edxapp"
+  - "restart edxapp_workers"
+
 - name: set up edxapp .npmrc
   template:
     src=.npmrc.j2 dest={{ edxapp_app_dir }}/.npmrc


### PR DESCRIPTION
The idea of this PR: making opportunity to install some extra debian packages that your python packages might require, for example.

You can use `edxapp_custom_debian_pkgs` key in `server-vars` to list packages you need.

This is not supposed to be mirged into master yet. It also might be closed. I wanted just to give an idea what I, as a edx-platform developer, lack of. :)
