### PR TITLE
Compile Programs Sass prior to running r.js and cache static assets

### DIFF
--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/programs.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/programs.j2
@@ -25,7 +25,7 @@ server {
 
   ssl_certificate /etc/ssl/certs/{{ NGINX_SSL_CERTIFICATE|basename }};
   ssl_certificate_key /etc/ssl/private/{{ NGINX_SSL_KEY|basename }};
-  # request the browser to use SSL for all connections
+  # Request that the browser use SSL for all connections.
   add_header Strict-Transport-Security "max-age=31536000; includeSubDomains";
 
   {% else %}
@@ -35,6 +35,15 @@ server {
   location ~ ^/static/(?P<file>.*) {
     root {{ COMMON_DATA_DIR }}/{{ programs_service_name }};
     try_files /staticfiles/$file =404;
+
+    # Request that the browser use SSL for these connections. Repeated here
+    # because add_header directives are only inherited from the previous level
+    # if there are no add_header directives defined on the current level.
+    # See: http://nginx.org/en/docs/http/ngx_http_headers_module.html#add_header.
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains";
+    
+    # Instruct the browser to cache static assets for one hour.
+    add_header Cache-Control "public; max-age=3600";
   }
 
   location / {

--- a/playbooks/roles/programs/tasks/main.yml
+++ b/playbooks/roles/programs/tasks/main.yml
@@ -61,6 +61,13 @@
   environment: "{{ programs_environment }}"
   when: migrate_db is defined and migrate_db|lower == "yes"
 
+- name: compile sass
+  shell: >
+    chdir={{ programs_code_dir }}
+    . {{ programs_nodeenv_bin }}/activate && {{ programs_node_bin }}/gulp css
+  sudo_user: "{{ programs_user }}"
+  when: not devstack
+
 - name: run r.js optimizer
   shell: >
     chdir={{ programs_code_dir }}


### PR DESCRIPTION
Allows r.js to minify CSS hosted by the Programs service. This in turn yields minified files with unhashed names we can use to fetch these assets from Studio. ECOM-2862.

Corresponds to https://github.com/edx/programs/pull/69. @jimabramson please review. I'd also appreciate a look from someone in @edx/devops. @AlasdairSwan FYI.
