### PR TITLE
Installing forums bundle with --deployment flag

### DIFF
--- a/playbooks/roles/forum/tasks/deploy.yml
+++ b/playbooks/roles/forum/tasks/deploy.yml
@@ -62,7 +62,7 @@
 # since the process owner needs write access
 # to the rbenv
 - name: install comments service bundle
-  shell: bundle install chdir={{ forum_code_dir }}
+  shell: bundle install --deployment chdir={{ forum_code_dir }}
   sudo_user: "{{ common_web_user }}"
   environment: "{{ forum_environment }}"
   notify: restart the forum service

--- a/playbooks/roles/forum/tasks/deploy.yml
+++ b/playbooks/roles/forum/tasks/deploy.yml
@@ -49,15 +49,6 @@
     - install
     - install:code
 
-- name: make Gemfile.lock writable by common_web_user
-  file:
-    path: "{{ forum_code_dir}}/Gemfile.lock"
-    owner: "{{ common_web_user }}"
-  tags:
-    - install
-    - install:code
-    - install:app-requirements
-
 # TODO: This is done as the common_web_user
 # since the process owner needs write access
 # to the rbenv


### PR DESCRIPTION
This will prevent Gemfile.lock from being modified. See http://bundler.io/deploying.html for additional information.

The `BUNDLED WITH` section of Gemfile.lock is there on purpose. See https://github.com/bundler/bundler/issues/3697 for more info.

OPS-1243
