### PR TITLE
Fix the packer script that provisions jenkins workers

### DIFF
--- a/util/packer/jenkins_worker.json
+++ b/util/packer/jenkins_worker.json
@@ -21,15 +21,30 @@
   }],
   "provisioners": [{
     "type": "shell",
-    "inline": ["rm -rf {{user `playbook_remote_dir`}}"]
+    "inline": ["rm -rf {{user `playbook_remote_dir`}}",
+      "mkdir {{user `playbook_remote_dir`}}"]
+  }, {
+        "type": "file",
+        "source": "../../playbooks/run_role.yml",
+        "destination": "{{user `playbook_remote_dir`}}/run_role.yml"
   }, {
     "type": "file",
-    "source": "../../playbooks",
-    "destination": "{{user `playbook_remote_dir`}}"
+    "source": "../../playbooks/roles",
+    "destination": "{{user `playbook_remote_dir`}}/roles"
+  }, {
+      "type": "file",
+      "source": "../../playbooks/edx-east",
+      "destination": "{{user `playbook_remote_dir`}}/edx-east"
   }, {
     "type": "file",
     "source": "../../requirements.txt",
     "destination": "{{user `playbook_remote_dir`}}/requirements.txt"
+  }, {
+    "type": "shell",
+    "inline": ["sudo add-apt-repository ppa:git-core/ppa -y"]
+  }, {
+    "type": "shell",
+    "inline": ["sudo apt-get -y install git-core"]
   }, {
     "type": "shell",
     "inline": ["cd {{user `playbook_remote_dir`}}",


### PR DESCRIPTION
- Selectively copy playbook dirs to avoid broken links
- Install git in packer script so that the edx ansible fork can be installed via requirements.txt

@benpatterson 
