### PR TITLE
Vagrant playbooks need common now.

### DIFF
--- a/playbooks/vagrant-analytics.yml
+++ b/playbooks/vagrant-analytics.yml
@@ -16,6 +16,7 @@
     EDXAPP_OAUTH_ENFORCE_SECURE: false
     EDXAPP_LMS_BASE_SCHEME: http
   roles:
+    - common
     - edx_ansible
     - mysql
     - edxlocal

--- a/playbooks/vagrant-devstack.yml
+++ b/playbooks/vagrant-devstack.yml
@@ -17,6 +17,7 @@
     EDXAPP_LMS_BASE_SCHEME: http
     ECOMMERCE_DJANGO_SETTINGS_MODULE: "ecommerce.settings.devstack"
   roles:
+    - common
     - edx_ansible
     - mysql
     - edxlocal

--- a/playbooks/vagrant-fullstack.yml
+++ b/playbooks/vagrant-fullstack.yml
@@ -15,6 +15,7 @@
     forum_version: '{{ OPENEDX_RELEASE | default("master") }}'
     xqueue_version: '{{ OPENEDX_RELEASE | default("master") }}'
   roles:
+    - common
     - edx_ansible
     - user
     - role: nginx


### PR DESCRIPTION
This is needed now because edx-ansible no longer directely depends on common.

@edx/devops 
