### PR TITLE
Revert "OPS-1208 Refactor Nginx SSL redirect bahavior"

### DIFF
--- a/playbooks/roles/nginx/defaults/main.yml
+++ b/playbooks/roles/nginx/defaults/main.yml
@@ -11,7 +11,6 @@ NGINX_EDXAPP_EXTRA_CONFIGS: []
 NGINX_EDXAPP_CUSTOM_REDIRECTS: {}
 
 NGINX_ENABLE_SSL: False
-NGINX_REDIRECT_TO_HTTPS: False
 # Set these to real paths on your
 # filesystem, otherwise nginx will
 # use a self-signed snake-oil cert

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/cms.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/cms.j2
@@ -30,38 +30,20 @@ server {
 error_page {{ k }} {{ v }};
   {% endfor %}
 
-  listen {{ EDXAPP_CMS_NGINX_PORT }} {{ default_site }};
-
   {% if NGINX_ENABLE_SSL %}
 
+  listen {{ EDXAPP_CMS_NGINX_PORT }} {{ default_site }};
   listen {{ EDXAPP_CMS_SSL_NGINX_PORT }} ssl;
 
   ssl_certificate /etc/ssl/certs/{{ NGINX_SSL_CERTIFICATE|basename }};
   ssl_certificate_key /etc/ssl/private/{{ NGINX_SSL_KEY|basename }};
   # request the browser to use SSL for all connections
   add_header Strict-Transport-Security "max-age=31536000; includeSubDomains";
-  {% endif %}
-  
-  {% if NGINX_REDIRECT_TO_HTTPS %}
-  # Redirect http to https over single instance
-  if ($scheme != "https") 
-  { 
-   set $do_redirect_to_https "true";
-  }
 
-  # Nginx does not support nested conditions 
-  # Forward to HTTPS if we're an HTTP request... and the server is behind ELB 
-  if ($http_x_forwarded_proto = "http") 
-  {
-   set $do_redirect_to_https "true";
-  }
-
-  if ($do_redirect_to_https = "true")
-  {
-  rewrite ^ https://$host$request_uri? permanent;
-  }
+  {% else %}
+  listen {{ EDXAPP_CMS_NGINX_PORT }} {{ default_site }};
   {% endif %}
-  
+
   server_name {{ CMS_HOSTNAME }};
 
   access_log {{ nginx_log_dir }}/access.log {{ NGINX_LOG_FORMAT_NAME }};
@@ -109,4 +91,19 @@ error_page {{ k }} {{ v }};
   {% include "robots.j2" %}
   {% include "static-files.j2" %}
 
+  {% if NGINX_SET_X_FORWARDED_HEADERS %}
+   if ($scheme != "https") {
+    rewrite ^ https://$host$uri permanent;
+   }
+ {% else %}
+  # Forward to HTTPS if we're an HTTP request...
+  if ($http_x_forwarded_proto = "http") {
+    set $do_redirect "true";
+  }
+
+  # Run our actual redirect...
+  if ($do_redirect = "true") {
+    rewrite ^ https://$host$request_uri? permanent;
+  }
+ {% endif %}
 }

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/ecommerce.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/ecommerce.j2
@@ -18,36 +18,18 @@ upstream ecommerce_app_server {
 server {
   server_name {{ ECOMMERCE_HOSTNAME }};
 
-  listen {{ ECOMMERCE_NGINX_PORT }} {{ default_site }};
-
   {% if NGINX_ENABLE_SSL %}
 
+  listen {{ ECOMMERCE_NGINX_PORT }} {{ default_site }};
   listen {{ ECOMMERCE_SSL_NGINX_PORT }} ssl;
 
   ssl_certificate /etc/ssl/certs/{{ NGINX_SSL_CERTIFICATE|basename }};
   ssl_certificate_key /etc/ssl/private/{{ NGINX_SSL_KEY|basename }};
   # request the browser to use SSL for all connections
   add_header Strict-Transport-Security "max-age=31536000; includeSubDomains";
-  {% endif %}
 
-  {% if NGINX_REDIRECT_TO_HTTPS %}
-  # Redirect http to https over single instance
-  if ($scheme != "https") 
-  { 
-   set $do_redirect_to_https "true";
-  }
-
-  # Nginx does not support nested conditions 
-  # Forward to HTTPS if we're an HTTP request... and the server is behind ELB 
-  if ($http_x_forwarded_proto = "http") 
-  {
-   set $do_redirect_to_https "true";
-  }
-
-  if ($do_redirect_to_https = "true")
-  {
-  rewrite ^ https://$host$request_uri? permanent;
-  }
+  {% else %}
+  listen {{ ECOMMERCE_NGINX_PORT }} {{ default_site }};
   {% endif %}
 
   location ~ ^/static/(?P<file>.*) {
@@ -71,5 +53,20 @@ location @proxy_to_app {
     proxy_pass http://ecommerce_app_server;
   }
 
+{% if NGINX_SET_X_FORWARDED_HEADERS %}
+   if ($scheme != "https") {
+    rewrite ^ https://$host$uri permanent;
+   }
+ {% else %}
+  # Forward to HTTPS if we're an HTTP request...
+  if ($http_x_forwarded_proto = "http") {
+    set $do_redirect "true";
+  }
+
+  # Run our actual redirect...
+  if ($do_redirect = "true") {
+    rewrite ^ https://$host$request_uri? permanent;
+  }
+ {% endif %}
 }
 

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/insights.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/insights.j2
@@ -33,23 +33,19 @@ location @proxy_to_app {
     proxy_pass http://insights_app_server;
   }
   
-  {% if NGINX_REDIRECT_TO_HTTPS %}
-  # Redirect http to https over single instance
-  if ($scheme != "https") 
-  { 
-   set $do_redirect_to_https "true";
+{% if NGINX_SET_X_FORWARDED_HEADERS %}
+   if ($scheme != "https") {
+    rewrite ^ https://$host$uri permanent;
+   }
+ {% else %}
+  # Forward to HTTPS if we're an HTTP request...
+  if ($http_x_forwarded_proto = "http") {
+    set $do_redirect "true";
   }
 
-  # Nginx does not support nested conditions 
-  # Forward to HTTPS if we're an HTTP request... and the server is behind ELB 
-  if ($http_x_forwarded_proto = "http") 
-  {
-   set $do_redirect_to_https "true";
+  # Run our actual redirect...
+  if ($do_redirect = "true") {
+    rewrite ^ https://$host$request_uri? permanent;
   }
-
-  if ($do_redirect_to_https = "true")
-  {
-  rewrite ^ https://$host$request_uri? permanent;
-  }
-  {% endif %}
+ {% endif %}
 }

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms-preview.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms-preview.j2
@@ -76,23 +76,19 @@ server {
     expires epoch;
   }
 
-  {% if NGINX_REDIRECT_TO_HTTPS %}
-  # Redirect http to https over single instance
-  if ($scheme != "https") 
-  { 
-   set $do_redirect_to_https "true";
+  {% if NGINX_SET_X_FORWARDED_HEADERS %}
+   if ($scheme != "https") {
+    rewrite ^ https://$host$uri permanent;
+   }
+ {% else %}
+  # Forward to HTTPS if we're an HTTP request...
+  if ($http_x_forwarded_proto = "http") {
+    set $do_redirect "true";
   }
 
-  # Nginx does not support nested conditions 
-  # Forward to HTTPS if we're an HTTP request... and the server is behind ELB 
-  if ($http_x_forwarded_proto = "http") 
-  {
-   set $do_redirect_to_https "true";
+  # Run our actual redirect...
+  if ($do_redirect = "true") {
+    rewrite ^ https://$host$request_uri? permanent;
   }
-
-  if ($do_redirect_to_https = "true")
-  {
-  rewrite ^ https://$host$request_uri? permanent;
-  }
-  {% endif %}
+ {% endif %}
 }

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
@@ -51,37 +51,21 @@ server {
 error_page {{ k }} {{ v }};
   {% endfor %}
 
-  listen {{ EDXAPP_LMS_NGINX_PORT }} {{ default_site }};
 
   {% if NGINX_ENABLE_SSL %}
+
+  listen {{ EDXAPP_LMS_NGINX_PORT }} {{ default_site }};
   listen {{ EDXAPP_LMS_SSL_NGINX_PORT }} {{ default_site }} ssl;
 
   ssl_certificate /etc/ssl/certs/{{ NGINX_SSL_CERTIFICATE|basename }};
   ssl_certificate_key /etc/ssl/private/{{ NGINX_SSL_KEY|basename }};
   # request the browser to use SSL for all connections
   add_header Strict-Transport-Security "max-age=31536000; includeSubDomains";
+
+  {% else %}
+  listen {{ EDXAPP_LMS_NGINX_PORT }} {{ default_site }};
   {% endif %}
 
-  {% if NGINX_REDIRECT_TO_HTTPS %}
-  # Redirect http to https over single instance
-  if ($scheme != "https") 
-  { 
-   set $do_redirect_to_https "true";
-  }
-
-  # Nginx does not support nested conditions 
-  # Forward to HTTPS if we're an HTTP request... and the server is behind ELB 
-  if ($http_x_forwarded_proto = "http") 
-  {
-   set $do_redirect_to_https "true";
-  }
-
-  if ($do_redirect_to_https = "true")
-  {
-  rewrite ^ https://$host$request_uri? permanent;
-  }
-  {% endif %}
-  
   access_log {{ nginx_log_dir }}/access.log {{ NGINX_LOG_FORMAT_NAME }};
   error_log {{ nginx_log_dir }}/error.log error;
 
@@ -201,4 +185,19 @@ location ~ ^{{ EDXAPP_MEDIA_URL }}/(?P<file>.*) {
   {% include "robots.j2" %}
   {% include "static-files.j2" %}
 
+ {% if NGINX_SET_X_FORWARDED_HEADERS %}
+   if ($scheme != "https") {
+    rewrite ^ https://$host$uri permanent;
+   }
+ {% else %}
+  # Forward to HTTPS if we're an HTTP request...
+  if ($http_x_forwarded_proto = "http") {
+    set $do_redirect "true";
+  }
+
+  # Run our actual redirect...
+  if ($do_redirect = "true") {
+    rewrite ^ https://$host$request_uri? permanent;
+  }
+ {% endif %}
 }

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/programs.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/programs.j2
@@ -17,11 +17,10 @@ upstream programs_app_server {
 
 server {
   server_name {{ PROGRAMS_HOSTNAME }};
-  
-  listen {{ PROGRAMS_NGINX_PORT }} {{ default_site }};
-  
+
   {% if NGINX_ENABLE_SSL %}
 
+  listen {{ PROGRAMS_NGINX_PORT }} {{ default_site }};
   listen {{ PROGRAMS_SSL_NGINX_PORT }} ssl;
 
   ssl_certificate /etc/ssl/certs/{{ NGINX_SSL_CERTIFICATE|basename }};
@@ -29,26 +28,8 @@ server {
   # Request that the browser use SSL for all connections.
   add_header Strict-Transport-Security "max-age=31536000; includeSubDomains";
 
-  {% endif %}
-
-  {% if NGINX_REDIRECT_TO_HTTPS %}
-  # Redirect http to https over single instance
-  if ($scheme != "https") 
-  { 
-   set $do_redirect_to_https "true";
-  }
-
-  # Nginx does not support nested conditions 
-  # Forward to HTTPS if we're an HTTP request... and the server is behind ELB 
-  if ($http_x_forwarded_proto = "http") 
-  {
-   set $do_redirect_to_https "true";
-  }
-
-  if ($do_redirect_to_https = "true")
-  {
-  rewrite ^ https://$host$request_uri? permanent;
-  }
+  {% else %}
+  listen {{ PROGRAMS_NGINX_PORT }} {{ default_site }};
   {% endif %}
 
   location ~ ^/static/(?P<file>.*) {
@@ -80,5 +61,19 @@ location @proxy_to_app {
     proxy_redirect off;
     proxy_pass http://programs_app_server;
   }
+{% if NGINX_SET_X_FORWARDED_HEADERS %}
+   if ($scheme != "https") {
+    rewrite ^ https://$host$uri permanent;
+   }
+ {% else %}
+  # Forward to HTTPS if we're an HTTP request...
+  if ($http_x_forwarded_proto = "http") {
+    set $do_redirect "true";
+  }
 
+  # Run our actual redirect...
+  if ($do_redirect = "true") {
+    rewrite ^ https://$host$request_uri? permanent;
+  }
+ {% endif %}
 }

--- a/util/jenkins/ansible-provision.sh
+++ b/util/jenkins/ansible-provision.sh
@@ -174,7 +174,6 @@ COURSE_DISCOVERY_SSL_NGINX_PORT: 443
 COURSE_DISCOVERY_VERSION: $course_discovery_version
 
 NGINX_SET_X_FORWARDED_HEADERS: True
-NGINX_REDIRECT_TO_HTTPS: True
 EDX_ANSIBLE_DUMP_VARS: true
 migrate_db: "yes"
 openid_workaround: True


### PR DESCRIPTION
This branch introduced NGINX_REDIRECT_TO_HTTPS, if that is not enabled
in our production instances, the HTTP -> HTTPS redirect is never
issued.  If we do enable that, then everything is forced to SSL,
including the load balancer heartbeats.

@edx/devops 

This reverts commit 57ee69856413acef6875b6c402d05c6919d2b253.
