### PR TITLE
Installing optional requirements for IDAs

### DIFF
--- a/playbooks/roles/ansible-role-django-ida/templates/defaults/main.yml.j2
+++ b/playbooks/roles/ansible-role-django-ida/templates/defaults/main.yml.j2
@@ -102,6 +102,7 @@
 {{ role_name }}_requirements_base: "{{ '{{' }} {{ role_name }}_code_dir }}/requirements"
 {{ role_name }}_requirements:
   - production.txt
+  - optional.txt
 
 
 #


### PR DESCRIPTION
Optional requirements usually include newrelic.

@feanil
