### PR TITLE
Download MongoDB signing key from keyserver

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -48,3 +48,4 @@ Andy Armstrong <andya@edx.org>
 Xiang Junfu <xiangjf.fnst@cn.fujitsu.com>
 Sarina Canelake <sarina@edx.org>
 Steven Burch <stv@stanford.edu>
+Dan Powell <dan@abakas.com>

--- a/playbooks/roles/ad_hoc_reporting/defaults/main.yml
+++ b/playbooks/roles/ad_hoc_reporting/defaults/main.yml
@@ -41,6 +41,7 @@ ad_hoc_reporting_pip_pkgs:
   # for running ansible mysql
   - mysql-python
 
-MONGODB_APT_KEY: "http://docs.mongodb.org/10gen-gpg-key.asc"
+MONGODB_APT_KEY: "7F0CEB10"
+MONGODB_APT_KEYSERVER: "keyserver.ubuntu.com"
 MONGODB_REPO: "deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen"
 mongo_version: 3.0.7

--- a/playbooks/roles/ad_hoc_reporting/tasks/main.yml
+++ b/playbooks/roles/ad_hoc_reporting/tasks/main.yml
@@ -30,8 +30,8 @@
 
 - name: add the mongodb signing key
   apt_key:
-    id: 7F0CEB10
-    url: "{{ MONGODB_APT_KEY }}"
+    id: "{{ MONGODB_APT_KEY }}"
+    keyserver: "{{ MONGODB_APT_KEYSERVER }}"
     state: present
   tags:
     - install:system-requirements

--- a/playbooks/roles/mongo/defaults/main.yml
+++ b/playbooks/roles/mongo/defaults/main.yml
@@ -11,7 +11,8 @@ mongo_data_dir: "{{ COMMON_DATA_DIR }}/mongo"
 mongo_log_dir: "{{ COMMON_LOG_DIR }}/mongo"
 mongo_user: mongodb
 
-MONGODB_APT_KEY: "http://docs.mongodb.org/10gen-gpg-key.asc"
+MONGODB_APT_KEY: "7F0CEB10"
+MONGODB_APT_KEYSERVER: "keyserver.ubuntu.com"
 MONGODB_REPO: "deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen"
 
 # Vars Meant to be overridden

--- a/playbooks/roles/mongo/tasks/main.yml
+++ b/playbooks/roles/mongo/tasks/main.yml
@@ -21,8 +21,8 @@
 
 - name: add the mongodb signing key
   apt_key: >
-    id=7F0CEB10
-    url={{ MONGODB_APT_KEY }}
+    id={{ MONGODB_APT_KEY }}
+    keyserver={{ MONGODB_APT_KEYSERVER }}
     state=present
 
 - name: add the mongodb repo to the sources list


### PR DESCRIPTION
The URL to download the MongoDB signing key is currently returning a 404.  Switch to downloading this from the key server instead, consistent with the mongo_3_0 role.
