### PR TITLE
DEVOPS-3685 ensure tools gets the same version the mongo play installs

### DIFF
--- a/playbooks/roles/ad_hoc_reporting/defaults/main.yml
+++ b/playbooks/roles/ad_hoc_reporting/defaults/main.yml
@@ -44,4 +44,4 @@ ad_hoc_reporting_pip_pkgs:
 MONGODB_APT_KEY: "7F0CEB10"
 MONGODB_APT_KEYSERVER: "keyserver.ubuntu.com"
 MONGODB_REPO: "deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen"
-mongo_version: 3.0.7
+mongo_version: 3.0.8


### PR DESCRIPTION
While fixing a downgrade from 3 -> 2 on tools, ensure this role uses the
same version the mongo_3 play uses.
