### PR TITLE
Use the correct format for dockerhub pulls

### DIFF
--- a/docker.mk
+++ b/docker.mk
@@ -34,7 +34,7 @@ docker.pkg: $(foreach image,$(images),$(docker_pkg)$(image))
 docker.push: $(foreach image,$(images),$(docker_push)$(image))
 
 $(docker_pull)%:
-	docker pull $*
+	docker pull $(subst @,:,$*)
 
 $(docker_build)%: docker/build/%/Dockerfile
 	docker build -f $< .


### PR DESCRIPTION
Docker Hub changed their allowed format for pulls. This change should fix our calls.
