### PR TITLE
Fix various installation failures

### DIFF
--- a/util/install/sandbox.sh
+++ b/util/install/sandbox.sh
@@ -17,6 +17,12 @@ if [[ ! "$(lsb_release -d | cut -f2)" =~ $'Ubuntu 12.04' ]]; then
 fi
 
 ##
+## Set ppa repository source for gcc/g++ 4.8 in order to install insights properly
+##
+sudo apt-get install -y python-software-properties
+sudo add-apt-repository ppa:ubuntu-toolchain-r/test
+
+##
 ## Update and Upgrade apt packages
 ##
 sudo apt-get update -y
@@ -25,9 +31,15 @@ sudo apt-get upgrade -y
 ##
 ## Install system pre-requisites
 ##
-sudo apt-get install -y build-essential software-properties-common python-software-properties curl git-core libxml2-dev libxslt1-dev python-pip python-apt python-dev
+sudo apt-get install -y build-essential software-properties-common python-software-properties curl git-core libxml2-dev libxslt1-dev python-pip python-apt python-dev libxmlsec1-dev libfreetype6-dev swig gcc-4.8 g++-4.8
 sudo pip install --upgrade pip
 sudo -H pip install --upgrade virtualenv
+
+##
+## Update alternatives so that gcc/g++ 4.8 is the default compiler
+##
+sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 50
+sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 50
 
 ## Did we specify an openedx release?
 if [ -n "$OPENEDX_RELEASE" ]; then


### PR DESCRIPTION
1. The libxmlsec1-dev package is missing from the script (but exists on the Wiki page), which causes installation fails on a fresh ubuntu 12.04 machine.
2. G++ 4.8 is required to build v8 engine which is required by nodejs used by edx-insights. But the offical Ubuntu 12.04 only provides gcc 4.6.3, so we should set ppa's tool chain and install gcc/g++ 4.8 before actual installation.
