### PR TITLE
Clean rebuild of a sandbox base image without distribute

### DIFF
--- a/util/jenkins/ansible-provision.sh
+++ b/util/jenkins/ansible-provision.sh
@@ -99,7 +99,7 @@ fi
 
 if [[ -z $ami ]]; then
   if [[ $server_type == "full_edx_installation" ]]; then
-    ami="ami-bdea3bd6"
+    ami="ami-ef862184"
   elif [[ $server_type == "ubuntu_12.04" || $server_type == "full_edx_installation_from_scratch" ]]; then
     ami="ami-93fb34f8"
   elif [[ $server_type == "ubuntu_14.04(experimental)" ]]; then


### PR DESCRIPTION
Without this, sandbox builds fail when edx-platform updates because the
virtualenv contains distribute and we try to install setuptools.
