### PR TITLE
Don't run credentials in CI

### DIFF
--- a/playbooks/edx-east/edx_continuous_integration.yml
+++ b/playbooks/edx-east/edx_continuous_integration.yml
@@ -18,7 +18,6 @@
       - analytics_api
       - ecommerce
       - programs
-      - credentials
       nginx_default_sites:
       - lms
     - mysql
@@ -41,7 +40,6 @@
     - analytics_api
     - ecommerce
     - programs
-    - credentials
     - oauth_client_setup
     - role: datadog
       when: COMMON_ENABLE_DATADOG


### PR DESCRIPTION
It runs out of memory on the CI box every time compressing assets and at
least it is tested in Travis as part of that CI job.

@edx/devops 

This may replace https://github.com/edx/configuration/pull/2732
