### PR TITLE
Add port for debugging ORA2 Karma tests

### DIFF
--- a/vagrant/release/devstack/Vagrantfile
+++ b/vagrant/release/devstack/Vagrantfile
@@ -105,6 +105,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.network :forwarded_port, guest: 18080, host: 18080  # Forums
   config.vm.network :forwarded_port, guest: 8100, host: 8100  # Analytics Data API
   config.vm.network :forwarded_port, guest: 8110, host: 8110  # Insights
+  config.vm.network :forwarded_port, guest: 9876, host: 9876  # ORA2 Karma tests
   config.vm.network :forwarded_port, guest: 50070, host: 50070  # HDFS Admin UI
   config.vm.network :forwarded_port, guest: 8088, host: 8088  # Hadoop Resource Manager
   config.ssh.insert_key = true


### PR DESCRIPTION
This is a trivial change to add port forwarding for the ORA2 Karma tests so that they can be debugged locally.

@feanil @benpatterson please review.
