### PR TITLE
Don't validate certs from S3.

### DIFF
--- a/playbooks/roles/browsers/tasks/main.yml
+++ b/playbooks/roles/browsers/tasks/main.yml
@@ -6,7 +6,7 @@
        state=present update_cache=yes
 
 - name: download browser debian packages from S3
-  get_url: dest="/tmp/{{ item.name }}" url="{{ item.url }}"
+  get_url: dest="/tmp/{{ item.name }}" url="{{ item.url }}" validate_certs=no
   register: download_deb
   with_items: browser_s3_deb_pkgs
 
@@ -19,6 +19,7 @@
   get_url:
     url={{ chromedriver_url }}
     dest=/var/tmp/chromedriver_{{ chromedriver_version }}.zip
+    validate_certs=no
 
 - name: Install ChromeDriver 2
   shell: unzip /var/tmp/chromedriver_{{ chromedriver_version }}.zip


### PR DESCRIPTION
Ansible 1.5.5 doesn't support validating certs if SSL v3 is not supported.

@singingwolfboy is this the correct branch to PR this change into?
