### PR TITLE
Switch to using the vpc_class_b for these subnets

### DIFF
--- a/playbooks/roles/edx_service_rds/defaults/main.yml
+++ b/playbooks/roles/edx_service_rds/defaults/main.yml
@@ -42,9 +42,9 @@ EDX_SERVICE_RDS_BACKUP_DAYS: 30
 EDX_SERVICE_RDS_BACKUP_WINDOW: "02:00-03:00"
 
 EDX_SERVICE_RDS_SUBNET_1_AZ: "us-east-1c"
-EDX_SERVICE_RDS_SUBNET_1_CIDR: "10.253.50.0/24"
+EDX_SERVICE_RDS_SUBNET_1_CIDR: "{{ vpc_class_b }}.50.0/24"
 EDX_SERVICE_RDS_SUBNET_2_AZ: "us-east-1d"
-EDX_SERVICE_RDS_SUBNET_2_CIDR: "10.253.51.0/24"
+EDX_SERVICE_RDS_SUBNET_2_CIDR: "{{ vpc_class_b }}.51.0/24"
 
 # The defaults are permissive, override
 EDX_SERVICE_RDS_SECURITY_GROUP:
@@ -81,7 +81,7 @@ EDX_SERVICE_RDS_VPC_DB_ACL:
       rule_action: "allow"
 
 EDX_SERVICE_RDS_VPC_DB_ROUTE_TABLE:
-  - cidr: "10.253.0.0/16"
+  - cidr: "{{ vpc_class_b }}.0.0/16"
     gateway: 'local'
       
 # typically override the all caps vars, but may


### PR DESCRIPTION
I suspect the third change is wrong - as is, it creates a route table,
but I cannot connect to the RDS.  However, there is no local gateway in
10.253.0.0 in loadtest, so the default isn't quite right either.

We should possible make SUBNET_[12]_CIDR easier to override, since I
ended up changing them anyway to use something other than .50.

@feanil - this is what I ran in the loadtest environment, along with the VPC file so
 ansible-playbook  -i localhost, edx_service_rds.yml -vv -e@/Users/kevinfalcone/git/ops/edx-secure/cloud_migrations/loadtest-edx.yml  -e@/Users/kevinfalcone/git/ops/edx-secure/ansible/vars/db/loadtest-edx-notes-rds.yml
