### PR TITLE
Change replica host var names to namespace them with the roles that use them

### DIFF
--- a/playbooks/roles/ad_hoc_reporting/tasks/main.yml
+++ b/playbooks/roles/ad_hoc_reporting/tasks/main.yml
@@ -61,20 +61,20 @@
       script_name: edxapp-mysql.sh
       depends_on: True
     
-    - db_host: "{{ XQUEUE_MYSQL_REPLICA_HOST }}"
+    - db_host: "{{ AD_HOC_REPORTING_XQUEUE_MYSQL_REPLICA_HOST }}"
       db_name: "{{ XQUEUE_MYSQL_DB_NAME }}"
       script_name: xqueue-mysql.sh
-      depends_on: "{{ XQUEUE_MYSQL_REPLICA_HOST | default(None) }}"
+      depends_on: "{{ AD_HOC_REPORTING_XQUEUE_MYSQL_REPLICA_HOST | default(None) }}"
     
-    - db_host: "{{ ANALYTICS_API_REPORTS_REPLICA_DB_HOST }}"
+    - db_host: "{{ AD_HOC_REPORTING_ANALYTICS_API_REPORTS_REPLICA_DB_HOST }}"
       db_name: "{{ ANALYTICS_API_REPORTS_DB_NAME }}"
       script_name: analytics-mysql.sh
-      depends_on: "{{ ANALYTICS_API_REPORTS_REPLICA_DB_HOST | default(None) }}"
+      depends_on: "{{ AD_HOC_REPORTING_ANALYTICS_API_REPORTS_REPLICA_DB_HOST | default(None) }}"
     
-    - db_host: "{{ ECOMMERCE_REPLICA_DB_HOST }}"
+    - db_host: "{{ AD_HOC_REPORTING_ECOMMERCE_REPLICA_DB_HOST }}"
       db_name: "{{ ECOMMERCE_DEFAULT_DB_NAME }}"
       script_name: ecommerce-mysql.sh
-      depends_on: "{{ ECOMMERCE_REPLICA_DB_HOST | default(None) }}"
+      depends_on: "{{ AD_HOC_REPORTING_ECOMMERCE_REPLICA_DB_HOST | default(None) }}"
   
 # These templates rely on there being a global
 # read_only mongo user, you must override the default


### PR DESCRIPTION
These vars are only used in the ad_hoc_reporting role, but their prefix indicates that they're part of their services' roles. This corrects the prefix.

Relates to https://github.com/edx-ops/edx-secure/pull/492
