### PR TITLE
Alter pdf invoice vars.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -50,3 +50,4 @@ Sarina Canelake <sarina@edx.org>
 Steven Burch <stv@stanford.edu>
 Dan Powell <dan@abakas.com>
 Omar Al-Ithawi <oithawi@qrf.org>
+David Adams<dcadams@stanford.edu>

--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -152,22 +152,17 @@ EDXAPP_FINANCIAL_REPORTS:
 
 #Only address should have newlines
 EDXAPP_PDF_RECEIPT_BILLING_ADDRESS: |
-  Fake Billing Services
-  123 Fake St.
-  Notaplaceshire, XX 00000
+  Enter your receipt billing
+  address here.
 
 EDXAPP_PDF_RECEIPT_DISCLAIMER_TEXT: >
-  THIS IS A DISCLAIMER ABOUT OUR STUFF. ALL OUR CONTENT ARE BELONG TO US.
-  YOU HAVE NO CHANCE TO SURVIVE MAKE YOUR TIME.
+  ENTER YOUR RECEIPT DISCLAIMER TEXT HERE.
 
 EDXAPP_PDF_RECEIPT_FOOTER_TEXT: >
-  Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-  Suspendisse pretium odio nec sodales dictum. Vestibulum eget
-  sollicitudin lorem. In mattis accumsan risus ac ultrices.
+  Enter your receipt footer text here.
 
 EDXAPP_PDF_RECEIPT_TERMS_AND_CONDITIONS: >
-  Here are some fake terms and conditions that say when payment is due and stuff.
-  For more info, see www.fakeschoolX.org/terms-and-conditions
+  Enter your receipt terms and conditions here.
 
 EDXAPP_PDF_RECEIPT_TAX_ID: "00-0000000"
 EDXAPP_PDF_RECEIPT_TAX_ID_LABEL: "fake Tax ID"


### PR DESCRIPTION
The previous variables, through an oversight on our part, became visible to customers of our system. This was rather embarrassing to us given the nature of the disclaimer text.

I've changed the vars to prevent a similar fate befalling other sites.
