### PR TITLE
Install a global mongorc.js

### DIFF
--- a/playbooks/roles/ad_hoc_reporting/tasks/main.yml
+++ b/playbooks/roles/ad_hoc_reporting/tasks/main.yml
@@ -148,3 +148,15 @@
     - scripts
     - scripts:mongo
     - install:code
+
+- name: install a global mongorc.js
+  template:
+    src: etc/mongorc.js.j2
+    dest: /etc/mongorc.js
+    mode: 0755
+    owner: root
+    group: root
+  tags:
+    - scripts
+    - scripts:mongo
+    - mongorc

--- a/playbooks/roles/ad_hoc_reporting/templates/etc/mongorc.js.j2
+++ b/playbooks/roles/ad_hoc_reporting/templates/etc/mongorc.js.j2
@@ -1,0 +1,2 @@
+// we only ever connect to secondaries, avoid people needing to remember to type this
+rs.slaveOk();


### PR DESCRIPTION
Right now, users need to type rs.slaveOk() after running a read-replica
mongo script.  This avoids that.  It is compatible with anyone who also
has a ~/.mongorc.js

@edx/devops
