### PR TITLE
update github_post_status.py for jenkins_worker role

### DIFF
--- a/playbooks/roles/jenkins_worker/templates/github_post_status.py.j2
+++ b/playbooks/roles/jenkins_worker/templates/github_post_status.py.j2
@@ -25,7 +25,7 @@ def parse_args(arg_list):
     Parse the list of arguments, returning a dict.
     Prints an error message and exits if the arguments are invalid.
     """
-    if len(arg_list) != 7:
+    if len(arg_list) != 8:
         print USAGE.format(arg_list[0])
         exit(1)
 
@@ -41,11 +41,12 @@ def parse_args(arg_list):
         'sha': arg_list[3],
         'status': arg_list[4],
         'target_url': arg_list[5],
-        'description': arg_list[6]
+        'description': arg_list[6],
+        'context': arg_list[7],
     }
 
 
-def post_status(org, repo, sha, status, target_url, description):
+def post_status(org, repo, sha, status, target_url, description, context):
     """
     Post a new status to GitHub.
     See http://developer.github.com/v3/repos/statuses/ for details.
@@ -59,7 +60,8 @@ def post_status(org, repo, sha, status, target_url, description):
     params = {
         'state': status,
         'target_url': target_url,
-        'description': description
+        'description': description,
+        'context': context,
     }
 
     response = requests.post(url, data=json.dumps(params))
@@ -85,7 +87,8 @@ def main():
     post_status(
         arg_dict['org'], arg_dict['repo'],
         arg_dict['sha'], arg_dict['status'],
-        arg_dict['target_url'], arg_dict['description']
+        arg_dict['target_url'], arg_dict['description'],
+        arg_dict['context'],
     )
 
 


### PR DESCRIPTION
@benpatterson  I'm updating this script to send context when posting the github status. It looks like this script is still up to date otherwise and we can use it from a post build script for our master builds.
