### PR TITLE
Adding go-agent Docker file

### DIFF
--- a/docker.mk
+++ b/docker.mk
@@ -52,7 +52,7 @@ $(docker_push)%: $(docker_pkg)%
 
 .build/%/Dockerfile.d: docker/build/%/Dockerfile Makefile
 	@mkdir -p .build/$*
-	$(eval FROM=$(shell grep "FROM" $< | sed --regexp-extended "s/FROM //" | sed --regexp-extended "s/:/@/g"))
+	$(eval FROM=$(shell grep "^\s*FROM" $< | sed --regexp-extended "s/FROM //" | sed --regexp-extended "s/:/@/g"))
 	$(eval EDXOPS_FROM=$(shell echo "$(FROM)" | sed --regexp-extended "s#edxops/([^@]+)(@.*)?#\1#"))
 	@echo "$(docker_build)$*: $(docker_pull)$(FROM)" > $@
 	@if [ "$(EDXOPS_FROM)" != "$(FROM)" ]; then \

--- a/docker/build/go-agent/Dockerfile
+++ b/docker/build/go-agent/Dockerfile
@@ -1,0 +1,18 @@
+# Build using: docker build -f Dockerfile.gocd-agent -t gocd-agent .
+# FROM edxops/precise-common:latest
+FROM gocd/gocd-agent:16.2.1
+
+LABEL version="0.01" \
+      description="This custom go-agent docker file installs additional requirements for the edx pipeline"
+
+
+RUN apt-get update && apt-get install -y -q \
+    python \
+    python-dev \
+    python-distribute \
+    python-pip
+
+# TODO: repalce this with a pip install command so we can version this properly
+RUN git clone -b bbeggs/cli https://github.com/edx/tubular.git /opt/tubular
+RUN pip install -r /opt/tubular/requirements.txt
+RUN cd /opt/tubular;python setup.py install

--- a/docker/build/go-agent/README.md
+++ b/docker/build/go-agent/README.md
@@ -1,0 +1,28 @@
+##Usage
+Start the container with this:
+
+```docker run -ti -e GO_SERVER=your.go.server.ip_or_host gocd/gocd-agent```
+
+If you need to start a few GoCD agents together, you can of course use the shell to do that. Start a few agents in the background, like this:
+
+```for each in 1 2 3; do docker run -d --link angry_feynman:go-server gocd/gocd-agent; done```
+
+##Getting into the container
+Sometimes, you need a shell inside the container (to create test repositories, etc). docker provides an easy way to do that:
+
+```docker exec -i -t CONTAINER-ID /bin/bash```
+
+To check the agent logs, you can do this:
+
+```docker exec -i -t CONTAINER-ID tail -f /var/log/go-agent/go-agent.log``` 
+
+##Agent Configuration
+The go-agent expects it's configuration to be found at ```/var/lib/go-agent/config/```. Sharing the 
+configuration between containers is done by mounting a volume at this location that contains any configuration files 
+necessary.
+
+
+**Example docker run command:**
+```docker run -ti -v /tmp/go-agent/conf:/var/lib/go-agent/config -e GO_SERVER=gocd.sandbox.edx.org 718d75c467c0 bash```
+
+[How to setup auto registration for remote agents](https://docs.go.cd/current/advanced_usage/agent_auto_register.html)


### PR DESCRIPTION
Docker file for go-agents. (Includes python 2.7.10 and PIP)
