### PR TITLE
Vagrantfile and Ansible playbook for ecomstack

### DIFF
--- a/playbooks/roles/local_dev/defaults/main.yml
+++ b/playbooks/roles/local_dev/defaults/main.yml
@@ -6,16 +6,16 @@ localdev_xauthority: "{{ localdev_home }}/.Xauthority"
 localdev_xvfb_display: ":1"
 
 localdev_accounts:
-    - { user: "{{ edxapp_user}}", home: "{{ edxapp_app_dir }}",
+    - { user: "{{ edxapp_user|default('None') }}", home: "{{ edxapp_app_dir }}",
         env: "edxapp_env", repo: "edx-platform" }
 
-    - { user: "{{ forum_user }}",home: "{{ forum_app_dir }}",
+    - { user: "{{ forum_user|default('None') }}", home: "{{ forum_app_dir }}",
         env: "forum_env", repo: "cs_comments_service" }
 
-    - { user: "{{ ora_user }}", home: "{{ ora_app_dir }}",
+    - { user: "{{ ora_user|default('None') }}", home: "{{ ora_app_dir }}",
         env: "ora_env", repo: "ora" }
 
-    - { user: "{{ notifier_user }}", home: "{{ notifier_app_dir }}",
+    - { user: "{{ notifier_user|default('None') }}", home: "{{ notifier_app_dir }}",
         env: "notifier_env", repo: "" }
 
 

--- a/playbooks/roles/local_dev/tasks/main.yml
+++ b/playbooks/roles/local_dev/tasks/main.yml
@@ -7,12 +7,14 @@
 - name: set login shell for app accounts
   user: name={{ item.user }} shell="/bin/bash"
   with_items: localdev_accounts
+  when: item.user != 'None'
 
 # Ensure forum user has permissions to access .gem and .rbenv
 # This is a little twisty: the forum role sets the owner and group to www-data
 # So we add the forum user to the www-data group and give group write permissions
 - name: add forum user to www-data group
   user: name={{ forum_user }} groups={{ common_web_group }} append=yes
+  when: forum_user is defined
 
 - name: set forum rbenv and gem permissions
   file:
@@ -20,6 +22,7 @@
   with_items:
     - "{{ forum_app_dir }}/.gem"
     - "{{ forum_app_dir }}/.rbenv"
+  when: forum_user is defined
 
 # Create scripts to configure environment
 - name: create login scripts
@@ -27,6 +30,7 @@
     src=app_bashrc.j2 dest={{ item.home }}/.bashrc
     owner={{ item.user }} mode=755
   with_items: localdev_accounts
+  when: item.user != 'None'
   ignore_errors: yes
 
 # Default to the correct git config
@@ -36,6 +40,7 @@
     src=gitconfig dest={{ item.home }}/.gitconfig
     owner={{ item.user }} mode=700
   with_items: localdev_accounts
+  when: item.user != 'None'
   ignore_errors: yes
 
 # Configure X11 for application users
@@ -62,6 +67,7 @@
     src=paver_autocomplete dest={{ item.home }}/.paver_autocomplete
     owner={{ item.user }} mode=755
   with_items: localdev_accounts
+  when: item.user != 'None'
   ignore_errors: yes
 
 # Edit the /etc/hosts file so that the Preview button will work in Studio

--- a/playbooks/vagrant-ecomstack.yml
+++ b/playbooks/vagrant-ecomstack.yml
@@ -1,0 +1,23 @@
+- name: Configure instance(s)
+  hosts: all
+  sudo: True
+  gather_facts: True
+  vars:
+    migrate_db: 'yes'
+    openid_workaround: true
+    devstack: true
+    disable_edx_services: true
+    EDXAPP_NO_PREREQ_INSTALL: 0
+    COMMON_MOTD_TEMPLATE: 'devstack_motd.tail.j2'
+    COMMON_SSH_PASSWORD_AUTH: "yes"
+  vars_files:
+    - "group_vars/all"
+  roles:
+    - edx_ansible
+    - edxlocal
+    - mongo
+    - edxapp
+    - browsers
+    - browsermob-proxy
+    - local_dev
+    - demo

--- a/vagrant/base/ecomstack/Vagrantfile
+++ b/vagrant/base/ecomstack/Vagrantfile
@@ -1,0 +1,99 @@
+Vagrant.require_version ">= 1.5.3"
+unless Vagrant.has_plugin?("vagrant-vbguest")
+  raise "Please install the vagrant-vbguest plugin by running `vagrant plugin install vagrant-vbguest`"
+end
+
+VAGRANTFILE_API_VERSION = "2"
+
+# Needed to accommodate compilation of SciPy and NumPy
+MEMORY = 4096
+CPU_COUNT = 2
+
+edx_platform_mount_dir = "edx-platform"
+edx_ecommerce_mount_dir = "edx-ecommerce"
+oscar_extensions_mount_dir = "django-oscar-extensions"
+
+if ENV['VAGRANT_MOUNT_BASE']
+
+  edx_platform_mount_dir = ENV['VAGRANT_MOUNT_BASE'] + "/" + edx_platform_mount_dir
+  edx_ecommerce_mount_dir = ENV['VAGRANT_MOUNT_BASE'] + "/" + edx_ecommerce_mount_dir
+  oscar_extensions_mount_dir = ENV['VAGRANT_MOUNT_BASE'] + "/" + oscar_extensions_mount_dir
+
+end
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+
+  # Creates a Vagrant machine from a base Ubuntu 12.04 image for virtualbox
+  config.vm.box = "precise64"
+  config.vm.box_url = "http://files.vagrantup.com/precise64.box"
+
+  config.vm.network :private_network, ip: "192.168.33.10"
+  config.vm.network :forwarded_port, guest: 8000, host: 8000
+  config.vm.network :forwarded_port, guest: 8001, host: 8001
+  config.vm.network :forwarded_port, guest: 8002, host: 8002
+  config.ssh.insert_key = true
+
+  config.vm.synced_folder ".", "/vagrant", disabled: true
+
+ # Enable X11 forwarding so we can interact with GUI applications
+  if ENV['VAGRANT_X11']
+    config.ssh.forward_x11 = true
+  end
+
+  if ENV['VAGRANT_USE_VBOXFS'] == 'true'
+    config.vm.synced_folder "#{edx_platform_mount_dir}", "/edx/app/edxapp/edx-platform",
+      create: true, owner: "edxapp", group: "www-data"
+    config.vm.synced_folder "#{edx_ecommerce_mount_dir}", "/edx/app/ecom/edx-ecommerce",
+      create: true, owner: "edxapp", group: "www-data"
+    config.vm.synced_folder "#{oscar_extensions_mount_dir}", "/edx/app/ecom/django-oscar-extensions",
+      create: true, owner: "edxapp", group: "www-data"
+  else
+    config.vm.synced_folder "#{edx_platform_mount_dir}", "/edx/app/edxapp/edx-platform",
+      create: true, nfs: true
+    config.vm.synced_folder "#{edx_ecommerce_mount_dir}", "/edx/app/ecom/edx-ecommerce",
+      create: true, nfs: true
+    config.vm.synced_folder "#{oscar_extensions_mount_dir}", "/edx/app/ecom/django-oscar-extensions",
+      create: true, nfs: true
+  end
+
+
+  config.vm.provider :virtualbox do |vb|
+    vb.customize ["modifyvm", :id, "--memory", MEMORY.to_s]
+    vb.customize ["modifyvm", :id, "--cpus", CPU_COUNT.to_s]
+
+    # Allow DNS to work for Ubuntu 12.10 host
+    # http://askubuntu.com/questions/238040/how-do-i-fix-name-service-for-vagrant-client
+    vb.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
+  end
+
+  ["vmware_fusion", "vmware_workstation"].each do |vmware_provider|
+    config.vm.provider vmware_provider do |v, override|
+      # Override box url to get vmware one
+      override.vm.box = "precise64_vmware"
+      override.vm.box_url = "http://files.vagrantup.com/precise64_vmware.box"
+      v.vmx["memsize"] = MEMORY.to_s
+      v.vmx["numvcpus"] = CPU_COUNT.to_s
+    end
+  end
+
+
+  # Make LC_ALL default to en_US.UTF-8 instead of en_US.
+  # See: https://github.com/mitchellh/vagrant/issues/1188
+  config.vm.provision "shell", inline: 'echo \'LC_ALL="en_US.UTF-8"\' > /etc/default/locale'
+
+  # Use vagrant-vbguest plugin to make sure Guest Additions are in sync
+  config.vbguest.auto_reboot = true
+  config.vbguest.auto_update = true
+
+  config.vm.provision :ansible do |ansible|
+    ansible.playbook = "../../../playbooks/vagrant-ecomstack.yml"
+    ansible.verbose = "vvvv"
+
+    ansible.extra_vars = {}
+    if ENV['OPENEDX_RELEASE']
+      ansible.extra_vars = {
+        edx_platform_version: ENV['OPENEDX_RELEASE'],
+      }
+    end
+  end
+end

--- a/vagrant/base/ecomstack/ansible.cfg
+++ b/vagrant/base/ecomstack/ansible.cfg
@@ -1,0 +1,9 @@
+# config file for ansible -- http://ansible.github.com
+# nearly all parameters can be overridden in ansible-playbook or with command line flags
+# ansible will read ~/.ansible.cfg or /etc/ansible/ansible.cfg, whichever it finds first
+
+[defaults]
+
+jinja2_extensions=jinja2.ext.do
+host_key_checking = False
+roles_path=../../ansible-roles/roles:../../ansible-private/roles:../../ansible-roles/


### PR DESCRIPTION
This adds a Vagrantfile and Ansible playbook used for creating an "ecomstack," a Vagrant machine which the eCommerce Architecture team can use for development. I'm able to run edx-platform's Python and JavaScript unit tests on the box, as well as acceptance tests. This PR doesn't include the "ecom" (or "ecommerce") role needed to install our new ecommerce service on the new machine.

The new Vagrantfile mounts a synced folder for [django-oscar-extensions](https://github.com/edx/django-oscar-extensions) on the machine so that active development of django-oscar-extensions doesn't require re-installing it after every change. Oscar itself should be static enough that we'll be able to get away with pip installing it.

I also modified the "local_dev" role so that provisioning doesn't fail when trying to set up user accounts on machines without forums, ora, or notifier.

@feanil, could you please review this when you're able? @stephensanchez, @dianakhuang, and @wedaly, FYI.
