### PR TITLE
Rebuild node-sass before compiling Sass

### DIFF
--- a/playbooks/roles/programs/tasks/main.yml
+++ b/playbooks/roles/programs/tasks/main.yml
@@ -64,7 +64,7 @@
 - name: compile sass
   shell: >
     chdir={{ programs_code_dir }}
-    . {{ programs_nodeenv_bin }}/activate && {{ programs_node_bin }}/gulp css
+    . {{ programs_nodeenv_bin }}/activate && npm rebuild node-sass && {{ programs_node_bin }}/gulp css
   sudo_user: "{{ programs_user }}"
   when: not devstack
 


### PR DESCRIPTION
This fixes CI build failures related to Programs Sass compilation. The issue at hand has been around for months; see https://github.com/sass/node-sass/issues/918 and https://github.com/sass/node-sass/issues/1162.

`node-sass` is a native module which compiles C++ code on installation. The failures observed in CI allegedly occur when the version of `node` which originally compiled the module differs from the version of `node` used to run the module. This requires that the module be rebuilt.

I experimented with sourcing the Programs `nodeenv` and executing `npm` directly instead of using Ansible's `npm` module, just in case that was allowing a different version of `node` to be used when installing dependencies. However, trial and error suggests this doesn't seem to be the case.

@jibsheet please review.
