### PR TITLE
[ECOM-3111] E-Commerce devstack uses wrong configuration

### DIFF
--- a/playbooks/vagrant-devstack.yml
+++ b/playbooks/vagrant-devstack.yml
@@ -15,6 +15,7 @@
     EDXAPP_LMS_BASE: 127.0.0.1:8000
     EDXAPP_OAUTH_ENFORCE_SECURE: false
     EDXAPP_LMS_BASE_SCHEME: http
+    ECOMMERCE_DJANGO_SETTINGS_MODULE: "ecommerce.settings.devstack"
   roles:
     - edx_ansible
     - mysql


### PR DESCRIPTION
Devstack ecommerce app should now use the proper 'ecommerce.settings.devstack' Django module.

https://openedx.atlassian.net/browse/ECOM-3111

@clintonb @feanil , please take a look.
