### PR TITLE
Create writable media dir on local filesystem (SOL-963)

### DIFF
--- a/playbooks/roles/edxapp/tasks/main.yml
+++ b/playbooks/roles/edxapp/tasks/main.yml
@@ -52,6 +52,7 @@
   with_items:
     - "{{ edxapp_course_data_dir }}"
     - "{{ edxapp_upload_dir }}"
+    - "{{ edxapp_media_dir }}"
 
 # adding chris-lea nodejs repo
 - name: add ppas for current versions of nodejs


### PR DESCRIPTION
**Description:** This is related to https://openedx.atlassian.net/browse/SOL-963 and https://github.com/edx/edx-platform/pull/8406

Currently the `MEDIA_ROOT` directory set by the edxapp playbook isn't created, so when the `DEFAULT_FILE_STORAGE` is set to the local filesystem, attempting to write files in it fails.

**Partner information:** Solutions client
**Merge deadline:** ASAP - currently the default fullstack deployment is broken, this is needed along with https://github.com/edx/edx-platform/pull/8406 to fix it

@Kelketek @fredsmith @feanil @carsongee
