### PR TITLE
Remove openid_workaround

### DIFF
--- a/util/jenkins/check-migrations.sh
+++ b/util/jenkins/check-migrations.sh
@@ -31,10 +31,6 @@ if [[ -f requirements/edx/local.txt ]]; then
 fi
 pip install --exists-action w -r requirements/edx/edx-private.txt
 
-if [[ $openid_workaround == "true" ]]; then
-    sed -i -e 's/claimed_id = models.TextField(max_length=2047, unique=True/claimed_id = models.TextField(max_length=2047/'  "$VIRTUAL_ENV/lib/python2.7/site-packages/django_openid_auth/models.py"
-fi
-
 cd "$WORKSPACE/configuration/playbooks/edx-east"
 
 if [[ -f ${WORKSPACE}/configuration-secure/ansible/vars/${deployment}.yml ]]; then


### PR DESCRIPTION
We now run off a fork of django_openid_auth
The unique constraint was removed in our fork, this sed is a no-op
https://github.com/edx/django-openid-auth/commit/ea49a01d85cb2fccc5fe34f3d0e042dc1deaf8e8

@edx-ops/devops
