### PR TITLE
update ec2 plugin version on testeng jenkins

### DIFF
--- a/playbooks/roles/jenkins_master/defaults/main.yml
+++ b/playbooks/roles/jenkins_master/defaults/main.yml
@@ -18,7 +18,7 @@ jenkins_plugins:
     - { name: "copy-to-slave", version: "1.4.3" }
     - { name: "credentials", version: "1.8.3" }
     - { name: "dashboard-view", version: "2.9.1" }
-    - { name: "ec2", version: "1.23" }
+    - { name: "ec2", version: "1.28" }
     - { name: "github", version: "1.8" }
     - { name: "github-api", version: "1.44" }
     - { name: "github-oauth", version: "0.14" }


### PR DESCRIPTION
@benpatterson @jzoldak  Just updated this on the test jenkins.  None of it's dependencies updated, so it's just the ec2 plugin version that changed.
