### PR TITLE
Only run the migration with the migration credentials.

### DIFF
--- a/playbooks/roles/xqueue/tasks/deploy.yml
+++ b/playbooks/roles/xqueue/tasks/deploy.yml
@@ -74,15 +74,6 @@
   notify:
     - restart xqueue
 
-- name: syncdb and migrate
-  shell: >
-    SERVICE_VARIANT=xqueue {{ xqueue_venv_bin }}/django-admin.py syncdb --migrate --noinput --settings=xqueue.aws_settings --pythonpath={{ xqueue_code_dir }}
-  sudo_user: "{{ xqueue_user }}"
-  when: migrate_db is defined and migrate_db|lower == "yes" and not COMMON_MYSQL_MIGRATE_PASS
-  notify:
-    - restart xqueue
-
-
 - name: create users
   shell: >
     SERVICE_VARIANT=xqueue {{ xqueue_venv_bin }}/django-admin.py update_users --settings=xqueue.aws_settings --pythonpath={{ xqueue_code_dir }}


### PR DESCRIPTION
Take a look at the task above this one which runs migrations using the migration credentials.
@e0d 
