### PR TITLE
exclude user_api from basic auth on stage

### DIFF
--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
@@ -124,6 +124,10 @@ error_page {{ k }} {{ v }};
     try_files $uri @proxy_to_lms_app;
   }
 
+  location /user_api {
+    try_files $uri @proxy_to_lms_app;
+  }
+
   # No basic auth security on the github_service_hook url, so that github can use it for cms
   location /github_service_hook {
     try_files $uri @proxy_to_lms_app;


### PR DESCRIPTION
Needed for mobile clients to access the user_api
