### PR TITLE
CI needs to run

### DIFF
--- a/util/jenkins/ansible-provision.sh
+++ b/util/jenkins/ansible-provision.sh
@@ -319,7 +319,7 @@ EOF
 fi
 
 declare -A deploy
-roles="edxapp forum ecommerce programs credentials course_discovery notifier xqueue xserver certs demo testcourses"
+roles="edxapp forum ecommerce programs course_discovery notifier xqueue xserver certs demo testcourses"
 for role in $roles; do
     deploy[$role]=${!role}
 done


### PR DESCRIPTION
@edx/devops @zubair-arbi I'm proposing  that we disable credentials in CI until we know how to fix the memory issues with collecting static resources.  CI for other roles is too important to let this remain broken and credentials has Docker coverage.
