### PR TITLE
Analytics pipeline acceptance test typo fix

### DIFF
--- a/playbooks/roles/analytics_pipeline/tasks/main.yml
+++ b/playbooks/roles/analytics_pipeline/tasks/main.yml
@@ -186,7 +186,7 @@
 
 - name: grant access to table storing test data in output database
   mysql_user: >
-    user={{ ANALYTICS_PIPELINE_OUTPUT_DATABASE.user }}
+    user={{ ANALYTICS_PIPELINE_OUTPUT_DATABASE.username }}
     password={{ ANALYTICS_PIPELINE_OUTPUT_DATABASE.password }}
     priv=acceptance%.*:ALL
     append_privs=yes


### PR DESCRIPTION
**Description:**
Provisioning fresh analyticsstack box fails with

```
TASK: [analytics_pipeline | grant access to table storing test data in output database] *** 
<127.0.0.1> ESTABLISH CONNECTION FOR USER: vagrant
fatal: [default] => One or more undefined variables: 'dict object' has no attribute 'user'
```

ANALYTICS_PIPELINE_OUTPUT_DATABASE contains `username` key, not `user`

**JIRA Ticket:** [OSPR-1187](https://openedx.atlassian.net/browse/OSPR-1187)
