### PR TITLE
This registers over the microsites theming

### DIFF
--- a/playbooks/roles/edxapp/tasks/deploy.yml
+++ b/playbooks/roles/edxapp/tasks/deploy.yml
@@ -118,7 +118,7 @@
   sudo_user: "{{ edxapp_user }}"
   environment:
     GIT_SSH: "{{ edxapp_git_ssh }}"
-  register: edxapp_theme_checkout
+  register: edxapp_comprehensive_theme_checkout
   tags:
     - install
     - install:code


### PR DESCRIPTION
This clobbers edxapp_theme_checkout set by the previous task, even when
the task is skipped because EDXAPP_COMPREHENSIVE_THEME_SOURCE_REPO is
unset.

edxapp_theme_checkout is used to tag the instance when the edxapp play
is run.

That tag is later used by our build infrastructure to ensure that
theme is consistent between builds.

If we want to also tag the comprehensive theme value, that's fine, but
it should not clobber the value needed by the other type of themes, and
should declare a different tag.
