### PR TITLE
Apply mirrored queue policy to all rabbitmq vhosts

### DIFF
--- a/playbooks/roles/rabbitmq/tasks/main.yml
+++ b/playbooks/roles/rabbitmq/tasks/main.yml
@@ -132,8 +132,10 @@
     - maintenance
 
 - name: make queues mirrored
-  shell: "/usr/sbin/rabbitmqctl set_policy HA '^(?!amq\\.).*' '{\"ha-mode\": \"all\"}'"
+  shell: >
+    /usr/sbin/rabbitmqctl -p {{ item }} set_policy HA "" '{"ha-mode":"all","ha-sync-mode":"automatic"}'
   when: RABBITMQ_CLUSTERED or rabbitmq_clustered_hosts|length > 1
+  with_items: RABBITMQ_VHOSTS
   tags:
     - ha
     - maintenance


### PR DESCRIPTION
We previously weren't mirroring queues if you only had more than one VHOST, it only applied it to the `/` host.  This now applies mirroring to all defined VHOSTS, simplified the policy, and set sync mode to automatic. Note the screenshot showing all three hosts have each queue from the vagrant cluster:
![image](https://cloud.githubusercontent.com/assets/596029/8239848/70fcab64-15cc-11e5-962d-c89ff9589d49.png)
