### PR TITLE
Use ansible-local provisioner.

### DIFF
--- a/playbooks/roles/test_build_server/defaults/main.yml
+++ b/playbooks/roles/test_build_server/defaults/main.yml
@@ -16,3 +16,4 @@
 #
 test_build_server_user: jenkins
 test_build_server_repo_path: /home/jenkins
+test_edx_platform_version: master

--- a/playbooks/roles/test_build_server/tasks/main.yml
+++ b/playbooks/roles/test_build_server/tasks/main.yml
@@ -24,7 +24,7 @@
   git: >
     repo=https://github.com/edx/edx-platform.git
     dest={{ test_build_server_repo_path }}/edx-platform-clone
-    version=master
+    version={{ test_edx_platform_version }}
   sudo_user: "{{ test_build_server_user }}"
 
 - name: get xargs limit

--- a/playbooks/roles/test_build_server/tasks/main.yml
+++ b/playbooks/roles/test_build_server/tasks/main.yml
@@ -27,12 +27,14 @@
     version=master
   sudo_user: "{{ test_build_server_user }}"
 
+- name: get xargs limit
+  shell: "xargs --show-limits"
+
 - name: Copy test-development-environment.sh to somewhere the jenkins user can access it
   copy: >
     src=test-development-environment.sh
     dest="{{ test_build_server_repo_path }}"
     mode=0755
-  sudo_user: "{{ test_build_server_user }}"
 
 - name: Validate build environment
   shell: "bash test-development-environment.sh"

--- a/util/packer/jenkins_worker.json
+++ b/util/packer/jenkins_worker.json
@@ -55,17 +55,32 @@
     "inline": ["cd {{user `playbook_remote_dir`}}",
       "virtualenv packer-venv",
       ". packer-venv/bin/activate",
-      "pip install -q -r requirements.txt",
-      "echo '[jenkins_worker]' > inventory.ini",
-      "echo 'localhost' >> inventory.ini",
-      "ansible-playbook edx-east/jenkins_worker.yml -i inventory.ini -c local -vvvv"]
+      "pip install -q -r requirements.txt"]
+  }, {
+    "type": "ansible-local",
+    "playbook_file": "../../playbooks/edx-east/jenkins_worker.yml",
+    "playbook_dir": "../../playbooks",
+    "command": "source {{user `playbook_remote_dir`}}/packer-venv/bin/activate && ansible-playbook",
+    "inventory_groups": "jenkins_worker",
+    "extra_arguments": [
+      "-vvv"
+      ]
   }, {
     "type": "shell",
     "inline": ["cd {{user `playbook_remote_dir`}}",
       "rm -rf packer-venv",
       "virtualenv packer-venv",
       ". packer-venv/bin/activate",
-      "pip install -q -r requirements.txt",
-      "ansible-playbook run_role.yml -i inventory.ini -c local -e role=test_build_server -vvvv"]
-  }]
+      "pip install -q -r requirements.txt"]
+  }, {
+    "type": "ansible-local",
+    "playbook_file": "../../playbooks/run_role.yml",
+    "playbook_dir": "../../playbooks",
+    "command": "source {{user `playbook_remote_dir`}}/packer-venv/bin/activate && ansible-playbook",
+    "inventory_groups": "jenkins_worker",
+    "extra_arguments": [
+      "-e \"role=test_build_server test_edx_platform_version={{user `test_platform_version`}}\"",
+      "-vvv"
+      ]
+    }]
 }

--- a/util/packer/jenkins_worker.json
+++ b/util/packer/jenkins_worker.json
@@ -3,7 +3,8 @@
     "aws_access_key": "{{env `AWS_ACCESS_KEY_ID`}}",
     "aws_secret_key": "{{env `AWS_SECRET_ACCESS_KEY`}}",
     "playbook_remote_dir": "/tmp/packer-edx-playbooks",
-    "ami": "{{env `JENKINS_WORKER_AMI`}}"
+    "ami": "{{env `JENKINS_WORKER_AMI`}}",
+    "test_platform_version": "{{env `TEST_PLATFORM_VERSION`}}"
   },
   "builders": [{
     "type": "amazon-ebs",


### PR DESCRIPTION
Note: We have some redundancy in terms of the virtualenv, and that's because our base image has python 2.7.3, and over the course of the upgrade, the python version will change. So, the subsequent ansible play will need a fresh virtual environment. We'll improve that aspect of things later.
