### PR TITLE
Rerun local_dev whenever /edx/bin/update is run on devstack

### DIFF
--- a/playbooks/local_dev.yml
+++ b/playbooks/local_dev.yml
@@ -1,0 +1,14 @@
+- name: Setup local development conveniences
+  hosts: all
+  sudo: True
+  gather_facts: True
+  vars:
+    edxapp_user: edxapp
+    forum_user: forum
+    ora_user: ora
+    notifier_user: notifier
+    ecommerce_user: ecommerce
+    analytics_api_user: analytics_api
+    insights_user: insights
+  roles:
+    - local_dev

--- a/playbooks/roles/edx_ansible/templates/update.j2
+++ b/playbooks/roles/edx_ansible/templates/update.j2
@@ -73,3 +73,12 @@ fi
 
 cd {{ edx_ansible_code_dir }}/playbooks/edx-east
 eval "sudo ${repos_to_cmd["$1"]} $verbose"
+
+{% if devstack %}
+if [ $? -eq 0 ]; then
+    cd {{ edx_ansible_code_dir }}/playbooks
+    echo
+    echo "Running local development configuration"
+    sudo {{ edx_ansible_venv_bin }}/ansible-playbook -i localhost, -c local local_dev.yml
+fi
+{% endif %}


### PR DESCRIPTION
Most of the plays that are run from the update command interfere with the conveniences that are setup by local_dev at the time of provisioning. E.g. the shell of the user for the app which is updated is reset to `/bin/false`.
