### PR TITLE
Add a key prefix to the config model.

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -807,6 +807,9 @@ generic_env_config:  &edxapp_generic_env
     staticfiles:
       <<: *default_generic_cache
       KEY_PREFIX: "{{ ansible_hostname|default('staticfiles') }}_general"
+    configuration:
+      <<: *default_generic_cache
+      KEY_PREFIX: "{{ ansible_hostname|default('configuration') }}"
     celery:
       <<: *default_generic_cache
       KEY_PREFIX:  'celery'


### PR DESCRIPTION
Add a prefix from the hostname.  If building images, this will be the hostname
of the machine that the image is based on.  If running in a rolling fashion,
this will give each machine its own cache.

@edx/devops 
