### PR TITLE
Index the jenkins master log in Splunk

### DIFF
--- a/playbooks/edx-east/jenkins_testeng_master.yml
+++ b/playbooks/edx-east/jenkins_testeng_master.yml
@@ -30,6 +30,10 @@
         sourcetype: build_log
         followSymlink: false
         crcSalt: '<SOURCE>'
+      - source: '/var/log/jenkins/jenkins.log'
+        index: 'testeng'
+        recursive: false
+        followSymlink: false
 
   roles:
     - common


### PR DESCRIPTION
Tested with test-jenkins. Looks good.
The sourcetype that splunk automatically is applying is "jenkins"

See the results with this query:
`index=testeng sourcetype=jenkins`

@clytwynec @benpatterson 
