### PR TITLE
Rotate mongodb.log and serverStatus.log independently

### DIFF
--- a/playbooks/roles/mongo_3_0/templates/mongo_logrotate.j2
+++ b/playbooks/roles/mongo_3_0/templates/mongo_logrotate.j2
@@ -1,4 +1,18 @@
-{{ mongo_log_dir }}/*.log {
+{{ mongo_log_dir }}/serverStatus.log {
+  create
+  compress
+  copytruncate
+  delaycompress
+  dateext
+  dateformat -%Y%m%d-%s
+  missingok
+  notifempty
+  daily
+  rotate 90
+  size 1M
+}
+
+{{ mongo_log_dir }}/mongodb.log {
   create
   compress
   copytruncate


### PR DESCRIPTION
We were ending up with gaps in our logs on disk (everything was in
splunk, but missing in /edx/var/log/mongo).  When this ran previously
and roatated serverStatus.log but mongodb.log was less than 1M and
didn't need to rotate, the killall -USR1 to mongo would cause the log to
be reopened and written over.
