### PR TITLE
download elasticsearch error during installation

### DIFF
--- a/playbooks/roles/elasticsearch/tasks/main.yml
+++ b/playbooks/roles/elasticsearch/tasks/main.yml
@@ -34,6 +34,7 @@
     url={{ elasticsearch_url }}
     dest=/var/tmp/{{ elasticsearch_file }}
     force=no
+    validate_certs=no
   register: elasticsearch_reinstall
 
 - name: install elasticsearch from local package


### PR DESCRIPTION
This solves the problem for installations failing with this message:
"msg: Failed to validate the SSL certificate for download.elasticsearch.org:443. Use validate_certs=no or make sure your managed systems have a valid CA certificate installed. Paths checked for this platform: /etc/ssl/certs, /etc/pki/ca-trust/extracted/pem, /etc/pki/tls/certs, /usr/share/ca-certificates/cacert.org, /etc/ansible"
