### PR TITLE
Remove VMware Fusion references from Vagrantfile

### DIFF
--- a/vagrant/release/devstack/Vagrantfile
+++ b/vagrant/release/devstack/Vagrantfile
@@ -134,15 +134,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     vb.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
   end
 
-  ["vmware_fusion", "vmware_workstation"].each do |vmware_provider|
-    config.vm.provider vmware_provider do |v, override|
-      override.vm.box     = "kifli-devstack-vmware"
-      override.vm.box_url = "http://files.edx.org/vagrant-images/20140829-kifli-devstack-vmware.box"
-      v.vmx["memsize"] = MEMORY.to_s
-      v.vmx["numvcpus"] = CPU_COUNT.to_s
-    end
-  end
-
   # Use vagrant-vbguest plugin to make sure Guest Additions are in sync
   config.vbguest.auto_reboot = true
   config.vbguest.auto_update = true

--- a/vagrant/release/fullstack/Vagrantfile
+++ b/vagrant/release/fullstack/Vagrantfile
@@ -56,13 +56,4 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     # http://askubuntu.com/questions/238040/how-do-i-fix-name-service-for-vagrant-client
     vb.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
   end
-
-  ["vmware_fusion", "vmware_workstation"].each do |vmware_provider|
-    config.vm.provider vmware_provider do |v, override|
-      override.vm.box     = "kifli-fullstack-vmware"
-      override.vm.box_url = "http://files.edx.org/vagrant-images/20140829-kifli-fullstack-vmware.box"
-      v.vmx["memsize"] = MEMORY.to_s
-      v.vmx["numvcpus"] = CPU_COUNT.to_s
-    end
-  end
 end


### PR DESCRIPTION
They're on kifli, rather than lavash. They don't support named releases. Realistically, anyone using VMware Fusion with this Vagrantfile is going to run into a lot of problems.
