### PR TITLE
Enable Subdomains

### DIFF
--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/cms.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/cms.j2
@@ -42,6 +42,7 @@ error_page {{ k }} {{ v }};
 
   {% else %}
   listen {{ EDXAPP_CMS_NGINX_PORT }} {{ default_site }};
+  listen {{ EDXAPP_LMS_NGINX_PORT }}
   {% endif %}
 
   server_name {{ CMS_HOSTNAME }};


### PR DESCRIPTION
This way, if you have a subdomain (i.e.: studio.xyz.org) configured in your configuration, it will work without the need of post installation altering the config file in sites-available.
