### PR TITLE
Mongo 3.0.8 includes a fix for data loss

### DIFF
--- a/playbooks/roles/mongo_3_0/defaults/main.yml
+++ b/playbooks/roles/mongo_3_0/defaults/main.yml
@@ -3,7 +3,7 @@ mongo_logappend: true
 #This way, when mongod receives a SIGUSR1, it'll close and reopen its log file handle
 mongo_logrotate: reopen
 
-mongo_version: 3.0.7
+mongo_version: 3.0.8
 mongo_port: "27017"
 mongo_extra_conf: ''
 mongo_key_file: '/etc/mongodb_key'
@@ -25,9 +25,7 @@ mongodb_debian_pkgs:
   - "mongodb-org-server={{ mongo_version }}" 
   - "mongodb-org-shell={{ mongo_version }}"
   - "mongodb-org-mongos={{ mongo_version }}" 
-# The mongo 3.0.7 mongorestore tool fails on most backups
-# https://jira.mongodb.org/browse/TOOLS-939
-  - "mongodb-org-tools=3.0.6"
+  - "mongodb-org-tools={{ mongo_version }}"
 
 
 # Vars Meant to be overridden


### PR DESCRIPTION
https://groups.google.com/forum/#!topic/mongodb-announce/mBesDEtR5l0

Additionally, it includes the fix for TOOLS-939 so we should not need to
pin to 3.0.6 any more.

@edx/devops
