### PR TITLE
Add CREDIT_PROVIDER_SECRET_KEYS configuration to edxapp role

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -495,6 +495,13 @@ EDXAPP_EDXNOTES_INTERNAL_API: http://localhost:18120/api/v1
 
 EDXAPP_XBLOCK_SETTINGS: {}
 
+# Secret keys shared with credit providers.
+# Used to digitally sign credit requests (us --> provider)
+# and validate responses (provider --> us).
+# Each key in the dictionary is a credit provider ID, and
+# the value is the 32-character key.
+EDXAPP_CREDIT_PROVIDER_SECRET_KEYS: {}
+
 #-------- Everything below this line is internal to the role ------------
 
 #Use YAML references (& and *) and hash merge <<: to factor out shared settings
@@ -652,6 +659,7 @@ edxapp_generic_auth_config:  &edxapp_generic_auth
   THIRD_PARTY_AUTH: "{{ EDXAPP_THIRD_PARTY_AUTH }}"
   AWS_STORAGE_BUCKET_NAME: "{{ EDXAPP_AWS_STORAGE_BUCKET_NAME }}"
   DJFS: "{{ EDXAPP_DJFS }}"
+  CREDIT_PROVIDER_SECRET_KEYS: "{{ EDXAPP_CREDIT_PROVIDER_SECRET_KEYS }}"
 
 generic_cache_config: &default_generic_cache
   BACKEND:  'django.core.cache.backends.memcached.MemcachedCache'


### PR DESCRIPTION
This exposes a setting to the Ansible scripts that we will need to configure courses for credit.  The original setting is here:

https://github.com/edx/edx-platform/blob/master/lms/envs/common.py#L2531-L2536

@feanil Could you please review this when you have a moment?  This isn't urgent to get in or configure, since we're not launching credit courses until August, but it will make sandbox testing less painful.
