### PR TITLE
Add PayPal defaults to the ecommerce role

### DIFF
--- a/playbooks/roles/ecommerce/defaults/main.yml
+++ b/playbooks/roles/ecommerce/defaults/main.yml
@@ -50,13 +50,20 @@ ECOMMERCE_SOCIAL_AUTH_EDX_OIDC_ID_TOKEN_DECRYPTION_KEY : 'some-secret'
 ECOMMERCE_SOCIAL_AUTH_EDX_OIDC_URL_ROOT : 'some-secret'
 ECOMMERCE_SOCIAL_AUTH_REDIRECT_IS_HTTPS: false
 
-# Cybersource related
+# CyberSource related
 ECOMMERCE_CYBERSOURCE_PROFILE_ID: 'SET-ME-PLEASE'
 ECOMMERCE_CYBERSOURCE_ACCESS_KEY: 'SET-ME-PLEASE'
 ECOMMERCE_CYBERSOURCE_SECRET_KEY: 'SET-ME-PLEASE'
-ECOMMERCE_CYBERSOURCE_PAYMENT_PAGE_URL: 'http://set-me-please'
-ECOMMERCE_CYBERSOURCE_RECEIPT_PAGE_URL: 'http://set-me-please'
-ECOMMERCE_CYBERSOURCE_CANCEL_PAGE_URL: 'http://set-me-please'
+ECOMMERCE_CYBERSOURCE_PAYMENT_PAGE_URL: 'https://set-me-please'
+ECOMMERCE_CYBERSOURCE_RECEIPT_PAGE_URL: '{{ ECOMMERCE_LMS_URL_ROOT }}/commerce/checkout/receipt/'
+ECOMMERCE_CYBERSOURCE_CANCEL_PAGE_URL: '{{ ECOMMERCE_LMS_URL_ROOT }}/commerce/checkout/cancel/'
+
+# PayPal related
+ECOMMERCE_PAYPAL_MODE: 'SET-ME-PLEASE'
+ECOMMERCE_PAYPAL_CLIENT_ID: 'SET-ME-PLEASE'
+ECOMMERCE_PAYPAL_CLIENT_SECRET: 'SET-ME-PLEASE'
+ECOMMERCE_PAYPAL_RECEIPT_URL: '{{ ECOMMERCE_LMS_URL_ROOT }}/commerce/checkout/receipt/'
+ECOMMERCE_PAYPAL_CANCEL_URL: '{{ ECOMMERCE_LMS_URL_ROOT }}/commerce/checkout/cancel/'
 
 ECOMMERCE_PAYMENT_PROCESSOR_CONFIG:
     cybersource:
@@ -66,6 +73,12 @@ ECOMMERCE_PAYMENT_PROCESSOR_CONFIG:
       payment_page_url: '{{ ECOMMERCE_CYBERSOURCE_PAYMENT_PAGE_URL }}'
       receipt_page_url: '{{ ECOMMERCE_CYBERSOURCE_RECEIPT_PAGE_URL }}'
       cancel_page_url: '{{ ECOMMERCE_CYBERSOURCE_CANCEL_PAGE_URL }}'
+    paypal:
+      mode: '{{ ECOMMERCE_PAYPAL_MODE }}'
+      client_id: '{{ ECOMMERCE_PAYPAL_CLIENT_ID }}'
+      client_secret: '{{ ECOMMERCE_PAYPAL_CLIENT_SECRET }}'
+      receipt_url: '{{ ECOMMERCE_PAYPAL_RECEIPT_URL }}'
+      cancel_url: '{{ ECOMMERCE_PAYPAL_CANCEL_URL }}'
 
 ECOMMERCE_ORDER_NUMBER_PREFIX: 'OSCR'
 
@@ -146,5 +159,7 @@ ecommerce_dev_requirements:
 ecommerce_debian_pkgs:
   - libmysqlclient-dev
   - libjpeg-dev
+  - libssl-dev
+  - libffi-dev
 
 ecommerce_redhat_pkgs: []


### PR DESCRIPTION
This adds PayPal defaults and two new Debian packages required by PayPal's Python SDK to the ecommerce role.

@feanil and @jibsheet, could you review this when you're able?

@clintonb and @jimabramson, FYI.
