### PR TITLE
We don't need it as a requirement it is in core as of 2.7.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ git+https://github.com/edx/ansible.git@stable-1.9-plus-edx#egg=ansible==1.9.1-ed
 PyYAML==3.11
 Jinja2==2.7.3
 MarkupSafe==0.23
-argparse==1.2.1
 boto==2.32.1
 ecdsa==0.11
 paramiko==1.15.1


### PR DESCRIPTION
See https://pypi.python.org/pypi/argparse for more details.
