### PR TITLE
The version in service-builder used a list while the one in master expected a dict.

### DIFF
--- a/playbooks/edx-east/edx_provision.yml
+++ b/playbooks/edx-east/edx_provision.yml
@@ -77,7 +77,7 @@
         module: ec2_lookup
         region: us-east-1
         tags:
-          Name: "{{ name_tag }}"
+          - Name: "{{ name_tag }}"
       register: ec2_info
       when: elb
       sudo: False

--- a/playbooks/roles/launch_ec2/tasks/main.yml
+++ b/playbooks/roles/launch_ec2/tasks/main.yml
@@ -8,7 +8,7 @@
     module: ec2_lookup
     region: "{{ region }}"
     tags:
-      Name: "{{ name_tag }}"
+      - Name: "{{ name_tag }}"
   register: tag_lookup
   when: terminate_instance == true
 


### PR DESCRIPTION
Updated all the usages to provide a list.
