### PR TITLE
Ubuntu 12.04 doesn't support 'git clone -b'

### DIFF
--- a/util/install/sandbox.sh
+++ b/util/install/sandbox.sh
@@ -45,7 +45,9 @@ fi
 ## Clone the configuration repository and run Ansible
 ##
 cd /var/tmp
-git clone -b $CONFIG_VER https://github.com/edx/configuration
+git clone https://github.com/edx/configuration
+cd configuration
+git checkout $CONFIG_VER
 
 ##
 ## Install the ansible requirements


### PR DESCRIPTION
This is to deal with the issue pointed out in #2036

@jibsheet @fredsmith @maxrothman 
