### PR TITLE
Ansible bootstrap script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+help:
+	@echo '													'
+	@echo 'Makefile for the edX Configuration                                                               ' 
+	@echo '                                                                                     		'
+	@echo 'Usage:                                                                               		'
+	@echo '    make requirements                 install requirements					'
+	@echo '                                                                                     		'
+
+requirements:
+	pip install -qr pre-requirements.txt --exists-action w
+	pip install -qr requirements.txt --exists-action w
+
+# Targets in a Makefile which do not produce an output file with the same name as the target name
+.PHONY: help requirements 

--- a/util/install/ansible-bootstrap.sh
+++ b/util/install/ansible-bootstrap.sh
@@ -79,10 +79,15 @@ fi
 # Required for add-apt-repository
 apt-get install -y software-properties-common python-software-properties git
 
-# Install python 2.7.10
-add-apt-repository ppa:fkrull/deadsnakes-python2.7
+# Add git PPA
+add-apt-repository ppa:git-core/ppa
+
+# Add python PPA
+ppa:git-core/ppa
+
+# Install python 2.7.10, git and other common requirements
 apt-get update -y
-apt-get install -y build-essential sudo python2.7 python2.7-dev python-pip python-apt python-yaml python-jinja2 libmysqlclient-dev
+apt-get install -y build-essential sudo git python2.7 python2.7-dev python-pip python-apt python-yaml python-jinja2 libmysqlclient-dev
 
 pip install virtualenv==${VIRTUAL_ENV_VERSION}
 

--- a/util/install/ansible-bootstrap.sh
+++ b/util/install/ansible-bootstrap.sh
@@ -7,8 +7,9 @@
 # for building images that requires having ansible available.
 #
 # Can be run as follows:
-# bash <(curl -s https://raw.githubusercontent.com/edx/configuration/e0d/bootstrap-script/util/install/ansible-bootstrap.sh)
 #
+# UPGRADE_OS=true CONFIGURATION_VERSION="master" \
+# bash <(curl -s https://raw.githubusercontent.com/edx/configuration/master/util/install/ansible-bootstrap.sh)
 
 set -xe
 
@@ -89,7 +90,9 @@ add-apt-repository -y ppa:git-core/ppa
 # Add python PPA
 add-apt-repository -y ppa:fkrull/deadsnakes-python2.7
 
-# Install python 2.7.10, git and other common requirements
+# Install python 2.7 latest, git and other common requirements
+# NOTE: This will install the latest version of python 2.7 and
+# which may differ from what is pinned in virtualenvironments
 apt-get update -y
 apt-get install -y build-essential sudo git-core python2.7 python2.7-dev python-pip python-apt python-yaml python-jinja2 libmysqlclient-dev
 
@@ -123,7 +126,9 @@ cat << EOF
 ******************************************************************************
 
 Done bootstrapping, edx_ansible is now installed in /edx/app/edx_ansible.
-Time to run some plays.
+Time to run some plays.  Activate the virtual env with 
+
+> . /edx/app/edx_ansible/venvs/edx_ansible/bin/activate 
 
 ******************************************************************************
 EOF

--- a/util/install/ansible-bootstrap.sh
+++ b/util/install/ansible-bootstrap.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+
+#
+# Script for installing Ansible and the edX configuration repostory
+# onto a host to enable running ansible to complete configuration.
+# This script can be used by Docker, Packer or any other system
+# for building images that requires having ansible available.
+#
+
+set -xe
+
+if [[ -z "$ANSIBLE_REPO" ]]; then
+  ANSIBLE_REPO="https://github.com/edx/ansible.git"
+fi
+
+if [[ -z "$ANSIBLE_VERSION" ]]; then
+  ANSIBLE_VERSION="master"
+fi
+
+if [[ -z "$CONFIGURATION_REPO" ]]; then
+  CONFIGURATION_REPO="https://github.com/edx/configuration.git"
+fi
+
+if [[ -z "$CONFIGURATION_VERSION" ]]; then
+  CONFIGURATION_VERSION="e0d/hacking"
+fi
+
+#
+# Bootstrapping constants
+#
+VIRTUAL_ENV="/tmp/bootstrap"
+PYTHON_BIN="${VIRTUAL_ENV}/bin"
+ANSIBLE_DIR="/tmp/ansible"
+CONFIGURATION_DIR="/tmp/configuration"
+
+cat << EOF
+******************************************************************************
+
+Running the edx-ansible bootstrap script with the following arguments:
+
+ANSIBLE_REPO="${ANSIBLE_REPO}"
+ANSIBLE_VERSION="${ANSIBLE_VERSION}"
+CONFIGURATION_REPO="${CONFIGURATION_REPO}"
+CONFIGURATION_VERSION="${CONFIGURATION_VERSION}"
+
+******************************************************************************
+EOF
+
+
+if [[ $(id -u) -ne 0 ]] ; then
+    "Please run as root";
+    exit 1;
+fi
+
+if ! grep -q 'Precise Pangolin' /etc/os-release; then
+    cat << EOF
+    This script is only known to work on Ubuntu Precise, exiting.
+    If you are interested in helping make installation possible
+    on other platforms, let us know.
+EOF
+   exit 1;
+fi
+
+# Upgrade the OS
+apt-get update -y
+apt-get upgrade -y
+
+# Required for add-apt-repository
+apt-get install -y software-properties-common python-software-properties git
+
+# Install python 2.7.10
+add-apt-repository ppa:fkrull/deadsnakes-python2.7
+apt-get update -y
+apt-get install -y build-essential sudo python2.7 python2.7-dev python-pip python-apt python-yaml python-jinja2 libmysqlclient-dev
+
+pip install virtualenv==13.1.2
+
+# create a new virtual env
+/usr/local/bin/virtualenv ${VIRTUAL_ENV}
+
+PATH=${PYTHON_BIN}:${PATH}
+
+# Install the configuration repository to install 
+# edx-ansible role
+git clone ${CONFIGURATION_REPO} ${CONFIGURATION_DIR}
+cd ${CONFIGURATION_DIR}
+git checkout ${CONFIGURATION_VERSION}
+make requirements
+
+cd ${CONFIGURATION_DIR}/playbooks/edx-east
+${PYTHON_BIN}/ansible-playbook edx_ansible.yml -i '127.0.0.1,' -c local -e "configuration_version=${CONFIGURATION_VERSION}"
+
+# cleanup
+rm -rf ${ANSIBLE_DIR}
+rm -rf ${CONFIGURATION_DIR}
+rm -rf ${VIRTUAL_ENV}
+
+cat << EOF
+******************************************************************************
+
+Done bootstrapping, edx-ansible is now installed in /edx/app/edx-ansible.
+Time to run some plays.
+
+******************************************************************************
+EOF
+

--- a/util/install/ansible-bootstrap.sh
+++ b/util/install/ansible-bootstrap.sh
@@ -22,12 +22,13 @@ if [[ -z "$CONFIGURATION_REPO" ]]; then
 fi
 
 if [[ -z "$CONFIGURATION_VERSION" ]]; then
-  CONFIGURATION_VERSION="e0d/hacking"
+  CONFIGURATION_VERSION="master"
 fi
 
 #
 # Bootstrapping constants
 #
+VIRTUAL_ENV_VERSION="13.1.2"
 VIRTUAL_ENV="/tmp/bootstrap"
 PYTHON_BIN="${VIRTUAL_ENV}/bin"
 ANSIBLE_DIR="/tmp/ansible"
@@ -48,7 +49,7 @@ EOF
 
 
 if [[ $(id -u) -ne 0 ]] ; then
-    "Please run as root";
+    echo "Please run as root";
     exit 1;
 fi
 
@@ -73,7 +74,7 @@ add-apt-repository ppa:fkrull/deadsnakes-python2.7
 apt-get update -y
 apt-get install -y build-essential sudo python2.7 python2.7-dev python-pip python-apt python-yaml python-jinja2 libmysqlclient-dev
 
-pip install virtualenv==13.1.2
+pip install virtualenv==${VIRTUAL_ENV_VERSION}
 
 # create a new virtual env
 /usr/local/bin/virtualenv ${VIRTUAL_ENV}

--- a/util/install/ansible-bootstrap.sh
+++ b/util/install/ansible-bootstrap.sh
@@ -25,6 +25,10 @@ if [[ -z "$CONFIGURATION_VERSION" ]]; then
   CONFIGURATION_VERSION="master"
 fi
 
+if [[ -z "UPGRADE_OS" ]]; then
+  UPGRADE_OS=false
+fi
+
 #
 # Bootstrapping constants
 #
@@ -53,18 +57,24 @@ if [[ $(id -u) -ne 0 ]] ; then
     exit 1;
 fi
 
-if ! grep -q 'Precise Pangolin' /etc/os-release; then
+if ! grep -q -e 'Precise Pangolin' -e 'Trusty Tahr' /etc/os-release; then
     cat << EOF
-    This script is only known to work on Ubuntu Precise, exiting.
-    If you are interested in helping make installation possible
+    
+    This script is only known to work on Ubuntu Precise and Trusty,
+    exiting.  If you are interested in helping make installation possible
     on other platforms, let us know.
+
 EOF
    exit 1;
 fi
 
 # Upgrade the OS
 apt-get update -y
-apt-get upgrade -y
+
+if [ "$UPGRADE_OS" = true ]; then
+    echo "Upgrading the OS..."
+    apt-get upgrade -y
+fi
 
 # Required for add-apt-repository
 apt-get install -y software-properties-common python-software-properties git

--- a/util/install/ansible-bootstrap.sh
+++ b/util/install/ansible-bootstrap.sh
@@ -90,6 +90,8 @@ add-apt-repository -y ppa:fkrull/deadsnakes-python2.7
 apt-get update -y
 apt-get install -y build-essential sudo git-core python2.7 python2.7-dev python-pip python-apt python-yaml python-jinja2 libmysqlclient-dev
 
+PATH=$PATH:/usr/local/bin
+
 pip install --upgrade pip setuptools
 pip install virtualenv==${VIRTUAL_ENV_VERSION}
 

--- a/util/install/ansible-bootstrap.sh
+++ b/util/install/ansible-bootstrap.sh
@@ -70,6 +70,7 @@ fi
 
 # Upgrade the OS
 apt-get update -y
+apt-key update -y
 
 if [ "$UPGRADE_OS" = true ]; then
     echo "Upgrading the OS..."

--- a/util/install/ansible-bootstrap.sh
+++ b/util/install/ansible-bootstrap.sh
@@ -90,6 +90,7 @@ add-apt-repository -y ppa:fkrull/deadsnakes-python2.7
 apt-get update -y
 apt-get install -y build-essential sudo git-core python2.7 python2.7-dev python-pip python-apt python-yaml python-jinja2 libmysqlclient-dev
 
+pip install --upgrade pip setuptools
 pip install virtualenv==${VIRTUAL_ENV_VERSION}
 
 # create a new virtual env

--- a/util/install/ansible-bootstrap.sh
+++ b/util/install/ansible-bootstrap.sh
@@ -77,17 +77,17 @@ if [ "$UPGRADE_OS" = true ]; then
 fi
 
 # Required for add-apt-repository
-apt-get install -y software-properties-common python-software-properties git
+apt-get install -y software-properties-common python-software-properties
 
 # Add git PPA
-add-apt-repository ppa:git-core/ppa
+add-apt-repository -y ppa:git-core/ppa
 
 # Add python PPA
-ppa:git-core/ppa
+add-apt-repository -y ppa:fkrull/deadsnakes-python2.7
 
 # Install python 2.7.10, git and other common requirements
 apt-get update -y
-apt-get install -y build-essential sudo git python2.7 python2.7-dev python-pip python-apt python-yaml python-jinja2 libmysqlclient-dev
+apt-get install -y build-essential sudo git-core python2.7 python2.7-dev python-pip python-apt python-yaml python-jinja2 libmysqlclient-dev
 
 pip install virtualenv==${VIRTUAL_ENV_VERSION}
 

--- a/util/install/ansible-bootstrap.sh
+++ b/util/install/ansible-bootstrap.sh
@@ -6,6 +6,9 @@
 # This script can be used by Docker, Packer or any other system
 # for building images that requires having ansible available.
 #
+# Can be run as follows:
+# bash <(curl -s https://raw.githubusercontent.com/edx/configuration/e0d/bootstrap-script/util/install/ansible-bootstrap.sh)
+#
 
 set -xe
 

--- a/util/install/ansible-bootstrap.sh
+++ b/util/install/ansible-bootstrap.sh
@@ -44,7 +44,7 @@ CONFIGURATION_DIR="/tmp/configuration"
 cat << EOF
 ******************************************************************************
 
-Running the edx-ansible bootstrap script with the following arguments:
+Running the edx_ansible bootstrap script with the following arguments:
 
 ANSIBLE_REPO="${ANSIBLE_REPO}"
 ANSIBLE_VERSION="${ANSIBLE_VERSION}"
@@ -105,7 +105,7 @@ pip install virtualenv==${VIRTUAL_ENV_VERSION}
 PATH=${PYTHON_BIN}:${PATH}
 
 # Install the configuration repository to install 
-# edx-ansible role
+# edx_ansible role
 git clone ${CONFIGURATION_REPO} ${CONFIGURATION_DIR}
 cd ${CONFIGURATION_DIR}
 git checkout ${CONFIGURATION_VERSION}
@@ -122,7 +122,7 @@ rm -rf ${VIRTUAL_ENV}
 cat << EOF
 ******************************************************************************
 
-Done bootstrapping, edx-ansible is now installed in /edx/app/edx-ansible.
+Done bootstrapping, edx_ansible is now installed in /edx/app/edx_ansible.
 Time to run some plays.
 
 ******************************************************************************

--- a/util/install/ansible-bootstrap.sh
+++ b/util/install/ansible-bootstrap.sh
@@ -93,9 +93,10 @@ add-apt-repository -y ppa:fkrull/deadsnakes-python2.7
 apt-get update -y
 apt-get install -y build-essential sudo git-core python2.7 python2.7-dev python-pip python-apt python-yaml python-jinja2 libmysqlclient-dev
 
-PATH=$PATH:/usr/local/bin
-
 pip install --upgrade pip setuptools
+
+# pip moves to /usr/local/bin when upgraded
+PATH=/usr/local/bin:${PATH}
 pip install virtualenv==${VIRTUAL_ENV_VERSION}
 
 # create a new virtual env


### PR DESCRIPTION
@benpatterson cleaned  up script and Makefile

@edx/devops Bootstrapping script that ultimately installs the edx_ansible role on an Ubuntu Precise hosts.  Overlaps with the sandbox.sh script, but that script should use this.  This script can be used by both packer and docker to bootstrap image building, regardless of the packing tools

I would like to merge this to master and rebase the docker branch to pull it in.  This will remove a substantial amount of duplication from the Dockerfiles.
