### PR TITLE
E0d/upgrade rabbitmq

### DIFF
--- a/docker/build/rabbitmq/Dockerfile
+++ b/docker/build/rabbitmq/Dockerfile
@@ -1,0 +1,17 @@
+FROM edxops/precise-common
+MAINTAINER edxops
+
+ADD . /edx/app/edx_ansible/edx_ansible
+COPY docker/build/rabbitmq/ansible_overrides.yml /
+COPY docker/build/rabbitmq/run_rabbitmq.sh /
+RUN chmod +x /run_rabbitmq.sh
+
+WORKDIR /edx/app/edx_ansible/edx_ansible/docker/plays
+
+RUN /edx/app/edx_ansible/venvs/edx_ansible/bin/ansible-playbook rabbitmq.yml \
+    -i '127.0.0.1,' -c local \
+    -e@/ansible_overrides.yml
+
+WORKDIR /edx/app
+
+CMD ["/run_rabbitmq.sh"]

--- a/docker/build/rabbitmq/ansible_overrides.yml
+++ b/docker/build/rabbitmq/ansible_overrides.yml
@@ -1,0 +1,2 @@
+---
+FLOCK_TLD: "edx"

--- a/docker/build/rabbitmq/run_rabbitmq.sh
+++ b/docker/build/rabbitmq/run_rabbitmq.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+ulimit -n 1024
+exec rabbitmq-server $@

--- a/docker/build/rabbitmq/sample.json
+++ b/docker/build/rabbitmq/sample.json
@@ -1,0 +1,23 @@
+{
+ "test-pull":
+    {
+    "AUTH": [
+        "lms", 
+        "password"
+    ], 
+    "CONNECTIONS": 2, 
+    "HANDLERS": [
+        {
+            "CODEJAIL": {
+                "name": "demo", 
+                "python_bin": "/edx/app/xqwatcher/venvs/demo/bin/python", 
+                "user": "demo"
+            }, 
+            "HANDLER": "xqueue_watcher.jailedgrader.JailedGrader", 
+            "KWARGS": {
+                "grader_root": "../data/edx-demo-course/graders/"
+            }
+        }
+    ], 
+    "SERVER": "http://xqueue.edx"
+}

--- a/playbooks/roles/common_vars/defaults/main.yml
+++ b/playbooks/roles/common_vars/defaults/main.yml
@@ -96,6 +96,7 @@ COMMON_ENABLE_MINOS: False
 COMMON_TAG_EC2_INSTANCE: False
 common_boto_version: '2.34.0'
 common_debian_pkgs:
+  - apt-transport-https
   - ntp
   - lynx-cur
   - logrotate

--- a/playbooks/roles/rabbitmq/defaults/main.yml
+++ b/playbooks/roles/rabbitmq/defaults/main.yml
@@ -33,7 +33,7 @@ rabbitmq_apt_key: "http://www.rabbitmq.com/rabbitmq-signing-key-public.asc"
 rabbitmq_repository: "deb http://www.rabbitmq.com/debian/ testing main"
 # We mirror the deb package for rabbitmq-server because
 # nodes need to be running the same version
-rabbitmq_pkg_url: "http://files.edx.org/rabbitmq_packages/rabbitmq-server_3.2.3-1_all.deb"
+rabbitmq_pkg_url: "https://files.edx.org/rabbitmq_packages/rabbitmq-server_3.6.1-1_all.deb"
 rabbitmq_pkg: "rabbitmq-server"
 rabbitmq_debian_pkgs:
   - python-software-properties

--- a/playbooks/roles/rabbitmq/defaults/main.yml
+++ b/playbooks/roles/rabbitmq/defaults/main.yml
@@ -1,5 +1,15 @@
-#Variables for rabbitmq
 ---
+#
+# edX Configuration
+#
+# github:     https://github.com/edx/configuration
+# wiki:       https://github.com/edx/configuration/wiki
+# code style: https://github.com/edx/configuration/wiki/Ansible-Coding-Conventions
+# license:    https://github.com/edx/configuration/blob/master/LICENSE.TXT
+#
+#
+# Defaults for role rabbitmq
+# 
 
 rabbitmq_app_dir: "{{ COMMON_APP_DIR }}/rabbitmq"
 rabbitmq_data_dir: "{{ COMMON_DATA_DIR }}/rabbitmq"
@@ -29,14 +39,20 @@ RABBITMQ_CLUSTERED_HOSTS: []
 # option to force deletion of the mnesia dir
 rabbitmq_refresh: false
 
-rabbitmq_apt_key: "http://www.rabbitmq.com/rabbitmq-signing-key-public.asc"
-rabbitmq_repository: "deb http://www.rabbitmq.com/debian/ testing main"
+extra_repos:
+  - {repo: "deb https://www.rabbitmq.com/debian/ testing main", key: "https://www.rabbitmq.com/rabbitmq-signing-key-public.asc"}
+  - {repo: "deb https://packages.erlang-solutions.com/ubuntu precise contrib", key: "https://packages.erlang-solutions.com/ubuntu/erlang_solutions.asc"}
+
 # We mirror the deb package for rabbitmq-server because
 # nodes need to be running the same version
 rabbitmq_pkg_url: "https://files.edx.org/rabbitmq_packages/rabbitmq-server_3.6.1-1_all.deb"
 rabbitmq_pkg: "rabbitmq-server"
 rabbitmq_debian_pkgs:
+  # why is is this needed?
   - python-software-properties
+  # erlang dependencies for rabbitmq
+  - erlang
+  - erlang-nox
   # for installing the deb package with
   # dependencies
   - gdebi

--- a/playbooks/roles/rabbitmq/defaults/main.yml
+++ b/playbooks/roles/rabbitmq/defaults/main.yml
@@ -11,6 +11,9 @@
 # Defaults for role rabbitmq
 # 
 
+#Setting this to false ensures rabbit will never be upgraded if the wrong version is installed
+CHECK_RABBIT_VERSION: true
+
 rabbitmq_app_dir: "{{ COMMON_APP_DIR }}/rabbitmq"
 rabbitmq_data_dir: "{{ COMMON_DATA_DIR }}/rabbitmq"
 rabbitmq_log_dir: "{{ COMMON_LOG_DIR }}/rabbitmq"

--- a/playbooks/roles/rabbitmq/defaults/main.yml
+++ b/playbooks/roles/rabbitmq/defaults/main.yml
@@ -33,6 +33,7 @@ RABBITMQ_VHOSTS:
   - '/'
 
 RABBITMQ_CLUSTERED_HOSTS: []
+RABBITMQ_VERSION: 3.6.1-1
 
 # Internal role variables below this line
 
@@ -45,7 +46,7 @@ extra_repos:
 
 # We mirror the deb package for rabbitmq-server because
 # nodes need to be running the same version
-rabbitmq_pkg_url: "https://files.edx.org/rabbitmq_packages/rabbitmq-server_3.6.1-1_all.deb"
+rabbitmq_pkg_url: "https://files.edx.org/rabbitmq_packages/rabbitmq-server_{{ RABBITMQ_VERSION }}_all.deb"
 rabbitmq_pkg: "rabbitmq-server"
 rabbitmq_debian_pkgs:
   # why is is this needed?

--- a/playbooks/roles/rabbitmq/tasks/main.yml
+++ b/playbooks/roles/rabbitmq/tasks/main.yml
@@ -13,7 +13,7 @@
     state=present
     update_cache=yes
   with_items: extra_repos
-  
+
 - name: install python-software-properties if debian
   apt: pkg={{ ",".join(rabbitmq_debian_pkgs) }} state=present
 
@@ -22,16 +22,21 @@
     url={{ rabbitmq_pkg_url }}
     dest=/var/tmp/{{ rabbitmq_pkg_url|basename }}
 
+# If we don't set pipefail first, `||` will be looking at the exit code of the last command in the pipe
 - name: check if rabbit is installed
-  shell: >
-    dpkg -s rabbitmq-server >/dev/null 2>&1 || echo "not installed"
-  register: is_installed
+  shell: |
+    set -o pipefail
+    dpkg -s rabbitmq-server | grep Version | sed -r 's/.*: (.*)/\1/' || echo 'not installed'
+  args:
+    executable: /bin/bash
+  register: installed_version
+  failed_when: installed_version.stdout is defined and installed_version.stdout not in [RABBITMQ_VERSION, 'not installed']
 
 - name: install rabbit package using gdebi
   shell: >
     gdebi --n {{ rabbitmq_pkg_url|basename }}
     chdir=/var/tmp
-  when: is_installed.stdout is defined and is_installed.stdout == "not installed"
+  when: installed_version.stdout is defined and installed_version.stdout == "not installed"
 
 - name: stop rabbit cluster
   service: name=rabbitmq-server state=stopped

--- a/playbooks/roles/rabbitmq/tasks/main.yml
+++ b/playbooks/roles/rabbitmq/tasks/main.yml
@@ -9,9 +9,9 @@
 
 - name: add extra repositories
   apt_repository:
-    repo="{{ item.repo }}"
-    state=present
-    update_cache=yes
+    repo: "{{ item.repo }}"
+    state: present
+    update_cache: yes
   with_items: extra_repos
 
 - name: install python-software-properties if debian
@@ -30,7 +30,10 @@
   args:
     executable: /bin/bash
   register: installed_version
-  failed_when: installed_version.stdout is defined and installed_version.stdout not in [RABBITMQ_VERSION, 'not installed']
+
+- name: Fail if wrong rabbit version is installed
+  fail: Expected rabbitmq version {{ RABBITMQ_VERSION }}, found {{ installed_version.stdout }}
+  when: CHECK_RABBIT_VERSION and installed_version.stdout is defined and installed_version.stdout not in [RABBITMQ_VERSION, 'not installed']
 
 - name: install rabbit package using gdebi
   shell: >
@@ -49,21 +52,21 @@
 # Create the rabbitmq directories
 - name: create rabbitmq edx directories
   file:
-    path={{ item }}
-    owner={{ rabbitmq_user }}
-    mode=0755
-    state=directory
+    path: {{ item }}
+    owner: {{ rabbitmq_user }}
+    mode: 0755
+    state: directory
   with_items:
     - "{{ rabbitmq_app_dir }}"
     - "{{ rabbitmq_log_dir }}"
 
 - name: add queue monitoring script
   template:
-    src="edx/app/rabbitmq/log-rabbitmq-queues.sh.j2"
-    dest="{{ rabbitmq_app_dir }}/log-rabbitmq-queues.sh"
-    owner="{{ rabbitmq_user }}"
-    group="{{ rabbitmq_group }}"
-    mode=0755
+    src: "edx/app/rabbitmq/log-rabbitmq-queues.sh.j2"
+    dest: "{{ rabbitmq_app_dir }}/log-rabbitmq-queues.sh"
+    owner: "{{ rabbitmq_user }}"
+    group: "{{ rabbitmq_group }}"
+    mode: "0755"
 
 - name: set up a cron job to run the script
   cron:

--- a/playbooks/roles/rabbitmq/tasks/main.yml
+++ b/playbooks/roles/rabbitmq/tasks/main.yml
@@ -3,14 +3,19 @@
 # There is a bug with initializing multiple nodes in the HA cluster at once
 # http://rabbitmq.1065348.n5.nabble.com/Rabbitmq-boot-failure-with-quot-tables-not-present-quot-td24494.html
 
-- name: trust rabbit repository
-  apt_key: url={{ rabbitmq_apt_key }} state=present
+- name: trust extra repositories
+  apt_key: url={{ item.key }} state=present
+  with_items: extra_repos
 
+- name: add extra repositories
+  apt_repository:
+    repo="{{ item.repo }}"
+    state=present
+    update_cache=yes
+  with_items: extra_repos
+  
 - name: install python-software-properties if debian
   apt: pkg={{ ",".join(rabbitmq_debian_pkgs) }} state=present
-
-- name: add rabbit repository
-  apt_repository: repo="{{ rabbitmq_repository }}" state=present update_cache=yes
 
 - name: fetch the rabbitmq server deb
   get_url: >


### PR DESCRIPTION
@edx/devops running upgraded RabbitMQ from our play, tested on sandbox and verified that tasks are processes as expected.

`/job/ansible-provision/6116/console`

```
[edward@alexis configuration]$ docker run  edxops/docker:v0
              RabbitMQ 3.6.1. Copyright (C) 2007-2016 Pivotal Software, Inc.
  ##  ##      Licensed under the MPL.  See http://www.rabbitmq.com/
  ##  ##
  ##########  Logs: /var/log/rabbitmq/rabbit@c6f48a3ac24f.log
  ######  ##        /var/log/rabbitmq/rabbit@c6f48a3ac24f-sasl.log
  ##########
              Starting broker... completed with 6 plugins.
```

On a sandbox 

```
With workers down 

# rabbitmqctl list_queues
Listing queues ...
edx.cms.core.default    0
edx.cms.core.high   0
edx.lms.core.low    0
edx.lms.core.default    0
certificates    0
edx.lms.core.high_mem   1
edx.cms.core.low    0
edX-Open_DemoX  0
edx.lms.core.high   0
celeryev.c1b794e8-dc28-47a2-a647-8423691e4aed   0

With workers restarted

# rabbitmqctl list_queues
Listing queues ...
celery@edx.lms.core.high_mem.e0d-rabbit-upgrade.celery.pidbox   0
edx.cms.core.default    0
celery@edx.lms.core.low.e0d-rabbit-upgrade.celery.pidbox    0
edx.cms.core.high   0
celeryev.d666d333-0045-4865-a9be-d8538749ca8a   0
edx.lms.core.low    0
edx.lms.core.default    0
certificates    0
celery@edx.lms.core.high.e0d-rabbit-upgrade.celery.pidbox   0
edx.lms.core.high_mem   0
edx.cms.core.low    0
celeryev.e9597f14-ed41-4b91-81b9-6c5d857ebd86   0
celeryev.05c5c455-1bff-4e48-9f6e-23da6e43e610   0
celery@edx.lms.core.default.e0d-rabbit-upgrade.celery.pidbox    0
celeryev.b4e7e467-593f-4940-bda2-06a53aefd405   0
edX-Open_DemoX  0
edx.lms.core.high   0
celeryev.c1b794e8-dc28-47a2-a647-8423691e4aed   0
```
