### PR TITLE
Ensure login shell is set correctly for Analytics users

### DIFF
--- a/playbooks/vagrant-analytics.yml
+++ b/playbooks/vagrant-analytics.yml
@@ -26,9 +26,9 @@
     - elasticsearch
     - forum
     - { role: 'rabbitmq', rabbitmq_ip: '127.0.0.1' }
+    - analytics_api
+    - insights
     - local_dev
     - demo
-    - analytics_api
     - analytics_pipeline
-    - insights
     - oauth_client_setup


### PR DESCRIPTION
This PR follows up on https://github.com/edx/configuration/pull/2753 and makes sure that the default login shell for the `analytics_api` and `insights` users is set to `/bin/bash` during provisioning.

**Test instructions**
1. Create a new base box for analyticstack by doing:
   
   ``` sh
   mkdir analytics
   cd analytics
   git clone https://github.com/open-craft/configuration.git
   cd configuration
   git checkout master-b3a7dc0
   virtualenv -p /usr/bin/python2 venv
   source venv/bin/activate
   pip install -r pre-requirements.txt
   pip install -r requirements.txt
   cd vagrant/base/analyticstack
   export OPENEDX_RELEASE=named-release/dogwood
   vagrant up
   ```
2. SSH into the VM and check the default shell for `analytics_api` and `insights` users:
   
   ``` sh
   vagrant ssh
   getent passwd analytics_api | cut -d: -f7
   getent passwd insights | cut -d: -f7
   ```
   
   The last two commands should output `/bin/bash`.
