### PR TITLE
We still need to coerce into a string

### DIFF
--- a/playbooks/library/util_map
+++ b/playbooks/library/util_map
@@ -159,7 +159,7 @@ def main():
 
     arg_spec = dict(
         function=dict(required=True, type='str'),
-        input=dict(required=True),
+        input=dict(required=True, type='str'),
         args=dict(required=False, type='list'),
     )
 


### PR DESCRIPTION
Later, zip_to_dict calls ast.literal_eval which requires this be a
string.  We can remove this _and_ the literal_eval call, however that
would require testing all the places we call these util functions.

@maxrothman
