### PR TITLE
Stop celery workers using SIGINT instead of SIGTERM.

### DIFF
--- a/playbooks/roles/edxapp/templates/workers.conf.j2
+++ b/playbooks/roles/edxapp/templates/workers.conf.j2
@@ -11,7 +11,7 @@ command={{ edxapp_venv_dir + '/bin/newrelic-admin run-program ' if w.monitor and
 killasgroup=true
 stopasgroup=true
 stopwaitsecs=432000
-stogsignal=INT
+stopsignal=INT
 
 {% endfor %}
 

--- a/playbooks/roles/edxapp/templates/workers.conf.j2
+++ b/playbooks/roles/edxapp/templates/workers.conf.j2
@@ -11,6 +11,7 @@ command={{ edxapp_venv_dir + '/bin/newrelic-admin run-program ' if w.monitor and
 killasgroup=true
 stopasgroup=true
 stopwaitsecs=432000
+stogsignal=INT
 
 {% endfor %}
 


### PR DESCRIPTION
According to the documentation TERM should do a graceful shutdown:
http://celery.readthedocs.org/en/latest/userguide/workers.html#process-signals

but this is not actually the case:
https://groups.google.com/forum/#!topic/celery-users/t8g5KvIvQZ8

SIGINT on the other hand seems to do what we want.

@edx/devops 
