### PR TITLE
Not needed with --deployment passed to bundle

### DIFF
--- a/playbooks/roles/forum/tasks/deploy.yml
+++ b/playbooks/roles/forum/tasks/deploy.yml
@@ -49,15 +49,6 @@
     - install
     - install:code
 
-- name: make Gemfile.lock writable by common_web_user
-  file:
-    path: "{{ forum_code_dir}}/Gemfile.lock"
-    owner: "{{ common_web_user }}"
-  tags:
-    - install
-    - install:code
-    - install:app-requirements
-
 # TODO: This is done as the common_web_user
 # since the process owner needs write access
 # to the rbenv


### PR DESCRIPTION
@clintonb  This was added to work-around a perms issues experienced when bundle was updating the Gemfile.lock.  While it fixed the immediate problem, it uncovered the more fundamental issue your PR fixes.

@fredsmith FYI
