### PR TITLE
Print only the 10 slowest tasks instead of all of them.

### DIFF
--- a/playbooks/callback_plugins/datadog_tasks_timing.py
+++ b/playbooks/callback_plugins/datadog_tasks_timing.py
@@ -94,7 +94,7 @@ class CallbackModule(object):
             )
 
         # Log the time of each task
-        for name, elapsed in results:
+        for name, elapsed in results[:10]:
             logger.info(
                 "{0:-<80}{1:->8}".format(
                     '{0} '.format(name),


### PR DESCRIPTION
Print only the top 10 slowest tasks to the console after an ansible run.  All data will still go to datadog but we don't print to the console.

@edx/devops 
