### PR TITLE
Provide separate internal/public API endpoints.

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -485,8 +485,11 @@ EDXAPP_PROFILE_IMAGE_MIN_BYTES: 100
 
 EDXAPP_PARSE_KEYS: {}
 
-EDXAPP_EDXNOTES_INTERFACE:
-  url: http://localhost:18120/api/v1
+# In a production environment when using separate clusters, you'll
+# want to route requests differently from the LMS (internal api) and
+# from JS (public API)
+EDXAPP_EDXNOTES_PUBLIC_API: http://localhost:18120/api/v1
+EDXAPP_EDXNOTES_INTERNAL_API: http://localhost:18120/api/v1
 
 #-------- Everything below this line is internal to the role ------------
 
@@ -829,7 +832,8 @@ lms_env_config:
   PROFILE_IMAGE_BACKEND: "{{ EDXAPP_PROFILE_IMAGE_BACKEND }}"
   PROFILE_IMAGE_MIN_BYTES: "{{ EDXAPP_PROFILE_IMAGE_MIN_BYTES }}"
   PROFILE_IMAGE_MAX_BYTES: "{{ EDXAPP_PROFILE_IMAGE_MAX_BYTES }}"
-  EDXNOTES_INTERFACE: "{{ EDXAPP_EDXNOTES_INTERFACE }}"
+  EDXNOTES_PUBLIC_API: "{{ EDXAPP_EDXNOTES_PUBLIC_API }}"
+  EDXNOTES_INTERNAL_API: "{{ EDXAPP_EDXNOTES_INTERNAL_API }}"
 
 cms_auth_config:
   <<: *edxapp_generic_auth


### PR DESCRIPTION
This allows us to route LMS requests over an internal ELB while public
JS direct requests to the API go over a separate ELB.

Implements changes from edx/edx-platform#8336
