### PR TITLE
Stop using the RABBITMQ_CLUSTERED var and tooling.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+- Role: rabbitmq
+  - Removed the RABBITMQ_CLUSTERED var and related tooling. The goal of the var was to be able to setup a cluster in the aws environment without having to know all the IPs of the cluster before hand.  It relied on the `hostvars` ansible varible to work correctly which it no longer does in 1.9.  This may get fixed in the future but for now, the "magic" setup doesn't work.
+  - Changed `rabbitmq_clustered_hosts` to RABBITMQ_CLUSTERED_HOSTS.
+
 - Role: edxapp
   - Removed SUBDOMAIN_BRANDING and SUBDOMAIN_COURSE_LISTINGS variables
 

--- a/playbooks/roles/elasticsearch/templates/edx/etc/elasticsearch/elasticsearch.yml.j2
+++ b/playbooks/roles/elasticsearch/templates/edx/etc/elasticsearch/elasticsearch.yml.j2
@@ -33,7 +33,7 @@ script.disable_dynamic: true
 #    to perform discovery when new nodes (master or data) are started:
 #
 # discovery.zen.ping.unicast.hosts: ["host1", "host2:port", "host3[portX-portY]"]
-{%- if ELASTICSEARCH_CLUSTER_MEMBERS|length > 1 -%}
+{% if ELASTICSEARCH_CLUSTER_MEMBERS|length > 1 -%}
 
 discovery.zen.ping.unicast.hosts: ['{{ELASTICSEARCH_CLUSTER_MEMBERS|join("\',\'") }}']
 

--- a/playbooks/roles/rabbitmq/defaults/main.yml
+++ b/playbooks/roles/rabbitmq/defaults/main.yml
@@ -19,10 +19,10 @@ RABBIT_USERS:
   - name: 'celery'
     password: 'celery'
 
-RABBITMQ_CLUSTERED: !!null
-
 RABBITMQ_VHOSTS:
   - '/'
+
+RABBITMQ_CLUSTERED_HOSTS: []
 
 # Internal role variables below this line
 
@@ -55,8 +55,6 @@ rabbitmq_ip: "{{ ansible_default_ipv4.address }}"
 rabbitmq_auth_config:
   erlang_cookie: "{{ RABBIT_ERLANG_COOKIE }}"
   admins: "{{ RABBIT_USERS }}"
-
-rabbitmq_clustered_hosts: []
 
 rabbitmq_plugins:
   - rabbitmq_management

--- a/playbooks/roles/rabbitmq/templates/etc/rabbitmq/rabbitmq.config.j2
+++ b/playbooks/roles/rabbitmq/templates/etc/rabbitmq/rabbitmq.config.j2
@@ -2,7 +2,7 @@
 
 [{rabbit, [
   {log_levels, [{connection, info}]},
-{# If RABBITMQ_CLUSTERED_HOSTS is set, use that instead assuming an aws stack.
+{# 
    Note: That these names should include the node name prefix. eg. 'rabbit@hostname'
 #}
   {cluster_nodes, {['{{ RABBITMQ_CLUSTERED_HOSTS|join("\',\'") }}'], disc}}

--- a/playbooks/roles/rabbitmq/templates/etc/rabbitmq/rabbitmq.config.j2
+++ b/playbooks/roles/rabbitmq/templates/etc/rabbitmq/rabbitmq.config.j2
@@ -2,19 +2,8 @@
 
 [{rabbit, [
   {log_levels, [{connection, info}]},
-{% if RABBITMQ_CLUSTERED -%}
-  {%- set hosts= [] -%}
-
-  {%- for host in hostvars.keys() -%}
-    {% do hosts.append("rabbit@ip-" + host.replace('.','-')) %}
-  {%- endfor %}
-
-  {cluster_nodes, {['{{ hosts|join("\',\'") }}'], disc}}
-
-{%- else -%}
-{# If rabbitmq_clustered_hosts is set, use that instead assuming an aws stack.
+{# If RABBITMQ_CLUSTERED_HOSTS is set, use that instead assuming an aws stack.
    Note: That these names should include the node name prefix. eg. 'rabbit@hostname'
 #}
-  {cluster_nodes, {['{{ rabbitmq_clustered_hosts|join("\',\'") }}'], disc}}
-{%- endif %}
+  {cluster_nodes, {['{{ RABBITMQ_CLUSTERED_HOSTS|join("\',\'") }}'], disc}}
 ]}].

--- a/playbooks/vagrant-cluster.yml
+++ b/playbooks/vagrant-cluster.yml
@@ -28,7 +28,7 @@
   serial: 1
   gather_facts: True
   vars:
-    rabbitmq_clustered_hosts: 
+    RABBITMQ_CLUSTERED_HOSTS: 
       - "rabbit@cluster1"
       - "rabbit@cluster2"
       - "rabbit@cluster3"


### PR DESCRIPTION
This method relied on the `hostvars` variable provided by ansible to always
be all the nodes in the rabbitmq cluster.  The hostvars var broke as a result
of the upgrade to ansible 1.9 but also even if it did work, this method
required that you always run rabbit plays on the whole cluster.  This is not
reasonable as it makes it very hard to heal a single node that may have fallen
over.

From here on, the RABBITMQ_CLUSTERED_HOSTS var should be used instead to
specify the rabbit hosts that are part of a cluster.

@edx/devops 
