### PR TITLE
E0d/refactor utils

### DIFF
--- a/playbooks/roles/common/meta/main.yml
+++ b/playbooks/roles/common/meta/main.yml
@@ -1,6 +1,7 @@
 ---
 dependencies:
   - common_vars
+  - server_utils
   - role: user
     user_info: "{{ COMMON_USER_INFO }}"
   - role: security

--- a/playbooks/roles/common_vars/defaults/main.yml
+++ b/playbooks/roles/common_vars/defaults/main.yml
@@ -88,23 +88,15 @@ COMMON_TAG_EC2_INSTANCE: False
 common_boto_version: '2.34.0'
 common_debian_pkgs:
   - ntp
-  - ack-grep
   - lynx-cur
   - logrotate
-  - mosh
   - rsyslog
-  - screen
-  - tmux
-  - tree
   - git
   - unzip
   - "python2.7=2.7.10-0+precise1"
   - python-pip
   - python2.7-dev
-  # Not installed by default on vagrant ubuntu
-  # boxes
-  - curl
-
+  
 common_pip_pkgs:
   - pip==7.1.2
   - setuptools==18.3.2

--- a/playbooks/roles/server_utils/defaults/main.yml
+++ b/playbooks/roles/server_utils/defaults/main.yml
@@ -21,6 +21,12 @@ server_utils_role_name: server_utils
 #
 
 server_utils_debian_pkgs:
+  # not sure why this is installed
+  - ack-grep
+  # not sure why this is installed
+  - mosh
+  # not sure why this is installed
+  - tree
   - screen
   - tmux
   - curl

--- a/playbooks/roles/server_utils/defaults/main.yml
+++ b/playbooks/roles/server_utils/defaults/main.yml
@@ -1,0 +1,32 @@
+---
+#
+# edX Configuration
+#
+# github:     https://github.com/edx/configuration
+# wiki:       https://github.com/edx/configuration/wiki
+# code style: https://github.com/edx/configuration/wiki/Ansible-Coding-Conventions
+# license:    https://github.com/edx/configuration/blob/master/LICENSE.TXT
+#
+##
+# Defaults for role server_utils
+# 
+
+#
+# vars are namespaced with the module name.
+#
+server_utils_role_name: server_utils
+
+#
+# OS packages
+#
+
+server_utils_debian_pkgs:
+  - screen
+  - tmux
+  - curl
+  - vim-tiny
+  - dnsutils
+  - inetutils-telnet
+  - netcat
+
+server_utils_redhat_pkgs: []

--- a/playbooks/roles/server_utils/defaults/main.yml
+++ b/playbooks/roles/server_utils/defaults/main.yml
@@ -26,6 +26,10 @@ server_utils_debian_pkgs:
   # not sure why this is installed
   - mosh
   # not sure why this is installed
+  # Not installed by default on vagrant ubuntu
+  # boxes.
+  # TODO: move to Vagrant role
+  - curl
   - tree
   - screen
   - tmux

--- a/playbooks/roles/server_utils/tasks/main.yml
+++ b/playbooks/roles/server_utils/tasks/main.yml
@@ -1,0 +1,30 @@
+---
+#
+# edX Configuration
+#
+# github:     https://github.com/edx/configuration
+# wiki:       https://github.com/edx/configuration/wiki
+# code style: https://github.com/edx/configuration/wiki/Ansible-Coding-Conventions
+# license:    https://github.com/edx/configuration/blob/master/LICENSE.TXT
+#
+#
+#
+# Tasks for role server_utils
+# 
+# Overview:
+#
+# Install useful interactive utilities for triange and debugging purposes.
+# Typically these would not need to be available on servers as shell access
+# is uneccessary.
+# 
+# Example play:
+#
+#
+
+- name: Install system packages
+  apt:
+    name: "{{ item }}"
+    install_recommends: yes
+    state: present 
+    update_cache: yes
+  with_items: server_utils_debian_pkgs


### PR DESCRIPTION
@edx/devops 

I'd like to move the rando apt dependencies that support interactive debugging to  the own role.

Phase two of this is adding this role explicitly to plays rather than making common dependent on it.

This has been re-based on https://github.com/edx/configuration/pull/2076, which should be merged first.
