### PR TITLE
Remove reference to old release branch

### DIFF
--- a/playbooks/roles/edx_ansible/defaults/main.yml
+++ b/playbooks/roles/edx_ansible/defaults/main.yml
@@ -44,5 +44,5 @@ edx_ansible_requirements_files:
   - "{{ edx_ansible_code_dir }}/requirements.txt"
 
 # edX configuration repo
-configuration_version: release
+configuration_version: master
 edx_ansible_var_file: "{{ edx_ansible_app_dir }}/server-vars.yml"


### PR DESCRIPTION
The edx_ansible role was installing the release branch of the config
repo. Release is dead! Long live master!
