### PR TITLE
Automate preparatory steps for running pipeline acceptance tests

### DIFF
--- a/playbooks/roles/analytics_pipeline/files/acceptance.json
+++ b/playbooks/roles/analytics_pipeline/files/acceptance.json
@@ -1,0 +1,17 @@
+{
+  "connection_user": "hadoop",
+  "credentials_file_url": "/edx/etc/edx-analytics-pipeline/output.json",
+  "exporter_output_bucket": "",
+  "geolocation_data": "/var/tmp/geolocation-data.mmdb",
+  "hive_user": "hadoop",
+  "host": "localhost",
+  "identifier": "local-devstack",
+  "manifest_input_format": "org.edx.hadoop.input.ManifestTextInputFormat",
+  "oddjob_jar": "hdfs://localhost:9000/edx-analytics-pipeline/packages/edx-analytics-hadoop-util.jar",
+  "tasks_branch": "origin/HEAD",
+  "tasks_log_path": "/tmp/acceptance/",
+  "tasks_output_url": "hdfs://localhost:9000/acceptance-test-output/",
+  "tasks_repo": "/edx/app/analytics_pipeline/analytics_pipeline",
+  "vertica_creds_url": "",
+  "wheel_url": "https://edx-wheelhouse.s3-website-us-east-1.amazonaws.com/Ubuntu/precise"
+}

--- a/playbooks/roles/analytics_pipeline/tasks/main.yml
+++ b/playbooks/roles/analytics_pipeline/tasks/main.yml
@@ -10,9 +10,9 @@
 #
 #
 # Tasks for role analytics_pipeline
-# 
+#
 # Overview:
-# 
+#
 # Prepare the machine to run the edX Analytics Data Pipeline. The pipeline currently "installs itself"
 # via an ansible playbook that is not included in the edx/configuration repo. However, in order to
 # run the pipeline in a devstack environment, some configuration needs to be performed. In a production
@@ -24,7 +24,7 @@
 # hadoop_master: ensures hadoop services are installed
 # hive: the pipeline makes extensive usage of hive, so that needs to be installed as well
 # sqoop: similarly to hive, the pipeline uses this tool extensively
-# 
+#
 # Example play:
 #
 # - name: Deploy all dependencies of edx-analytics-pipeline to the node
@@ -171,6 +171,25 @@
     user={{ hadoop_common_user }}
     name="Sync tracking log to HDFS"
     job="{{ HADOOP_COMMON_HOME }}/bin/hdfs dfs -put -f {{ COMMON_LOG_DIR }}/tracking/tracking.log {{ ANALYTICS_PIPELINE_HDFS_DATA_DIR }}/tracking.log"
+  tags:
+    - install
+    - install:configuration
+
+- name: store configuration for acceptance tests
+  copy: >
+    src=acceptance.json
+    dest=/var/tmp/acceptance.json
+    mode=644
+  tags:
+    - install
+    - install:configuration
+
+- name: grant access to table storing test data in output database
+  mysql_user: >
+    user={{ ANALYTICS_PIPELINE_OUTPUT_DATABASE.user }}
+    password={{ ANALYTICS_PIPELINE_OUTPUT_DATABASE.password }}
+    priv=acceptance%.*:ALL
+    append_privs=yes
   tags:
     - install
     - install:configuration

--- a/vagrant/release/analyticstack/Vagrantfile
+++ b/vagrant/release/analyticstack/Vagrantfile
@@ -46,6 +46,7 @@ MOUNT_DIRS = {
   :forum => {:repo => "cs_comments_service", :local => "/edx/app/forum/cs_comments_service", :owner => "forum"},
   :insights => {:repo => "insights", :local => "/edx/app/insights/edx_analytics_dashboard", :owner => "insights"},
   :analytics_api => {:repo => "analytics_api", :local => "/edx/app/analytics_api/analytics_api", :owner => "analytics_api"},
+  :analytics_pipeline => {:repo => "edx-analytics-pipeline", :local => "/edx/app/analytics_pipeline/analytics_pipeline", :owner => "hadoop"},
   # This src directory won't have useful permissions. You can set them from the
   # vagrant user in the guest OS. "sudo chmod 0777 /edx/src" is useful.
   :src => {:repo => "src", :local => "/edx/src", :owner => "root"},


### PR DESCRIPTION
Building on https://github.com/edx/configuration/pull/2753, this PR automates configuration steps that are required to run acceptance tests for [edx-analytics-pipeline](https://github.com/edx/edx-analytics-pipeline).

**Test instructions**
- Set up an instance of Analytics Devstack following the steps in the description of https://github.com/edx/configuration/pull/2753.
- Verify that `/var/tmp` contains a file called `acceptance.json` whose contents match the new `playbooks/roles/analytics_pipeline/files/acceptance.json` file.
- Verify that the `pipeline001` user has access to tables storing acceptance test data:
  
  ``` sh
  mysql -u root
  SHOW GRANTS FOR 'pipeline001'@'localhost';
  ```
  
  Expected output:
  
  ```
  +----------------------------------------------------------------------+
  | Grants for pipeline001@localhost                                     |
  +----------------------------------------------------------------------+
  | ...                                                                  |
  | GRANT ALL PRIVILEGES ON `acceptance%`.* TO 'pipeline001'@'localhost' |
  +----------------------------------------------------------------------+
  ```
