### PR TITLE
fixing ref error

### DIFF
--- a/playbooks/callback_plugins/datadog_tasks_timing.py
+++ b/playbooks/callback_plugins/datadog_tasks_timing.py
@@ -1,0 +1,94 @@
+import os
+import datetime
+import time
+import logging
+import datadog
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+"""
+Originally written by 'Jharrod LaFon'
+#https://github.com/jlafon/ansible-profile/blob/master/callback_plugins/profile_tasks.py
+
+"""
+
+
+class CallbackModule(object):
+
+    """
+
+    Ansible plugin get the time of each task and total time to run the complete playbook
+
+    """
+    def __init__(self):
+        self.stats = {}
+        self.current_task = None
+        self.datadog_api_key = os.getenv('DATADOG_API_KEY')
+        self.datadog_app_key = os.getenv('DATADOG_APP_KEY')
+        self.datadog_api_initialized = False
+
+        if self.datadog_api_key and self.datadog_app_key:
+            datadog.initialize(api_key=self.datadog_api_key,
+                               app_key=self.datadog_app_key)
+            self.datadog_api_initialized = True
+
+    def playbook_on_task_start(self, name, is_conditional):
+
+        """
+        Logs the start of each task 
+        """
+
+        if self.current_task is not None:
+            # Record the running time of the last executed task
+            self.stats[self.current_task] = (time.time(), time.time() - self.stats[self.current_task])
+
+        # Record the start time of the current task
+        self.current_task = name
+        self.stats[self.current_task] = time.time()
+
+    def playbook_on_stats(self, stats):
+
+        """
+        Prints the timing of each task and total time to run the complete playbook
+        """
+
+        # Record the timing of the very last task, we use it here, because we don't have stop task function by default
+        if self.current_task is not None:
+            self.stats[self.current_task] = (time.time(), time.time() - self.stats[self.current_task])
+
+        # Sort the tasks by their running time
+        results = sorted(self.stats.items(), key=lambda value: value[1][1], reverse=True)
+
+        # Total time to run the complete playbook
+        total_seconds = sum([x[1][1] for x in self.stats.items()])
+
+        # send the metric to datadog
+        if self.datadog_api_initialized:
+            for name, points in results:
+                datadog.api.Metric.send(
+                    metric="edx.ansible.{0}.task_duration".format(name.replace(" | ", ".").replace(" ", "-").lower()),
+                    date_happened=[0],
+                    points=points[1],
+                )
+            datadog.api.Metric.send(
+                metric="edx.ansible.play_duration",
+                date_happened=time.time(),
+                points=total_seconds,
+            )
+
+        # Log the time of each task
+        for name, elapsed in results:
+            logger.info(
+                "{0:-<80}{1:->8}".format(
+                    '{0} '.format(name),
+                    ' {0:.02f}s'.format(elapsed[1]),
+                )
+            )
+
+        logger.info("\nPlaybook finished: {0}, {1} total tasks.  {2} elapsed. \n".format(
+                time.asctime(),
+                len(self.stats.items()),
+                datetime.timedelta(seconds=(int(total_seconds)))
+                )
+          )


### PR DESCRIPTION
In Jenkins we were seeing the following error after merging @arbabnazar branch.

```
15:34:31 Traceback (most recent call last):
15:34:31   File "/var/lib/jenkins/shiningpanda/jobs/be565cb2/virtualenvs/d41d8cd9/bin/ansible-playbook", line 324, in <module>
15:34:31     sys.exit(main(sys.argv[1:]))
15:34:31   File "/var/lib/jenkins/shiningpanda/jobs/be565cb2/virtualenvs/d41d8cd9/bin/ansible-playbook", line 210, in main
15:34:31     force_handlers=options.force_handlers,
15:34:31   File "/var/lib/jenkins/shiningpanda/jobs/be565cb2/virtualenvs/d41d8cd9/local/lib/python2.7/site-packages/ansible/playbook/__init__.py", line 181, in __init__
15:34:31     ansible.callbacks.load_callback_plugins()
15:34:31   File "/var/lib/jenkins/shiningpanda/jobs/be565cb2/virtualenvs/d41d8cd9/local/lib/python2.7/site-packages/ansible/callbacks.py", line 51, in load_callback_plugins
15:34:31     callback_plugins = [x for x in utils.plugins.callback_loader.all()]
15:34:31   File "/var/lib/jenkins/shiningpanda/jobs/be565cb2/virtualenvs/d41d8cd9/local/lib/python2.7/site-packages/ansible/utils/plugins.py", line 232, in all
15:34:31     self._module_cache[path] = imp.load_source('.'.join([self.package, name]), path)
15:34:31   File "/vol/ebs-01/jenkins/jobs/ansible-provision/workspace/configuration/playbooks/callback_plugins/datadog_tasks_timing.py", line 5, in <module>
15:34:31     import datadog
15:34:31   File "/var/lib/jenkins/shiningpanda/jobs/be565cb2/virtualenvs/d41d8cd9/local/lib/python2.7/site-packages/datadog/__init__.py", line 10, in <module>
15:34:31     from pkg_resources import get_distribution, DistributionNotFound
15:34:31   File "/var/lib/jenkins/shiningpanda/jobs/be565cb2/virtualenvs/d41d8cd9/local/lib/python2.7/site-packages/setuptools-0.6c11-py2.7.egg/pkg_resources.py", line 2603, in <module>
15:34:31   File "/var/lib/jenkins/shiningpanda/jobs/be565cb2/virtualenvs/d41d8cd9/local/lib/python2.7/site-packages/setuptools-0.6c11-py2.7.egg/pkg_resources.py", line 666, in require
15:34:31   File "/var/lib/jenkins/shiningpanda/jobs/be565cb2/virtualenvs/d41d8cd9/local/lib/python2.7/site-packages/setuptools-0.6c11-py2.7.egg/pkg_resources.py", line 565, in resolve
15:34:31 pkg_resources.DistributionNotFound: paramiko
```

This error was not particularly helpful as the root cause was a NameError in the plugin...

```
NameError: global name 'datadog_api_key' is not defined
```
