### PR TITLE
Fix the HTTP-to-HTTPS redirect on sandboxes

### DIFF
--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/cms.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/cms.j2
@@ -91,6 +91,11 @@ error_page {{ k }} {{ v }};
   {% include "robots.j2" %}
   {% include "static-files.j2" %}
 
+  {% if NGINX_SET_X_FORWARDED_HEADERS %}
+   if ($scheme != "https") {
+    rewrite ^ https://$host$uri permanent;
+   }
+ {% else %}
   # Forward to HTTPS if we're an HTTP request...
   if ($http_x_forwarded_proto = "http") {
     set $do_redirect "true";
@@ -100,5 +105,5 @@ error_page {{ k }} {{ v }};
   if ($do_redirect = "true") {
     rewrite ^ https://$host$request_uri? permanent;
   }
-
+ {% endif %}
 }

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/ecommerce.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/ecommerce.j2
@@ -53,7 +53,12 @@ location @proxy_to_app {
     proxy_pass http://ecommerce_app_server;
   }
 
-# Forward to HTTPS if we're an HTTP request...
+{% if NGINX_SET_X_FORWARDED_HEADERS %}
+   if ($scheme != "https") {
+    rewrite ^ https://$host$uri permanent;
+   }
+ {% else %}
+  # Forward to HTTPS if we're an HTTP request...
   if ($http_x_forwarded_proto = "http") {
     set $do_redirect "true";
   }
@@ -62,5 +67,6 @@ location @proxy_to_app {
   if ($do_redirect = "true") {
     rewrite ^ https://$host$request_uri? permanent;
   }
+ {% endif %}
 }
 

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/insights.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/insights.j2
@@ -33,7 +33,12 @@ location @proxy_to_app {
     proxy_pass http://insights_app_server;
   }
   
-# Forward to HTTPS if we're an HTTP request...
+{% if NGINX_SET_X_FORWARDED_HEADERS %}
+   if ($scheme != "https") {
+    rewrite ^ https://$host$uri permanent;
+   }
+ {% else %}
+  # Forward to HTTPS if we're an HTTP request...
   if ($http_x_forwarded_proto = "http") {
     set $do_redirect "true";
   }
@@ -42,4 +47,5 @@ location @proxy_to_app {
   if ($do_redirect = "true") {
     rewrite ^ https://$host$request_uri? permanent;
   }
+ {% endif %}
 }

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms-preview.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms-preview.j2
@@ -76,6 +76,11 @@ server {
     expires epoch;
   }
 
+  {% if NGINX_SET_X_FORWARDED_HEADERS %}
+   if ($scheme != "https") {
+    rewrite ^ https://$host$uri permanent;
+   }
+ {% else %}
   # Forward to HTTPS if we're an HTTP request...
   if ($http_x_forwarded_proto = "http") {
     set $do_redirect "true";
@@ -85,4 +90,5 @@ server {
   if ($do_redirect = "true") {
     rewrite ^ https://$host$request_uri? permanent;
   }
+ {% endif %}
 }

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
@@ -180,6 +180,11 @@ location ~ ^{{ EDXAPP_MEDIA_URL }}/(?P<file>.*) {
   {% include "robots.j2" %}
   {% include "static-files.j2" %}
 
+ {% if NGINX_SET_X_FORWARDED_HEADERS %}
+   if ($scheme != "https") {
+    rewrite ^ https://$host$uri permanent;
+   }
+ {% else %}
   # Forward to HTTPS if we're an HTTP request...
   if ($http_x_forwarded_proto = "http") {
     set $do_redirect "true";
@@ -189,4 +194,5 @@ location ~ ^{{ EDXAPP_MEDIA_URL }}/(?P<file>.*) {
   if ($do_redirect = "true") {
     rewrite ^ https://$host$request_uri? permanent;
   }
+ {% endif %}
 }

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/programs.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/programs.j2
@@ -52,7 +52,12 @@ location @proxy_to_app {
     proxy_redirect off;
     proxy_pass http://programs_app_server;
   }
-# Forward to HTTPS if we're an HTTP request...
+{% if NGINX_SET_X_FORWARDED_HEADERS %}
+   if ($scheme != "https") {
+    rewrite ^ https://$host$uri permanent;
+   }
+ {% else %}
+  # Forward to HTTPS if we're an HTTP request...
   if ($http_x_forwarded_proto = "http") {
     set $do_redirect "true";
   }
@@ -61,4 +66,5 @@ location @proxy_to_app {
   if ($do_redirect = "true") {
     rewrite ^ https://$host$request_uri? permanent;
   }
+ {% endif %}
 }


### PR DESCRIPTION
@edx/devops , can you please check this change, so I can modify the other nginx configs as well. Thanks

P.S: "COMMON_ENVIRONMENT" variable is taken from the [ansible-provision.sh](https://github.com/edx/configuration/blob/master/util/jenkins/ansible-provision.sh#L180). 
