### PR TITLE
Update syntax to match the new format.

### DIFF
--- a/playbooks/roles/launch_ec2/tasks/main.yml
+++ b/playbooks/roles/launch_ec2/tasks/main.yml
@@ -91,18 +91,18 @@
 
 
 - name: Add new instance to host group
-  local_action: >
-    add_host
-      hostname={{ item.public_ip }}
-      groupname=launched
+  local_action:
+    module: add_host
+    hostname: "{{ item.public_ip }}"
+    groups: launched
   with_items: ec2.instances
 
 - name: Wait for SSH to come up
-  local_action: >
-    wait_for
-      host={{ item.public_dns_name }}
-      state=started
-      port=22
-      delay=60
-      timeout=320
+  local_action:
+    module: wait_for
+    host: "{{ item.public_dns_name }}"
+    state: started
+    port: 22
+    delay: 60
+    timeout: 320
   with_items: ec2.instances


### PR DESCRIPTION
The old syntax was:
- causing the module name lookup to fail probably because it was having trouble dealing with the white space.
- using an older name for a module argument
