### PR TITLE
Django 1.8 migration changes for xqueue

### DIFF
--- a/playbooks/roles/xqueue/tasks/deploy.yml
+++ b/playbooks/roles/xqueue/tasks/deploy.yml
@@ -87,9 +87,9 @@
 
 # If there is a common user for migrations run migrations using his username
 # and credentials. If not we use the xqueue mysql user
-- name: syncdb and migrate
+- name: migrate
   shell: >
-    SERVICE_VARIANT=xqueue {{ xqueue_venv_bin }}/django-admin.py syncdb --migrate --noinput --settings=xqueue.aws_migrate --pythonpath={{ xqueue_code_dir }}
+    SERVICE_VARIANT=xqueue {{ xqueue_venv_bin }}/django-admin.py migrate --noinput --settings=xqueue.aws_migrate --pythonpath={{ xqueue_code_dir }}
   sudo_user: "{{ xqueue_user }}"
   environment:
     DB_MIGRATION_USER: "{{ COMMON_MYSQL_MIGRATE_USER }}"


### PR DESCRIPTION
Now that XQueue's repo is running on 1.8, we need to use the new syntax
https://docs.djangoproject.com/en/1.8/ref/django-admin/#syncdb

@edx/devops 
