### PR TITLE
remove the demo role

### DIFF
--- a/util/jenkins/ansible-provision.sh
+++ b/util/jenkins/ansible-provision.sh
@@ -319,7 +319,7 @@ EOF
 fi
 
 declare -A deploy
-roles="edxapp forum ecommerce programs credentials course_discovery notifier xqueue xserver certs demo testcourses"
+roles="edxapp forum ecommerce programs credentials course_discovery notifier xqueue xserver certs testcourses"
 for role in $roles; do
     deploy[$role]=${!role}
 done


### PR DESCRIPTION
@edx/devops kindly review this, we are not using the `demo` role, instead of this we are using `testcourses` role to import all the courses even the demo course that `demo` role import. Thanks
