### PR TITLE
On vagrant curl is not available by default.

### DIFF
--- a/playbooks/roles/user/defaults/main.yml
+++ b/playbooks/roles/user/defaults/main.yml
@@ -35,4 +35,6 @@ user_rbash_links:
 # will take precedence over the paramter
 user_info: []
 
-
+user_debian_pkgs:
+  # Need this to get keys.
+  - curl

--- a/playbooks/roles/user/tasks/main.yml
+++ b/playbooks/roles/user/tasks/main.yml
@@ -74,6 +74,15 @@
 - name: create the edxadmin group
   group: name=edxadmin state=present
 
+- name: Install role-independent useful system packages
+  # do this before log dir setup; rsyslog package guarantees syslog user present
+  apt:
+    pkg: "{{ item }}"
+    install_recommends: yes
+    state: present
+    update_cache: yes
+  with_items: user_debian_pkgs
+
 # some AMIs (such as EMR master nodes) don't read the config files out of /etc/sudoers.d by default
 - name: ensure sudoers.d is read
   lineinfile: >


### PR DESCRIPTION
This breaks running the user role on a fresh vagrant box where common has not already been run. This
change should fix that.

@edx/devops 
