### PR TITLE
Disable installation of the "certs" service, as it's not used in sandbox

### DIFF
--- a/playbooks/edx_sandbox.yml
+++ b/playbooks/edx_sandbox.yml
@@ -22,6 +22,7 @@
   roles:
     - role: nginx
       nginx_sites:
+      - certs
       - cms
       - lms
       - forum


### PR DESCRIPTION
The `edx_sandbox.yml` playbook will try to install the "certs" service and fail
because it does not enable the `certs` site in NginX.

This patch disables installation of "certs" altogether.
