### PR TITLE
Recurse through dirs for sitespeed indexing on splunk. PERF-182

### DIFF
--- a/playbooks/edx-east/jenkins_testeng_master.yml
+++ b/playbooks/edx-east/jenkins_testeng_master.yml
@@ -35,7 +35,7 @@
 
       - source: '/var/lib/jenkins/jobs/*/builds/*/archive/sitespeed-result/*/data/result.json'
         index: 'testeng'
-        recursive: false
+        recursive: true
         sourcetype: sitespeed_result
         followSymlink: false
 


### PR DESCRIPTION
@benpatterson 

Otherwise the "*" from the source specifier doesn't really do anything, so the files don't get indexed.
