### PR TITLE
Make tagging work with new tag input format for ec2_asg

### DIFF
--- a/playbooks/edx-east/edx_service.yml
+++ b/playbooks/edx-east/edx_service.yml
@@ -163,19 +163,27 @@
     - debug: msg="{{ created_service_subnets.results|map(attribute='subnet_id')| list | join(',') }}"
       register: service_vpc_zone_identifier_string
 
+    - name: Transform tags into list dict format for the modules that expect it
+      util_map:
+        function: zip_to_listdict
+        input: "{{ asg_instance_tags }}"
+        args: ['key', 'value']
+      register: listdict_asg_instance_tags
+
+    - debug: msg="Instance Tags:{{ listdict_asg_instance_tags }}"
+
     - name: Manage ASG
       ec2_asg:
         profile: "{{ profile }}"
         region: "{{ aws_region }}"
         name: "{{ asg_name }}"
         launch_config_name: "{{ service_config.name }}"
-        load_balancers: "{{ elb_name }}"
         availability_zones: "{{ aws_availability_zones }}"
         min_size: "{{ asg_min_size }}"
         max_size: "{{ asg_max_size }}"
         desired_capacity: "{{ asg_desired_capacity }}"
         vpc_zone_identifier: "{{ service_vpc_zone_identifier_string.msg }}"
-        tags: "{{ asg_instance_tags }}"
+        tags: "{{ listdict_asg_instance_tags.function_output }}"
         load_balancers: "{{ created_elbs.results|map(attribute='elb.name')|list }}"
       register: asg
       when: auto_scaling_service

--- a/playbooks/library/util_map
+++ b/playbooks/library/util_map
@@ -130,6 +130,31 @@ def zip_to_list(module, input, key):
 
     module.exit_json(function_output = results)
 
+def zip_to_listdict(module, input, key_name, value_name):
+    """
+    Take an array of dicts and build a list of dicts where the name of the key
+    is taken as a value of one of the keys in the input list and the vaule is
+    the value of a different key.
+
+    For example with an input like
+    [{'tag_name': 'Name', 'tag_value': 'stage-edx-edxapp'}, {'tag_name': 'cluster', 'tag_value': 'edxapp'}]
+
+    and an args array of ['tag_name', 'tag_value']
+
+    would return
+
+    [{'Name': 'stage-edx-edxapp'}, {'cluster': 'edxapp'}]
+
+    NB: This is used to work around the fact that we can template out the names
+    of keys in dictionaries in ansible.
+    """
+
+    results = []
+    for item in input:
+        results.append({ item[key_name]: item[value_name]})
+
+    module.exit_json(function_output=results)
+
 def main():
 
     arg_spec = dict(
@@ -151,6 +176,8 @@ def main():
         flatten(module,input)
     elif target == 'zip_to_list':
         zip_to_list(module, input, *args)
+    elif target == 'zip_to_listdict':
+        zip_to_listdict(module, input, *args)
     else:
         raise NotImplemented("Function {0} is not implemented.".format(target))
 


### PR DESCRIPTION
It looks like the format of this module changed in one of the upgrades on is not compatible with what we're doing right now.  This resolves it.

Module docs: http://docs.ansible.com/ansible/ec2_asg_module.html
