### PR TITLE
Add ansible install log

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -42,3 +42,4 @@ Riccardo Murri <riccardo.murri@uzh.ch>
 Xaver Y.R. Chen <yrchen@ATCity.org>
 Cristian Salamea <cristian.salamea@cecep-iaen.edu.ec>
 Jonathan Peter <jonathan.peter@blue-planet-life.org>
+Allen Heavey <xheavey@gmail.com>

--- a/playbooks/ansible.cfg
+++ b/playbooks/ansible.cfg
@@ -8,3 +8,4 @@ jinja2_extensions=jinja2.ext.do
 host_key_checking = False
 roles_path=../../ansible-roles/roles:../../ansible-private/roles:../../ansible-roles/
 ansible_managed=This file is created and updated by ansible, edit at your peril
+log_path=/var/log/ansible_install_edx.log


### PR DESCRIPTION
I think it good for us to have an install log.
A log file can record install failed tasks, it's helpful to track where the problem is.
