### PR TITLE
Feanil/update sandbox workers

### DIFF
--- a/playbooks/roles/edx_ansible/templates/update.j2
+++ b/playbooks/roles/edx_ansible/templates/update.j2
@@ -12,7 +12,7 @@ IFS=","
             -v        add verbosity to edx_ansible run
             -h        this
 
-    <repo> - must be one of edx-platform, xqueue, cs_comments_service, xserver, ease, edx-ora, configuration, read-only-certificate-code, edx-analytics-data-api
+    <repo> - must be one of edx-platform, edx-workers, xqueue, cs_comments_service, xserver, ease, edx-ora, configuration, read-only-certificate-code, edx-analytics-data-api
     <version> - can be a commit or tag
 
 EO

--- a/playbooks/roles/edx_ansible/templates/update.j2
+++ b/playbooks/roles/edx_ansible/templates/update.j2
@@ -46,6 +46,7 @@ declare -A repos_to_cmd
 edx_ansible_cmd="{{ edx_ansible_venv_bin }}/ansible-playbook -i localhost, -c local $extra_args"
 
 repos_to_cmd["edx-platform"]="$edx_ansible_cmd edxapp.yml -e 'edx_platform_version=$2'"
+repos_to_cmd["edx-workers"]="$edx_ansible_cmd edxapp.yml -e 'edx_platform_version=$2' -e 'celery_worker=true'"
 repos_to_cmd["xqueue"]="$edx_ansible_cmd xqueue.yml -e 'xqueue_version=$2' -e 'elb_pre_post=false'"
 repos_to_cmd["cs_comments_service"]="$edx_ansible_cmd forum.yml -e 'forum_version=$2'"
 repos_to_cmd["xserver"]="$edx_ansible_cmd xserver.yml -e 'xserver_version=$2'"


### PR DESCRIPTION
Before this change, you couldn't actually update workers because their config never got updated and they never got restarted when you updated the edx-platform.  This will allow us to quickly update the workers.  We can't do this as part of the edxapp.yml play because that is used in multiple places.

@edx/devops @jibsheet 
