### PR TITLE
Jibsheet/migrate multiple databases

### DIFF
--- a/playbooks/edx-east/edxapp_migrate.yml
+++ b/playbooks/edx-east/edxapp_migrate.yml
@@ -4,14 +4,32 @@
   gather_facts: False
   vars:
     db_dry_run: "--list"
+  roles:
+    - edxapp
   tasks:
-    - name: migrate
+    - name: migrate lms
       shell: >
         chdir={{ edxapp_code_dir }}
-        python manage.py {{ item }} migrate --noinput {{ db_dry_run }} --settings=aws_migrate
+        python manage.py lms migrate --database {{ item }} --noinput {{ db_dry_run }} --settings=aws_migrate
       environment:
         DB_MIGRATION_USER: "{{ COMMON_MYSQL_MIGRATE_USER }}"
         DB_MIGRATION_PASS: "{{ COMMON_MYSQL_MIGRATE_PASS }}"
+      # Migrate any database in the config, but not the read_replica
+      when: item != 'read_replica'
       with_items:
-        - lms
-        - cms
+        - "{{ lms_auth_config.DATABASES.keys() }}"
+      tags:
+        - always
+    - name: migrate cms
+      shell: >
+        chdir={{ edxapp_code_dir }}
+        python manage.py cms migrate --database {{ item }} --noinput {{ db_dry_run }} --settings=aws_migrate
+      environment:
+        DB_MIGRATION_USER: "{{ COMMON_MYSQL_MIGRATE_USER }}"
+        DB_MIGRATION_PASS: "{{ COMMON_MYSQL_MIGRATE_PASS }}"
+      # Migrate any database in the config, but not the read_replica
+      when: item != 'read_replica'
+      with_items:
+        - "{{ cms_auth_config.DATABASES.keys() }}"
+      tags:
+        - always

--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -662,6 +662,9 @@ edxapp_generic_auth_config:  &edxapp_generic_auth
     ADDITIONAL_OPTIONS: "{{ EDXAPP_CONTENTSTORE_ADDITIONAL_OPTS }}"
     DOC_STORE_CONFIG: *edxapp_generic_default_docstore
   DATABASES:
+    # edxapp's edxapp-migrate scripts and the edxapp_migrate play
+    # will ensure that any DB not named read_replica will be migrated
+    # for both the lms and cms.
     read_replica:
       ENGINE: 'django.db.backends.mysql'
       NAME: "{{ EDXAPP_MYSQL_REPLICA_DB_NAME }}"

--- a/playbooks/roles/edxapp/templates/edx/bin/edxapp-migrate-cms.j2
+++ b/playbooks/roles/edxapp/templates/edx/bin/edxapp-migrate-cms.j2
@@ -1,7 +1,11 @@
 {% include "edxapp_common.j2" %}
 
+if [[ -z "$NO_EDXAPP_SUDO" ]]; then
+    SUDO='sudo -E -u {{ edxapp_user }} env "PATH=$PATH"'
+fi
+
 {% for db in cms_auth_config.DATABASES.keys() %}
   {%- if db != 'read_replica' %}
-sudo -E -u {{ edxapp_user }} env "PATH=$PATH" {{ edxapp_venv_bin}}/python manage.py cms migrate --database {{ db }} --noinput --settings $EDX_PLATFORM_SETTINGS $@
+$SUDO {{ edxapp_venv_bin}}/python manage.py cms migrate --database {{ db }} --noinput --settings $EDX_PLATFORM_SETTINGS $@
   {% endif %}
 {% endfor %}

--- a/playbooks/roles/edxapp/templates/edx/bin/edxapp-migrate-cms.j2
+++ b/playbooks/roles/edxapp/templates/edx/bin/edxapp-migrate-cms.j2
@@ -2,6 +2,6 @@
 
 {% for db in cms_auth_config.DATABASES.keys() %}
   {%- if db != 'read_replica' %}
-sudo -E -u {{ edxapp_user }} env "PATH=$PATH" {{ edxapp_venv_bin}}/python manage.py cms migrate --database {{ db }} --noinput --settings $EDX_PLATFORM_SETTINGS
+sudo -E -u {{ edxapp_user }} env "PATH=$PATH" {{ edxapp_venv_bin}}/python manage.py cms migrate --database {{ db }} --noinput --settings $EDX_PLATFORM_SETTINGS $@
   {% endif %}
 {% endfor %}

--- a/playbooks/roles/edxapp/templates/edx/bin/edxapp-migrate-cms.j2
+++ b/playbooks/roles/edxapp/templates/edx/bin/edxapp-migrate-cms.j2
@@ -1,3 +1,7 @@
 {% include "edxapp_common.j2" %}
 
-sudo -E -u {{ edxapp_user }} env "PATH=$PATH" {{ edxapp_venv_bin}}/python manage.py cms migrate --noinput --settings $EDX_PLATFORM_SETTINGS
+{% for db in cms_auth_config.DATABASES.keys() %}
+  {%- if db != 'read_replica' %}
+sudo -E -u {{ edxapp_user }} env "PATH=$PATH" {{ edxapp_venv_bin}}/python manage.py cms migrate --database {{ db }} --noinput --settings $EDX_PLATFORM_SETTINGS
+  {% endif %}
+{% endfor %}

--- a/playbooks/roles/edxapp/templates/edx/bin/edxapp-migrate-lms.j2
+++ b/playbooks/roles/edxapp/templates/edx/bin/edxapp-migrate-lms.j2
@@ -2,6 +2,6 @@
 
 {% for db in lms_auth_config.DATABASES.keys() %}
   {%- if db != 'read_replica' %}
-sudo -E -u {{ edxapp_user }} env "PATH=$PATH" {{ edxapp_venv_bin}}/python manage.py lms migrate --database {{ db }} --noinput --settings $EDX_PLATFORM_SETTINGS
+sudo -E -u {{ edxapp_user }} env "PATH=$PATH" {{ edxapp_venv_bin}}/python manage.py lms migrate --database {{ db }} --noinput --settings $EDX_PLATFORM_SETTINGS $@
   {% endif %}
 {% endfor %}

--- a/playbooks/roles/edxapp/templates/edx/bin/edxapp-migrate-lms.j2
+++ b/playbooks/roles/edxapp/templates/edx/bin/edxapp-migrate-lms.j2
@@ -1,3 +1,7 @@
 {% include "edxapp_common.j2" %}
 
-sudo -E -u {{ edxapp_user }} env "PATH=$PATH" {{ edxapp_venv_bin}}/python manage.py lms migrate --noinput --settings $EDX_PLATFORM_SETTINGS
+{% for db in lms_auth_config.DATABASES.keys() %}
+  {%- if db != 'read_replica' %}
+sudo -E -u {{ edxapp_user }} env "PATH=$PATH" {{ edxapp_venv_bin}}/python manage.py lms migrate --database {{ db }} --noinput --settings $EDX_PLATFORM_SETTINGS
+  {% endif %}
+{% endfor %}

--- a/playbooks/roles/edxapp/templates/edx/bin/edxapp-migrate-lms.j2
+++ b/playbooks/roles/edxapp/templates/edx/bin/edxapp-migrate-lms.j2
@@ -1,7 +1,11 @@
 {% include "edxapp_common.j2" %}
 
+if [[ -z "$NO_EDXAPP_SUDO" ]]; then
+    SUDO='sudo -E -u {{ edxapp_user }} env "PATH=$PATH"'
+fi
+
 {% for db in lms_auth_config.DATABASES.keys() %}
   {%- if db != 'read_replica' %}
-sudo -E -u {{ edxapp_user }} env "PATH=$PATH" {{ edxapp_venv_bin}}/python manage.py lms migrate --database {{ db }} --noinput --settings $EDX_PLATFORM_SETTINGS $@
+$SUDO {{ edxapp_venv_bin}}/python manage.py lms migrate --database {{ db }} --noinput --settings $EDX_PLATFORM_SETTINGS $@
   {% endif %}
 {% endfor %}

--- a/playbooks/roles/supervisor/files/pre_supervisor_checks.py
+++ b/playbooks/roles/supervisor/files/pre_supervisor_checks.py
@@ -11,8 +11,8 @@ import time
 
 # Services that should be checked for migrations.
 MIGRATION_COMMANDS = {
-        'lms':     ". {env_file}; {python} {code_dir}/manage.py lms migrate --noinput --list --settings=aws",
-        'cms':     ". {env_file}; {python} {code_dir}/manage.py cms migrate --noinput --list --settings=aws",
+        'lms':     ". {env_file}; /edx/bin/edxapp-migrate-lms --noinput --list",
+        'cms':     ". {env_file}; /edx/bin/edxapp-migrate-cms --noinput --list",
         'xqueue': "{python} {code_dir}/manage.py xqueue migrate --noinput --settings=aws --db-dry-run --merge",
         'ecommerce':     ". {env_file}; {python} {code_dir}/manage.py migrate --noinput --list",
         'programs':     ". {env_file}; {python} {code_dir}/manage.py migrate --noinput --list",

--- a/playbooks/roles/supervisor/files/pre_supervisor_checks.py
+++ b/playbooks/roles/supervisor/files/pre_supervisor_checks.py
@@ -217,7 +217,7 @@ if __name__ == '__main__':
                         if 'Migrating' in output:
                             raise Exception("Migrations have not been run for {}".format(service))
                 else:
-                    new_services = {
+                    services = {
                         "lms": {'python': args.edxapp_python, 'env_file': args.edxapp_env, 'code_dir': args.edxapp_code_dir},
                         "cms": {'python': args.edxapp_python, 'env_file': args.edxapp_env, 'code_dir': args.edxapp_code_dir},
                         "ecommerce": {'python': args.ecommerce_python, 'env_file': args.ecommerce_env, 'code_dir': args.ecommerce_code_dir},
@@ -226,8 +226,8 @@ if __name__ == '__main__':
                         "analytics_api": {'python': args.analytics_api_python, 'env_file': args.analytics_api_env, 'code_dir': args.analytics_api_code_dir}
                     }
 
-                    if service in new_services and all(arg!=None for arg in new_services[service].values()) and service in MIGRATION_COMMANDS:
-                        serv_vars = new_services[service]
+                    if service in services and all(arg!=None for arg in services[service].values()) and service in MIGRATION_COMMANDS:
+                        serv_vars = services[service]
 
                         cmd = MIGRATION_COMMANDS[service].format(**serv_vars)
                         if os.path.exists(serv_vars['code_dir']):

--- a/playbooks/roles/supervisor/files/pre_supervisor_checks.py
+++ b/playbooks/roles/supervisor/files/pre_supervisor_checks.py
@@ -11,8 +11,8 @@ import time
 
 # Services that should be checked for migrations.
 MIGRATION_COMMANDS = {
-        'lms':     ". {env_file}; /edx/bin/edxapp-migrate-lms --noinput --list",
-        'cms':     ". {env_file}; /edx/bin/edxapp-migrate-cms --noinput --list",
+        'lms':     "NO_EDXAPP_SUDO=1 /edx/bin/edxapp-migrate-lms --noinput --list",
+        'cms':     "NO_EDXAPP_SUDO=1 /edx/bin/edxapp-migrate-cms --noinput --list",
         'xqueue': "{python} {code_dir}/manage.py xqueue migrate --noinput --settings=aws --db-dry-run --merge",
         'ecommerce':     ". {env_file}; {python} {code_dir}/manage.py migrate --noinput --list",
         'programs':     ". {env_file}; {python} {code_dir}/manage.py migrate --noinput --list",

--- a/util/jenkins/check-migrations.sh
+++ b/util/jenkins/check-migrations.sh
@@ -58,13 +58,12 @@ extra_var_args+=" -e edxapp_code_dir=${WORKSPACE}/edx-platform"
 extra_var_args+=" -e edxapp_user=jenkins"
 extra_var_args+=" -e EDXAPP_CFG_DIR=${WORKSPACE}"
 
-# Generate the json configuration files
-ansible-playbook -c local $extra_var_args --tags edxapp_cfg -i localhost, -s -U jenkins edxapp.yml
-
 # Run migrations and replace literal '\n' with actual newlines to make the output
 # easier to read
+# We use the edxapp_cfg tag so that the edxapp role will generate config files but
+# nothing else.  The actual migrate commands are then run from the playbook.
 
-ansible-playbook -v -c local $extra_var_args -i localhost, -s -U jenkins edxapp_migrate.yml | sed 's/\\n/\n/g'
+ansible-playbook -v -c local $extra_var_args --tags edxapp_cfg -i localhost, -s -U jenkins edxapp_migrate.yml | sed 's/\\n/\n/g'
 
 #We don't care about the exit status of the `sed`
 exit ${PIPESTATUS[0]}


### PR DESCRIPTION
Change the edxapp role, edxapp_migrate play and pre_supervisor to support multiple databases.

pre_supervisor leverages changes to edxapp to do so.  If we don't like the pre_supervisor changes, we'll need to go the route of https://github.com/edx/configuration/commit/8c893e24d6b46c3b26e3a70eda51633e91dc6a5e possibly having it autogen the databases from lms.auth.json.  This seemed better.
