### PR TITLE
Define the CSMH database so it is created / migrate users defined

### DIFF
--- a/playbooks/roles/edxlocal/defaults/main.yml
+++ b/playbooks/roles/edxlocal/defaults/main.yml
@@ -9,6 +9,7 @@ edxlocal_databases:
   - "{{ ORA_MYSQL_DB_NAME | default(None) }}"
   - "{{ XQUEUE_MYSQL_DB_NAME | default(None) }}"
   - "{{ EDXAPP_MYSQL_DB_NAME | default(None) }}"
+  - "{{ EDXAPP_MYSQL_CSMH_DB_NAME | default(None) }}"
   - "{{ EDX_NOTES_API_MYSQL_DB_NAME | default(None) }}"
   - "{{ PROGRAMS_DEFAULT_DB_NAME | default(None) }}"
   - "{{ ANALYTICS_API_DEFAULT_DB_NAME | default(None) }}"
@@ -41,6 +42,11 @@ edxlocal_database_users:
       db: "{{ EDXAPP_MYSQL_DB_NAME | default(None) }}",
       user: "{{ EDXAPP_MYSQL_USER | default(None) }}",
       pass: "{{ EDXAPP_MYSQL_PASSWORD | default(None) }}"
+    }
+  - {
+      db: "{{ EDXAPP_MYSQL_CSMH_DB_NAME | default(None) }}",
+      user: "{{ EDXAPP_MYSQL_CSMH_USER | default(None) }}",
+      pass: "{{ EDXAPP_MYSQL_CSMH_PASSWORD | default(None) }}"
     }
   - {
       db: "{{ PROGRAMS_DEFAULT_DB_NAME | default(None) }}",


### PR DESCRIPTION
This is safe to merge since it creates databases on sandboxes built from scratch and devstacks, but they're unused until we also merge code to enable the second database / define them in lms.auth.json:DATABASES
