### PR TITLE
Remove remenants of removed vars.

### DIFF
--- a/playbooks/roles/rabbitmq/tasks/main.yml
+++ b/playbooks/roles/rabbitmq/tasks/main.yml
@@ -134,7 +134,7 @@
 - name: make queues mirrored
   shell: >
     /usr/sbin/rabbitmqctl -p {{ item }} set_policy HA "" '{"ha-mode":"all","ha-sync-mode":"automatic"}'
-  when: RABBITMQ_CLUSTERED or rabbitmq_clustered_hosts|length > 1
+  when: RABBITMQ_CLUSTERED_HOSTS|length > 1
   with_items: RABBITMQ_VHOSTS
   tags:
     - ha


### PR DESCRIPTION
RABBITMQ_CLUSTERED was removed and rabbitmq_clustered_hosts was renamed.

@edx/devops 
