### PR TITLE
Explicitly set MTU for interfaces to avoid jumbo frame bug.

### DIFF
--- a/playbooks/roles/aws/tasks/main.yml
+++ b/playbooks/roles/aws/tasks/main.yml
@@ -24,9 +24,17 @@
 #
 # Start dealing with Jumbo frames issue in mixed MTU deployements in AWS
 #
-- lineinfile: dest=/etc/network/interfaces regexp=^mtu line="mtu 1500"
+- shell: >
+    /sbin/ifconfig eth0 mtu 1500 up
   when: ansible_distribution in common_debian_variants
 
+- lineinfile: >
+    dest=/etc/dhcp/dhclient.conf
+    regexp="^supercede interfact-mtu"
+    line="supercede interface-mtu 1500;"
+    insertbefore="^request"
+  when: ansible_distribution in common_debian_variants
+  
 #
 # End dealing with Jumbo frames issue in mixed MTU deployements in AWS
 #


### PR DESCRIPTION
@feanil prior commit didn't work for DHCP, this does and sets the MTU for running hosts as well.
