### PR TITLE
Don't need pycurl for apt_repository anymore.

### DIFF
--- a/playbooks/roles/common/tasks/main.yml
+++ b/playbooks/roles/common/tasks/main.yml
@@ -25,10 +25,6 @@
   stat: path=/home/vagrant
   register: vagrant_home_dir
 
-# Need to install python-pycurl to use Ansible's apt_repository module
-- name: Install python-pycurl
-  apt: pkg=python-pycurl state=present update_cache=yes
-
 # Ensure that we get a current version of Git
 # GitHub requires version 1.7.10 or later
 # https://help.github.com/articles/https-cloning-errors


### PR DESCRIPTION
We used to need to install python-pycurl so that the
apt_repository module would work correctly but the code
of that module has changed. It uses the apt python api
instead and installs it automatically if it is not available.

https://github.com/ansible/ansible-modules-core/blob/devel/packaging/os/apt_repository.py#L104-L118
