### PR TITLE
Add ability to use SSL for mongo connections.

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -53,6 +53,7 @@ EDXAPP_MONGO_PASSWORD: 'password'
 EDXAPP_MONGO_PORT: 27017
 EDXAPP_MONGO_USER: 'edxapp'
 EDXAPP_MONGO_DB_NAME: 'edxapp'
+EDXAPP_MONGO_USE_SSL: False
 
 EDXAPP_MYSQL_DB_NAME: 'edxapp'
 EDXAPP_MYSQL_USER: 'edxapp001'
@@ -578,6 +579,7 @@ edxapp_generic_auth_config:  &edxapp_generic_auth
     port: "{{ EDXAPP_MONGO_PORT }}"
     user: "{{ EDXAPP_MONGO_USER }}"
     collection:  'modulestore'
+    ssl: "{{ EDXAPP_MONGO_USE_SSL }}"
   CONTENTSTORE:
     ENGINE:  'xmodule.contentstore.mongo.MongoContentStore'
     #
@@ -590,6 +592,7 @@ edxapp_generic_auth_config:  &edxapp_generic_auth
       password: "{{ EDXAPP_MONGO_PASSWORD }}"
       port: "{{ EDXAPP_MONGO_PORT }}"
       user: "{{ EDXAPP_MONGO_USER }}"
+      ssl: "{{ EDXAPP_MONGO_USE_SSL }}"
     ADDITIONAL_OPTIONS: "{{ EDXAPP_CONTENTSTORE_ADDITIONAL_OPTS }}"
     DOC_STORE_CONFIG: *edxapp_generic_default_docstore
   MODULESTORE:

--- a/playbooks/roles/forum/defaults/main.yml
+++ b/playbooks/roles/forum/defaults/main.yml
@@ -18,6 +18,7 @@ FORUM_MONGO_HOSTS:
 FORUM_MONGO_TAGS: !!null
 FORUM_MONGO_PORT: "27017"
 FORUM_MONGO_DATABASE: "cs_comments_service"
+FORUM_MONGO_USE_SSL: false
 FORUM_MONGO_URL: "mongodb://{{ FORUM_MONGO_USER }}:{{ FORUM_MONGO_PASSWORD }}@{%- for host in FORUM_MONGO_HOSTS -%}{{ host }}:{{ FORUM_MONGO_PORT }}{%- if not loop.last -%},{%- endif -%}{%- endfor -%}/{{ FORUM_MONGO_DATABASE }}{%- if FORUM_MONGO_TAGS -%}?tags={{ FORUM_MONGO_TAGS }}{%- endif -%}"
 FORUM_SINATRA_ENV: "development"
 FORUM_RACK_ENV: "development"
@@ -47,6 +48,7 @@ forum_environment:
   API_KEY: "{{ FORUM_API_KEY }}"
   SEARCH_SERVER: "{{ FORUM_ELASTICSEARCH_URL }}"
   MONGOHQ_URL: "{{ FORUM_MONGO_URL }}"
+  MONGOID_USE_SSL: "{{ FORUM_MONGO_USE_SSL }}"
   HOME: "{{ forum_app_dir }}"
   NEW_RELIC_ENABLE: "{{ FORUM_NEW_RELIC_ENABLE }}"
   NEW_RELIC_APP_NAME: "{{ FORUM_NEW_RELIC_APP_NAME }}"


### PR DESCRIPTION
Introduces two new configuration variables `EDXAPP_MONGO_USE_SSL` and `FORUM_MONGO_USE_SSL` that when set to `True` will [configure ssl](http://docs.mongodb.org/v2.2/administration/ssl) for contentstore/module store and forum mongo client connections.

When enabled, contentstore and and modulestore `MongoClient` instances are instantiated with `ssl=True` parameter. The cs_comments_service Mongoid connection is also instantiated with `ssl: true`. The forum setting depends on https://github.com/edx/cs_comments_service/pull/126

_Background_: A third-party Open edX installation for Harvard is using an externally hosted mongo cluster. Due to security policies, the connections from edxapp to the mongo cluster are required to be encrypted. Python's `PyMongo` and Ruby's `Mongoid` both support ssl connections. This change makes it possible to initialize `PyMongo`/`Mongoid` connections so that they are use SSL encryption by toggling some ansible vars.
_Partner information_: Harvard, for a third-party Open edX installation
_Jira ticket_: https://openedx.atlassian.net/browse/OSPR-519
