### PR TITLE
Rotate mongo logs

### DIFF
--- a/playbooks/roles/mongo_3_0/defaults/main.yml
+++ b/playbooks/roles/mongo_3_0/defaults/main.yml
@@ -1,4 +1,8 @@
 mongo_logappend: true
+
+#This way, when mongod receives a SIGUSR1, it'll close and reopen its log file handle
+mongo_logrotate: reopen
+
 mongo_version: 3.0.4
 mongo_port: "27017"
 mongo_extra_conf: ''

--- a/playbooks/roles/mongo_3_0/tasks/main.yml
+++ b/playbooks/roles/mongo_3_0/tasks/main.yml
@@ -94,6 +94,9 @@
   template: src=mongodb-standalone.conf.j2 dest=/etc/mongod.conf backup=yes
   notify: restart mongo
 
+- name: install logrotate configuration
+  template: src=mongo_logrotate.j2 dest=/etc/logrotate.d/hourly/mongo
+
 - name: start mongo service
   service: name=mongod state=started
 

--- a/playbooks/roles/mongo_3_0/templates/mongo_logrotate.j2
+++ b/playbooks/roles/mongo_3_0/templates/mongo_logrotate.j2
@@ -1,0 +1,16 @@
+{{ mongo_log_dir }}/* {
+  create
+  compress
+  copytruncate
+  delaycompress
+  dateext
+  dateformat -%Y%m%d-%s
+  missingok
+  notifempty
+  daily
+  rotate 90
+  size 1M
+  postrotate
+    /usr/bin/killall -USR1 mongod
+  endscript
+}

--- a/playbooks/roles/mongo_3_0/templates/mongodb-standalone.conf.j2
+++ b/playbooks/roles/mongo_3_0/templates/mongodb-standalone.conf.j2
@@ -24,6 +24,7 @@ systemLog:
 {% else %}
   logAppend: false
 {% endif %}
+  logRotate: {{ mongo_logrotate }}
 
 net:
 {% if MONGO_CLUSTERED is not defined %}


### PR DESCRIPTION
Explanation: if mongo is set with systemLog.logRotate='reopen', when it
receives a SIGURS1, it'll close and reopen its log file handle.
