### PR TITLE
Work around a supervisord bug causing the provisioning to hang intermittently.

### DIFF
--- a/playbooks/roles/edxapp/tasks/deploy.yml
+++ b/playbooks/roles/edxapp/tasks/deploy.yml
@@ -378,21 +378,19 @@
     state=started
     supervisorctl_path={{ supervisor_ctl }}
     config={{ supervisor_cfg }}
-    name="edxapp:{{ item }}"
+    name="edxapp:"
   sudo_user: "{{ supervisor_service_user }}"
   when: celery_worker is not defined and not disable_edx_services
-  with_items: service_variants_enabled
   tags:
     - manage
 
 - name: ensure edxapp_workers has started
   supervisorctl: >
-    name="edxapp_worker:{{ item.service_variant }}_{{ item.queue }}_{{ item.concurrency }}"
+    name="edxapp_worker:"
     supervisorctl_path={{ supervisor_ctl }}
     config={{ supervisor_cfg }}
     state=started
   when: celery_worker is defined and not disable_edx_services
-  with_items: edxapp_workers
   sudo_user: "{{ supervisor_service_user }}"
   tags:
     - manage
@@ -442,21 +440,19 @@
     state=restarted
     supervisorctl_path={{ supervisor_ctl }}
     config={{ supervisor_cfg }}
-    name="edxapp:{{ item }}"
+    name="edxapp:"
   when: edxapp_installed is defined and celery_worker is not defined and not disable_edx_services
   sudo_user: "{{ supervisor_service_user }}"
-  with_items: service_variants_enabled
   tags:
     - manage
 
 - name: restart edxapp_workers
   supervisorctl: >
-    name="edxapp_worker:{{ item.service_variant }}_{{ item.queue }}_{{ item.concurrency }}"
+    name="edxapp_worker:"
     supervisorctl_path={{ supervisor_ctl }}
     config={{ supervisor_cfg }}
     state=restarted
   when: edxapp_installed is defined and celery_worker is defined and not disable_edx_services
-  with_items: edxapp_workers
   sudo_user: "{{ common_web_user }}"
   tags:
     - manage


### PR DESCRIPTION
We've experienced an intermittent problem with supervisorctl hanging when restarting the edxapp celery workers on our sandboxes.  When the problem occurred, [the Ansible task that starts (or checks) the workers](https://github.com/edx/configuration/blob/385733109afdc13e9b6b8b149b408d8c934b1971/playbooks/roles/edxapp/tasks/deploy.yml#L439) hung indefintely on one of the workers.  When logging in to the machine, calling `supervisorctl status` on the respective procees showed in the state "STOPPING".  The corresponding child process of supervisord sometimes has zombie child processes, and the supervisorctl process was hanging.  Killing either supervisorctl or the right child process of supervisord resolved the situation (and caused the Ansible task to fail).  The exact symptoms of the problem varied across multiple executions with exactly the same configuration, and one incarnation of the problem was reported on the openedx-ops mailing list a while ago (I don't have the link at the moment).

Similar problems with supervisord have been reported on superuser.com, various Linux distribution bug trackers and the bug tracker of supervisord itself, e.g. [this bug](https://github.com/Supervisor/supervisor/issues/131).  To me, it looks like some kind of deadlock, either in the communication between supervisorctl and supervisord or in the communication between supervisord and the celery worker.  Some sources indicate that the problem is fixed in newer versions of supervisord.

We usually only encountered the problem intermittently when under memory pressure, but during the tests for #2527 it occurred consistently even with swap enabled, which gave me the opportunity to test work-arounds.  The patch in this PR resulted in the provisioning consistently working, while it consistently failed without it.  Since it is also a code simplification, I hope it qualifies for inclusion in spite of the elusive nature of the bug it works around.

(Chesterton's fence: Support for group names was [added to Ansible in version 1.6](http://docs.ansible.com/ansible/supervisorctl_module.html), which explains the current version of the code.)
