### PR TITLE
Removing xqwatcher as there's no opensource course exemplar

### DIFF
--- a/playbooks/edx_sandbox.yml
+++ b/playbooks/edx_sandbox.yml
@@ -45,7 +45,6 @@
     - forum
     - { role: notifier, NOTIFIER_DIGEST_TASK_INTERVAL: "5" }
     - { role: "xqueue", update_users: True }
-    - xqwatcher
     - role: ora
       when: ENABLE_LEGACY_ORA
     - certs


### PR DESCRIPTION
@singingwolfboy @sarina @jbarciauskas 

OK, looking back at this, I think that removing xqwatcher is the right thing to do.  The issue is that we still don't have an open course that can be included with the xqwatcher.  I think that we could create one from prior-art without much difficulty.  But, for now, we should remove the watcher from full stack.
