### PR TITLE
Fix Insights db variable name in edxlocal.

### DIFF
--- a/playbooks/roles/edxlocal/defaults/main.yml
+++ b/playbooks/roles/edxlocal/defaults/main.yml
@@ -9,7 +9,7 @@ edxlocal_debian_pkgs:
 
 edxlocal_databases:
   - "{{ ECOMMERCE_DEFAULT_DB_NAME | default(None) }}"
-  - "{{ INSIGHTS_DEFAULT_DB_NAME | default(None) }}"
+  - "{{ INSIGHTS_DATABASE_NAME | default(None) }}"
   - "{{ ORA_MYSQL_DB_NAME | default(None) }}"
   - "{{ XQUEUE_MYSQL_DB_NAME | default(None) }}"
   - "{{ EDXAPP_MYSQL_DB_NAME | default(None) }}"
@@ -25,7 +25,7 @@ edxlocal_database_users:
       pass: "{{ ECOMMERCE_DATABASES.default.PASSWORD | default(None) }}"
     }
   - {
-      db: "{{ INSIGHTS_DEFAULT_DB_NAME | default(None) }}",
+      db: "{{ INSIGHTS_DATABASE_NAME | default(None) }}",
       user: "{{ INSIGHTS_DATABASES.default.USER | default(None) }}",
       pass: "{{ INSIGHTS_DATABASES.default.PASSWORD | default(None) }}"
     }


### PR DESCRIPTION
## Background

The ansible variable that holds the Insights database name is called `INSIGHTS_DATABASE_NAME`,
not `INSIGHTS_DEFAULT_DB_NAME`, which is what is being used in the `edxlocal` role
that creates databases and database users.

Due to wrong variable name, the Insights database and migration user are currently not created
and fullstack provisioning fails at the Insights migrate task, see https://groups.google.com/forum/#!topic/openedx-ops/Ve_lBa3oGk8.

**Merge deadline**: as soon as possible - it's breaking new fullstack installations
**Jira ticket**: https://openedx.atlassian.net/browse/OSPR-869
## Testing Instructions

Follow the instructions at https://github.com/edx/configuration/wiki/edX-Ubuntu-12.04-64-bit-Installation to create a new fullstack installation.

Without this patch, ansible provisioning fails at the `insights | migrate` step with this error:

```
django.db.utils.OperationalError: (1044, "Access denied for user 'migrate'@'localhost' to database 'dashboard'")
```

Then cherry-pick the changes from this PR to the `configuration` checkout:

```
cd /var/tmp/configuration
git remote add open-craft https://github.com/open-craft/configuration.git
git fetch open-craft
git cherry-pick -n 96d5bde663a1f1cf46b685a925708dacedb5d9dc
```

And re-run ansible:

```
cd /var/tmp/configuration/playbooks && sudo ansible-playbook -c local ./edx_sandbox.yml -i "localhost,"
```
