### PR TITLE
Restart based on the flower user, not a hardcoded service name

### DIFF
--- a/playbooks/roles/flower/handlers/main.yml
+++ b/playbooks/roles/flower/handlers/main.yml
@@ -4,5 +4,5 @@
     state=restarted
     supervisorctl_path={{ supervisor_ctl }}
     config={{ supervisor_cfg }}
-    name="flower"
+    name="{{ FLOWER_USER }}"
   sudo_user: "{{supervisor_service_user }}"


### PR DESCRIPTION
d267342a changed supervisor to run as FLOWER_USER not flower, without
this change, ansible errors out asking supervisor to restart when the
tools box has jobs named stage_flower, prod_flower etc.

@edx/devops
