### PR TITLE
Without this, users with a password of "pass word" fail

### DIFF
--- a/playbooks/roles/mongo_3_0/tasks/main.yml
+++ b/playbooks/roles/mongo_3_0/tasks/main.yml
@@ -157,7 +157,7 @@
     login_user={{ MONGO_ADMIN_USER }}
     login_password={{ MONGO_ADMIN_PASSWORD }}
     name={{ item.user }}
-    password={{ item.password }}
+    password="{{ item.password }}"
     roles={{ item.roles }}
     state=present
   with_items: MONGO_USERS
@@ -169,7 +169,7 @@
     login_user={{ MONGO_ADMIN_USER }}
     login_password={{ MONGO_ADMIN_PASSWORD }}
     name={{ item.user }}
-    password={{ item.password }}
+    password="{{ item.password }}"
     roles={{ item.roles }}
     state=present
     replica_set={{ mongo_repl_set }}


### PR DESCRIPTION
It turns it into key/value arguments to the ansible module, causing
hilarious failures.
