### PR TITLE
Fix 'install python extra requirements' task.

### DIFF
--- a/playbooks/roles/edxapp/tasks/deploy.yml
+++ b/playbooks/roles/edxapp/tasks/deploy.yml
@@ -201,7 +201,7 @@
 - name: install python extra requirements
   pip: >
     name="{{ item.name }}"
-    {% if 'version' in item %}version="{{ item.version }}"{% endif %}
+    version="{{ item.version|default(omit) }}"
     extra_args="--exists-action w --use-mirrors {{ item.extra_args|default('') }}"
     virtualenv="{{ edxapp_venv_dir }}"
     state=present


### PR DESCRIPTION
if/else blocks that emit content that includes the `=` sign are no longer
supported in recent versions of ansible.

Trying to run the task under ansible 1.9 results in this error:

```
 variable inserted a new parameter into the module args.
 Be sure to quote variables if they contain equal signs (for example: "{{var}}").
```

Replace the `{% if %}` block with the new `default(omit)` filter/keyword.

For more info see:
https://groups.google.com/forum/#!msg/ansible-project/W9bG0tAI3aU/GFtrD9Ao9EwJ

_Partner Information_: Harvard, for a third-party Open edX installation
_Jira ticket_: https://openedx.atlassian.net/browse/OSPR-685
