### PR TITLE
Remove reference to group_vars/all

### DIFF
--- a/playbooks/vagrant-cluster.yml
+++ b/playbooks/vagrant-cluster.yml
@@ -13,8 +13,6 @@
     ELASTICSEARCH_CLUSTERED: yes
     MARIADB_CLUSTERED: yes
     MARIADB_CREATE_DBS: no
-  vars_files:
-    - "group_vars/all"
   roles:
     - user
     - mongo
@@ -35,8 +33,6 @@
       - "rabbit@cluster2"
       - "rabbit@cluster3"
     rabbitmq_ip: ""
-  vars_files:
-    - "group_vars/all"
   roles:
     - rabbitmq
 
@@ -51,7 +47,6 @@
     MARIADB_CLUSTERED: yes
     MARIADB_CREATE_DBS: yes
   vars_files:
-    - "group_vars/all"
     - "roles/analytics_api/defaults/main.yml"
   roles:
     - mariadb

--- a/playbooks/vagrant-devstack.yml
+++ b/playbooks/vagrant-devstack.yml
@@ -12,8 +12,6 @@
     COMMON_MOTD_TEMPLATE: 'devstack_motd.tail.j2'
     COMMON_SSH_PASSWORD_AUTH: "yes"
     ENABLE_LEGACY_ORA: !!null
-  vars_files:
-    - "group_vars/all"
   roles:
     - edx_ansible
     - edxlocal

--- a/playbooks/vagrant-ecomstack.yml
+++ b/playbooks/vagrant-ecomstack.yml
@@ -10,8 +10,6 @@
     EDXAPP_NO_PREREQ_INSTALL: 0
     COMMON_MOTD_TEMPLATE: 'devstack_motd.tail.j2'
     COMMON_SSH_PASSWORD_AUTH: "yes"
-  vars_files:
-    - "group_vars/all"
   roles:
     - edx_ansible
     - edxlocal

--- a/playbooks/vagrant-fullstack.yml
+++ b/playbooks/vagrant-fullstack.yml
@@ -14,8 +14,6 @@
     certs_version: '{{ OPENEDX_RELEASE | default("master") }}'
     forum_version: '{{ OPENEDX_RELEASE | default("master") }}'
     xqueue_version: '{{ OPENEDX_RELEASE | default("master") }}'
-  vars_files:
-    - "group_vars/all"
   roles:
     - edx_ansible
     - user


### PR DESCRIPTION
It appears we removed this file, but all the vagrant plays were still referencing it.
