### PR TITLE
Allow configuring third party auth backends

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -119,8 +119,10 @@ EDXAPP_CAS_ATTRIBUTE_PACKAGE: ""
 # Enable an end-point that creates a user and logs them in
 # Used for performance testing
 EDXAPP_ENABLE_AUTO_AUTH: false
+
 # Settings for enabling and configuring third party authorization
 EDXAPP_ENABLE_THIRD_PARTY_AUTH: false
+EDXAPP_THIRD_PARTY_AUTH_BACKENDS: !!null
 
 EDXAPP_ENABLE_EDXNOTES: false
 
@@ -803,6 +805,7 @@ generic_env_config:  &edxapp_generic_env
   REGISTRATION_EXTRA_FIELDS: "{{ EDXAPP_REGISTRATION_EXTRA_FIELDS }}"
   XBLOCK_SETTINGS: "{{ EDXAPP_XBLOCK_SETTINGS }}"
   EDXMKTG_USER_INFO_COOKIE_NAME: "{{ EDXAPP_EDXMKTG_USER_INFO_COOKIE_NAME }}"
+  THIRD_PARTY_AUTH_BACKENDS: "{{ EDXAPP_THIRD_PARTY_AUTH_BACKENDS }}"
 
 lms_auth_config:
   <<: *edxapp_generic_auth


### PR DESCRIPTION
Those are already used in [`aws.py`](https://github.com/edx/edx-platform/blob/35503ebda2ef0a34a9c53379e45e5f2b1c24d186/lms/envs/aws.py#L550) in edx-platform.
