### PR TITLE
Revert "Make pre-supervisor more readable."

### DIFF
--- a/playbooks/roles/supervisor/templates/etc/init/pre_supervisor.conf.j2
+++ b/playbooks/roles/supervisor/templates/etc/init/pre_supervisor.conf.j2
@@ -5,44 +5,10 @@ task
 
 setuid {{ supervisor_user }}
 
-{%- if programs_code_dir is defined %}
-  {% set programs_command = "--programs-env {{ programs_home }}/programs_env --programs-code-dir {{ programs_code_dir }} --programs-python {{ COMMON_BIN_DIR }}/python.programs" %}
+{% if programs_code_dir is defined %}
+  {% set programs_command = "--programs-env " + programs_home + "/programs_env --programs-code-dir " + programs_code_dir + " --programs-python " + COMMON_BIN_DIR + "/python.programs" %}
 {% else %}
   {% set programs_command = "" %}
 {% endif %}
 
-{%- if edxapp_code_dir is defined %}
-  {% set edxapp_command = "--edxapp-python {{ COMMON_BIN_DIR }}/python.edxapp --edxapp-code-dir {{ edxapp_code_dir }}" %}
-{% else %}
-  {% set edxapp_command = "" %}
-{% endif %}
-
-{%- if xqueue_code_dir is defined %}
-  {% set xqueue_command = "--xqueue-code-dir {{ xqueue_code_dir }} --xqueue-python {{ COMMON_BIN_DIR }}/python.xqueue" %}
-{% else %}
-  {% set xqueue_command = "" %}
-{% endif %}
-
-{% if ecommerce_code_dir is defined %}
-  {% set ecommerce_command = "--ecommerce-env {{ ecommerce_home }}/ecommerce_env --ecommerce-code-dir {{ ecommerce_code_dir }} --ecommerce-python {{ COMMON_BIN_DIR }}/python.ecommerce" %}
-{% else %}
-  {% set ecommerce_command = "" %}
-{% endif %}
-
-{% if insights_code_dir is defined %}
-  {% set insights_command = "--insights-env {{ insights_home }}/insights_env --insights-code-dir {{ insights_code_dir }} --insights-python {{ COMMON_BIN_DIR }}/python.insights" %}
-{% else %}
-  {% set insights_command = "" %}
-{% endif %}
-
-{% if analytics_api_code_dir is defined %}
-  {% set analytics_api_command = "--analytics-api-env {{ analytics_api_home }}/analytics_api_env --analytics-api-code-dir {{ analytics_api_code_dir }} --analytics-api-python {{ COMMON_BIN_DIR }}/python.analytics_api" %}
-{% else %}
-  {% set analytics_api_command = "" %}
-{% endif %}
-
-{% if SUPERVISOR_HIPCHAT_API_KEY is defined %}
-  {% set hipchat_command = "--hipchat-api-key {{ SUPERVISOR_HIPCHAT_API_KEY }} --hipchat-room {{ SUPERVISOR_HIPCHAT_ROOM }}" %}
-{% endif %}
-
-exec {{ supervisor_venv_dir }}/bin/python {{ supervisor_app_dir }}/pre_supervisor_checks.py --available={{ supervisor_available_dir }} --enabled={{ supervisor_cfg_dir }} {{ hipchat_command }}  {{ programs_command }} {{ edxapp_command }} {{ xqueue_command }} {{ ecommerce_command }} {{ insights_command }} {{ analytics_api_command }}
+exec {{ supervisor_venv_dir }}/bin/python {{ supervisor_app_dir }}/pre_supervisor_checks.py --available={{ supervisor_available_dir }} --enabled={{ supervisor_cfg_dir }} {% if SUPERVISOR_HIPCHAT_API_KEY is defined %}--hipchat-api-key {{ SUPERVISOR_HIPCHAT_API_KEY }} --hipchat-room {{ SUPERVISOR_HIPCHAT_ROOM }} {% endif %} {% if edxapp_code_dir is defined %}--edxapp-python {{ COMMON_BIN_DIR }}/python.edxapp --edxapp-code-dir {{ edxapp_code_dir }}{% endif %} {% if xqueue_code_dir is defined %}--xqueue-code-dir {{ xqueue_code_dir }} --xqueue-python {{ COMMON_BIN_DIR }}/python.xqueue {% endif %} {% if ecommerce_code_dir is defined %}--ecommerce-env {{ ecommerce_home }}/ecommerce_env --ecommerce-code-dir {{ ecommerce_code_dir }} --ecommerce-python {{ COMMON_BIN_DIR }}/python.ecommerce {% endif %} {% if insights_code_dir is defined %}--insights-env {{ insights_home }}/insights_env --insights-code-dir {{ insights_code_dir }} --insights-python {{ COMMON_BIN_DIR }}/python.insights {% endif %} {% if analytics_api_code_dir is defined %}--analytics-api-env {{ analytics_api_home }}/analytics_api_env --analytics-api-code-dir {{ analytics_api_code_dir }} --analytics-api-python {{ COMMON_BIN_DIR }}/python.analytics_api {% endif %} {{ programs_command }}


### PR DESCRIPTION
Reverts edx/configuration#2420

On a matasano build

exec /edx/app/supervisor/venvs/supervisor/bin/python /edx/app/supervisor/pre_supervisor_checks.py --available=/edx/app/supervisor/conf.available.d --enabled=/edx/app/supervisor/conf.d --hipchat-api-key {{ SUPERVISOR_HIPCHAT_API_KEY }} --hipchat-room {{ SUPERVISOR_HIPCHAT_ROOM }}   --edxapp-python {{ COMMON_BIN_DIR }}/python.edxapp --edxapp-code-dir {{ edxapp_code_dir }}

Is in the /etc/init/pre_supervisor.conf file
