### PR TITLE
Change when we tag instances.

### DIFF
--- a/playbooks/roles/edx_service/tasks/main.yml
+++ b/playbooks/roles/edx_service/tasks/main.yml
@@ -161,7 +161,7 @@
     tags:
       - Name: version:{{edx_service_name}}
         Value: "{{ item.0.DOMAIN }}/{{ item.0.PATH }}/{{ item.0.REPO }} {{ item.1.after |truncate(7,True,'') }}"
-  when: item.1.after is defined and ansible_ec2_instance_id is defined and edx_service_repos is defined
+  when: item.1.after is defined and COMMON_TAG_EC2_INSTANCE and edx_service_repos is defined
   with_together: 
     - edx_service_repos
     - code_checkout.results


### PR DESCRIPTION
In all other roles, tagging is not done implicitly on EC2 instances, it is done when the tagging flag is set to true.  The service role should follow the same pattern.

This caused a problem on an open source deployment here: https://groups.google.com/forum/#!msg/openedx-ops/GTaZi6tAVOM/CCF_OSpxbsEJ
