### PR TITLE
Remove almost all references to syncdb 🔥🔥🔥

### DIFF
--- a/playbooks/edx-east/ora2.yml
+++ b/playbooks/edx-east/ora2.yml
@@ -32,7 +32,7 @@
       tags:
         - deploy
 
-    - name: syncdb and migrate
+    - name: migrate
       shell: >
         {{ edxapp_venv_dir }}/bin/python manage.py lms migrate --settings=aws
         chdir={{ edxapp_code_dir }}

--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -311,8 +311,6 @@ EDXAPP_AUTOMATOR_AUTHORIZED_KEYS: []
 EDXAPP_AUTOMATOR_SUDO_CMDS:
 - "ALL=({{ common_web_user }})  NOPASSWD:SETENV:{{ COMMON_BIN_DIR }}/python.edxapp {{ COMMON_BIN_DIR }}/manage.edxapp lms migrate *"
 - "ALL=({{ common_web_user }})  NOPASSWD:SETENV:{{ COMMON_BIN_DIR }}/python.edxapp {{ COMMON_BIN_DIR }}/manage.edxapp cms migrate *"
-- "ALL=({{ common_web_user }})  NOPASSWD:SETENV:{{ COMMON_BIN_DIR }}/python.edxapp {{ COMMON_BIN_DIR }}/manage.edxapp lms syncdb *"
-- "ALL=({{ common_web_user }})  NOPASSWD:SETENV:{{ COMMON_BIN_DIR }}/python.edxapp {{ COMMON_BIN_DIR }}/manage.edxapp cms syncdb *"
 - "ALL=({{ common_web_user }})  NOPASSWD:SETENV:{{ COMMON_BIN_DIR }}/python.edxapp {{ COMMON_BIN_DIR }}/manage.edxapp lms seed_permissions_roles *"
 - "ALL=({{ common_web_user }})  NOPASSWD:SETENV:{{ COMMON_BIN_DIR }}/python.edxapp {{ COMMON_BIN_DIR }}/manage.edxapp lms set_staff *"
 - "ALL=({{ common_web_user }})  NOPASSWD:SETENV:{{ COMMON_BIN_DIR }}/python.edxapp {{ COMMON_BIN_DIR }}/manage.edxapp lms transfer_students *"
@@ -596,7 +594,6 @@ edxapp_aa_command: "{% if EDXAPP_SANDBOX_ENFORCE %}aa-enforce{% else %}aa-compla
 edxapp_helper_scripts:
     - edxapp-migrate
     - edxapp-runserver
-    - edxapp-syncdb
     - edxapp-update-assets
     - edxapp-shell
 

--- a/playbooks/roles/edxapp/tasks/deploy.yml
+++ b/playbooks/roles/edxapp/tasks/deploy.yml
@@ -340,17 +340,6 @@
     - install
     - install:code
 
-# https://code.launchpad.net/~wligtenberg/django-openid-auth/mysql_fix/+merge/22726
-# This is necessary for when syncdb is run and the django_openid_auth module is installed,
-# not sure if this fix will ever get merged
-- name: openid workaround
-  shell: sed -i -e 's/claimed_id = models.TextField(max_length=2047, unique=True/claimed_id = models.TextField(max_length=2047/' {{ edxapp_venv_dir }}/lib/python2.7/site-packages/django_openid_auth/models.py
-  when: openid_workaround is defined
-  sudo_user: "{{ edxapp_user }}"
-  tags:
-    - install
-    - install:code
-
 # creates the supervisor jobs for the
 # service variants configured, runs
 # gather_assets and db migrations

--- a/playbooks/roles/edxapp/tasks/service_variant_config.yml
+++ b/playbooks/roles/edxapp/tasks/service_variant_config.yml
@@ -137,7 +137,7 @@
     - install
     - install:configuration
 
-# Syncdb with migrate when the migrate user is overridden in extra vars
+# migrate when the migrate user is overridden in extra vars
 - name: migrate
   command: "{{ COMMON_BIN_DIR }}/edxapp-migrate-{{ item }}"
   when: migrate_db is defined and migrate_db|lower == "yes" and COMMON_MYSQL_MIGRATE_PASS and item != "lms-preview"

--- a/playbooks/roles/edxapp/templates/edx/bin/edxapp-syncdb-cms.j2
+++ b/playbooks/roles/edxapp/templates/edx/bin/edxapp-syncdb-cms.j2
@@ -1,3 +1,0 @@
-{% include "edxapp_common.j2" %}
-
-sudo -E -u {{ edxapp_user }} env "PATH=$PATH" {{ edxapp_venv_bin}}/python manage.py cms syncdb --migrate --noinput --settings $EDX_PLATFORM_SETTINGS

--- a/playbooks/roles/edxapp/templates/edx/bin/edxapp-syncdb-lms.j2
+++ b/playbooks/roles/edxapp/templates/edx/bin/edxapp-syncdb-lms.j2
@@ -1,3 +1,0 @@
-{% include "edxapp_common.j2" %}
-
-sudo -E -u {{ edxapp_user }} env "PATH=$PATH" {{ edxapp_venv_bin}}/python manage.py lms syncdb --migrate --noinput --settings $EDX_PLATFORM_SETTINGS


### PR DESCRIPTION
Django 1.8 removed the syncdb command so we can no longer run it, don't
imply that we are running it in documentation/messages, also don't
provide the scripts used on devstack/sandboxes to run it since they'll
never work anyway.

@edx/devops 
