### PR TITLE
Playbook to create mongo users

### DIFF
--- a/playbooks/edx-east/create_mongo_users.yml
+++ b/playbooks/edx-east/create_mongo_users.yml
@@ -1,0 +1,44 @@
+#
+# This play expects PyMongo to be installed locally.  You need to provide
+# the hostname or IP address of one of the mongo hosts, 
+#
+# ansible-playbook -i localhost, create_mongo_users.yml -e@edx.yml -e@stage-edx.yml -e@db/edxapp-mongo.yml
+#
+# edxapp-mongo.yml should define MONGO_USERS with the following format
+#
+# MONGO_USERS:
+#   - user: edxapp001
+#     password: secret
+#     database: edxapp
+#     roles: readWrite
+# 
+# It should also define a login_host and repl_set.  You can set login_host to
+# be any member of your cluster as this code will find and connect to the
+# primary.
+#
+# login_host: 10.17.90.123
+# repl_set: prod-edx-edxapp
+
+- name: Create mongo users
+  hosts: all
+  gather_facts: False
+  connection: local
+# This allows you to use your virtualenv's pymongo instead of installing it globally
+  vars:
+    ansible_python_interpreter: "/usr/bin/env python"
+  tasks:
+    - name: install python mongo module
+      pip: name=pymongo state=present
+
+    - name: create a mongodb user
+      mongodb_user:
+        database: "{{ item.database }}"
+        login_user: "{{ MONGO_ADMIN_USER }}"
+        login_password: "{{ MONGO_ADMIN_PASSWORD }}"
+        login_host: "{{ login_host }}"
+        name: "{{ item.user }}"
+        password: "{{ item.password }}"
+        roles: "{{ item.roles }}"
+        state: present
+        replica_set: "{{ repl_set }}"
+      with_items: MONGO_USERS


### PR DESCRIPTION
This runs from the local machine and needs to know an IP of any member
of the cluster as well as the replica set.  We can add both of those to
the shim db/edxapp-mongo.yml file in the secure directories easily (see relevant PRs).

@edx/devops 
