### PR TITLE
Set default for GIT_REPO_EXPORT_DIR

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -121,6 +121,7 @@ EDXAPP_MODULESTORE_MAPPINGS:
     'preview\.': 'draft-preferred'
 
 EDXAPP_GIT_REPO_DIR: '/edx/var/edxapp/course_repos'
+EDXAPP_GIT_REPO_EXPORT_DIR: '/edx/var/edxapp/export_course_repos'
 
 EDXAPP_TENDER_DOMAIN: "None"
 

--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -761,6 +761,7 @@ cms_auth_config:
 cms_env_config:
   <<: *edxapp_generic_env
   SITE_NAME:  "{{ EDXAPP_CMS_SITE_NAME }}"
+  GIT_REPO_EXPORT_DIR: "{{ EDXAPP_GIT_REPO_EXPORT_DIR }}"
 
 # install dir for the edx-platform repo
 edxapp_code_dir: "{{ edxapp_app_dir }}/edx-platform"


### PR DESCRIPTION
Setting GIT_REPO_EXPORT_DIR to default to `/edx/var/edxapp/export_course_repos`

Thanks Carson Gee. https://groups.google.com/forum/#!topic/edx-code/nBfcPQy_W0k
