### PR TITLE
Allow adding in of storage specific configuration

### DIFF
--- a/playbooks/roles/mongo_3_0/defaults/main.yml
+++ b/playbooks/roles/mongo_3_0/defaults/main.yml
@@ -48,6 +48,10 @@ MONGO_BIND_IP: 127.0.0.1
 MONGO_STORAGE_ENGINE: "mmapv1"
 ##
 
+# WiredTiger takes a number of optional configuration settings
+# which can be defined as a yaml structure in your secure configuration.
+MONGO_STORAGE_ENGINE_OPTIONS: !!null
+
 mongo_logpath: "{{ mongo_log_dir }}/mongodb.log"
 mongo_dbpath: "{{ mongo_data_dir }}/mongodb"
 

--- a/playbooks/roles/mongo_3_0/templates/mongodb-clustered.conf.j2
+++ b/playbooks/roles/mongo_3_0/templates/mongodb-clustered.conf.j2
@@ -14,6 +14,9 @@ storage:
 {% else %}
     enabled: false
 {% endif %}
+{% if MONGO_STORAGE_ENGINE_OPTIONS %}
+  {{ MONGO_STORAGE_ENGINE_OPTIONS | to_nice_yaml }}
+{% endif %}
 
 systemLog:
   #where to log

--- a/playbooks/roles/mongo_3_0/templates/mongodb-standalone.conf.j2
+++ b/playbooks/roles/mongo_3_0/templates/mongodb-standalone.conf.j2
@@ -14,6 +14,9 @@ storage:
 {% else %}
     enabled: false
 {% endif %}
+{% if MONGO_STORAGE_ENGINE_OPTIONS %}
+  {{ MONGO_STORAGE_ENGINE_OPTIONS | to_nice_yaml }}
+{% endif %}
 
 systemLog:
   #where to log


### PR DESCRIPTION
This can be used to configure wiredTiger's memory usage away from "half
of the RAM on the box".

@edx/devops
