### PR TITLE
Add a swapfile role to edx_sandbox playbook

### DIFF
--- a/playbooks/edx_sandbox.yml
+++ b/playbooks/edx_sandbox.yml
@@ -51,6 +51,7 @@
       when: ENABLE_LEGACY_ORA
     - certs
     - edx_ansible
+    - { role: swapfile, SWAPFILE_SIZE: "2GB" }
     - role: datadog
       when: COMMON_ENABLE_DATADOG
     - role: splunkforwarder

--- a/playbooks/roles/swapfile/LICENSE
+++ b/playbooks/roles/swapfile/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2014 Kamal Nasser <hello@kamal.io>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/playbooks/roles/swapfile/README.md
+++ b/playbooks/roles/swapfile/README.md
@@ -1,0 +1,30 @@
+swapfile
+========
+
+Creates and enables a swap file.
+
+Slightly modified from https://github.com/kamaln7/ansible-swapfile
+
+## License
+
+The MIT License (MIT)
+
+Copyright (c) 2014 Kamal Nasser <hello@kamal.io>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/playbooks/roles/swapfile/defaults/main.yml
+++ b/playbooks/roles/swapfile/defaults/main.yml
@@ -1,11 +1,22 @@
 ---
-# To enable the swapfile role, set this variable using a MB or GB suffix
-# e.g. SWAPFILE_SIZE: 512MB
-# To disable the role, leave the default value of 'false'
-SWAPFILE_SIZE: false
+# Size of the desired swap file. Use a MB or GB suffix.
+SWAPFILE_SIZE: 2GB
+# SWAPFILE_LOCATION: Location of the swap file managed by this role.
+SWAPFILE_LOCATION: /swapfile
+# SWAPFILE_USE_DD: set this to True if your filesystem does not support 
+# fallocate (e.g. if you use ext3). dd will then be used instead of fallocate.
+SWAPFILE_USE_DD: False
 
+#
+# Advanced, optional settings: 
+#
 
-swapfile_location: /swapfile
-swapfile_swappiness: False
-swapfile_vfs_cache_pressure: False
-swapfile_use_dd: False
+# SWAPFILE_SWAPPINESS: Update sysctl.conf to set the swappiness percentage
+# (vm.swappiness) -- the lower it is, the less your system swaps memory pages.
+# If this is False (default), no change will be made.
+SWAPFILE_SWAPPINESS: False
+# SWAPFILE_VFS_CACHE_PRESSURE: Update sysctl.conf to set the VFS cache pressure.
+# "this percentage value controls the tendency of the kernel to reclaim the
+#  memory which is used for caching of directory and inode objects."
+# If this is False (default), no change will be made.
+SWAPFILE_VFS_CACHE_PRESSURE: False

--- a/playbooks/roles/swapfile/defaults/main.yml
+++ b/playbooks/roles/swapfile/defaults/main.yml
@@ -1,0 +1,11 @@
+---
+# To enable the swapfile role, set this variable using a MB or GB suffix
+# e.g. SWAPFILE_SIZE: 512MB
+# To disable the role, leave the default value of 'false'
+SWAPFILE_SIZE: false
+
+
+swapfile_location: /swapfile
+swapfile_swappiness: False
+swapfile_vfs_cache_pressure: False
+swapfile_use_dd: False

--- a/playbooks/roles/swapfile/handlers/main.yml
+++ b/playbooks/roles/swapfile/handlers/main.yml
@@ -1,0 +1,3 @@
+---
+- name: reload sysctl
+  command: sysctl -p

--- a/playbooks/roles/swapfile/meta/main.yml
+++ b/playbooks/roles/swapfile/meta/main.yml
@@ -1,0 +1,10 @@
+---
+galaxy_info:
+  author: "Kamal Nasser"
+  description: swapfile
+  license: MIT
+  min_ansible_version: 1.4
+  version: 0.4
+  categories:
+    - system
+  dependencies: []

--- a/playbooks/roles/swapfile/tasks/main.yml
+++ b/playbooks/roles/swapfile/tasks/main.yml
@@ -1,0 +1,37 @@
+---
+- name: Write swapfile
+  command: |
+    {% if swapfile_use_dd %}
+    dd if=/dev/zero of={{ swapfile_location }} bs=1M count={{ SWAPFILE_SIZE }} creates={{ swapfile_location }}
+    {% else %}
+    fallocate -l {{ SWAPFILE_SIZE }} {{ swapfile_location }} creates={{ swapfile_location }}
+    {% endif %}
+  register: write_swapfile
+  when: SWAPFILE_SIZE != false
+
+- name: Set swapfile permissions
+  file: path={{ swapfile_location }} mode=600
+  when: SWAPFILE_SIZE != false
+
+- name: Create swapfile
+  command: mkswap {{ swapfile_location }}
+  register: create_swapfile
+  when: SWAPFILE_SIZE != false and write_swapfile.changed
+
+- name: Enable swapfile
+  command: swapon {{ swapfile_location }}
+  when: SWAPFILE_SIZE != false and create_swapfile.changed
+
+- name: Add swapfile to /etc/fstab
+  lineinfile: dest=/etc/fstab line="{{ swapfile_location }}   none    swap    sw    0   0" state=present
+  when: SWAPFILE_SIZE != false
+
+- name: Configure vm.swappiness
+  lineinfile: dest=/etc/sysctl.conf line="vm.swappiness = {{ swapfile_swappiness }}" regexp="^vm.swappiness[\s]?=" state=present
+  notify: reload sysctl
+  when: swapfile_swappiness != false
+
+- name: Configure vm.vfs_cache_pressure
+  lineinfile: dest=/etc/sysctl.conf line="vm.vfs_cache_pressure = {{ swapfile_vfs_cache_pressure }}" regexp="^vm.vfs_cache_pressure[\s]?=" state=present
+  notify: reload sysctl
+  when: swapfile_vfs_cache_pressure != false

--- a/playbooks/roles/swapfile/tasks/main.yml
+++ b/playbooks/roles/swapfile/tasks/main.yml
@@ -1,37 +1,37 @@
 ---
 - name: Write swapfile
   command: |
-    {% if swapfile_use_dd %}
-    dd if=/dev/zero of={{ swapfile_location }} bs=1M count={{ SWAPFILE_SIZE }} creates={{ swapfile_location }}
+    {% if SWAPFILE_USE_DD %}
+    dd if=/dev/zero of={{ SWAPFILE_LOCATION }} bs=1M count={{ SWAPFILE_SIZE }} creates={{ SWAPFILE_LOCATION }}
     {% else %}
-    fallocate -l {{ SWAPFILE_SIZE }} {{ swapfile_location }} creates={{ swapfile_location }}
+    fallocate -l {{ SWAPFILE_SIZE }} {{ SWAPFILE_LOCATION }} creates={{ SWAPFILE_LOCATION }}
     {% endif %}
   register: write_swapfile
   when: SWAPFILE_SIZE != false
 
 - name: Set swapfile permissions
-  file: path={{ swapfile_location }} mode=600
+  file: path={{ SWAPFILE_LOCATION }} mode=600
   when: SWAPFILE_SIZE != false
 
 - name: Create swapfile
-  command: mkswap {{ swapfile_location }}
+  command: mkswap {{ SWAPFILE_LOCATION }}
   register: create_swapfile
   when: SWAPFILE_SIZE != false and write_swapfile.changed
 
 - name: Enable swapfile
-  command: swapon {{ swapfile_location }}
+  command: swapon {{ SWAPFILE_LOCATION }}
   when: SWAPFILE_SIZE != false and create_swapfile.changed
 
 - name: Add swapfile to /etc/fstab
-  lineinfile: dest=/etc/fstab line="{{ swapfile_location }}   none    swap    sw    0   0" state=present
+  lineinfile: dest=/etc/fstab line="{{ SWAPFILE_LOCATION }}   none    swap    sw    0   0" state=present
   when: SWAPFILE_SIZE != false
 
 - name: Configure vm.swappiness
-  lineinfile: dest=/etc/sysctl.conf line="vm.swappiness = {{ swapfile_swappiness }}" regexp="^vm.swappiness[\s]?=" state=present
+  lineinfile: dest=/etc/sysctl.conf line="vm.swappiness = {{ SWAPFILE_SWAPPINESS }}" regexp="^vm.swappiness[\s]?=" state=present
   notify: reload sysctl
-  when: swapfile_swappiness != false
+  when: SWAPFILE_SWAPPINESS != false
 
 - name: Configure vm.vfs_cache_pressure
-  lineinfile: dest=/etc/sysctl.conf line="vm.vfs_cache_pressure = {{ swapfile_vfs_cache_pressure }}" regexp="^vm.vfs_cache_pressure[\s]?=" state=present
+  lineinfile: dest=/etc/sysctl.conf line="vm.vfs_cache_pressure = {{ SWAPFILE_VFS_CACHE_PRESSURE }}" regexp="^vm.vfs_cache_pressure[\s]?=" state=present
   notify: reload sysctl
-  when: swapfile_vfs_cache_pressure != false
+  when: SWAPFILE_VFS_CACHE_PRESSURE != false

--- a/playbooks/roles/swapfile/tasks/main.yml
+++ b/playbooks/roles/swapfile/tasks/main.yml
@@ -23,7 +23,7 @@
   when: SWAPFILE_SIZE != false and create_swapfile.changed
 
 - name: Add swapfile to /etc/fstab
-  lineinfile: dest=/etc/fstab line="{{ SWAPFILE_LOCATION }}   none    swap    sw    0   0" state=present
+  mount: name=none src="{{ SWAPFILE_LOCATION }}" fstype=swap opts=sw passno=0 dump=0 state=present
   when: SWAPFILE_SIZE != false
 
 - name: Configure vm.swappiness


### PR DESCRIPTION
We (OpenCraft) are running into occasional out-of-memory issues with sandboxes on some VMs.

This is a simple import of [Kamal Nasser's ansible `swapfile` role](https://github.com/kamaln7/ansible-swapfile) (MIT licensed), which will enable a swapfile for the `edx_sandbox` playbook by default. It is enabled by default with `SWAPFILE_SIZE = 2GB` but can easily be disabled by setting `SWAPFILE_SIZE = false`

The role is unmodified from the upstream version except that a couple variables are capitalized differently to fit better with edX ansible conventions.

Test instructions: You can test this on any VM by running:

```
ansible-playbook -i localhost, -c local run_role.yml -e role=swapfile -e "SWAPFILE_SIZE=2GB"
```

**Project / Deadline**: This is an OpenCraft project  with no specific deadline and is just a community contribution.

**Questions for edX reviewer**:
- Should this be enabled or disabled by default?
- Any comments on importing an external ansible galaxy role like this? Should I keep the `galaxy_info` or not?
