### PR TITLE
Send front-end PageView custom metrics to New Relic Insights.

### DIFF
--- a/playbooks/roles/newrelic/templates/etc/newrelic/nrsysmond.cfg.j2
+++ b/playbooks/roles/newrelic/templates/etc/newrelic/nrsysmond.cfg.j2
@@ -231,3 +231,9 @@ labels={{ labels }}
 #          path if, for example, you have multiple CGroup mounts.
 # Default: Distribution dependent, but usually /sys/fs/cgroup or /cgroup.
 #cgroup_root=
+
+# Allow custom attributes to be sent to Insights for browser PageViews
+#
+# https://docs.newrelic.com/docs/agents/python-agent/installation-configuration/python-agent-configuration#browser-settings
+#
+browser_monitoring.attributes.enabled = true


### PR DESCRIPTION
@maxrothman, @feanil: May I get a review from someone on your team?

We're emitting custom attributes to record the `course_id` and `org` for courseware views, and those show up in the server side transactions on NR Insights. However, they're not forwarded on through to PageViews. [This doc](https://docs.newrelic.com/docs/agents/python-agent/installation-configuration/python-agent-configuration#browser-settings) leads me to believe it's because `browser_monitoring.attributes.enabled` defaults to false:

>  This setting can be used to turn on or off all attributes for browser monitoring. This is the data which gets sent to page views in Insights.

Though it's not entirely clear to me because [this doc](https://docs.newrelic.com/docs/insights/new-relic-insights/decorating-events/insights-custom-attributes#adding-attributes) says that we need to modify `browser_monitoring.capture_attributes` (maybe just outdated docs?)

FYI: @benpatterson, @tobz 
