### PR TITLE
Don't provision databases in sandbox unless needed

### DIFF
--- a/playbooks/edx_sandbox.yml
+++ b/playbooks/edx_sandbox.yml
@@ -30,9 +30,11 @@
       - xqueue
       nginx_default_sites:
       - lms
-    - mysql
+    - role: mysql
+      when: EDXAPP_MYSQL_HOST == 'localhost'
     - edxlocal
-    - mongo
+    - role: mongo
+      when: "'localhost' in EDXAPP_MONGO_HOSTS"
     - { role: 'edxapp', celery_worker: True }
     - edxapp
     - notifier
@@ -43,7 +45,8 @@
     - oauth_client_setup
     - { role: 'rabbitmq', rabbitmq_ip: '127.0.0.1' }
     - oraclejdk
-    - elasticsearch
+    - role: elasticsearch
+      when: "'localhost' in EDXAPP_ELASTIC_SEARCH_CONFIG|map(attribute='host')"
     - forum
     - { role: notifier, NOTIFIER_DIGEST_TASK_INTERVAL: "5" }
     - { role: "xqueue", update_users: True }


### PR DESCRIPTION
We would like to provision sandboxes that use external mysql, mongo and elasticsearch services. This pull request modifies the sandbox playbook to only install these services locally if the configuration specifies a local database.
