### PR TITLE
Add splunk indexing from jenkins of sitespeed results

### DIFF
--- a/playbooks/edx-east/jenkins_testeng_master.yml
+++ b/playbooks/edx-east/jenkins_testeng_master.yml
@@ -18,18 +18,27 @@
         sourcetype: junit
         followSymlink: false
         crcSalt: '<SOURCE>'
+
       - source: '/var/lib/jenkins/jobs/*/builds/*/build.xml'
         index: 'testeng'
         recursive: true
         sourcetype: build_result
         followSymlink: false
         crcSalt: '<SOURCE>'
+
       - source: '/var/lib/jenkins/jobs/*/builds/*/log'
         index: 'testeng'
         recursive: true
         sourcetype: build_log
         followSymlink: false
         crcSalt: '<SOURCE>'
+
+      - source: '/var/lib/jenkins/jobs/*/builds/*/archive/sitespeed-result/*/data/result.json'
+        index: 'testeng'
+        recursive: false
+        sourcetype: sitespeed_result
+        followSymlink: false
+
       - source: '/var/log/jenkins/jenkins.log'
         index: 'testeng'
         recursive: false


### PR DESCRIPTION
This needs the props.conf change from DEVOPS-3130 to be done first before applying to jenkins, so that the data will index correctly.

@benpatterson @arbabnazar 
