### PR TITLE
Update python version.

### DIFF
--- a/playbooks/roles/common_vars/defaults/main.yml
+++ b/playbooks/roles/common_vars/defaults/main.yml
@@ -93,7 +93,7 @@ common_debian_pkgs:
   - rsyslog
   - git
   - unzip
-  - "python2.7=2.7.10-0+{{ ansible_distribution_release }}1"
+  - "python2.7=2.7.11-0+{{ ansible_distribution_release }}1"
   - python-pip
   - python2.7-dev
   


### PR DESCRIPTION
Version `2.7.10` has disappeared from the [deadsnakes](https://launchpad.net/~fkrull/+archive/ubuntu/deadsnakes-python2.7) PPA and was replaced by `2.7.11`.
