### PR TITLE
Installation Script: Fix configuration version bug and update to make use of the latest pip's cache feature

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -45,3 +45,4 @@ Jonathan Peter <jonathan.peter@blue-planet-life.org>
 Kevin Falcone <kevin@edx.org>
 Max Rothman <max@edx.org>
 Andy Armstrong <andya@edx.org>
+Xiang Junfu <xiangjf.fnst@cn.fujitsu.com>

--- a/util/install/sandbox.sh
+++ b/util/install/sandbox.sh
@@ -27,7 +27,7 @@ sudo apt-get upgrade -y
 ##
 sudo apt-get install -y build-essential software-properties-common python-software-properties curl git-core libxml2-dev libxslt1-dev python-pip python-apt python-dev
 sudo pip install --upgrade pip
-sudo pip install --upgrade virtualenv
+sudo -H pip install --upgrade virtualenv
 
 ## Did we specify an openedx release?
 if [ -n "$OPENEDX_RELEASE" ]; then
@@ -54,7 +54,7 @@ git checkout $CONFIG_VER
 ## Install the ansible requirements
 ##
 cd /var/tmp/configuration
-sudo pip install -r requirements.txt
+sudo -H pip install -r requirements.txt
 
 ##
 ## Run the edx_sandbox.yml playbook in the configuration/playbooks directory

--- a/util/install/sandbox.sh
+++ b/util/install/sandbox.sh
@@ -35,6 +35,7 @@ if [ -n "$OPENEDX_RELEASE" ]; then
     -e certs_version=$OPENEDX_RELEASE \
     -e forum_version=$OPENEDX_RELEASE \
     -e xqueue_version=$OPENEDX_RELEASE \
+    -e configuration_version=$OPENEDX_RELEASE \
   "
   CONFIG_VER=$OPENEDX_RELEASE
 else


### PR DESCRIPTION
**Background**: This PR consists of two commits.
The **first** one fixes the bug that the configuration_version is not set in the EXTRA_VARS viable when OPENEDX_RELEASE is set. Without the configuration_version been set, the edx_ansible role wil checkout the 'release' branch of the configuration repo, which will be used when people update edx repos using /edx/bin/update, then some error will be raised because people install edx with the OPENEDX_RELEASE version but update edx with the 'release' version of configuration.
The **second** one enhance the script to make use of the latest pip's cache feature. After upgrading pip to the latest version, cache feature will be turn on automatically, all the packages downloaded will be cached, without -H option been set, the feature will be disabled because pip is execute with sudo but the $HOME environment is still set to the current user's home path.
