### PR TITLE
Update configuration to CyberSource2 as the previous Hosted Order Page A...

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -235,7 +235,7 @@ EDXAPP_GRADE_BUCKET: 'edx-grades'
 EDXAPP_GRADE_ROOT_PATH: '/tmp/edx-s3/grades'
 # Credit card processor
 # These are the same defaults set in common.py
-EDXAPP_CC_PROCESSOR_NAME: "CyberSource"
+EDXAPP_CC_PROCESSOR_NAME: "CyberSource2"
 EDXAPP_CC_PROCESSOR:
   CyberSource:
     SHARED_SECRET: ""


### PR DESCRIPTION
...PI is being deprecated as of 9/14

https://github.com/edx/edx-platform/blob/b048d98eb99bb0fe3e570d5eb4bbe6e6baa14265/lms/djangoapps/shoppingcart/processors/CyberSource2.py#L3
