### PR TITLE
Fix profile image backend docs

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -451,8 +451,8 @@ EDXAPP_ECOMMERCE_API_SIGNING_KEY: 'SET-ME-PLEASE'
 
 #To use AWS S3 as your backend, you need different kwargs:
 # EDXAPP_PROFILE_IMAGE_BACKEND_CONFIG:
-#   storage_class: storages.backends.s3boto.S3BotoStorage
-#   storage_kwargs:
+#   class: storages.backends.s3boto.S3BotoStorage
+#   options:
 #     location: /path/to/images
 #     bucket: mybucket
 #     custom_domain: mybucket.s3.amazonaws.com


### PR DESCRIPTION
The doc comment was using an older version of the config datastructure that was changed pre-merge.
