### PR TITLE
Add SVGs to the list of things gzip can work on.

### DIFF
--- a/playbooks/roles/nginx/templates/etc/nginx/nginx.conf.j2
+++ b/playbooks/roles/nginx/templates/etc/nginx/nginx.conf.j2
@@ -56,7 +56,7 @@ http {
         gzip_comp_level 6;
         gzip_buffers 16 8k;
         gzip_http_version 1.1;
-        gzip_types text/plain text/css application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript;
+        gzip_types text/plain text/css application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript image/svg+xml;
 
         ##
         # Virtual Host Configs


### PR DESCRIPTION
Since SVGs are text-based, they have the potential to actually compress, unlike binary image formats such as PNG or JPEG.  Basic testing shows that something like the Apple App Store SVG badge compresses roughly 66% under gzip.
