### PR TITLE
Fix notifier role defaults never working

### DIFF
--- a/playbooks/roles/notifier/defaults/main.yml
+++ b/playbooks/roles/notifier/defaults/main.yml
@@ -19,7 +19,7 @@ NOTIFIER_THEME_NAME: ""
 NOTIFIER_THEME_REPO: ""
 NOTIFIER_THEME_VERSION: "master"
 notifier_git_ssh:  "/tmp/notifier_git_ssh.sh"
-NOTIFIER_GIT_IDENTITY: !!null
+NOTIFIER_GIT_IDENTITY: ""
 notifier_git_identity: "{{ NOTIFIER_HOME }}/notifier-git-identity"
 
 NOTIFIER_DIGEST_EMAIL_SENDER: "notifications@example.com"

--- a/playbooks/roles/notifier/tasks/deploy.yml
+++ b/playbooks/roles/notifier/tasks/deploy.yml
@@ -16,19 +16,19 @@
   template: >
     src=git_ssh_noauth.sh.j2 dest={{ notifier_git_ssh }}
     owner={{ NOTIFIER_USER }} mode=750
-  when: not NOTIFIER_USE_GIT_IDENTITY
+  when: NOTIFIER_GIT_IDENTITY == ""
 
 - name: create ssh script for git (authenticated)
   template: >
     src=git_ssh_auth.sh.j2 dest={{ notifier_git_ssh }}
     owner={{ NOTIFIER_USER }} mode=750
-  when: NOTIFIER_USE_GIT_IDENTITY
+  when: NOTIFIER_GIT_IDENTITY != ""
 
 - name: install read-only ssh key
   copy: >
     content="{{ NOTIFIER_GIT_IDENTITY }}" dest={{ notifier_git_identity }}
     force=yes owner={{ NOTIFIER_USER }} mode=0600
-  when: NOTIFIER_USE_GIT_IDENTITY
+  when: NOTIFIER_GIT_IDENTITY != ""
 
 - name: checkout theme
   git: >


### PR DESCRIPTION
Refactored `NOTIFIER_USE_GIT_IDENTITY` to be represented by `NOTIFIER_GIT_IDENTITY` being an empty string.
