### PR TITLE
Use symbolic mode instead of explicit.

### DIFF
--- a/playbooks/roles/local_dev/tasks/main.yml
+++ b/playbooks/roles/local_dev/tasks/main.yml
@@ -21,7 +21,7 @@
 # would break the bin directory under .gem
 - name: set forum rbenv and gem permissions
   file:
-    path={{ item }} state=directory recurse=yes mode=770
+    path={{ item }} state=directory recurse=yes mode="g+rw"
   with_items:
     - "{{ forum_app_dir }}/.gem"
   when: forum_user is defined


### PR DESCRIPTION
Since we don't want to break other permissions we just want to give
the group write permission.

@jibsheet 
