### PR TITLE
.rbenv is a git repo don't change permissions.

### DIFF
--- a/playbooks/roles/local_dev/tasks/main.yml
+++ b/playbooks/roles/local_dev/tasks/main.yml
@@ -16,12 +16,14 @@
   user: name={{ forum_user }} groups={{ common_web_group }} append=yes
   when: forum_user is defined
 
+# Need this in order for the forum user to install and uninstall
+# gems using 'bundle' or 'gem'.  Can't make it 760 because that
+# would break the bin directory under .gem
 - name: set forum rbenv and gem permissions
   file:
     path={{ item }} state=directory recurse=yes mode=770
   with_items:
     - "{{ forum_app_dir }}/.gem"
-    - "{{ forum_app_dir }}/.rbenv"
   when: forum_user is defined
 
 # Create scripts to configure environment


### PR DESCRIPTION
Permissions were changed widely so that on devstack forum user
can do gem and bundle install of ruby gems.  Modifying the .rbenv
directory is not ncessary to do this and the www-data user has
sufficient permssion to use the rbenv without modifying the rbenv
repo.
