### PR TITLE
Update migration script for Cypress

### DIFF
--- a/playbooks/vagrant-fullstack.yml
+++ b/playbooks/vagrant-fullstack.yml
@@ -29,8 +29,8 @@
       - cms
     - edxlocal
     - mongo
-    - { role: 'edxapp', celery_worker: True }
     - edxapp
+    - { role: 'edxapp', celery_worker: True }
     - demo
     - { role: 'rabbitmq', rabbitmq_ip: '127.0.0.1' }
     - oraclejdk

--- a/util/vagrant/migrate.sh
+++ b/util/vagrant/migrate.sh
@@ -80,23 +80,10 @@ fi
 if [[ $TARGET == *cypress* && $INTERACTIVE == true ]] ; then
   cat <<"EOM"
           WARNING WARNING WARNING WARNING WARNING
-The Cypress release of Open edX upgraded the version of Celery used
-by the edx-platform workers.  This change was introduced to fix the fact
-that when trying to restart the celery worker, the process hangs while
-trying to shutdown.  This will cause it to block indefinitely. In order
-to prevent this from happening during the upgrade we will pre-emptively
-kill all celery workers on this machine.
+Due to the changes introduced between Birch and Cypress, you may encounter
+some problems in this migration. If so, check this webpage for solutions:
 
-Birch also introduced a change that breaks the newer version of
-ansible when it tries to update the forums rbenv repository. In order
-to fix the issue, uncommited modifications made to the /edx/app/forum/.rbenv
-repo will be reverted.
-
-Note: that this script assumes the standard location for all tools
-installed by edx-ansible (under the '/edx') directory if this is
-not the case for you please re-run this script after setting the
-'OPENEDX_ROOT' environment variable to your equivalent of '/edx'
-and re-running this script.
+https://openedx.atlassian.net/wiki/display/OpenOPS/Potential+Problems+Migrating+from+Birch+to+Cypress
 
 Do you wish to proceed?
 EOM

--- a/util/vagrant/migrate.sh
+++ b/util/vagrant/migrate.sh
@@ -16,8 +16,9 @@ Attempts to migrate your Open edX installation to a different release.
     Migrate to the given git ref. Defaults to \"$TARGET\"
 -y
     Run in non-interactive mode (reply \"yes\" to all questions)
--r EDX_ROOT
-    The root directory under which all edx applications are installed.
+-r OPENEDX_ROOT
+    The root directory under which all Open edX applications are installed.
+    Defaults to \"$OPENEDX_ROOT\"
 -h
     Show this help and exit.
 EOM
@@ -120,7 +121,7 @@ EOM
 fi
 
 if [ -f /edx/app/edx_ansible/server-vars.yml ]; then
-  SERVER_VARS="--extra-vars=\"@/edx/app/edx_ansible/server-vars.yml\""
+  SERVER_VARS="--extra-vars=\"@${OPENEDX_ROOT}/app/edx_ansible/server-vars.yml\""
 fi
 
 TEMPDIR=`mktemp -d`

--- a/util/vagrant/migrate.sh
+++ b/util/vagrant/migrate.sh
@@ -106,13 +106,14 @@ EOM
   else
     echo "Killing all celery worker processes."
     sudo ${OPENEDX_ROOT}/bin/supervisorctl stop edxapp_worker:* &
+    sleep 3
     # Supervisor restarts the process a couple of times so we have to kill it multiple times.
     sudo pgrep -lf celery | grep worker | awk '{ print $1}' | sudo xargs -I {} kill -9 {}
-    sleep 2
+    sleep 3
     sudo pgrep -lf celery | grep worker | awk '{ print $1}' | sudo xargs -I {} kill -9 {}
-    sleep 2
+    sleep 3
     sudo pgrep -lf celery | grep worker | awk '{ print $1}' | sudo xargs -I {} kill -9 {}
-    sleep 2
+    sleep 3
     sudo pgrep -lf celery | grep worker | awk '{ print $1}' | sudo xargs -I {} kill -9 {}
     sudo -u forum git -C ${OPENEDX_ROOT}/app/forum/.rbenv reset --hard
   fi

--- a/util/vagrant/migrate.sh
+++ b/util/vagrant/migrate.sh
@@ -2,7 +2,7 @@
 
 # defaults
 CONFIGURATION="fullstack"
-TARGET="named-release/birch"
+TARGET="named-release/cypress.rc"
 INTERACTIVE=true
 
 read -d '' HELP_TEXT <<- EOM

--- a/util/vagrant/migrate.sh
+++ b/util/vagrant/migrate.sh
@@ -78,13 +78,16 @@ TEMPDIR=`mktemp -d`
 chmod 777 $TEMPDIR
 cd $TEMPDIR
 git clone https://github.com/edx/configuration.git --depth=1 --single-branch --branch=$TARGET
+virtualenv venv
+source venv/bin/activate
+pip install -r configuration/requirements.txt
 echo "edx_platform_version: $TARGET" >> vars.yml
 echo "ora2_version: $TARGET" >> vars.yml
 echo "certs_version: $TARGET" >> vars.yml
 echo "forum_version: $TARGET" >> vars.yml
 echo "xqueue_version: $TARGET" >> vars.yml
 cd configuration/playbooks
-sudo /edx/app/edx_ansible/venvs/edx_ansible/bin/ansible-playbook \
+sudo ansible-playbook \
     --inventory-file=localhost, \
     --connection=local \
     --extra-vars=\"@../../vars.yml\" \


### PR DESCRIPTION
Ansible was upgraded between Birch and Cypress, so the migration script can no longer use the already-installed version of Ansible -- we need to create a new virtualenv, instead.
