### PR TITLE
Tag the paver static assets task

### DIFF
--- a/playbooks/roles/edxapp/tasks/service_variant_config.yml
+++ b/playbooks/roles/edxapp/tasks/service_variant_config.yml
@@ -117,4 +117,5 @@
 - name: gather {{ item }} static assets with paver
   command: "{{ COMMON_BIN_DIR }}/edxapp-update-assets-{{ item }}"
   when: celery_worker is not defined and not devstack and item != "lms-preview"
+  tags: gather_static_assets
   with_items: service_variants_enabled


### PR DESCRIPTION
This lets you run ansible-playbook with --skip-tags gather_static_assets
so you can redeploy edx-platform on your sandbox to test configuration
changes without waiting for paver.

Likely wants a change to /edx/bin/update but I just ran things manually to test.
