### PR TITLE
Remove ora2_version as it is unused in configuration.

### DIFF
--- a/playbooks/vagrant-fullstack.yml
+++ b/playbooks/vagrant-fullstack.yml
@@ -11,7 +11,6 @@
     CERTS_VERIFY_URL: 'http://192.168.33.10:18090'
     # used for releases
     edx_platform_version: '{{ OPENEDX_RELEASE | default("master") }}'
-    ora2_version: '{{ OPENEDX_RELEASE | default("master") }}'
     certs_version: '{{ OPENEDX_RELEASE | default("master") }}'
     forum_version: '{{ OPENEDX_RELEASE | default("master") }}'
     xqueue_version: '{{ OPENEDX_RELEASE | default("master") }}'

--- a/util/install/vagrant.sh
+++ b/util/install/vagrant.sh
@@ -32,7 +32,6 @@ sudo pip install --upgrade virtualenv
 ## Did we specify an openedx release?
 if [ -n "$OPENEDX_RELEASE" ]; then
   EXTRA_VARS="-e edx_platform_version=$OPENEDX_RELEASE \
-    -e ora2_version=$OPENEDX_RELEASE \
     -e certs_version=$OPENEDX_RELEASE \
     -e forum_version=$OPENEDX_RELEASE \
     -e xqueue_version=$OPENEDX_RELEASE \

--- a/vagrant/base/devstack/Vagrantfile
+++ b/vagrant/base/devstack/Vagrantfile
@@ -109,7 +109,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     if ENV['OPENEDX_RELEASE']
       ansible.extra_vars = {
         edx_platform_version: ENV['OPENEDX_RELEASE'],
-        ora2_version: ENV['OPENEDX_RELEASE'],
         certs_version: ENV['OPENEDX_RELEASE'],
         forum_version: ENV['OPENEDX_RELEASE'],
         xqueue_version: ENV['OPENEDX_RELEASE'],

--- a/vagrant/base/fullstack/Vagrantfile
+++ b/vagrant/base/fullstack/Vagrantfile
@@ -46,7 +46,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     if ENV['OPENEDX_RELEASE']
       ansible.extra_vars = {
         edx_platform_version: ENV['OPENEDX_RELEASE'],
-        ora2_version: ENV['OPENEDX_RELEASE'],
         certs_version: ENV['OPENEDX_RELEASE'],
         forum_version: ENV['OPENEDX_RELEASE'],
         xqueue_version: ENV['OPENEDX_RELEASE'],

--- a/vagrant/release/devstack/Vagrantfile
+++ b/vagrant/release/devstack/Vagrantfile
@@ -21,7 +21,6 @@ cd /edx/app/edx_ansible/edx_ansible/playbooks
 # Did we specify an openedx release?
 if [ -n "$OPENEDX_RELEASE" ]; then
   EXTRA_VARS="-e edx_platform_version=$OPENEDX_RELEASE \
-    -e ora2_version=$OPENEDX_RELEASE \
     -e certs_version=$OPENEDX_RELEASE \
     -e forum_version=$OPENEDX_RELEASE \
     -e xqueue_version=$OPENEDX_RELEASE \


### PR DESCRIPTION
Other than https://github.com/edx/configuration/blob/master/playbooks/roles/edx_ansible/templates/update.j2#L57 for use in developing on ora2 with the specialized update ora2 playbook in edx-east the `ora2_version` variable is unused and shouldn't need to be defined in the vagrant boxes since it is installed in the `edxapp` role and specified by the requirements file therein.
