### PR TITLE
Quote username and password in migrate command

### DIFF
--- a/playbooks/roles/analytics_api/tasks/main.yml
+++ b/playbooks/roles/analytics_api/tasks/main.yml
@@ -66,8 +66,8 @@
 - name: migrate
   shell: >
     chdir={{ analytics_api_code_dir }}
-    DB_MIGRATION_USER={{ COMMON_MYSQL_MIGRATE_USER }}
-    DB_MIGRATION_PASS={{ COMMON_MYSQL_MIGRATE_PASS }}
+    DB_MIGRATION_USER='{{ COMMON_MYSQL_MIGRATE_USER }}'
+    DB_MIGRATION_PASS='{{ COMMON_MYSQL_MIGRATE_PASS }}'
     {{ analytics_api_home }}/venvs/{{ analytics_api_service_name }}/bin/python ./manage.py migrate --noinput
   sudo_user: "{{ analytics_api_user }}"
   environment: "{{ analytics_api_environment }}"

--- a/playbooks/roles/ecommerce/tasks/main.yml
+++ b/playbooks/roles/ecommerce/tasks/main.yml
@@ -54,8 +54,8 @@
 - name: migrate
   shell: >
     chdir={{ ecommerce_code_dir }}
-    DB_MIGRATION_USER={{ COMMON_MYSQL_MIGRATE_USER }}
-    DB_MIGRATION_PASS={{ COMMON_MYSQL_MIGRATE_PASS }}
+    DB_MIGRATION_USER='{{ COMMON_MYSQL_MIGRATE_USER }}'
+    DB_MIGRATION_PASS='{{ COMMON_MYSQL_MIGRATE_PASS }}'
     {{ ecommerce_venv_dir }}/bin/python ./manage.py migrate --noinput
   sudo_user: "{{ ecommerce_user }}"
   environment: "{{ ecommerce_environment }}"

--- a/playbooks/roles/edx_notes_api/tasks/main.yml
+++ b/playbooks/roles/edx_notes_api/tasks/main.yml
@@ -55,8 +55,8 @@
 - name: migrate
   shell: >
     chdir={{ edx_notes_api_code_dir }}
-    DB_MIGRATION_USER={{ COMMON_MYSQL_MIGRATE_USER }}
-    DB_MIGRATION_PASS={{ COMMON_MYSQL_MIGRATE_PASS }}
+    DB_MIGRATION_USER='{{ COMMON_MYSQL_MIGRATE_USER }}'
+    DB_MIGRATION_PASS='{{ COMMON_MYSQL_MIGRATE_PASS }}'
     {{ edx_notes_api_home }}/venvs/{{ edx_notes_api_service_name }}/bin/python {{ edx_notes_api_manage }} migrate --noinput --settings="notesserver.settings.yaml_config"
   sudo_user: "{{ edx_notes_api_user }}"
   environment:

--- a/playbooks/roles/insights/tasks/main.yml
+++ b/playbooks/roles/insights/tasks/main.yml
@@ -71,8 +71,8 @@
 - name: migrate
   shell: >
     chdir={{ insights_code_dir }}
-    DB_MIGRATION_USER={{ COMMON_MYSQL_MIGRATE_USER }}
-    DB_MIGRATION_PASS={{ COMMON_MYSQL_MIGRATE_PASS }}
+    DB_MIGRATION_USER='{{ COMMON_MYSQL_MIGRATE_USER }}'
+    DB_MIGRATION_PASS='{{ COMMON_MYSQL_MIGRATE_PASS }}'
     {{ insights_home }}/venvs/{{ insights_service_name }}/bin/python {{ insights_manage }} migrate --noinput
   sudo_user: "{{ insights_user }}"
   environment: "{{ insights_environment }}"


### PR DESCRIPTION
Otherwise the command fails if the mysql password includes special shell characters such as '&' or '<':

```
TASK: [analytics_api | migrate] ***********************************************
failed: [54.169.190.135] => {"changed": true, "cmd": "DB_MIGRATION_USER=edxapp DB_MIGRATION_PASS=QC&I9W[redacted]
d": "2016-03-04 05:45:14.367368", "rc": 127, "start": "2016-03-04 05:45:14.361723", "warnings": []}
stderr: /bin/sh: 1: I9W[redacted]: not found
```
