### PR TITLE
Revert "OPS-241 Ansible: MySql 5.6 installs should remove the 'test' database"

### DIFF
--- a/playbooks/edx-east/mysql.yml
+++ b/playbooks/edx-east/mysql.yml
@@ -1,6 +1,0 @@
-- name: Deploy MySQL
-  hosts: all
-  sudo: True
-  gather_facts: True
-  roles:
-    - mysql

--- a/playbooks/roles/mysql/defaults/main.yml
+++ b/playbooks/roles/mysql/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
 mysql_debian_pkgs:
-  - software-properties-common
+  # Note that mysql 5.6 is installed from a non standard PPA in tasks/main.yml
+  # It is not listed here because of non-standard steps required to install
+  # mysql 5.6 on 12.04
   - python-mysqldb
-  - mysql-server

--- a/playbooks/roles/mysql/tasks/main.yml
+++ b/playbooks/roles/mysql/tasks/main.yml
@@ -3,43 +3,43 @@
 #  - group_vars/all
 #  - common/tasks/main.yml
 #
-#  This installs mysql-server-5.6
+#  This installs mysql-server-5.5 though
+#  in production we use mysql-5.1.62.
+#
+#  We could install from source instead:
+#  http://downloads.mysql.com/archives/mysql-5.1/mysql-5.1.62.tar.gz
 #
 ---
-- name: Install PPA for installing MySQL 5.6 on Ubuntu 12.04LTS
+
+# Install PPA for installing MySQL 5.6 on Ubuntu 12.04LTS
+- name: install ppa key
   apt_key:
-    id: E5267A6C
-    url: '{{ COMMON_UBUNTU_APT_KEYSERVER }}0x14AA40EC0831756756D7F66C4F4EA0AAE5267A6C'
-    state: present
+    id=E5267A6C
+    url='{{ COMMON_UBUNTU_APT_KEYSERVER }}0x14AA40EC0831756756D7F66C4F4EA0AAE5267A6C'
+    state=present
 
 - name: install apt repository
   apt_repository:
-    repo: 'deb http://ppa.launchpad.net/ondrej/mysql-5.6/ubuntu precise main'
-    update_cache: yes
+    repo='deb http://ppa.launchpad.net/ondrej/mysql-5.6/ubuntu precise main'
+    update_cache=yes
+
+- name: look for mysql 5.5
+  shell: dpkg -L mysql-server-5.5
+  ignore_errors: true
+  register: mysql_55_installed
+
+- include: remove_mysql_55.yml
+  when: mysql_55_installed.rc != 1
 
 - name: install mysql 56 and dependencies
-  apt: 
-    name: "{{ item }}" 
-    install_recommends: yes 
-    force: yes 
-    state: present
+  apt: pkg={{ item }} install_recommends=yes force=yes state=present
+  with_items:
+    - software-properties-common
+    - mysql-server
+
+- name: install mysql debian packages
+  apt: pkg={{ item }} install_recommends=yes state=present
   with_items: mysql_debian_pkgs
 
-- name: Ensure Anonymous user(s) does not exist
-  mysql_user: 
-    name: '' 
-    host: "{{ item }}" 
-    state: absent
-  with_items:
-    - localhost
-    - "{{ ansible_hostname }}"
- 
-- name: Remove the test database
-  mysql_db: 
-    name: test 
-    state: absent
-
 - name: start mysql
-  service: 
-    name: mysql 
-    state: started
+  service: name=mysql state=started

--- a/playbooks/roles/mysql/tasks/remove_mysql_55.yml
+++ b/playbooks/roles/mysql/tasks/remove_mysql_55.yml
@@ -1,0 +1,16 @@
+---
+
+#
+# Tasks for fully removing mysql 5.5 from environments
+# conditionally included when 5.5 is installed on the
+# target system
+#
+
+- name: stop mysql
+  service: name=mysql state=stopped
+
+- name: remove prior version of mysql
+  apt: pkg='{{ item }}' state='absent' purge='yes'
+  with_items:
+    - mysql-server-5.5
+    - mysql-server  


### PR DESCRIPTION
Reverts edx/configuration#2566
