### PR TITLE
Correct when statement for git prune

### DIFF
--- a/playbooks/roles/edxapp/tasks/deploy.yml
+++ b/playbooks/roles/edxapp/tasks/deploy.yml
@@ -46,7 +46,7 @@
   notify:
   - "restart edxapp"
   - "restart edxapp_workers"
-  when: git_dir.stat.exists and (git_dir.isdir is defined) and git_dir.stat.isdir
+  when: git_dir.stat.exists and git_dir.stat.isdir
 
 # Do A Checkout
 - name: checkout edx-platform repo into {{ edxapp_code_dir }}


### PR DESCRIPTION
`git_dir.isdir` is never defined, even if `/edx/app/edxapp/edx-platform/.git` exists and is a directory.
