### PR TITLE
Whitelist the lti_provider endpoint

### DIFF
--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
@@ -149,6 +149,11 @@ error_page {{ k }} {{ v }};
     try_files $uri @proxy_to_lms_app;
   }
 
+  # No basic auth on the LTI provider endpoint, it does OAuth1
+  location /lti_provider {
+    try_files $uri @proxy_to_lms_app;
+  }
+
   location /courses {
     {%- if EDXAPP_ENABLE_RATE_LIMITING -%}
     # Set Limit


### PR DESCRIPTION
This uses OAuth1 and configured tokens and shouldn't use basic auth.

@edx/devops
