### PR TITLE
Tag jenkins_worker AMIs for deletion

### DIFF
--- a/util/packer/jenkins_worker.json
+++ b/util/packer/jenkins_worker.json
@@ -4,7 +4,8 @@
     "aws_secret_key": "{{env `AWS_SECRET_ACCESS_KEY`}}",
     "playbook_remote_dir": "/tmp/packer-edx-playbooks",
     "ami": "{{env `JENKINS_WORKER_AMI`}}",
-    "test_platform_version": "{{env `TEST_PLATFORM_VERSION`}}"
+    "test_platform_version": "{{env `TEST_PLATFORM_VERSION`}}",
+    "delete_or_keep": "{{env `DELETE_OR_KEEP_AMI`}}"
   },
   "builders": [{
     "type": "amazon-ebs",
@@ -17,7 +18,10 @@
     "ssh_username": "ubuntu",
     "ami_description": "jenkins worker",
     "iam_instance_profile": "jenkins-worker",
-    "security_group_id": "sg-75af5e18"
+    "security_group_id": "sg-75af5e18",
+    "tags": {
+      "delete_or_keep": "{{user `delete_or_keep`}}"
+    }
   }],
   "provisioners": [{
     "type": "shell",


### PR DESCRIPTION
This will give us the ability to run packer builds (which will
actually register an AMI) for the strict purpose of testing
the packer buildout itself. Currently, we only build an AMI
as-needed, and when we want to test the buildout, we must manually
delete the registered AMI if the build is successful. The ability
to tag according to testing or real-use will also allow us to
automatically deregister AMIs that were only being used for test
purposes, rather than actual Jenkins builds.
