### PR TITLE
Increase RAM to avoid out of memory in stacks

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -39,3 +39,4 @@ Brandon DeRosier <bdero@mit.edu>
 Arbab Nazar <arbab@edx.org>
 Nilesh Londhe <nilesh@cloudgeni.us>
 Riccardo Murri <riccardo.murri@uzh.ch>
+Xaver Y.R. Chen <yrchen@ATCity.org>

--- a/vagrant/release/devstack/Vagrantfile
+++ b/vagrant/release/devstack/Vagrantfile
@@ -5,7 +5,7 @@ end
 
 VAGRANTFILE_API_VERSION = "2"
 
-MEMORY = 2048
+MEMORY = 4096
 CPU_COUNT = 2
 
 $script = <<SCRIPT

--- a/vagrant/release/fullstack/Vagrantfile
+++ b/vagrant/release/fullstack/Vagrantfile
@@ -2,7 +2,7 @@ Vagrant.require_version ">= 1.5.3"
 
 VAGRANTFILE_API_VERSION = "2"
 
-MEMORY = 2048
+MEMORY = 4096
 CPU_COUNT = 2
 
 # map the name of the git branch that we use for a release


### PR DESCRIPTION
After Birch release, the default services use over 2G RAM and 4xxMB swap after system boot. I suggest to increase RAM setting for devstack and fullstack environments to avoid out of memory issue. 
