### PR TITLE
Support externally hosted comprehensive themes

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -51,3 +51,4 @@ Steven Burch <stv@stanford.edu>
 Dan Powell <dan@abakas.com>
 Omar Al-Ithawi <oithawi@qrf.org>
 David Adams<dcadams@stanford.edu>
+Florian Haas <florian@hastexo.com>

--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -537,7 +537,14 @@ EDXAPP_PROCTORING_BACKEND_PROVIDER:
   options: {}
 
 # Comprehensive Theming
+# Full path to the comprehensive theme directory
 EDXAPP_COMPREHENSIVE_THEME_DIR: ""
+# Git repo for the comprehensive theme (if using a comprehensive theme
+# other than the ones bundled with edx/platform)
+EDXAPP_COMPREHENSIVE_THEME_SOURCE_REPO: ""
+# Git branch, tag, or revision to check out from
+# EDXAPP_COMPREHENSIVE_THEME_SOURCE_REPO
+EDXAPP_COMPREHENSIVE_THEME_VERSION: ""
 
 # SAML KEYS
 EDXAPP_SOCIAL_AUTH_SAML_SP_PRIVATE_KEY: ''

--- a/playbooks/roles/edxapp/tasks/deploy.yml
+++ b/playbooks/roles/edxapp/tasks/deploy.yml
@@ -83,6 +83,12 @@
     - install
     - install:code
 
+# edX supports two theme types, Comprehensive themes and the older
+# Stanford-style themes. They are mutually exclusive.
+#
+# To enable Stanford theming, point edxapp_theme_source_repo
+# (yes, lowercase) to a Stanford-style theme and set
+# edxapp_theme_name (again, lowercase) to its name.
 - name: checkout Stanford-style theme
   git: >
     dest={{ edxapp_app_dir }}/themes/{{ edxapp_theme_name }}
@@ -98,6 +104,10 @@
     - install
     - install:code
 
+# To enable Comprehensive theming, point
+# EDXAPP_COMPREHENSIVE_THEME_SOURCE_REPO to your theme repo, and set
+# EDXAPP_COMPREHENSIVE_THEME_DIR to the directory you want to check
+# out to.
 - name: checkout comprehensive theme
   git: >
     dest={{ EDXAPP_COMPREHENSIVE_THEME_DIR }}

--- a/playbooks/roles/edxapp/tasks/deploy.yml
+++ b/playbooks/roles/edxapp/tasks/deploy.yml
@@ -83,13 +83,28 @@
     - install
     - install:code
 
-- name: checkout theme
+- name: checkout Stanford-style theme
   git: >
     dest={{ edxapp_app_dir }}/themes/{{ edxapp_theme_name }}
     repo={{ edxapp_theme_source_repo }}
     version={{ edxapp_theme_version }}
     accept_hostkey=yes
   when: edxapp_theme_name != ''
+  sudo_user: "{{ edxapp_user }}"
+  environment:
+    GIT_SSH: "{{ edxapp_git_ssh }}"
+  register: edxapp_theme_checkout
+  tags:
+    - install
+    - install:code
+
+- name: checkout comprehensive theme
+  git: >
+    dest={{ EDXAPP_COMPREHENSIVE_THEME_DIR }}
+    repo={{ EDXAPP_COMPREHENSIVE_THEME_SOURCE_REPO }}
+    version={{ EDXAPP_COMPREHENSIVE_THEME_VERSION }}
+    accept_hostkey=yes
+  when: EDXAPP_COMPREHENSIVE_THEME_SOURCE_REPO != ''
   sudo_user: "{{ edxapp_user }}"
   environment:
     GIT_SSH: "{{ edxapp_git_ssh }}"


### PR DESCRIPTION
The old Stanford-style themes can be pulled in from an external Git repo; no such provision was previously available for comprehensive themes.
- Introduce two new configuration variables:
  - EDXAPP_COMPREHENSIVE_THEME_SOURCE_REPO: Git repo for the   comprehensive theme
  - EDXAPP_COMPREHENSIVE_THEME_VERSION: Git branch, tag, or revision to   check out from the repo
- Introduce a new task, "checkout comprehensive theme", doing the equivalent of the previously existing "checkout theme" task. Check out the theme repo to EDXAPP_COMPREHENSIVE_THEME_DIR. If 
  EDXAPP_COMPREHENSIVE_THEME_SOURCE_REPO is unset, continue to assume that EDXAPP_COMPREHENSIVE_THEME_DIR already exists and is populated with a comprehensive theme.
- Rename the "checkout theme" task to "checkout Stanford-style theme".
