### PR TITLE
Allow us to override the boto ebs_optimized flag

### DIFF
--- a/playbooks/edx-east/edx_service.yml
+++ b/playbooks/edx-east/edx_service.yml
@@ -258,6 +258,7 @@
         image: "{{ service_config.ami }}"
         instance_profile_name: "{{ instance_profile_name }}"
         volumes: "{{ service_config.volumes }}"
+        ebs_optimized: "{{ service_config.ebs_optimized }}"
       with_sequence: count={{ create_instances | default(created_service_subnets.results | length) }}
       when: not auto_scaling_service and potential_existing_instances.instances|length == 0
       register: created_instances


### PR DESCRIPTION
Ansible defaults to False, despite documentation that doesn't state
this.  Boto then turns off EBS Optimization on instance types where this
should be impossible.
https://github.com/ansible/ansible-modules-core/pull/2326

@edx/devops
