### PR TITLE
Install XDomain proxy static file

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -446,6 +446,18 @@ PERFORMANCE_GRAPHITE_URL: 'SetPerformanceGraphiteHostName'
 EDXAPP_ECOMMERCE_API_URL: 'http://localhost:18130'
 EDXAPP_ECOMMERCE_API_SIGNING_KEY: 'SET-ME-PLEASE'
 
+# XDomain proxy
+# This allows browsers (including IE9) to make cross-domain requests
+# to the service.  See https://github.com/jpillora/xdomain for the docs.
+# To enable this, configure EDXAPP_XDOMAIN_MASTERS.  For example:
+#
+# EDXAPP_XDOMAIN_MASTERS:
+#   - "https://example.com"
+#   - "https://subdomain.example.com"
+#
+EDXAPP_XDOMAIN_JS_URL: "//cdn.rawgit.com/jpillora/xdomain/0.6.17/dist/xdomain.min.js"
+EDXAPP_XDOMAIN_MASTERS: []
+
 #-------- Everything below this line is internal to the role ------------
 
 #Use YAML references (& and *) and hash merge <<: to factor out shared settings
@@ -886,3 +898,4 @@ edxapp_cms_variant: cms
 
 # Worker Settings
 worker_django_settings_module: 'aws'
+

--- a/playbooks/roles/edxapp/tasks/service_variant_config.yml
+++ b/playbooks/roles/edxapp/tasks/service_variant_config.yml
@@ -118,3 +118,10 @@
   command: "{{ COMMON_BIN_DIR }}/edxapp-update-assets-{{ item }}"
   when: celery_worker is not defined and not devstack and item != "lms-preview"
   with_items: service_variants_enabled
+
+# Install XDomain proxy static file
+- name: install XDomain proxy static file
+  template: >
+    src=xdomain_proxy.html.j2
+    dest={{ edxapp_staticfile_dir }}/xdomain_proxy.html
+  when: EDXAPP_XDOMAIN_MASTERS

--- a/playbooks/roles/edxapp/templates/xdomain_proxy.html.j2
+++ b/playbooks/roles/edxapp/templates/xdomain_proxy.html.j2
@@ -1,0 +1,9 @@
+<!DOCTYPE HTML>
+<script src="{{ EDXAPP_XDOMAIN_JS_URL }}"></script>
+<script>
+ xdomain.masters({
+{% for domain in EDXAPP_XDOMAIN_MASTERS %}
+    '{{ domain }}': '*'
+{% endfor %}
+});
+</script>


### PR DESCRIPTION
Internet Explorer 9 does not send cookie information with CORS, which means we can't make cross-domain POST requests that require authentication (for example, from the course details page on the marketing site to the enrollment API to auto-enroll a user in an "honor" track).

The [XDomain](https://github.com/jpillora/xdomain) library provides an alternative to using CORS.  The library works as follows:

1) A static HTML file ("xdomain_proxy.html") is served from courses.edx.org.  The file includes JavaScript and a domain whitelist.

2) The course details page (on edx.org) creates an invisible iframe that loads the proxy HTML file.

3) A JS shim library on the course details page intercepts AJAX requests and communicates with JavaScript on the iframed page.  The iframed page then proxies the request to the LMS.  Since the iframed page is served from courses.edx.org, this is a same-domain request, so all cookies for the domain are sent along with the request.

I have included the proxy file in the configuration scripts so it can be served by nginx, avoiding additional traffic to the application servers.

@feanil please review when you have a moment.
