### PR TITLE
Stop looking for docker in our production boxes

### DIFF
--- a/playbooks/roles/newrelic/templates/etc/newrelic/nrsysmond.cfg.j2
+++ b/playbooks/roles/newrelic/templates/etc/newrelic/nrsysmond.cfg.j2
@@ -221,7 +221,7 @@ labels={{ labels }}
 # Value  : Set to true to disable Docker container statistics gathering.
 # Default: false
 #
-#disable_docker=false
+disable_docker=true
 
 #
 # Option : cgroup_root


### PR DESCRIPTION
This quiets a bunch of logging like
error: Docker GET from 'http://localhost/info' failed

@edx/devops
