### PR TITLE
Add apt packages required for new shibboleth implementation

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -913,6 +913,9 @@ edxapp_debian_pkgs:
   - ntp
   # matplotlib needs libfreetype6-dev
   - libfreetype6-dev
+  # python-saml dependencies: (required for Shibboleth in third_party_auth)
+  - libxmlsec1-dev
+  - swig
 
 # Ruby Specific Vars
 edxapp_ruby_version: "1.9.3-p374"


### PR DESCRIPTION
**Description**
The upcoming implementation of Shibboleth/SAML SSO in third_party_auth requires python-saml, which in turn requires two new debian packages not installed on most edX instances: `libxmlsec1-dev` and `swig`.

This PR adds those dependencies. See link below to the main PR for more details.
