### PR TITLE
Installing OpenJDK on Insights Servers

### DIFF
--- a/playbooks/roles/insights/defaults/main.yml
+++ b/playbooks/roles/insights/defaults/main.yml
@@ -163,6 +163,8 @@ insights_debian_pkgs:
   - 'libmysqlclient-dev'
   - 'build-essential'
   - gettext
+  - openjdk-7-jdk
 
 insights_redhat_pkgs:
   - 'community-mysql-devel'
+  - openjdk-7-jdk


### PR DESCRIPTION
This is needed to make use of Closure Compiler for JS minification.
