### PR TITLE
Need to install Python-MySQL pre-reqs

### DIFF
--- a/playbooks/roles/edx_ansible/defaults/main.yml
+++ b/playbooks/roles/edx_ansible/defaults/main.yml
@@ -23,6 +23,7 @@ EDX_ANSIBLE_DUMP_VARS: false
 edx_ansible_debian_pkgs:
   - python-pip
   - python-apt
+  - libmysqlclient-dev
   - git-core
   - build-essential
   - python-dev

--- a/util/vpc-tools/abbey.py
+++ b/util/vpc-tools/abbey.py
@@ -277,7 +277,7 @@ if [[ ! -x /usr/bin/git || ! -x /usr/bin/pip ]]; then
     /usr/bin/apt-get update
     /usr/bin/apt-get install -y git python-pip python-apt \\
         git-core build-essential python-dev libxml2-dev \\
-        libxslt-dev curl --force-yes
+        libxslt-dev curl libmysqlclient-dev --force-yes
 fi
 
 


### PR DESCRIPTION
libmysqlclient-dev needs to be installed for the configuration repo pip requirements to install now.

@jibsheet @feanil @clintonb @cpennington 
