### PR TITLE
Enable other possible attribute to forward New Relic browser attributes.

### DIFF
--- a/playbooks/roles/newrelic/templates/etc/newrelic/nrsysmond.cfg.j2
+++ b/playbooks/roles/newrelic/templates/etc/newrelic/nrsysmond.cfg.j2
@@ -237,3 +237,6 @@ labels={{ labels }}
 # https://docs.newrelic.com/docs/agents/python-agent/installation-configuration/python-agent-configuration#browser-settings
 #
 browser_monitoring.attributes.enabled = true
+
+# https://docs.newrelic.com/docs/insights/new-relic-insights/decorating-events/insights-custom-attributes#forwarding-attributes
+browser_monitoring.capture_attributes = true


### PR DESCRIPTION
Remember how there were two different ways listed in the New Relic documentation to do the forwarding of browser attribute data to Insights? This is the other one. :-/

@feanil, @maxrothman 
