### PR TITLE
Increase minimum vagrant version to 1.6.5

### DIFF
--- a/vagrant/release/devstack/Vagrantfile
+++ b/vagrant/release/devstack/Vagrantfile
@@ -1,4 +1,4 @@
-Vagrant.require_version ">= 1.5.3"
+Vagrant.require_version ">= 1.6.5"
 unless Vagrant.has_plugin?("vagrant-vbguest")
   raise "Please install the vagrant-vbguest plugin by running `vagrant plugin install vagrant-vbguest`"
 end


### PR DESCRIPTION
The wiki page [here](https://github.com/edx/configuration/wiki/edX-Developer-Stack#installing-the-edx-developer-stack) says that the minimum Vagrant version is 1.6.5, not 1.5.3.
