### PR TITLE
Set better defaults for LMS_BASE, CMS_BASE

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -23,9 +23,9 @@ EDXAPP_DJFS:
   directory_root: '{{ edxapp_data_dir }}/django-pyfs/static/django-pyfs'
   url_root : '/static/django-pyfs'
 
-EDXAPP_LMS_BASE: ""
-EDXAPP_PREVIEW_LMS_BASE: ""
-EDXAPP_CMS_BASE: ""
+EDXAPP_LMS_BASE: "localhost:8000"
+EDXAPP_PREVIEW_LMS_BASE: "preview.localhost:8000"
+EDXAPP_CMS_BASE: "localhost:8001"
 
 EDXAPP_LMS_GUNICORN_EXTRA: ""
 EDXAPP_LMS_GUNICORN_EXTRA_CONF: ""


### PR DESCRIPTION
One of our contributors reported an issue in devstack where the "View Unit in Studio" button on the LMS wasn't working. Turns out the problem was that the `CMS_BASE` variable was blank, so that when the URL to Studio was constructed, it was missing a crucial component. This PR sets better defaults for `CMS_BASE`, `LMS_BASE`, and `PREVIEW_LMS_BASE` so that they work better for devstack.
