### PR TITLE
add COMMON_RUBYGEMS_MIRROR_URL

### DIFF
--- a/playbooks/roles/common/defaults/main.yml
+++ b/playbooks/roles/common/defaults/main.yml
@@ -29,6 +29,7 @@ COMMON_ENVIRONMENT: 'default_env'
 COMMON_DEPLOYMENT: 'default_deployment'
 COMMON_PYPI_MIRROR_URL: 'https://pypi.python.org/simple'
 COMMON_NPM_MIRROR_URL: 'http://registry.npmjs.org'
+COMMON_RUBYGEMS_MIRROR_URL: 'https:\/\/rubygems.org\/'
 COMMON_UBUNTU_APT_KEYSERVER: "http://keyserver.ubuntu.com/pks/lookup?op=get&fingerprint=on&search="
 # do not include http/https
 COMMON_GIT_MIRROR: 'github.com'

--- a/playbooks/roles/edxapp/tasks/deploy.yml
+++ b/playbooks/roles/edxapp/tasks/deploy.yml
@@ -89,6 +89,11 @@
   sudo_user: "{{ edxapp_user }}"
 
 # Ruby plays that need to be run after platform updates.
+- name: Updating Gemfile for rubygems mirror
+  command: |
+    /bin/sed -i -e 's/https:\/\/rubygems.org/{{ COMMON_RUBYGEMS_MIRROR_URL }}/g' {{ edxapp_code_dir }}/Gemfile
+  sudo_user: "{{ edxapp_user }}"
+
 - name: gem install bundler
   shell: >
     gem install bundle

--- a/playbooks/roles/forum/tasks/deploy.yml
+++ b/playbooks/roles/forum/tasks/deploy.yml
@@ -37,6 +37,17 @@
   register: forum_checkout
   notify: restart the forum service
 
+- name: Updating Gemfile for rubygems mirror
+  command: |
+    /bin/sed -i -e 's/https:\/\/rubygems.org/{{ COMMON_RUBYGEMS_MIRROR_URL }}/g' {{ forum_code_dir }}/Gemfile
+  sudo_user: "{{ forum_user }}"
+
+# Make sure www-data can update Gemfile.lock
+- name: Updating Gemfile.lock mode
+  command: |
+    /bin/chmod 0646 {{ forum_code_dir }}/Gemfile.lock
+  sudo_user: "{{ forum_user }}"
+
 # TODO: This is done as the common_web_user
 # since the process owner needs write access
 # to the rbenv

--- a/playbooks/roles/rbenv/tasks/main.yml
+++ b/playbooks/roles/rbenv/tasks/main.yml
@@ -112,6 +112,11 @@
   sudo_user: "{{ rbenv_user }}"
   environment: "{{ rbenv_environment }}"
 
+- name: change gem source to {{ COMMON_RUBYGEMS_MIRROR_URL }}
+  shell: "gem source -r http://rubygems.org/ && gem source -a {{ COMMON_RUBYGEMS_MIRROR_URL }}"
+  sudo_user: "{{ rbenv_user }}"
+  environment: "{{ rbenv_environment }}"
+
 - name: install bundler
   shell: "gem install bundler -v {{ rbenv_bundler_version }}"
   sudo_user: "{{ rbenv_user }}"


### PR DESCRIPTION
Background:
Some times ,because of the GFW or worse network,people in China can not use rubygems.org services.

I open this pull to make sure we can switch our local rubygems repo mirrors.

Studio Updates: None.

LMS Updates: None

Test: [travis](https://travis-ci.org/fmyzjs/configuration/builds/49562554)
