### PR TITLE
Fix edxlocal when not running analytics stack build

### DIFF
--- a/playbooks/roles/analytics_pipeline/defaults/main.yml
+++ b/playbooks/roles/analytics_pipeline/defaults/main.yml
@@ -11,6 +11,7 @@
 # Defaults for role analytics_pipeline
 #
 
+ANALYTICS_PIPELINE_OUTPUT_DATABASE_NAME: "{{ ANALYTICS_API_REPORTS_DB_NAME }}"
 ANALYTICS_PIPELINE_OUTPUT_DATABASE:
   username: pipeline001
   password: password

--- a/playbooks/roles/edxlocal/defaults/main.yml
+++ b/playbooks/roles/edxlocal/defaults/main.yml
@@ -50,12 +50,12 @@ edxlocal_database_users:
       pass: "{{ PROGRAMS_DATABASES.default.PASSWORD | default(None) }}"
     }
   - {
-      db: "{{ ANALYTICS_API_REPORTS_DB_NAME | default(None) }}",
-      user: "pipeline001",
-      pass: "password"
+      db: "{{ ANALYTICS_PIPELINE_OUTPUT_DATABASE_NAME | default(None) }}",
+      user: "{{ ANALYTICS_PIPELINE_OUTPUT_DATABASE.username }}",
+      pass: "{{ ANALYTICS_PIPELINE_OUTPUT_DATABASE.password }}"
     }
   - {
-      db: "{{ HIVE_METASTORE_DATABASE.name | default(None) }}",
+      db: "{{ HIVE_METASTORE_DATABASE_NAME | default(None) }}",
       user: "{{ HIVE_METASTORE_DATABASE.user | default(None) }}",
       pass: "{{ HIVE_METASTORE_DATABASE.password | default(None) }}"
     }

--- a/playbooks/roles/hive/defaults/main.yml
+++ b/playbooks/roles/hive/defaults/main.yml
@@ -17,10 +17,11 @@ HIVE_HOME: "{{ HADOOP_COMMON_USER_HOME }}/hive"
 HIVE_CONF: "{{ HIVE_HOME }}/conf"
 HIVE_LIB: "{{ HIVE_HOME }}/lib"
 
+HIVE_METASTORE_DATABASE_NAME: edx_hive_metastore
 HIVE_METASTORE_DATABASE:
   user: edx_hive
   password: edx
-  name: edx_hive_metastore
+  name: "{{ HIVE_METASTORE_DATABASE_NAME }}"
   host: 127.0.0.1
   port: 3306
 


### PR DESCRIPTION
@e0d - I'm far from an ansible expert, it looks like there is a consequential difference between {{ FOO | default(None) }} and {{ FOO.bar | default(None) }}. In the former case, it actually falls back to the default if FOO is not defined, in the later case, it uses {# FOO.bar | default(None) #} as the value of the variable. Is that correct? If so, the "| default(None)" clause is not really very meaningful. For future reference - is there a simple way I can run the CI build locally before merging?

@shnayder, @feanil - sanity check me here
