### PR TITLE
Fix typo in supervisord log file names.

### DIFF
--- a/playbooks/roles/alton/templates/alton.conf.j2
+++ b/playbooks/roles/alton/templates/alton.conf.j2
@@ -3,8 +3,8 @@
 command={{ alton_supervisor_wrapper }}
 priority=999
 user={{ common_web_user }}
-stdout_logfile={{ supervisor_log_dir }}/%(program_name)-stdout.log
-stderr_logfile={{ supervisor_log_dir }}/%(program_name)-stderr.log
+stdout_logfile={{ supervisor_log_dir }}/%(program_name)s-stdout.log
+stderr_logfile={{ supervisor_log_dir }}/%(program_name)s-stderr.log
 killasgroup=true
 stopasgroup=true
 stopsignal=QUIT

--- a/playbooks/roles/analytics-api/templates/edx/app/supervisor/conf.d.available/analytics-api.conf.j2
+++ b/playbooks/roles/analytics-api/templates/edx/app/supervisor/conf.d.available/analytics-api.conf.j2
@@ -5,7 +5,7 @@
 command={{ analytics_api_app_dir }}/analytics-api.sh
 user={{ common_web_user }}
 directory={{ analytics_api_code_dir }}
-stdout_logfile={{ supervisor_log_dir }}/%(program_name)-stdout.log
-stderr_logfile={{ supervisor_log_dir }}/%(program_name)-stderr.log
+stdout_logfile={{ supervisor_log_dir }}/%(program_name)s-stdout.log
+stderr_logfile={{ supervisor_log_dir }}/%(program_name)s-stderr.log
 killasgroup=true
 stopasgroup=true

--- a/playbooks/roles/certs/templates/certs.conf.j2
+++ b/playbooks/roles/certs/templates/certs.conf.j2
@@ -3,7 +3,7 @@ command={{ certs_venv_bin }}/python {{ certs_code_dir }}/certificate_agent.py
 priority=999
 environment=SERVICE_VARIANT="certs",HOME="/"
 user={{ common_web_user }}
-stdout_logfile={{ supervisor_log_dir }}/%(program_name)-stdout.log
-stderr_logfile={{ supervisor_log_dir }}/%(program_name)-stderr.log
+stdout_logfile={{ supervisor_log_dir }}/%(program_name)s-stdout.log
+stderr_logfile={{ supervisor_log_dir }}/%(program_name)s-stderr.log
 killasgroup=true
 stopasgroup=true

--- a/playbooks/roles/devpi/templates/devpi.conf.j2
+++ b/playbooks/roles/devpi/templates/devpi.conf.j2
@@ -2,8 +2,8 @@
 command={{ devpi_venv_bin }}/devpi-server --port {{ devpi_port }} --serverdir {{ devpi_mirror_dir }}
 user={{ devpi_supervisor_user }}
 priority=999
-stdout_logfile={{ devpi_supervisor_log_dir }}/%(program_name)-stdout.log
-stderr_logfile={{ devpi_supervisor_log_dir }}/%(program_name)-stderr.log
+stdout_logfile={{ devpi_supervisor_log_dir }}/%(program_name)s-stdout.log
+stderr_logfile={{ devpi_supervisor_log_dir }}/%(program_name)s-stderr.log
 autostart=True
 killasgroup=true
 stopasgroup=true

--- a/playbooks/roles/discern/templates/discern.conf.j2
+++ b/playbooks/roles/discern/templates/discern.conf.j2
@@ -8,7 +8,7 @@ command={{ discern_venv_bin }}/gunicorn --preload -b {{ discern_gunicorn_host }}
 user={{ common_web_user }}
 directory={{ discern_code_dir }}
 environment=LANG={{ DISCERN_LANG }},DJANGO_SETTINGS_MODULE={{ discern_settings }},SERVICE_VARIANT=discern
-stdout_logfile={{ supervisor_log_dir }}/%(program_name)-stdout.log
-stderr_logfile={{ supervisor_log_dir }}/%(program_name)-stderr.log
+stdout_logfile={{ supervisor_log_dir }}/%(program_name)s-stdout.log
+stderr_logfile={{ supervisor_log_dir }}/%(program_name)s-stderr.log
 killasgroup=true
 stopasgroup=true

--- a/playbooks/roles/discern/templates/discern_celery.conf.j2
+++ b/playbooks/roles/discern/templates/discern_celery.conf.j2
@@ -7,8 +7,8 @@ directory={{ discern_code_dir }}
 
 environment=DJANGO_SETTINGS_MODULE=discern.aws,SERVICE_VARIANT=discern
 
-stdout_logfile={{ supervisor_log_dir }}/%(program_name)-stdout.log
-stderr_logfile={{ supervisor_log_dir }}/%(program_name)-stderr.log
+stdout_logfile={{ supervisor_log_dir }}/%(program_name)s-stdout.log
+stderr_logfile={{ supervisor_log_dir }}/%(program_name)s-stderr.log
 
 killasgroup=true
 stopasgroup=true

--- a/playbooks/roles/edxapp/templates/cms.conf.j2
+++ b/playbooks/roles/edxapp/templates/cms.conf.j2
@@ -11,7 +11,7 @@ command={{ executable }} -c {{ edxapp_app_dir }}/cms_gunicorn.py {{ EDXAPP_CMS_G
 user={{ common_web_user }}
 directory={{ edxapp_code_dir }}
 environment={% if COMMON_ENABLE_NEWRELIC_APP %}NEW_RELIC_APP_NAME={{ EDXAPP_NEWRELIC_CMS_APPNAME }},NEW_RELIC_LICENSE_KEY={{ NEWRELIC_LICENSE_KEY }},{% endif -%}PORT={{ edxapp_cms_gunicorn_port }},ADDRESS={{ edxapp_cms_gunicorn_host }},LANG={{ EDXAPP_LANG }},DJANGO_SETTINGS_MODULE={{ EDXAPP_CMS_ENV }},SERVICE_VARIANT="cms"
-stdout_logfile={{ supervisor_log_dir }}/%(program_name)-stdout.log
-stderr_logfile={{ supervisor_log_dir }}/%(program_name)-stderr.log
+stdout_logfile={{ supervisor_log_dir }}/%(program_name)s-stdout.log
+stderr_logfile={{ supervisor_log_dir }}/%(program_name)s-stderr.log
 killasgroup=true
 stopasgroup=true

--- a/playbooks/roles/edxapp/templates/lms.conf.j2
+++ b/playbooks/roles/edxapp/templates/lms.conf.j2
@@ -11,7 +11,7 @@ command={{ executable }} -c {{ edxapp_app_dir }}/lms_gunicorn.py lms.wsgi
 user={{ common_web_user }}
 directory={{ edxapp_code_dir }}
 environment={% if COMMON_ENABLE_NEWRELIC_APP %}NEW_RELIC_APP_NAME={{ EDXAPP_NEWRELIC_LMS_APPNAME }},NEW_RELIC_LICENSE_KEY={{ NEWRELIC_LICENSE_KEY }},{% endif -%}  PORT={{ edxapp_lms_gunicorn_port }},ADDRESS={{ edxapp_lms_gunicorn_host }},LANG={{ EDXAPP_LANG }},DJANGO_SETTINGS_MODULE={{ EDXAPP_LMS_ENV }},SERVICE_VARIANT="lms",PATH="{{ edxapp_deploy_path }}"
-stdout_logfile={{ supervisor_log_dir }}/%(program_name)-stdout.log
-stderr_logfile={{ supervisor_log_dir }}/%(program_name)-stderr.log
+stdout_logfile={{ supervisor_log_dir }}/%(program_name)s-stdout.log
+stderr_logfile={{ supervisor_log_dir }}/%(program_name)s-stderr.log
 killasgroup=true
 stopasgroup=true

--- a/playbooks/roles/edxapp/templates/workers.conf.j2
+++ b/playbooks/roles/edxapp/templates/workers.conf.j2
@@ -4,8 +4,8 @@
 environment=CONCURRENCY={{ w.concurrency }},LOGLEVEL=info,DJANGO_SETTINGS_MODULE=aws,PYTHONPATH={{ edxapp_code_dir }},SERVICE_VARIANT={{ w.service_variant }}
 user={{ common_web_user }}
 directory={{ edxapp_code_dir }}
-stdout_logfile={{ supervisor_log_dir }}/%(program_name)-stdout.log
-stderr_logfile={{ supervisor_log_dir }}/%(program_name)-stderr.log
+stdout_logfile={{ supervisor_log_dir }}/%(program_name)s-stdout.log
+stderr_logfile={{ supervisor_log_dir }}/%(program_name)s-stderr.log
 
 command={{ edxapp_venv_bin}}/python {{ edxapp_code_dir }}/manage.py {{ w.service_variant }} --settings=aws celery worker --loglevel=info --queues=edx.{{ w.service_variant }}.core.{{ w.queue }} --hostname=edx.{{ w.service_variant }}.core.{{ w.queue }}.%%h --concurrency={{ w.concurrency }}
 killasgroup=true

--- a/playbooks/roles/forum/templates/forum.conf.j2
+++ b/playbooks/roles/forum/templates/forum.conf.j2
@@ -2,8 +2,8 @@
 command={{ forum_supervisor_wrapper }}
 priority=999
 user={{ common_web_user }}
-stdout_logfile={{ supervisor_log_dir }}/%(program_name)-stdout.log
-stderr_logfile={{ supervisor_log_dir }}/%(program_name)-stderr.log
+stdout_logfile={{ supervisor_log_dir }}/%(program_name)s-stdout.log
+stderr_logfile={{ supervisor_log_dir }}/%(program_name)s-stderr.log
 killasgroup=true
 stopasgroup=true
 stopsignal=QUIT

--- a/playbooks/roles/gitreload/templates/edx/app/supervisor/conf.available.d/gitreload.conf.j2
+++ b/playbooks/roles/gitreload/templates/edx/app/supervisor/conf.available.d/gitreload.conf.j2
@@ -7,7 +7,7 @@ umask=002
 command={{ gitreload_venv }}/bin/gunicorn -c {{ gitreload_dir }}/gitreload_gunicorn.py {{ GITRELOAD_GUNICORN_EXTRA }} gitreload.web:app
 
 environment=PID=/var/tmp/gitreload.pid
-stdout_logfile={{ supervisor_log_dir }}/%(program_name)-stdout.log
-stderr_logfile={{ supervisor_log_dir }}/%(program_name)-stderr.log
+stdout_logfile={{ supervisor_log_dir }}/%(program_name)s-stdout.log
+stderr_logfile={{ supervisor_log_dir }}/%(program_name)s-stderr.log
 killasgroup=true
 stopasgroup=true

--- a/playbooks/roles/insights/templates/edx/app/supervisor/conf.d.available/insights.conf.j2
+++ b/playbooks/roles/insights/templates/edx/app/supervisor/conf.d.available/insights.conf.j2
@@ -5,7 +5,7 @@
 command={{ insights_app_dir }}/insights.sh
 user={{ common_web_user }}
 directory={{ insights_code_dir }}
-stdout_logfile={{ supervisor_log_dir }}/%(program_name)-stdout.log
-stderr_logfile={{ supervisor_log_dir }}/%(program_name)-stderr.log
+stdout_logfile={{ supervisor_log_dir }}/%(program_name)s-stdout.log
+stderr_logfile={{ supervisor_log_dir }}/%(program_name)s-stderr.log
 killasgroup=true
 stopasgroup=true

--- a/playbooks/roles/jenkins_admin/templates/nat-monitor.conf.j2
+++ b/playbooks/roles/jenkins_admin/templates/nat-monitor.conf.j2
@@ -6,8 +6,8 @@ environment=VPC_NAME="{{ m.vpc_name }}",AWS_DEFAULT_REGION="{{ m.region }}",AWS_
 user={{ jenkins_supervisor_service_user }}
 
 directory={{ jenkins_admin_scripts_dir }}
-stdout_logfile={{ jenkins_supervisor_log_dir }}/%(program_name)-stdout.log
-stderr_logfile={{ jenkins_supervisor_log_dir }}/%(program_name)-stderr.log
+stdout_logfile={{ jenkins_supervisor_log_dir }}/%(program_name)s-stdout.log
+stderr_logfile={{ jenkins_supervisor_log_dir }}/%(program_name)s-stderr.log
 
 command={{ jenkins_admin_scripts_dir }}/nat-monitor.sh
 killasgroup=true

--- a/playbooks/roles/newrelic/templates/s3watcher.conf.j2
+++ b/playbooks/roles/newrelic/templates/s3watcher.conf.j2
@@ -2,8 +2,8 @@
 command={{ newrelic_s3watcher_dir }}/s3-watcher-supervisor.sh
 priority=999
 user={{ newrelic_plugin_user }}
-stdout_logfile={{ supervisor_log_dir }}/%(program_name)-stdout.log
-stderr_logfile={{ supervisor_log_dir }}/%(program_name)-stderr.log
+stdout_logfile={{ supervisor_log_dir }}/%(program_name)s-stdout.log
+stderr_logfile={{ supervisor_log_dir }}/%(program_name)s-stderr.log
 killasgroup=true
 stopasgroup=true
 stopsignal=QUIT

--- a/playbooks/roles/ora/templates/ora.conf.j2
+++ b/playbooks/roles/ora/templates/ora.conf.j2
@@ -7,8 +7,8 @@ directory={{ ora_code_dir }}
 
 environment=PID=/var/run/gunicorn/edx-ora.pid,WORKERS={{ ora_gunicorn_workers }},PORT={{ ora_gunicorn_port }},ADDRESS={{ ora_gunicorn_host }},LANG={{ ORA_LANG }},DJANGO_SETTINGS_MODULE=edx_ora.aws,SERVICE_VARIANT=ora
 
-stdout_logfile={{ supervisor_log_dir }}/%(program_name)-stdout.log
-stderr_logfile={{ supervisor_log_dir }}/%(program_name)-stderr.log
+stdout_logfile={{ supervisor_log_dir }}/%(program_name)s-stdout.log
+stderr_logfile={{ supervisor_log_dir }}/%(program_name)s-stderr.log
 killasgroup=true
 stopasgroup=true
 

--- a/playbooks/roles/ora/templates/ora_celery.conf.j2
+++ b/playbooks/roles/ora/templates/ora_celery.conf.j2
@@ -7,8 +7,8 @@ directory={{ ora_code_dir }}
 
 environment=DJANGO_SETTINGS_MODULE=edx_ora.aws,SERVICE_VARIANT=ora
 
-stdout_logfile={{ supervisor_log_dir }}/%(program_name)-stdout.log
-stderr_logfile={{ supervisor_log_dir }}/%(program_name)-stderr.log
+stdout_logfile={{ supervisor_log_dir }}/%(program_name)s-stdout.log
+stderr_logfile={{ supervisor_log_dir }}/%(program_name)s-stderr.log
 killasgroup=true
 stopasgroup=true
 

--- a/playbooks/roles/xqueue/templates/xqueue.conf.j2
+++ b/playbooks/roles/xqueue/templates/xqueue.conf.j2
@@ -13,7 +13,7 @@ directory={{ xqueue_code_dir }}
 
 environment={% if COMMON_ENABLE_NEWRELIC_APP %}NEW_RELIC_APP_NAME={{ XQUEUE_NEWRELIC_APPNAME }},NEW_RELIC_LICENSE_KEY={{ NEWRELIC_LICENSE_KEY }},{% endif -%}PID=/var/tmp/xqueue.pid,PORT={{ xqueue_gunicorn_port }},ADDRESS={{ xqueue_gunicorn_host }},LANG={{ XQUEUE_LANG }},DJANGO_SETTINGS_MODULE=xqueue.aws_settings,SERVICE_VARIANT="xqueue"
 
-stdout_logfile={{ supervisor_log_dir }}/%(program_name)-stdout.log
-stderr_logfile={{ supervisor_log_dir }}/%(program_name)-stderr.log
+stdout_logfile={{ supervisor_log_dir }}/%(program_name)s-stdout.log
+stderr_logfile={{ supervisor_log_dir }}/%(program_name)s-stderr.log
 killasgroup=true
 stopasgroup=true

--- a/playbooks/roles/xqueue/templates/xqueue_consumer.conf.j2
+++ b/playbooks/roles/xqueue/templates/xqueue_consumer.conf.j2
@@ -7,8 +7,8 @@ directory={{ xqueue_code_dir }}
 
 environment=LANG={{ XQUEUE_LANG }},WORKERS_PER_QUEUE={{xqueue_env_config.XQUEUE_WORKERS_PER_QUEUE}},SERVICE_VARIANT="xqueue"
 
-stdout_logfile={{ supervisor_log_dir }}/%(program_name)-stdout.log
-stderr_logfile={{ supervisor_log_dir }}/%(program_name)-stderr.log
+stdout_logfile={{ supervisor_log_dir }}/%(program_name)s-stdout.log
+stderr_logfile={{ supervisor_log_dir }}/%(program_name)s-stderr.log
 killasgroup=true
 stopasgroup=true
 startsecs=0

--- a/playbooks/roles/xqwatcher/templates/edx/app/supervisor/conf.d/xqwatcher.conf.j2
+++ b/playbooks/roles/xqwatcher/templates/edx/app/supervisor/conf.d/xqwatcher.conf.j2
@@ -12,8 +12,8 @@ command={{ executable }} -m {{ xqwatcher_module }} -d {{ xqwatcher_conf_dir }}
 process_name=%(program_name)s
 user={{ xqwatcher_user }}
 directory={{ xqwatcher_code_dir }}
-stdout_logfile={{ xqwatcher_supervisor_log_dir }}/%(program_name)-stdout.log
-stderr_logfile={{ xqwatcher_supervisor_log_dir }}/%(program_name)-stderr.log
+stdout_logfile={{ xqwatcher_supervisor_log_dir }}/%(program_name)s-stdout.log
+stderr_logfile={{ xqwatcher_supervisor_log_dir }}/%(program_name)s-stderr.log
 environment={% if COMMON_ENABLE_NEWRELIC_APP %}NEW_RELIC_APP_NAME={{ XQWATCHER_NEWRELIC_APPNAME }},NEW_RELIC_LICENSE_KEY={{ NEWRELIC_LICENSE_KEY }},{% endif -%}
 killasgroup=true
 stopasgroup=true

--- a/playbooks/roles/xserver/templates/xserver.conf.j2
+++ b/playbooks/roles/xserver/templates/xserver.conf.j2
@@ -7,7 +7,7 @@ directory={{ xserver_code_dir }}
 
 environment=PID=/var/tmp/xserver.pid,NEW_RELIC_CONFIG_FILE={{ xserver_app_dir }}/newrelic.ini,NEWRELIC={{ xserver_venv_dir }}/bin/newrelic-admin,PORT={{ xserver_gunicorn_port }},ADDRESS={{ xserver_gunicorn_host }},LANG={{ XSERVER_LANG }},DJANGO_SETTINGS_MODULE=xserver_aws_settings,SERVICE_VARIANT="xserver"
 
-stdout_logfile={{ supervisor_log_dir }}/%(program_name)-stdout.log
-stderr_logfile={{ supervisor_log_dir }}/%(program_name)-stderr.log
+stdout_logfile={{ supervisor_log_dir }}/%(program_name)s-stdout.log
+stderr_logfile={{ supervisor_log_dir }}/%(program_name)s-stderr.log
 killasgroup=true
 stopasgroup=true


### PR DESCRIPTION
Part of the file name template is eaten up by Python's `%` formatting,
resulting in log files missing the `s` of "stderr" and "stdout".
