### PR TITLE
Run update commands with devstack=true on devstacks

### DIFF
--- a/playbooks/roles/edx_ansible/templates/update.j2
+++ b/playbooks/roles/edx_ansible/templates/update.j2
@@ -39,7 +39,7 @@ if [[ -f {{ edx_ansible_var_file }} ]]; then
 fi
 
 {% if devstack %}
-extra_args="$extra_args -e 'disable_edx_services=true'"
+extra_args="$extra_args -e 'disable_edx_services=true' -e devstack=true"
 {% endif %}
 
 declare -A repos_to_cmd


### PR DESCRIPTION
This fixes another issue with running /edx/bin/update on devstacks. Some plays use the devstack flag - if it's not there, running the django test server as the edxapp user results in any code sandbox problems failing after updating edx-platform, for instance: https://github.com/edx/configuration/blob/master/playbooks/roles/edxapp/templates/95-sandbox-sudoer.j2#L1-L5
