### PR TITLE
use django's storage backend ManifestStaticFilesStorage for static fi…

### DIFF
--- a/playbooks/roles/credentials/defaults/main.yml
+++ b/playbooks/roles/credentials/defaults/main.yml
@@ -121,7 +121,7 @@ CREDENTIALS_FILE_STORAGE_BACKEND:
   STATIC_ROOT: '{{ CREDENTIALS_STATIC_ROOT }}'
   MEDIA_URL: '{{ CREDENTIALS_MEDIA_URL }}'
   STATIC_URL: '{{ CREDENTIALS_STATIC_URL }}'
-  STATICFILES_STORAGE: 'django.contrib.staticfiles.storage.StaticFilesStorage'
+  STATICFILES_STORAGE: 'django.contrib.staticfiles.storage.ManifestStaticFilesStorage'
   DEFAULT_FILE_STORAGE: 'django.core.files.storage.FileSystemStorage'
 
 # Note: the protocol for CORS whitelist values is necessary for matching the correct origin by nginx

--- a/playbooks/roles/credentials/templates/edx/app/nginx/sites-available/credentials.j2
+++ b/playbooks/roles/credentials/templates/edx/app/nginx/sites-available/credentials.j2
@@ -45,6 +45,7 @@ server {
   location ~ ^{{ CREDENTIALS_STATIC_URL }}(?P<file>.*) {
     root {{ CREDENTIALS_STATIC_ROOT }};
     add_header Access-Control-Allow-Origin $cors_header always;
+    add_header Cache-Control "max-age=31536000";
     try_files /$file =404;
   }
 


### PR DESCRIPTION
…les versioning

ECOM-3905
@awais786 @tasawernawaz @waheedahmed 

Use [django's storage backend 'ManifestStaticFilesStorage'](https://docs.djangoproject.com/en/1.8/ref/contrib/staticfiles/#manifeststaticfilesstorage) which stores the file by appending the `MD5` hash of the file’s content to the filename. This will help cache busting on cloudfront for only those static files which are modified.

FYI: @maxrothman @jimabramson 

Related PR: https://github.com/edx/credentials/pull/86
