### PR TITLE
SEC-79: Install nginx from their ppa

### DIFF
--- a/playbooks/roles/nginx/defaults/main.yml
+++ b/playbooks/roles/nginx/defaults/main.yml
@@ -49,6 +49,7 @@ NGINX_SERVER_HTML_FILES:
 
 
 
+
 nginx_app_dir: "{{ COMMON_APP_DIR }}/nginx"
 nginx_data_dir: "{{ COMMON_DATA_DIR }}/nginx"
 nginx_server_static_dir: "{{ nginx_data_dir }}/server-static"
@@ -60,7 +61,6 @@ nginx_user: root
 nginx_htpasswd_file: "{{ nginx_app_dir }}/nginx.htpasswd"
 nginx_default_sites: []
 nginx_debian_pkgs:
-  - nginx
   - python-passlib
 
 NGINX_EDXAPP_ENABLE_S3_MAINTENANCE: False

--- a/playbooks/roles/nginx/defaults/main.yml
+++ b/playbooks/roles/nginx/defaults/main.yml
@@ -47,7 +47,7 @@ NGINX_SERVER_HTML_FILES:
     img: "{{ NGINX_SERVER_ERROR_IMG }}"
     heading: 'Uh oh, we are having some server issues..'
 
-
+NGINX_APT_REPO: deb http://nginx.org/packages/ubuntu/ {{ ansible_distribution_release }} nginx
 
 
 nginx_app_dir: "{{ COMMON_APP_DIR }}/nginx"

--- a/playbooks/roles/nginx/tasks/main.yml
+++ b/playbooks/roles/nginx/tasks/main.yml
@@ -52,7 +52,7 @@
 
 - name: Add nginx repository
   apt_repository:
-    repo: deb http://nginx.org/packages/ubuntu/ {{ ansible_distribution_release }} nginx
+    repo: "{{ NGINX_APT_REPO }}"
     state: present
   notify: restart nginx
   tags:

--- a/playbooks/roles/nginx/tasks/main.yml
+++ b/playbooks/roles/nginx/tasks/main.yml
@@ -59,6 +59,20 @@
     - install
     - install:system-requirements
 
+# REMOVE THIS AFTER LATEST NGINX HAS BEEN DEPLOYED EVERYWHERE
+# New package does not identify conflicts properly.
+# "nginx-common" only appears as requirement for ubuntu-distributed package, thus
+# removing it will remove all nginx packages installed from Ubuntu's repo.
+# This is only required if nginx was previously installed from Ubuntu's repo
+# and you're switching to Nginx's PPA
+- name: Remove old nginx packages
+  apt:
+    name: nginx-common
+    state: absent
+  tags:
+    - install
+    - install:system-requirements
+
 - name: Install the nginx package
   apt:
     name: nginx

--- a/playbooks/roles/nginx/tasks/main.yml
+++ b/playbooks/roles/nginx/tasks/main.yml
@@ -33,8 +33,37 @@
     - install
     - install:configuration
 
-- name: Install nginx packages
-  apt: pkg={{','.join(nginx_debian_pkgs)}} state=present
+- name: Install needed packages
+  apt: pkg={{ item }} state=present
+  notify: restart nginx
+  with_items: nginx_debian_pkgs
+  tags:
+    - install
+    - install:system-requirements
+
+- name: Add apt key
+  apt_key:
+    url: http://nginx.org/keys/nginx_signing.key
+    state: present
+  notify: restart nginx
+  tags:
+    - install
+    - install:system-requirements
+
+- name: Add nginx repository
+  apt_repository:
+    repo: deb http://nginx.org/packages/ubuntu/ {{ ansible_distribution_release }} nginx
+    state: present
+  notify: restart nginx
+  tags:
+    - install
+    - install:system-requirements
+
+- name: Install the nginx package
+  apt:
+    name: nginx
+    state: latest
+    update_cache: yes
   notify: restart nginx
   tags:
     - install


### PR DESCRIPTION
This change allows us to install nginx from nginx's ppa as per their
instructions at http://nginx.org/en/linux_packages.html

@edx/devops 
