### PR TITLE
DEVOPS-3420 MTU not being set to 1500

### DIFF
--- a/playbooks/roles/aws/tasks/main.yml
+++ b/playbooks/roles/aws/tasks/main.yml
@@ -35,9 +35,12 @@
 
 - lineinfile: >
     dest=/etc/dhcp/dhclient.conf
-    regexp="^supercede interfact-mtu"
-    line="supercede interface-mtu 1500;"
+    regexp="^{{ item.regexp }}"
+    line="{{ item.line }}"
     insertbefore="^request"
+  with_items:
+     - { regexp: "default interface-mtu", line: "default interface-mtu 1500;" }
+     - { regexp: "supercede interfact-mtu", line: "supercede interface-mtu 1500;" }
   when: ansible_distribution in common_debian_variants
   
 #


### PR DESCRIPTION
@edx/devops,  forums suggest that adding `default interface-mtu 1500;` will solve the problem. Kindly review. Thanks
