### PR TITLE
Minor update and typo fix for mariadb

### DIFF
--- a/playbooks/roles/mariadb/defaults/main.yml
+++ b/playbooks/roles/mariadb/defaults/main.yml
@@ -119,5 +119,5 @@ mariadb_solo_packages:
   - mariadb-server
 
 mariadb_cluster_packages:
-  - mariadb-galera-server
-  - galera
+  - mariadb-galera-server-10.0
+  - galera-3

--- a/playbooks/roles/mariadb/tasks/main.yml
+++ b/playbooks/roles/mariadb/tasks/main.yml
@@ -25,7 +25,7 @@
   apt: name={{ item }} state=present
   with_items: mariadb_debian_pkgs
 
-- name: Add mongo key
+- name: Add mariadb apt key
   apt_key: url="{{ COMMON_UBUNTU_APT_KEYSERVER }}{{ MARIADB_APT_KEY_ID }}"
 
 - name: add the mariadb repo to the sources list


### PR DESCRIPTION
It appears the apt repository for mariadb has changed a bit, and in order to avoid broken packages, the package names need to change a bit.
