### PR TITLE
Don't pkill some services.

### DIFF
--- a/playbooks/roles/stop_all_edx_services/handlers/main.yml
+++ b/playbooks/roles/stop_all_edx_services/handlers/main.yml
@@ -42,8 +42,9 @@
 - name: stop mongodb
   service: name=mongodb state=stopped arguments="{{ STOP_ALL_EDX_SERVICES_EXTRA_ARGS }}"
 
+# Celery and Supervisord should not be killed because they may have long running tasks that need to finish
 - name: kill processes by user
-  shell: pkill -u {{ item }} || true
+  shell: pgrep -u {{ item }} -lf | grep -v celery | grep -v supervisord | grep -v gunicorn |  awk '{ print $1}' | xargs -I {} kill {} || true
   with_items:
   - www-data
   - devpi.supervisor


### PR DESCRIPTION
Certain services will shutdown gracefully and so they may not be dead by the
time this task is run.  Those services should not be explicitly killed since
they may need to do things like finish a grading run or other instructor tasks.

@edx/devops If you guys have other suggestions for how to do this let me know.  But this does what I need and prevents workers from getting killed prematurely.
