### PR TITLE
Benp/break out tests

### DIFF
--- a/playbooks/roles/test_build_server/defaults/main.yml
+++ b/playbooks/roles/test_build_server/defaults/main.yml
@@ -16,3 +16,4 @@
 #
 test_build_server_user: jenkins
 test_build_server_repo_path: /home/jenkins
+test_edx_platform_version: master

--- a/playbooks/roles/test_build_server/files/test-development-environment.sh
+++ b/playbooks/roles/test_build_server/files/test-development-environment.sh
@@ -34,6 +34,7 @@ case "$1" in
         paver test_system -t lms/djangoapps/courseware/tests/tests.py
         paver test_system -t cms/djangoapps/course_creators/tests/test_views.py
         ;;
+
     "js")
 
         # Run some of the javascript unit tests

--- a/playbooks/roles/test_build_server/files/test-development-environment.sh
+++ b/playbooks/roles/test_build_server/files/test-development-environment.sh
@@ -20,28 +20,46 @@ cd edx-platform-clone
 # tests because TEST_SUITE isn't defined.
 source scripts/jenkins-common.sh
 
-# Now we can run a subset of the tests via paver.
-# Run some of the common/lib unit tests
-paver test_lib -t common/lib/xmodule/xmodule/tests/test_stringify.py
+case "$1" in
+    "unit")
 
-# Generate some coverage reports
-paver coverage
+        # Now we can run a subset of the tests via paver.
+        # Run some of the common/lib unit tests
+        paver test_lib -t common/lib/xmodule/xmodule/tests/test_stringify.py
 
-# Run some of the djangoapp unit tests
-paver test_system -t lms/djangoapps/courseware/tests/tests.py
-paver test_system -t cms/djangoapps/course_creators/tests/test_views.py
+        # Generate some coverage reports
+        paver coverage
 
-# Run some of the javascript unit tests
-paver test_js_run -s xmodule
+        # Run some of the djangoapp unit tests
+        paver test_system -t lms/djangoapps/courseware/tests/tests.py
+        paver test_system -t cms/djangoapps/course_creators/tests/test_views.py
+        ;;
+    "js")
 
-# Run some of the bok-choy tests
-paver test_bokchoy -t discussion/test_discussion.py:DiscussionTabSingleThreadTest
-paver test_bokchoy -t studio/test_studio_outline.py:WarningMessagesTest.test_unreleased_published_locked --fasttest
-paver test_bokchoy -t lms/test_lms_matlab_problem.py:MatlabProblemTest --fasttest
+        # Run some of the javascript unit tests
+        paver test_js_run -s xmodule
+        ;;
 
-# Run some of the lettuce acceptance tests
-paver test_acceptance -s lms --extra_args="lms/djangoapps/courseware/features/problems.feature -s 1"
-paver test_acceptance -s cms --extra_args="cms/djangoapps/contentstore/features/html-editor.feature -s 1"
+    "bokchoy")
 
-# Generate quality reports
-paver run_quality
+        # Run some of the bok-choy tests
+        paver test_bokchoy -t discussion/test_discussion.py:DiscussionTabSingleThreadTest
+        paver test_bokchoy -t studio/test_studio_outline.py:WarningMessagesTest.test_unreleased_published_locked --fasttest
+        paver test_bokchoy -t lms/test_lms_matlab_problem.py:MatlabProblemTest --fasttest
+        ;;
+
+    "lettuce")
+        # Run some of the lettuce acceptance tests
+        paver test_acceptance -s lms --extra_args="lms/djangoapps/courseware/features/problems.feature -s 1"
+        paver test_acceptance -s cms --extra_args="cms/djangoapps/contentstore/features/html-editor.feature -s 1"
+        ;;
+
+    "quality")
+        # Generate quality reports
+        paver run_quality
+        ;;
+
+    *)
+        echo "args required"
+        exit 1
+esac

--- a/playbooks/roles/test_build_server/files/test-development-environment.sh
+++ b/playbooks/roles/test_build_server/files/test-development-environment.sh
@@ -51,7 +51,7 @@ case "$1" in
     "lettuce")
         # Run some of the lettuce acceptance tests
         paver test_acceptance -s lms --extra_args="lms/djangoapps/courseware/features/problems.feature -s 1"
-        paver test_acceptance -s cms --extra_args="cms/djangoapps/contentstore/features/html-editor.feature -s 1"
+        paver test_acceptance -s cms --extra_args="cms/djangoapps/contentstore/features/html-editor.feature -s 1" --fasttest
         ;;
 
     "quality")

--- a/playbooks/roles/test_build_server/tasks/main.yml
+++ b/playbooks/roles/test_build_server/tasks/main.yml
@@ -24,7 +24,7 @@
   git: >
     repo=https://github.com/edx/edx-platform.git
     dest={{ test_build_server_repo_path }}/edx-platform-clone
-    version=master
+    version={{ test_edx_platform_version }}
   sudo_user: "{{ test_build_server_user }}"
 
 - name: Copy test-development-environment.sh to somewhere the jenkins user can access it

--- a/playbooks/roles/test_build_server/tasks/main.yml
+++ b/playbooks/roles/test_build_server/tasks/main.yml
@@ -35,7 +35,13 @@
   sudo_user: "{{ test_build_server_user }}"
 
 - name: Validate build environment
-  shell: "bash test-development-environment.sh"
+  shell: "bash test-development-environment.sh {{ item }}"
   args:
     chdir: "{{ test_build_server_repo_path }}/"
   sudo_user: "{{ test_build_server_user }}"
+  with_items:
+    - "unit"
+    - "js"
+    - "bokchoy"
+    - "lettuce"
+    - "quality"


### PR DESCRIPTION
@jzoldak @jibsheet 

This will help when reading packer output. Currently, there is just a general 'validate build environment' step that takes a very long time. Here, we'll provide a few more hints to the end-user, to get a sense of which step is being run. It also makes reading failures easier, since it's very clear which particular class of smoketests failed.
