### PR TITLE
Add publicly-accessible ecommerce URL root

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -454,7 +454,8 @@ CDN_VIDEO_URLS: {}
 PERFORMANCE_GRAPHITE_URL: 'SetPerformanceGraphiteHostName'
 
 # E-Commerce Related Settings
-EDXAPP_ECOMMERCE_API_URL: 'http://localhost:18130'
+EDXAPP_ECOMMERCE_PUBLIC_URL_ROOT: 'https://www.example.com'
+EDXAPP_ECOMMERCE_API_URL: 'https://www-internal.example.com/api'
 EDXAPP_ECOMMERCE_API_SIGNING_KEY: 'SET-ME-PLEASE'
 
 #To use AWS S3 as your backend, you need different kwargs:
@@ -673,6 +674,7 @@ generic_cache_config: &default_generic_cache
   LOCATION: "{{ EDXAPP_MEMCACHE }}"
 
 generic_env_config:  &edxapp_generic_env
+  ECOMMERCE_PUBLIC_URL_ROOT: "{{ EDXAPP_ECOMMERCE_PUBLIC_URL_ROOT }}"
   ECOMMERCE_API_URL: "{{ EDXAPP_ECOMMERCE_API_URL }}"
   FINANCIAL_REPORTS: "{{ EDXAPP_FINANCIAL_REPORTS }}"
   ONLOAD_BEACON_SAMPLE_RATE: "{{ EDXAPP_ONLOAD_BEACON_SAMPLE_RATE }}"


### PR DESCRIPTION
The LMS needs an externally-accessible ecommerce URL root when constructing refund notification emails sent to the student support team.

@feanil, could you please review this when you're able? @jimabramson and @clintonb, FYI.
