### PR TITLE
The short circuit logic does not work on jenkins.

### DIFF
--- a/util/jenkins/ansible-provision.sh
+++ b/util/jenkins/ansible-provision.sh
@@ -25,7 +25,9 @@ export BOTO_CONFIG=/var/lib/jenkins/${aws_account}.boto
 run_ansible() {
   ansible-playbook $@
   ret=$?
-  [ $ret -ne 0 ] && exit $ret
+  if [[ $ret -ne 0 ]]; then
+    exit $ret
+  fi
 }
 
 # This DATE_TIME will be used as instance launch time tag


### PR DESCRIPTION
```
13:08:11 + ret=0
13:08:11 + echo 0
13:08:11 0
13:08:11 + '[' 0 -ne 0 ']'
13:08:11 Build step 'Virtualenv Builder' marked build as failure
13:08:11 [ssh-agent] Stopped.
13:08:11 Finished: FAILURE
```

The example above is a snippet from jenkins which the integration test runs into,
meaning it is often suceeding but reporting it as failure.  There is still an issue
with the cms worker which is related to 'stopwaitsecs' which is really high for all
workers due to grading.  That work will need to be refactored so that cms workers
don't wait so long before killing the worker.

The problem is the same as what is described here but more investigation will be
useful.

http://stackoverflow.com/questions/9971627/why-is-celery-not-shutting-down-cleanly
