### PR TITLE
Bump version of mongo to 3.0.7

### DIFF
--- a/playbooks/roles/mongo_3_0/defaults/main.yml
+++ b/playbooks/roles/mongo_3_0/defaults/main.yml
@@ -3,7 +3,7 @@ mongo_logappend: true
 #This way, when mongod receives a SIGUSR1, it'll close and reopen its log file handle
 mongo_logrotate: reopen
 
-mongo_version: 3.0.6
+mongo_version: 3.0.7
 mongo_port: "27017"
 mongo_extra_conf: ''
 mongo_key_file: '/etc/mongodb_key'
@@ -25,7 +25,9 @@ mongodb_debian_pkgs:
   - "mongodb-org-server={{ mongo_version }}" 
   - "mongodb-org-shell={{ mongo_version }}"
   - "mongodb-org-mongos={{ mongo_version }}" 
-  - "mongodb-org-tools={{ mongo_version }}"
+# The mongo 3.0.7 mongorestore tool fails on most backups
+# https://jira.mongodb.org/browse/TOOLS-939
+  - "mongodb-org-tools=3.0.6"
 
 
 # Vars Meant to be overridden

--- a/playbooks/roles/mongo_3_0/tasks/main.yml
+++ b/playbooks/roles/mongo_3_0/tasks/main.yml
@@ -76,6 +76,10 @@
     pkg={{','.join(mongodb_debian_pkgs)}}
     state=present install_recommends=yes
     force=yes update_cache=yes
+  tags:
+    - install
+    - install:system-requirements
+    - mongo_packages
 
 - name: create mongo dirs
   file: >


### PR DESCRIPTION
We can't use the 3.0.7 tools (mongodump/mongorestore) because of bugs in
the restore on gridfs and even draft mongo modulestore.
https://jira.mongodb.org/browse/TOOLS-939

This does not affect the mongo shell version

@edx/devops
