### PR TITLE
Add JS Cover for both local dev and jenkins_worker.

### DIFF
--- a/playbooks/roles/jenkins_worker/defaults/main.yml
+++ b/playbooks/roles/jenkins_worker/defaults/main.yml
@@ -15,10 +15,6 @@ jenkins_debian_pkgs:
 jenkins_rbenv_root: "{{ jenkins_home }}/.rbenv"
 jenkins_ruby_version: "1.9.3-p374"
 
-# JSCover direct download URL
-jscover_url: "http://files.edx.org/testeng/JSCover-1.0.2.zip"
-jscover_version: "1.0.2"
-
 # packer direct download URL
 packer_url: "https://dl.bintray.com/mitchellh/packer/0.6.1_linux_amd64.zip"
 

--- a/playbooks/roles/jenkins_worker/meta/main.yml
+++ b/playbooks/roles/jenkins_worker/meta/main.yml
@@ -1,6 +1,7 @@
 ---
 dependencies:
   - common
+  - jscover
   - role: rbenv
     rbenv_user: "{{ jenkins_user }}"
     rbenv_dir: "{{ jenkins_home }}"

--- a/playbooks/roles/jenkins_worker/tasks/java.yml
+++ b/playbooks/roles/jenkins_worker/tasks/java.yml
@@ -1,0 +1,3 @@
+---
+- name: Install Java
+  apt: pkg=openjdk-7-jre-headless state=present

--- a/playbooks/roles/jenkins_worker/tasks/main.yml
+++ b/playbooks/roles/jenkins_worker/tasks/main.yml
@@ -12,5 +12,5 @@
 - include: system.yml
 - include: python.yml
 - include: ruby.yml
-- include: jscover.yml
+- include: java.yml
 - include: test.yml

--- a/playbooks/roles/jscover/defaults/main.yml
+++ b/playbooks/roles/jscover/defaults/main.yml
@@ -1,0 +1,11 @@
+---
+# Installs JSCover jar.
+# Java is a pre-requisite for JSCover. This role is not responsible
+# for installing Java.
+#
+jscover_role_name: jscover
+
+# JSCover direct download URL
+jscover_url: "http://files.edx.org/testeng/JSCover-1.0.2.zip"
+jscover_version: "1.0.2"
+

--- a/playbooks/roles/jscover/defaults/main.yml
+++ b/playbooks/roles/jscover/defaults/main.yml
@@ -6,6 +6,5 @@
 jscover_role_name: jscover
 
 # JSCover direct download URL
-jscover_url: "http://files.edx.org/testeng/JSCover-1.0.2.zip"
 jscover_version: "1.0.2"
-
+jscover_url: "http://files.edx.org/testeng/JSCover-{{ jscover_version }}.zip"

--- a/playbooks/roles/jscover/tasks/main.yml
+++ b/playbooks/roles/jscover/tasks/main.yml
@@ -1,6 +1,4 @@
 ---
-- name: Install Java
-  apt: pkg=openjdk-7-jre-headless state=present
 
 - name: Download JSCover
   get_url: url={{ jscover_url }} dest=/var/tmp/jscover.zip
@@ -16,3 +14,4 @@
 - name: Set JSCover permissions
   file: path="/usr/local/bin/JSCover-all-{{ jscover_version }}.jar" state=file
         owner=root group=root mode=0755
+

--- a/playbooks/roles/local_dev/defaults/main.yml
+++ b/playbooks/roles/local_dev/defaults/main.yml
@@ -25,3 +25,5 @@ local_dev_pkgs:
     - emacs
     - xorg
     - openbox
+
+localdev_jscover_version: "1.0.2"

--- a/playbooks/roles/local_dev/meta/main.yml
+++ b/playbooks/roles/local_dev/meta/main.yml
@@ -1,0 +1,4 @@
+---
+dependencies:
+  - role: jscover
+    jscover_version: "{{ localdev_jscover_version }}"

--- a/playbooks/roles/local_dev/templates/app_bashrc.j2
+++ b/playbooks/roles/local_dev/templates/app_bashrc.j2
@@ -31,3 +31,5 @@ fi
 cd "{{ item.home }}/{{ item.repo }}"
 
 source "{{ item.home }}/.paver_autocomplete"
+
+export JSCOVER_JAR="/usr/local/bin/JSCover-all-{{ localdev_jscover_version }}.jar"


### PR DESCRIPTION
@e0d @clytwynec @singingwolfboy @feanil @maxrothman @jzoldak 

Currently JSCover is not installed on devstack by default. This change will put it there and make it available to the edxapp user. This way, when running the javascript tests on platform, a coverage report will be generated. This can be used for examining coverage, but it can also be used by running diff-cover. (A subsequent change, when I have the time, would be wrapping diff-cover (for javascript) into our existing paver commands).

This change also keeps the JSCover as an installable for jenkins_workers, which is still a requirement today.

Please let me know what you think. My hope/goal is to get this in for Birch.
