### PR TITLE
Fix insights DB name to use the right variable

### DIFF
--- a/playbooks/roles/edxlocal/defaults/main.yml
+++ b/playbooks/roles/edxlocal/defaults/main.yml
@@ -9,7 +9,7 @@ edxlocal_debian_pkgs:
 
 edxlocal_databases:
   - "{{ ECOMMERCE_DEFAULT_DB_NAME | default(None) }}"
-  - "{{ INSIGHTS_DEFAULT_DB_NAME | default(None) }}"
+  - "{{ INSIGHTS_DATABASE_NAME | default(None) }}"
   - "{{ ORA_MYSQL_DB_NAME | default(None) }}"
   - "{{ XQUEUE_MYSQL_DB_NAME | default(None) }}"
   - "{{ EDXAPP_MYSQL_DB_NAME | default(None) }}"
@@ -25,7 +25,7 @@ edxlocal_database_users:
       pass: "{{ ECOMMERCE_DATABASES.default.PASSWORD | default(None) }}"
     }
   - {
-      db: "{{ INSIGHTS_DEFAULT_DB_NAME | default(None) }}",
+      db: "{{ INSIGHTS_DATABASE_NAME | default(None) }}",
       user: "{{ INSIGHTS_DATABASES.default.USER | default(None) }}",
       pass: "{{ INSIGHTS_DATABASES.default.PASSWORD | default(None) }}"
     }

--- a/playbooks/roles/edxlocal/tasks/main.yml
+++ b/playbooks/roles/edxlocal/tasks/main.yml
@@ -82,7 +82,7 @@
     priv='{{ ANALYTICS_API_DATABASES.reports.NAME }}.*:SELECT'
   when: ANALYTICS_API_SERVICE_CONFIG is defined
 
-- name: create a database for thie hive metastore
+- name: create a database for the hive metastore
   mysql_db: >
     db={{ HIVE_METASTORE_DATABASE.name }}
     state=present


### PR DESCRIPTION
INSIGHTS_DEFAULT_DB_NAME isn't actually set anywhere.

We verified that the playbook got past the migrate step for Insights with this change. 

@mulby @clintonb @e0d 
