### PR TITLE
Adjust index.conf splunk settings for jenkins monitors

### DIFF
--- a/playbooks/edx-east/jenkins_testeng_master.yml
+++ b/playbooks/edx-east/jenkins_testeng_master.yml
@@ -17,18 +17,19 @@
         index: 'testeng'
         sourcetype: junit
         followSymlink: false
+        crcSalt: '<SOURCE>'
       - source: '/var/lib/jenkins/jobs/*/builds/.../build.xml'
         index: 'testeng'
         recursive: true
         sourcetype: build_result
         followSymlink: false
-        initCrcLength: 1024
+        crcSalt: '<SOURCE>'
       - source: '/var/lib/jenkins/jobs/*/builds/.../log'
         index: 'testeng'
         recursive: true
         sourcetype: build_log
         followSymlink: false
-        initCrcLength: 2048
+        crcSalt: '<SOURCE>'
 
   roles:
     - common

--- a/playbooks/roles/splunkforwarder/templates/opt/splunkforwarder/etc/system/local/inputs.conf.j2
+++ b/playbooks/roles/splunkforwarder/templates/opt/splunkforwarder/etc/system/local/inputs.conf.j2
@@ -15,7 +15,7 @@ _TCP_ROUTING = {{ loggable._TCP_ROUTING }}
 {% if loggable.followSymlink is defined %}
 followSymlink = {{ loggable.followSymlink }}
 {% endif %}
-{% if loggable.initCrcLength is defined %}
-initCrcLength = {{ loggable.initCrcLength }}
+{% if loggable.crcSalt is defined %}
+crcSalt = {{ loggable.crcSalt }}
 {% endif %}
 {% endfor %}


### PR DESCRIPTION
Add the the full directory path to the source file to the CRC. This ensures that each file being monitored has a unique CRC. See splunk docs on [inputs.conf](http://docs.splunk.com/Documentation/Splunk/latest/Admin/Inputsconf)

@benpatterson @clytwynec 
