### PR TITLE
Added a dummy date in the date_joined

### DIFF
--- a/util/vpc-tools/sanitize-db-wwc.sql
+++ b/util/vpc-tools/sanitize-db-wwc.sql
@@ -24,7 +24,7 @@ UPDATE auth_user
         first_name = concat('user-',cast(id AS CHAR)),
         last_name = concat('user-',cast(id AS CHAR)),
         last_login = null,
-        date_joined = null
+        date_joined = "2010-01-01 00:00:00"
             where email not like ('%@edx.org');
 
 /*

--- a/util/vpc-tools/sanitize-db-wwc.sql
+++ b/util/vpc-tools/sanitize-db-wwc.sql
@@ -24,7 +24,7 @@ UPDATE auth_user
         first_name = concat('user-',cast(id AS CHAR)),
         last_name = concat('user-',cast(id AS CHAR)),
         last_login = null,
-        date_joined = "2010-01-01 00:00:00"
+        date_joined = "1970-01-01 00:00:00"
             where email not like ('%@edx.org');
 
 /*


### PR DESCRIPTION
It was causing 500 internal server errors because after
sanitization it would be set to null but a valid value would be
needed for a couple of actions on the website, like assigning
students to programs and assigning students to courses.
