### PR TITLE
Fix CI by appending privileges

### DIFF
--- a/playbooks/roles/credentials/tasks/main.yml
+++ b/playbooks/roles/credentials/tasks/main.yml
@@ -99,6 +99,7 @@
     host: "{{ CREDENTIALS_MYSQL_MATCHER }}"
     password: "{{ item.password }}"
     priv: "{{ CREDENTIALS_DEFAULT_DB_NAME }}.*:ALL"
+    append_privs: yes
   with_items:
     - name: "{{ CREDENTIALS_DATABASES.default.USER }}"
       password: "{{ CREDENTIALS_DATABASES.default.PASSWORD }}"

--- a/playbooks/roles/discovery/tasks/main.yml
+++ b/playbooks/roles/discovery/tasks/main.yml
@@ -106,6 +106,7 @@
     host: "{{ DISCOVERY_MYSQL_MATCHER }}"
     password: "{{ item.password }}"
     priv: "{{ DISCOVERY_DEFAULT_DB_NAME }}.*:ALL"
+    append_privs: yes
   with_items:
     - name: "{{ DISCOVERY_DATABASES.default.USER }}"
       password: "{{ DISCOVERY_DATABASES.default.PASSWORD }}"


### PR DESCRIPTION
@cpennington @zubair-arbi @feanil @maxrothman this fixes CI

Currently migrating DBs is failing because credentials and discovery are paving over the privileges for the migrate user.  I'm going to merge this now.

```
19:19:15     return Connection(*args, **kwargs)
19:19:15   File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/MySQLdb/connections.py", line 193, in __init__
19:19:15     super(Connection, self).__init__(*args, **kwargs2)
19:19:15 django.db.utils.OperationalError: (1044, "Access denied for user 'migrate'@'localhost' to database 
```
