### PR TITLE
Move swapfile role to the beginning of the edx_sandbox.yml playbook.

### DIFF
--- a/playbooks/edx_sandbox.yml
+++ b/playbooks/edx_sandbox.yml
@@ -20,6 +20,7 @@
     COMMON_ENABLE_SPLUNKFORWARDER: False
     ENABLE_LEGACY_ORA: !!null
   roles:
+    - { role: swapfile, SWAPFILE_SIZE: "2GB" }
     - role: nginx
       nginx_sites:
       - certs
@@ -54,7 +55,6 @@
       when: ENABLE_LEGACY_ORA
     - certs
     - edx_ansible
-    - { role: swapfile, SWAPFILE_SIZE: "2GB" }
     - role: datadog
       when: COMMON_ENABLE_DATADOG
     - role: splunkforwarder


### PR DESCRIPTION
We deploy on our sandboxes on OpenStack machines with 4 GB of RAM and no swap enabled by default, which results in memory pressure already during the installation process, so we need to have the swapfile role first.
