### PR TITLE
Move the default location for the locust requiremnts files.

### DIFF
--- a/playbooks/roles/locust/defaults/main.yml
+++ b/playbooks/roles/locust/defaults/main.yml
@@ -18,7 +18,7 @@ locust_service_name: "locust"
 locust_home: "{{ COMMON_APP_DIR }}/{{ locust_service_name }}"
 locust_user: "locust"
 locust_code_dir: "{{ locust_home }}/load-tests"
-locust_requirements_base: "{{ locust_code_dir }}/locust"
+locust_requirements_base: "{{ locust_code_dir }}"
 locust_requirements:
   - "requirements.txt"
 locust_run_dir: "{{ locust_code_dir }}/{{ LOCUST_LOADTEST_DIR }}"


### PR DESCRIPTION
There is a corresponding change in the repo so the public
and private repos have the requirements file in the same
location.

@fredsmith 

Requires that this merge: https://github.com/edx/load-tests/pull/88
