### PR TITLE
Use Django 1.8 migration command when updating ORA2.

### DIFF
--- a/playbooks/edx-east/ora2.yml
+++ b/playbooks/edx-east/ora2.yml
@@ -34,7 +34,7 @@
 
     - name: syncdb and migrate
       shell: >
-        {{ edxapp_venv_dir }}/bin/python manage.py lms syncdb --migrate --noinput --settings=aws_migrate
+        {{ edxapp_venv_dir }}/bin/python manage.py lms migrate --settings=aws
         chdir={{ edxapp_code_dir }}
       environment:
         DB_MIGRATION_USER: "{{ edxapp_mysql_user }}"


### PR DESCRIPTION
Using `manange.py lms syncdb --migrate` is no longer the correct command for running all the migrations.

@andy-armstrong @efischer19 
