### PR TITLE
Use templated ElasticSearch config for single-instance deployment

### DIFF
--- a/playbooks/roles/elasticsearch/tasks/main.yml
+++ b/playbooks/roles/elasticsearch/tasks/main.yml
@@ -1,14 +1,14 @@
 ---
 
 # elasticsearch
-# 
+#
 # Dependencies:
 #
 #   * common
 #   * oraclejdk
-# 
+#
 # Example play:
-#  
+#
 # This role can be used to do a single-server or clustered
 # installation of the elasticsearch service.  When a cluster
 # is being installed, there are two important things that
@@ -57,20 +57,17 @@
 - name: update elasticsearch defaults
   template: >
     src=etc/default/elasticsearch.j2 dest=/etc/default/elasticsearch
-  when: ELASTICSEARCH_CLUSTERED
-    
+
 - name: drop the elasticsearch config
   template: >
     src=edx/etc/elasticsearch/elasticsearch.yml.j2 dest={{ elasticsearch_cfg_dir }}/elasticsearch.yml
     mode=0744
-  when: ELASTICSEARCH_CLUSTERED
 
 - name: drop the elasticsearch logging config
   template: >
     src=edx/etc/elasticsearch/logging.yml.j2 dest={{ elasticsearch_cfg_dir }}/logging.yml
     mode=0744
-  when: ELASTICSEARCH_CLUSTERED  
-    
+
 - name: Ensure elasticsearch is enabled and started
   service: name=elasticsearch state=started enabled=yes
 


### PR DESCRIPTION
We use a custom elasticsearch.yml configuration file when deploying in clustered mode. The same configuration file should be used in single-instance mode. The templated file tweaks some settings and disables the insecure dynamic scripting, so it makes sense to use it in both deployment scenarios.

_Background_: The main motivation behind this change is to disable dynamic scripting when deploying to a single instance (it was already disabled in cluster mode).
_Partner Information_: Harvard, for a third-party Open edX installation
_Jira ticket_: https://openedx.atlassian.net/browse/OSPR-544
