### PR TITLE
Don't run `/edx/bin/update`  with `--tags deplay` by default.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+-Role: edx-ansible
+  - `/edx/bin/update` no longer runs the ansible command with `--tags deploy`
+
 - Role: edxapp
   - Added newrelic monitoring capabilities to edxapp workers. Note that this is a BACKWARDS-INCOMPATABLE CHANGE, as it introduces a new key, `monitor`, to each item in `EDXAPP_CELERY_WORKERS` in `defaults/main.yml`, and plays including this role will fail if that key is not set.
 

--- a/playbooks/roles/edx_ansible/templates/update.j2
+++ b/playbooks/roles/edx_ansible/templates/update.j2
@@ -43,7 +43,7 @@ extra_args="$extra_args -e 'disable_edx_services=true'"
 {% endif %}
 
 declare -A repos_to_cmd
-edx_ansible_cmd="{{ edx_ansible_venv_bin }}/ansible-playbook -i localhost, -c local --tags deploy $extra_args "
+edx_ansible_cmd="{{ edx_ansible_venv_bin }}/ansible-playbook -i localhost, -c local $extra_args"
 
 repos_to_cmd["edx-platform"]="$edx_ansible_cmd edxapp.yml -e 'edx_platform_version=$2'"
 repos_to_cmd["xqueue"]="$edx_ansible_cmd xqueue.yml -e 'xqueue_version=$2'"


### PR DESCRIPTION
Having `--tags deploy` be part of the ansible-playbook call
that `/edx/bin/update` makes is not intuitive.  It's broken
us a few times recently and I don't think the benefit it
provides is worth the cost and confusion.  I feel that anyone
who wants to use tags will know how to do it without using
`/edx/bin/update`.

Review: @e0d @maxrothman @fredsmith
