### PR TITLE
Freeze pip, setuptools, and virtualenv

### DIFF
--- a/util/install/ansible-bootstrap.sh
+++ b/util/install/ansible-bootstrap.sh
@@ -37,6 +37,8 @@ fi
 # Bootstrapping constants
 #
 VIRTUAL_ENV_VERSION="13.1.2"
+PIP_VERSION="7.1.2"
+SETUPTOOLS_VERSION="18.3.2"
 VIRTUAL_ENV="/tmp/bootstrap"
 PYTHON_BIN="${VIRTUAL_ENV}/bin"
 ANSIBLE_DIR="/tmp/ansible"
@@ -108,10 +110,11 @@ add-apt-repository -y "${EDX_PPA}"
 apt-get update -y
 apt-get install -y build-essential sudo git-core python2.7 python2.7-dev python-pip python-apt python-yaml python-jinja2 libmysqlclient-dev
 
-pip install --upgrade pip setuptools
+pip install --upgrade pip=="${PIP_VERSION}"
 
 # pip moves to /usr/local/bin when upgraded
 PATH=/usr/local/bin:${PATH}
+pip install setuptools=="${SETUPTOOLS_VERSION}"
 pip install virtualenv=="${VIRTUAL_ENV_VERSION}"
 
 # create a new virtual env

--- a/util/install/sandbox.sh
+++ b/util/install/sandbox.sh
@@ -32,9 +32,9 @@ sudo apt-get upgrade -y
 ## Install system pre-requisites
 ##
 sudo apt-get install -y build-essential software-properties-common curl git-core libxml2-dev libxslt1-dev python-pip libmysqlclient-dev python-apt python-dev libxmlsec1-dev libfreetype6-dev swig gcc-4.8 g++-4.8
-sudo pip install --upgrade pip
-sudo pip install --upgrade setuptools
-sudo -H pip install --upgrade virtualenv
+sudo pip install --upgrade pip==7.1.2
+sudo pip install --upgrade setuptools==18.3.2
+sudo -H pip install --upgrade virtualenv==13.1.2
 
 ##
 ## Update alternatives so that gcc/g++ 4.8 is the default compiler


### PR DESCRIPTION
Pip 8.0.0, released a few hours ago, tries to uninstall deb-installed
python modules that it wants to upgrade, and always fails when doing so.
The effect is that configuration/requirements.txt cannot be fulfilled,
notably ansible 1.9.3-edx, which requires an upgrade to pycrypto.

This forces the installation of pip to the latest one prior to 8.0.0,
7.1.2.

It also freezes setuptools and virtualenv, so that they should all match
the current versions required on
playbooks/roles/common_vars/defaults/main.yml:common_pip_pkgs.

Fixes #2714
