### PR TITLE
Allow a single user access to multiple databases

### DIFF
--- a/playbooks/roles/edxlocal/tasks/main.yml
+++ b/playbooks/roles/edxlocal/tasks/main.yml
@@ -21,6 +21,7 @@
     name: "{{ item.user }}"
     password: "{{ item.pass }}"
     priv: "{{ item.db }}.*:ALL"
+    append_privs: yes
   when: item.db != None and item.db != ''
   with_items: "{{ edxlocal_database_users }}"
 


### PR DESCRIPTION
This avoids a class of confusing problems where a user might be given
access to two DBs and then when starting the app, fail because they can
only access one DB.
