### PR TITLE
Create nodeenv using prebuilt package

### DIFF
--- a/playbooks/roles/ecommerce/tasks/main.yml
+++ b/playbooks/roles/ecommerce/tasks/main.yml
@@ -38,7 +38,7 @@
 - name: create nodeenv
   shell: >
     creates={{ ecommerce_nodeenv_dir }}
-    {{ ecommerce_home }}/venvs/{{ ecommerce_service_name }}/bin/nodeenv {{ ecommerce_nodeenv_dir }}
+    {{ ecommerce_home }}/venvs/{{ ecommerce_service_name }}/bin/nodeenv {{ ecommerce_nodeenv_dir }} --prebuilt
   sudo_user: "{{ ecommerce_user }}"
 
 - name: install node dependencies

--- a/playbooks/roles/insights/tasks/main.yml
+++ b/playbooks/roles/insights/tasks/main.yml
@@ -40,7 +40,7 @@
 - name: create nodeenv
   shell: >
     creates={{ insights_nodeenv_dir }}
-    {{ insights_home }}/venvs/{{ insights_service_name }}/bin/nodeenv {{ insights_nodeenv_dir }}
+    {{ insights_home }}/venvs/{{ insights_service_name }}/bin/nodeenv {{ insights_nodeenv_dir }}  --prebuilt
   sudo_user: "{{ insights_user }}"
 
 - name: install node dependencies


### PR DESCRIPTION
Using a prebuilt node package decreases the time to create a nodeenv from minutes to a couple seconds.

ECOM-2185

@feanil 

FYI @rlucioni @jimabramson @dsjen @mulby 
