### PR TITLE
Remove un-necessary directory permission change.

### DIFF
--- a/playbooks/roles/notifier/tasks/deploy.yml
+++ b/playbooks/roles/notifier/tasks/deploy.yml
@@ -50,10 +50,6 @@
   notify:
     - restart notifier-celery-workers
 
-- name: source repo group perms
-  file:
-    path={{ NOTIFIER_SOURCE_REPO }} mode=2775 state=directory
-
 - name: install application requirements
   pip:
     requirements="{{ NOTIFIER_REQUIREMENTS_FILE }}"


### PR DESCRIPTION
The var it points to is actually the github URL and not the location of the source code. Since
the code has continued to work without these permissions being applied to the code directory,
I think this is un-necessary and should just be deleted.

@edx/devops 
