### PR TITLE
Update the apt-cache if it hasn't been updated within the last hour (…

### DIFF
--- a/playbooks/roles/edx_service/tasks/main.yml
+++ b/playbooks/roles/edx_service/tasks/main.yml
@@ -116,7 +116,11 @@
     - install:configuration
   
 - name: install a bunch of system packages on which edx_service relies
-  apt: pkg={{ item }} state=present
+  apt:
+    pkg: "{{ item }}"
+    state: present
+    update_cache: true
+    cache_valid_time: 3600
   with_items: edx_service_packages.debian
   when: ansible_distribution in common_debian_variants
   tags:


### PR DESCRIPTION
…when installing system packages in edx_service)

@feanil @e0d: apt-get cache updates, as promised.
