### PR TITLE
Remove unsupported Vagrant boxes

### DIFF
--- a/vagrant/release/devstack/Vagrantfile
+++ b/vagrant/release/devstack/Vagrantfile
@@ -66,6 +66,10 @@ openedx_releases = {
   "named-release/cypress" => {
     :name => "cypress-devstack", :file => "cypress-devstack.box",
   },
+  # Birch is deprecated and unsupported
+  # "named-release/birch.2" => {
+  #   :name => "birch-devstack-2", :file => "birch-2-devstack.box",
+  # },
 }
 openedx_releases.default = {
   :name => "cypress-devstack", :file => "cypress-devstack.box",

--- a/vagrant/release/devstack/Vagrantfile
+++ b/vagrant/release/devstack/Vagrantfile
@@ -63,45 +63,6 @@ end
 # to a name and a file path, which are used for retrieving
 # a Vagrant box from the internet.
 openedx_releases = {
-  "openedx/rc/aspen-2014-09-10" => {
-    :name => "aspen-devstack-rc1", :file => "20141009-aspen-devstack-rc1.box",
-  },
-  "aspen.1" => {
-    :name => "aspen-devstack-1", :file => "20141028-aspen-devstack-1.box",
-  },
-  "named-release/aspen" => {
-    :name => "aspen-devstack-1", :file => "20141028-aspen-devstack-1.box",
-  },
-  "named-release/birch.rc1" => {
-    :name => "birch-devstack-rc1", :file => "20150203-birch-devstack-rc1.box",
-  },
-  "named-release/birch.rc2" => {
-    :name => "birch-devstack-rc2", :file => "20150211-birch-devstack-rc2.box",
-  },
-  "named-release/birch.rc3" => {
-    :name => "birch-devstack-rc3", :file => "20150213-birch-devstack-rc3.box",
-  },
-  "named-release/birch" => {
-    :name => "birch-devstack", :file => "20150224-birch-devstack.box",
-  },
-  "named-release/birch.1" => {
-    :name => "birch-devstack-1", :file => "birch-1-devstack.box",
-  },
-  "named-release/birch.2" => {
-    :name => "birch-devstack-2", :file => "birch-2-devstack.box",
-  },
-  "named-release/cypress.rc1" => {
-    :name => "cypress-devstack-rc1", :file => "20150714-cypress-devstack-rc1.box",
-  },
-  "named-release/cypress.rc2" => {
-    :name => "cypress-devstack-rc2", :file => "20150717-cypress-devstack-rc2.box",
-  },
-  "named-release/cypress.rc3" => {
-    :name => "cypress-devstack-rc3", :file => "20150724-cypress-devstack-rc3.box",
-  },
-  "named-release/cypress.rc4" => {
-    :name => "cypress-devstack-rc4", :file => "cypress-rc4-devstack.box",
-  },
   "named-release/cypress" => {
     :name => "cypress-devstack", :file => "cypress-devstack.box",
   },

--- a/vagrant/release/fullstack/Vagrantfile
+++ b/vagrant/release/fullstack/Vagrantfile
@@ -12,6 +12,10 @@ openedx_releases = {
   "named-release/cypress" => {
     :name => "cypress-fullstack", :file => "cypress-fullstack.box",
   },
+  # Birch is deprecated and unsupported
+  # "named-release/birch.2" => {
+  #   :name => "birch-fullstack-2", :file => "birch-2-fullstack.box",
+  # },
 }
 openedx_releases.default = {
   :name => "cypress-fullstack", :file => "cypress-fullstack.box",

--- a/vagrant/release/fullstack/Vagrantfile
+++ b/vagrant/release/fullstack/Vagrantfile
@@ -9,42 +9,6 @@ CPU_COUNT = 2
 # to a name and a file path, which are used for retrieving
 # a Vagrant box from the internet.
 openedx_releases = {
-  "openedx/rc/aspen-2014-09-10" => {
-    :name => "aspen-fullstack-rc1", :file => "20141010-aspen-fullstack-rc1.box",
-  },
-  "aspen.1" => {
-    :name => "aspen-fullstack-1", :file => "20141028-aspen-fullstack-1.box",
-  },
-  "named-release/aspen" => {
-    :name => "aspen-fullstack-1", :file => "20141028-aspen-fullstack-1.box",
-  },
-  "named-release/birch.rc1" => {
-    :name => "birch-fullstack-rc1", :file => "20150204-birch-fullstack-rc1.box"
-  },
-  "named-release/birch.rc2" => {
-    :name => "birch-fullstack-rc2", :file => "20150211-birch-fullstack-rc2.box"
-  },
-  "named-release/birch.rc3" => {
-    :name => "birch-fullstack-rc3", :file => "20150213-birch-fullstack-rc3.box"
-  },
-  "named-release/birch" => {
-    :name => "birch-fullstack", :file => "20150224-birch-fullstack.box",
-  },
-  "named-release/birch.1" => {
-    :name => "birch-fullstack-1", :file => "birch-1-fullstack.box",
-  },
-  "named-release/birch.2" => {
-    :name => "birch-fullstack-2", :file => "birch-2-fullstack.box",
-  },
-  "named-release/cypress.rc2" => {
-    :name => "cypress-fullstack-rc2", :file => "20150720-cypress-fullstack-rc2.box",
-  },
-  "named-release/cypress.rc3" => {
-    :name => "cypress-fullstack-rc3", :file => "20150724-cypress-fullstack-rc3.box",
-  },
-  "named-release/cypress.rc4" => {
-    :name => "cypress-fullstack-rc4", :file => "cypress-rc4-fullstack.box",
-  },
   "named-release/cypress" => {
     :name => "cypress-fullstack", :file => "cypress-fullstack.box",
   },


### PR DESCRIPTION
edX can only support the latest Open edX release, which is Cypress. This commit clears out all the cruft from old Open edX releases that we cannot support anyway.
