### PR TITLE
Wire in the SESSION_SAVE_EVERY_REQUEST django setting for profiling

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -539,6 +539,10 @@ EDXAPP_COMP_THEME_DIR: ""
 EDXAPP_SOCIAL_AUTH_SAML_SP_PRIVATE_KEY: ''
 EDXAPP_SOCIAL_AUTH_SAML_SP_PUBLIC_CERT: ''
 
+# Session cookie setting
+# Only set this to true for client side profiling, never for production
+EDXAPP_SESSION_SAVE_EVERY_REQUEST: false
+
 #-------- Everything below this line is internal to the role ------------
 
 #Use YAML references (& and *) and hash merge <<: to factor out shared settings
@@ -838,6 +842,7 @@ generic_env_config:  &edxapp_generic_env
   XBLOCK_SETTINGS: "{{ EDXAPP_XBLOCK_SETTINGS }}"
   EDXMKTG_USER_INFO_COOKIE_NAME: "{{ EDXAPP_EDXMKTG_USER_INFO_COOKIE_NAME }}"
   COMP_THEME_DIR: "{{ EDXAPP_COMP_THEME_DIR }}"
+  SESSION_SAVE_EVERY_REQUEST: "{{ EDXAPP_SESSION_SAVE_EVERY_REQUEST }}"
 
 lms_auth_config:
   <<: *edxapp_generic_auth

--- a/util/jenkins/ansible-provision.sh
+++ b/util/jenkins/ansible-provision.sh
@@ -119,6 +119,10 @@ if [[ -z $enable_datadog ]]; then
   enable_datadog="false"
 fi
 
+if [[ -z $enable_client_profiling ]]; then
+  enable_client_profiling="false"
+fi
+
 # Lowercase the dns name to deal with an ansible bug
 dns_name="${dns_name,,}"
 
@@ -171,6 +175,12 @@ else
 COMMON_ENABLE_BASIC_AUTH: False
 EOF_AUTH
 
+fi
+
+if [[ $enable_client_profiling == "true" ]]; then
+    cat << EOF_PROFILING >> $extra_vars_file
+EDXAPP_SESSION_SAVE_EVERY_REQUEST: True
+EOF_PROFILING
 fi
 
 if [[ $edx_internal == "true" ]]; then


### PR DESCRIPTION
@feanil @benpatterson please review.
Also requires platform [PR #9793](https://github.com/edx/edx-platform/pull/9793).
I've already added a new checkbox to the ansible-provision job.

Tested by running the provisioning job with my branches of the edx-platform and configuration branches (these 2 PRs), and then running the get-sitespeed job against the account/settings page to confirm that the django server was running with the SESSION_SAVE_EVERY_REQUEST setting.
