### PR TITLE
Skip tags fail when tags don't exist, which in this case is most ever…

### DIFF
--- a/util/vpc-tools/abbey.py
+++ b/util/vpc-tools/abbey.py
@@ -360,8 +360,8 @@ fi
 
 extra_args_opts+=" -e@$extra_vars"
 
-ansible-playbook -vvvv -c local -i "localhost," --skip-tags="install:devstack,migrate:devstack" $play.yml $extra_args_opts
-ansible-playbook -vvvv -c local -i "localhost," --skip-tags="install:devstack,migrate:devstack" stop_all_edx_services.yml $extra_args_opts
+ansible-playbook -vvvv -c local -i "localhost," $play.yml $extra_args_opts
+ansible-playbook -vvvv -c local -i "localhost," stop_all_edx_services.yml $extra_args_opts
 
 rm -rf $base_dir
 


### PR DESCRIPTION
…ywhere.

@feanil @clintonb @cpennington 

This needs to be reverted to unblock building AMIs for anything other than course-discovery.  

```
+ ansible-playbook -vvvv -c local -i localhost, --skip-tags=install:devstack,migrate:devstack ecommerce.yml -e@/var/tmp/edx-cfg/edx-secure/ansible/vars/edx.yml -e@/var/tmp/edx-cfg/edx-secure/ansible/vars/stage-edx.yml -e@/var/tmp/edx-cfg/extra-vars-1375.yml
ERROR: tag(s) not found in playbook: install:devstack,migrate:devstack.  possible values:
```

We'll need to adjust our approach here, may make sense to make an Ansible change.
