### PR TITLE
Create ecommerce MySQL user with the correct name

### DIFF
--- a/playbooks/roles/edxlocal/tasks/main.yml
+++ b/playbooks/roles/edxlocal/tasks/main.yml
@@ -111,7 +111,7 @@
 
 - name: setup users for ecommerce
   mysql_user: >
-    name="{{ ECOMMERCE_DEFAULT_DB_NAME }}"
+    name="{{ ECOMMERCE_DATABASES.default.USER }}"
     password="{{ ECOMMERCE_DATABASES.default.PASSWORD }}"
     priv='{{ ECOMMERCE_DEFAULT_DB_NAME }}.*:SELECT,INSERT,UPDATE,DELETE'
   when: ECOMMERCE_DEFAULT_DB_NAME is defined


### PR DESCRIPTION
Formerly, the database user was set up with username `ecommerce`, not the the user configured for the default ecommerce database, `ecomm001`.

@feanil 
