### PR TITLE
Increase client upload size limit for jenkins master

### DIFF
--- a/playbooks/roles/jenkins_master/templates/etc/nginx/sites-available/jenkins.j2
+++ b/playbooks/roles/jenkins_master/templates/etc/nginx/sites-available/jenkins.j2
@@ -18,7 +18,7 @@ server {
     proxy_send_timeout      100;
     proxy_read_timeout      100;
     proxy_buffers           4 32k;
-    client_max_body_size    8m;
+    client_max_body_size    16m;
     client_body_buffer_size 128k;
 
   }


### PR DESCRIPTION
@benpatterson @e0d 

nginx was giving a 413 response code when trying to upload a local copy of the github-sqs-plugin from pluginManager/advanced because the .hpi is just under 16M.
