### PR TITLE
Don't disable token checking on notes

### DIFF
--- a/playbooks/roles/edx_notes_api/defaults/main.yml
+++ b/playbooks/roles/edx_notes_api/defaults/main.yml
@@ -40,6 +40,7 @@ EDX_NOTES_API_DATABASES:
     PORT: 3306
 EDX_NOTES_API_ALLOWED_HOSTS:
   - localhost
+EDX_NOTES_API_DISABLE_TOKEN_CHECK: False
 
 EDX_NOTES_API_REPOS:
   - PROTOCOL: "{{ COMMON_GIT_PROTOCOL }}"
@@ -75,7 +76,7 @@ edx_notes_api_service_config:
       ENGINE: 'notesserver.highlight.ElasticsearchSearchEngine'
       URL: "{{ EDX_NOTES_API_ELASTICSEARCH_URL }}"
       INDEX_NAME: '{{ EDX_NOTES_API_DATASTORE_NAME }}'
-  DISABLE_TOKEN_CHECK: True
+  DISABLE_TOKEN_CHECK: "{{ EDX_NOTES_API_DISABLE_TOKEN_CHECK }}"
 
 #
 # vars are namespace with the module name.


### PR DESCRIPTION
The default is to enforce token checking (in edx-notes-api's common.py)
and we should be doing the same thing in deployed configuration.

Make this into a variable in case other systems (sandboxes?) want to
disable it in the future.
