### PR TITLE
Move to using a more recent build for the default devstack.

### DIFF
--- a/vagrant/release/devstack/Vagrantfile
+++ b/vagrant/release/devstack/Vagrantfile
@@ -75,7 +75,7 @@ openedx_releases = {
   # },
 }
 openedx_releases.default = {
-  :name => "dogwood-devstack-rc2", :file => "20151221-dogwood-devstack-rc2.box",
+  :name => "devstack-nightly-20160125", :file => "20160125-nightly-devstack.box",
 }
 rel = ENV['OPENEDX_RELEASE']
 

--- a/vagrant/release/devstack/Vagrantfile
+++ b/vagrant/release/devstack/Vagrantfile
@@ -75,7 +75,7 @@ openedx_releases = {
   # },
 }
 openedx_releases.default = {
-  :name => "devstack-nightly-20160125", :file => "20160125-nightly-devstack.box",
+  :name => "devstack-nightly-20160125", :file => "20160125-devstack-from-nightly.box",
 }
 rel = ENV['OPENEDX_RELEASE']
 


### PR DESCRIPTION
The dogwood devstack was not compatible with some changes made after dogwood was cut.

@edx/devops @nedbat 
