### PR TITLE
Add the ability to embargo users based on CIDR blocks.

### DIFF
--- a/playbooks/roles/nginx/defaults/main.yml
+++ b/playbooks/roles/nginx/defaults/main.yml
@@ -104,3 +104,4 @@ nginx_cfg:
   version_json: "{{ nginx_app_dir }}/versions.json"
 
 NGINX_ROBOT_RULES: [ ]
+NGINX_EDXAPP_EMBARGO_CIDRS: []

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
@@ -8,12 +8,29 @@ upstream lms-backend {
     {% for host in nginx_lms_gunicorn_hosts %}
         server {{ host }}:{{ edxapp_lms_gunicorn_port }} fail_timeout=0;
     {% endfor %}
+
 }
 
 {%- if EDXAPP_ENABLE_RATE_LIMITING -%}
 # Make Zone
 limit_req_zone $cookie_{{ EDXAPP_SESSION_COOKIE_NAME }} zone=cookies:10m rate={{ EDXAPP_COURSES_REQUEST_RATE }};
-{%- endif -%}
+{%- endif %}
+
+
+{% if NGINX_EDXAPP_EMBARGO_CIDRS %}
+  {%- if NGINX_SET_X_FORWARDED_HEADERS %}
+geo $remote_addr $embargo {
+  {%- else %}
+geo $http_x_forwarded_for $embargo {
+  {% endif -%}
+  default 0;
+
+  {% for cidr in NGINX_EDXAPP_EMBARGO_CIDRS -%}
+  {{ cidr }} 1;
+  {% endfor %}
+
+}
+{%- endif %}
 
 server {
   # LMS configuration file for nginx, templated by ansible
@@ -77,8 +94,20 @@ error_page {{ k }} {{ v }};
 
   location / {
     {% include "basic-auth.j2" %}
+    {% if NGINX_EDXAPP_EMBARGO_CIDRS -%}
+    if ( $embargo ) {
+      rewrite ^ /embargo;
+    }
+    {% endif -%}
     try_files $uri @proxy_to_lms_app;
   }
+
+{% if NGINX_EDXAPP_EMBARGO_CIDRS %}
+  location /embargo {
+    try_files $uri @proxy_to_lms_app;
+  }
+{% endif %}
+
   # No basic auth for /segmentio/event
   location /segmentio/event {
     try_files $uri @proxy_to_lms_app;


### PR DESCRIPTION
This can be seen in action on my sandbox right now feanil.m.sandbox.edx.org

Normal traffic is fine, traffic from the MIT vpn will get the embargo page.
