### PR TITLE
Tighten up splunk monitor recursion for jenkins TE-807

### DIFF
--- a/playbooks/edx-east/jenkins_testeng_master.yml
+++ b/playbooks/edx-east/jenkins_testeng_master.yml
@@ -12,19 +12,19 @@
     COMMON_ENABLE_SPLUNKFORWARDER: True
 
     SPLUNKFORWARDER_LOG_ITEMS:
-      - source: '/var/lib/jenkins/jobs/*/builds/.../junitResult.xml'
+      - source: '/var/lib/jenkins/jobs/*/builds/*/junitResult.xml'
         recursive: true
         index: 'testeng'
         sourcetype: junit
         followSymlink: false
         crcSalt: '<SOURCE>'
-      - source: '/var/lib/jenkins/jobs/*/builds/.../build.xml'
+      - source: '/var/lib/jenkins/jobs/*/builds/*/build.xml'
         index: 'testeng'
         recursive: true
         sourcetype: build_result
         followSymlink: false
         crcSalt: '<SOURCE>'
-      - source: '/var/lib/jenkins/jobs/*/builds/.../log'
+      - source: '/var/lib/jenkins/jobs/*/builds/*/log'
         index: 'testeng'
         recursive: true
         sourcetype: build_log


### PR DESCRIPTION
Now running at 23 %CPU and 1.0 %MEM.

@benpatterson 
