### PR TITLE
credentials: default cache key_prefix to service_name

### DIFF
--- a/playbooks/roles/credentials/defaults/main.yml
+++ b/playbooks/roles/credentials/defaults/main.yml
@@ -46,7 +46,7 @@ CREDENTIALS_MEMCACHE: [ 'memcache' ]
 CREDENTIALS_CACHES:
   default:
     BACKEND:  'django.core.cache.backends.memcached.MemcachedCache'
-    KEY_PREFIX: 'default'
+    KEY_PREFIX: '{{ credentials_service_name }}'
     LOCATION: '{{ CREDENTIALS_MEMCACHE }}'
 
 CREDENTIALS_VERSION: "master"


### PR DESCRIPTION
@maxrothman  please review 
@zubair-arbi FYI.   This should better insulate us from collisions when memcached hosts are shared.
