### PR TITLE
Update to not receive input on apt-get tasks.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,8 @@ addons:
       - python-demjson
 
 before_install:
-  - sudo apt-get update
-  - sudo apt-get install docker-engine
+  - sudo apt-get -y update
+  - sudo apt-get -y install -o Dpkg::Options::="--force-confold" docker-engine
 
 install:
   - "pip install --allow-all-external -r requirements.txt"


### PR DESCRIPTION
Without the '-y' the tests stop to ask for input.

@edx/devops I'm not sure why we haven't seen issues with this before but https://github.com/edx/configuration/pull/2749 ran into this.
