### PR TITLE
Update the course ID to match the split course_id

### DIFF
--- a/playbooks/roles/demo/defaults/main.yml
+++ b/playbooks/roles/demo/defaults/main.yml
@@ -16,7 +16,7 @@ DEMO_CREATE_STAFF_USER: true
 demo_app_dir: "{{ COMMON_APP_DIR }}/demo"
 demo_code_dir: "{{ demo_app_dir }}/edx-demo-course"
 demo_repo: "https://{{ COMMON_GIT_MIRROR }}/edx/edx-demo-course.git"
-demo_course_id: 'edX/DemoX/Demo_Course'
+demo_course_id: 'course-v1:edX+DemoX+Demo_Course'
 demo_version: "master"
 demo_test_users:
   - email: 'honor@example.com'


### PR DESCRIPTION
We updated code elsewhere so that by default courses that are
imported are imported into the split modules store but that also
changes the course_id of this course and breaks the enrolling of
test students into the demo course.  This change should resolve
the issue.

@edx/devops 

FYI: @chrisndodge 
