### PR TITLE
Modify ecommerce installation to reflect its subsuming of extensions

### DIFF
--- a/playbooks/roles/ecommerce/defaults/main.yml
+++ b/playbooks/roles/ecommerce/defaults/main.yml
@@ -34,8 +34,6 @@ ECOMMERCE_DATABASES:
     CONN_MAX_AGE: 60
 
 ECOMMERCE_VERSION: "master"
-EDX_DJANGO_OSCAR_VERSION: "master"
-EDX_DJANGO_OSCAR_EXTENSIONS_VERSION: "master"
 
 ECOMMERCE_SECRET_KEY: 'Your secret key here'
 ECOMMERCE_TIME_ZONE: 'UTC'
@@ -102,20 +100,6 @@ ECOMMERCE_REPOS:
     REPO: edx-ecommerce.git
     VERSION: "{{ ECOMMERCE_VERSION }}"
     DESTINATION: "{{ ecommerce_code_dir }}"
-    SSH_KEY: "{{ ECOMMERCE_GIT_IDENTITY }}"
-  - PROTOCOL: "{{ COMMON_GIT_PROTOCOL }}"
-    DOMAIN: "{{ COMMON_GIT_MIRROR }}"
-    PATH: "{{ COMMON_GIT_PATH }}"
-    REPO: django-oscar.git
-    VERSION: "{{ EDX_DJANGO_OSCAR_VERSION }}"
-    DESTINATION: "{{ ecommerce_home }}/depends/django-oscar"
-    SSH_KEY: "{{ ECOMMERCE_GIT_IDENTITY }}"
-  - PROTOCOL: "{{ COMMON_GIT_PROTOCOL }}"
-    DOMAIN: "{{ COMMON_GIT_MIRROR }}"
-    PATH: "{{ COMMON_GIT_PATH }}"
-    REPO: django-oscar-extensions.git
-    VERSION: "{{ EDX_DJANGO_OSCAR_EXTENSIONS_VERSION }}"
-    DESTINATION: "{{ ecommerce_home }}/depends/django-oscar-extensions"
     SSH_KEY: "{{ ECOMMERCE_GIT_IDENTITY }}"
 
     

--- a/vagrant/base/ecomstack/Vagrantfile
+++ b/vagrant/base/ecomstack/Vagrantfile
@@ -11,15 +11,11 @@ CPU_COUNT = 2
 
 edx_platform_mount_dir = "edx-platform"
 ecommerce_mount_dir = "ecommerce"
-oscar_extensions_mount_dir = "django-oscar-extensions"
-django_oscar_mount_dir = "django-oscar"
 
 if ENV['VAGRANT_MOUNT_BASE']
 
   edx_platform_mount_dir = ENV['VAGRANT_MOUNT_BASE'] + "/" + edx_platform_mount_dir
   ecommerce_mount_dir = ENV['VAGRANT_MOUNT_BASE'] + "/" + ecommerce_mount_dir
-  oscar_extensions_mount_dir = ENV['VAGRANT_MOUNT_BASE'] + "/" + oscar_extensions_mount_dir
-  django_oscar_mount_dir = ENV['VAGRANT_MOUNT_BASE'] + "/" + django_oscar_mount_dir
 
 end
 
@@ -47,18 +43,10 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       create: true, owner: "edxapp", group: "www-data"
     config.vm.synced_folder "#{ecommerce_mount_dir}", "/edx/app/ecommerce/ecommerce",
       create: true, owner: "ecommerce", group: "www-data"
-    config.vm.synced_folder "#{oscar_extensions_mount_dir}", "/edx/app/ecommerce/depends/django-oscar-extensions",
-      create: true, owner: "ecommerce", group: "www-data"
-    config.vm.synced_folder "#{django_oscar_mount_dir}", "/edx/app/ecommerce/depends/django-oscar",
-      create: true, owner: "ecommerce", group: "www-data"
   else
     config.vm.synced_folder "#{edx_platform_mount_dir}", "/edx/app/edxapp/edx-platform",
       create: true, nfs: true
     config.vm.synced_folder "#{ecommerce_mount_dir}", "/edx/app/ecommerce/ecommerce",
-      create: true, nfs: true
-    config.vm.synced_folder "#{oscar_extensions_mount_dir}", "/edx/app/ecommerce/depends/django-oscar-extensions",
-      create: true, nfs: true
-    config.vm.synced_folder "#{django_oscar_mount_dir}", "/edx/app/ecommerce/depends/django-oscar",
       create: true, nfs: true
   end
 


### PR DESCRIPTION
Having an editable installation of django-oscar hasn't proven necessary during development of the ecommerce service, so that step has been removed as well. The base ecommerce requirements file installs a non-editable version.

This accompanies [#49](https://github.com/edx/ecommerce/pull/49) in the ecommerce repo.

@feanil, could you take a look at this when you're able? If there are other changes that need to be made, please let me know.
