### PR TITLE
Sandboxes for ecommerce don't pass along the scheme properly

### DIFF
--- a/playbooks/roles/ansible-role-django-ida/templates/templates/edx/app/nginx/sites-available/ROLE_NAME.j2
+++ b/playbooks/roles/ansible-role-django-ida/templates/templates/edx/app/nginx/sites-available/ROLE_NAME.j2
@@ -49,9 +49,15 @@ server {
   {{ '{%' }} endif {{ '%}' }}
 
   location @proxy_to_app {
+    {{ '{%' }} if NGINX_SET_X_FORWARDED_HEADERS {{ '%}' }}
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-Port $server_port;
+    proxy_set_header X-Forwarded-For $remote_addr;
+    {{ '{%' }} else {{ '%}' }}
     proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
     proxy_set_header X-Forwarded-Port $http_x_forwarded_port;
     proxy_set_header X-Forwarded-For $http_x_forwarded_for;
+    {{ '{%' }} endif {{ '%}' }}
     proxy_set_header Host $http_host;
 
     proxy_redirect off;

--- a/playbooks/roles/course_discovery/templates/edx/app/nginx/sites-available/course_discovery.j2
+++ b/playbooks/roles/course_discovery/templates/edx/app/nginx/sites-available/course_discovery.j2
@@ -49,9 +49,15 @@ server {
   {% endif %}
 
   location @proxy_to_app {
+    {% if NGINX_SET_X_FORWARDED_HEADERS %}
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-Port $server_port;
+    proxy_set_header X-Forwarded-For $remote_addr;
+    {% else %}
     proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
     proxy_set_header X-Forwarded-Port $http_x_forwarded_port;
     proxy_set_header X-Forwarded-For $http_x_forwarded_for;
+    {% endif %}
     proxy_set_header Host $http_host;
 
     proxy_redirect off;

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/credentials.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/credentials.j2
@@ -44,9 +44,15 @@ server {
   {% include "robots.j2" %}
 
 location @proxy_to_app {
+    {% if NGINX_SET_X_FORWARDED_HEADERS %}
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-Port $server_port;
+    proxy_set_header X-Forwarded-For $remote_addr;
+    {% else %}
     proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
     proxy_set_header X-Forwarded-Port $http_x_forwarded_port;
     proxy_set_header X-Forwarded-For $http_x_forwarded_for;
+    {% endif %}
     proxy_set_header Host $http_host;
 
     proxy_redirect off;

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/ecommerce.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/ecommerce.j2
@@ -66,9 +66,15 @@ server {
   {% include "robots.j2" %}
 
 location @proxy_to_app {
+    {% if NGINX_SET_X_FORWARDED_HEADERS %}
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-Port $server_port;
+    proxy_set_header X-Forwarded-For $remote_addr;
+    {% else %}
     proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
     proxy_set_header X-Forwarded-Port $http_x_forwarded_port;
     proxy_set_header X-Forwarded-For $http_x_forwarded_for;
+    {% endif %}
     proxy_set_header Host $http_host;
 
     proxy_redirect off;

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/programs.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/programs.j2
@@ -78,9 +78,15 @@ server {
   {% include "robots.j2" %}
 
 location @proxy_to_app {
+    {% if NGINX_SET_X_FORWARDED_HEADERS %}
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-Port $server_port;
+    proxy_set_header X-Forwarded-For $remote_addr;
+    {% else %}
     proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
     proxy_set_header X-Forwarded-Port $http_x_forwarded_port;
     proxy_set_header X-Forwarded-For $http_x_forwarded_for;
+    {% endif %}
     proxy_set_header Host $http_host;
 
     proxy_redirect off;


### PR DESCRIPTION
The nginx config is only configured for prod (when it is behind an ELB
and has http_x_forwarded headers).  We want to pass along the NGINX
headers too (mainly scheme) whcih is what the LMS/CMS does on sandboxes.

@clintonb Let me know how this goes
