### PR TITLE
OPS-976: Remove serial option from mongo play

### DIFF
--- a/playbooks/edx-east/mongo.yml
+++ b/playbooks/edx-east/mongo.yml
@@ -2,9 +2,6 @@
   hosts: all
   sudo: True
   gather_facts: True
-  vars:
-    serial_count: 1
-  serial: "{{ serial_count }}"
   roles:
     - mongo
     - role: datadog


### PR DESCRIPTION
The mongo play doesn't work when run serially. It's run non-serially in
other places (vagrant-cluster.yml, for example). The serial option seems
to have been added mistakenly in 2632cb8 (#1522) and not tested.

@edx/devops 
FYI @carsongee 
