### PR TITLE
Move Shibboleth deps to edxapp_common so they'll be available on Jenkins

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -940,9 +940,6 @@ edxapp_debian_pkgs:
   - ntp
   # matplotlib needs libfreetype6-dev
   - libfreetype6-dev
-  # python-saml dependencies: (required for Shibboleth in third_party_auth)
-  - libxmlsec1-dev
-  - swig
 
 # Ruby Specific Vars
 edxapp_ruby_version: "1.9.3-p374"

--- a/playbooks/roles/edxapp_common/defaults/main.yml
+++ b/playbooks/roles/edxapp_common/defaults/main.yml
@@ -22,3 +22,6 @@ edxapp_common_debian_pkgs:
     # Needed by the CMS to manipulate images.
     - libjpeg8-dev
     - libpng12-dev
+    # python-saml dependencies: (required for Shibboleth in third_party_auth)
+    - libxmlsec1-dev
+    - swig


### PR DESCRIPTION
This is a follow-up to #2002, which added two new system packages required by the new Shibboleth SSO functionality coming to edx-platform.

In that first PR, I added the new requirements to the edxapp role, but I should have added them to the edxap_common role, so that they are also included on Jenkins worker instances. See discussion on #2002.

@e0d @benpatterson Please review.
