### PR TITLE
Tweak python package versions to remove hardcoded os version and calculate it instead

### DIFF
--- a/playbooks/roles/common_vars/defaults/main.yml
+++ b/playbooks/roles/common_vars/defaults/main.yml
@@ -93,7 +93,7 @@ common_debian_pkgs:
   - rsyslog
   - git
   - unzip
-  - "python2.7=2.7.10-0+precise1"
+  - "python2.7=2.7.10-0+{{ ansible_distribution_release }}1"
   - python-pip
   - python2.7-dev
   


### PR DESCRIPTION
Without this - installation of python 2.7.10 fails on 14.04

@edx/devops This was preventing AMI builds of programs on Friday due to the
2.7.10 upgrade and the precise package not existing on 14.04
