### PR TITLE
E0d/remove aws include

### DIFF
--- a/playbooks/edx-east/edx_ansible.yml
+++ b/playbooks/edx-east/edx_ansible.yml
@@ -1,4 +1,4 @@
-- name: Deploy the edx_ansible role
+- name: Deploy the edx_ansible on AWS
   hosts: all
   sudo: True
   gather_facts: True
@@ -6,4 +6,6 @@
     serial_count: 1
   serial: "{{ serial_count }}"
   roles:
+    - common
+    - aws
     - edx_ansible

--- a/playbooks/roles/edx_ansible/meta/main.yml
+++ b/playbooks/roles/edx_ansible/meta/main.yml
@@ -9,5 +9,5 @@
 #
 ##
 # Role includes for role edx_ansible
-dependencies:
-  - common
+
+dependencies: []

--- a/playbooks/roles/edx_ansible/meta/main.yml
+++ b/playbooks/roles/edx_ansible/meta/main.yml
@@ -11,4 +11,3 @@
 # Role includes for role edx_ansible
 dependencies:
   - common
-  - aws

--- a/playbooks/roles/edx_ansible/meta/main.yml
+++ b/playbooks/roles/edx_ansible/meta/main.yml
@@ -10,4 +10,5 @@
 ##
 # Role includes for role edx_ansible
 
-dependencies: []
+dependencies:
+  - common_vars


### PR DESCRIPTION
@edx/devops 

This refactors role dependencies to the play  so they are very explicit.  I have mixed feelings about common.  I think if it were truly common I'd say it belongs here more.

Thoughts about this as a general pattern?  I'm thinking that the only place we would use meta includes for things that are more likely inheritance and plays for things that are more like composition. 
