### PR TITLE
Remove old custom plugins and code that is needed to build them.

### DIFF
--- a/playbooks/roles/jenkins_master/defaults/main.yml
+++ b/playbooks/roles/jenkins_master/defaults/main.yml
@@ -4,7 +4,7 @@ jenkins_group: "edx"
 jenkins_server_name: "jenkins.testeng.edx.org"
 jenkins_port: 8080
 
-jenkins_version: 1.574
+jenkins_version: "1.630"
 jenkins_deb_url: "http://pkg.jenkins-ci.org/debian/binary/jenkins_{{ jenkins_version }}_all.deb"
 jenkins_deb: "jenkins_{{ jenkins_version }}_all.deb"
 
@@ -49,6 +49,8 @@ jenkins_plugins:
     - { name: "timestamper", version: "1.5.7" }
     - { name: "thinBackup", version: "1.7.4"}
     - { name: "xunit", version: "1.89"}
+    - { name: "git-client", version: "1.19.0"}
+    - { name: "git", version: "2.4.0"}
 
 jenkins_bundled_plugins:
     - "credentials"
@@ -56,18 +58,7 @@ jenkins_bundled_plugins:
     - "ssh-credentials"
     - "ssh-slaves"
 
-jenkins_custom_plugins:
-    - { repo_name: "git-client-plugin",
-        repo_url: "https://github.com/edx/git-client-plugin.git",
-        package: "git-client.hpi",
-        version: "2f7fc4648fe7239918a7babd0515930d40d0a761" }
-    - { repo_name: "git-plugin",
-        repo_url: "https://github.com/edx/git-plugin.git",
-        package: "git.hpi",
-        version: "4dc0c5ce7d38855d0ab0d9cef9cd3325917d748b" }
-
 jenkins_debian_pkgs:
-    - openjdk-7-jdk
     - nginx
     - git
     - maven

--- a/playbooks/roles/jenkins_master/meta/main.yml
+++ b/playbooks/roles/jenkins_master/meta/main.yml
@@ -1,3 +1,4 @@
 ---
 dependencies:
   - common
+  - oraclejdk

--- a/playbooks/roles/jenkins_master/tasks/main.yml
+++ b/playbooks/roles/jenkins_master/tasks/main.yml
@@ -24,10 +24,10 @@
 # https://issues.jenkins-ci.org/browse/JENKINS-20407
 - name: workaround for JENKINS-20407
   file:
-    path="/var/run/jenkins"
-    state=directory
-    owner="{{ jenkins_user }}"
-    group="{{ jenkins_group }}"
+    path: "/var/run/jenkins"
+    state: directory
+    owner: "{{ jenkins_user }}"
+    group: "{{ jenkins_group }}"
   
 - name: download Jenkins package
   get_url: url="{{ jenkins_deb_url }}" dest="/tmp/{{ jenkins_deb }}"
@@ -62,62 +62,36 @@
 
 - name: make plugins directory
   file:
-    path="{{ jenkins_home }}/plugins"
-    state=directory
-    owner="{{ jenkins_user }}"
-    group="{{ jenkins_group }}"
+    path: "{{ jenkins_home }}/plugins"
+    state: directory
+    owner: "{{ jenkins_user }}"
+    group: "{{ jenkins_group }}"
 
 # We first download the plugins to a temp directory and include
 # the version in the file name.  That way, if we increment
 # the version, the plugin will be updated in Jenkins
 - name: download Jenkins plugins
-  get_url: url=http://updates.jenkins-ci.org/download/plugins/{{ item.name }}/{{ item.version }}/{{ item.name }}.hpi
-           dest=/tmp/{{ item.name }}_{{ item.version }}
+  get_url:
+    url: http://updates.jenkins-ci.org/download/plugins/{{ item.name }}/{{ item.version }}/{{ item.name }}.hpi
+    dest: /tmp/{{ item.name }}_{{ item.version }}
   with_items: jenkins_plugins
   register: jenkins_plugin_downloads
 
 - name: install Jenkins plugins
-  command: cp {{ item.dest }} {{ jenkins_home }}/plugins/{{ item.item.name }}.hpi
+  command: "cp {{ item.dest }} {{ jenkins_home }}/plugins/{{ item.item.name }}.hpi"
   with_items: jenkins_plugin_downloads.results
   when: item.changed
 
 - name: set Jenkins plugin permissions
-  file: path={{ jenkins_home }}/plugins/{{ item.item.name }}.hpi
-        owner={{ jenkins_user }} group={{ jenkins_group }} mode=700
+  file:
+    path: "{{ jenkins_home }}/plugins/{{ item.item.name }}.hpi"
+    owner: "{{ jenkins_user }}"
+    group: "{{ jenkins_group }}"
+    mode: 700
   with_items: jenkins_plugin_downloads.results
   when: item.changed
   notify:
     - restart Jenkins
-
-# We had to fork some plugins to workaround
-# certain issues.  If these changes get merged
-# upstream, we may be able to use the regular plugin install process.
-# Until then, we compile and install the forks ourselves.
-- name: checkout custom plugin repo
-  git: >
-    repo={{ item.repo_url }} dest=/tmp/{{ item.repo_name }} version={{ item.version }}
-    accept_hostkey=yes
-  with_items: jenkins_custom_plugins
-  register: jenkins_custom_plugins_checkout
-
-- name: compile custom plugins
-  command: mvn -Dmaven.test.skip=true install chdir=/tmp/{{ item.item.repo_name }}
-  with_items: jenkins_custom_plugins_checkout.results
-  when: item.changed 
-
-- name: install custom plugins
-  command: mv /tmp/{{ item.item.repo_name }}/target/{{ item.item.package }}
-           {{ jenkins_home }}/plugins/{{ item.item.package }}
-  with_items: jenkins_custom_plugins_checkout.results
-  when: item.changed 
-  notify:
-    - restart Jenkins
-
-- name: set custom plugin permissions
-  file: path={{ jenkins_home }}/plugins/{{ item.item.package }}
-        owner={{ jenkins_user }} group={{ jenkins_group }} mode=700
-  with_items: jenkins_custom_plugins_checkout.results
-  when: item.changed 
 
 # Plugins that are bundled with Jenkins are "pinned".
 # Jenkins will overwrite updated plugins with its built-in version


### PR DESCRIPTION
We don't use the feature that we added to our fork.

@edx/devops @edx/testeng 
