### PR TITLE
Run an update before security installs.

### DIFF
--- a/playbooks/roles/security/tasks/security-ubuntu.yml
+++ b/playbooks/roles/security/tasks/security-ubuntu.yml
@@ -1,7 +1,7 @@
 #### Enable periodic security updates
 
 - name: install security packages
-  apt: name={{ item }} state=latest
+  apt: name={{ item }} state=latest update_cache=yes
   with_items: security_debian_pkgs 
 
 


### PR DESCRIPTION
Need to do this so installs for security fixes don't fail when building from scratch.
