### PR TITLE
Install rabbitmq before celery workers in sandboxes

### DIFF
--- a/playbooks/edx_sandbox.yml
+++ b/playbooks/edx_sandbox.yml
@@ -34,6 +34,7 @@
     - edxlocal
     - role: mongo
       when: "'localhost' in EDXAPP_MONGO_HOSTS"
+    - { role: 'rabbitmq', rabbitmq_ip: '127.0.0.1' }
     - { role: 'edxapp', celery_worker: True }
     - edxapp
     - notifier
@@ -42,7 +43,6 @@
     - edx_notes_api
     - demo
     - oauth_client_setup
-    - { role: 'rabbitmq', rabbitmq_ip: '127.0.0.1' }
     - oraclejdk
     - role: elasticsearch
       when: "'localhost' in EDXAPP_ELASTIC_SEARCH_CONFIG|map(attribute='host')"


### PR DESCRIPTION
#### Problem

We have been seeing this error when provisioning sandboxes:

```
TASK: [edxapp | ensure edxapp_workers has started] ****************************
failed: [149.202.174.205] => {"failed": true}
msg: edxapp_worker:cms_default_1: ERROR (abnormal termination)

FATAL: all hosts have already failed -- aborting
```

In `/edx/var/log/supervisor/cms_default_1-stderr.log` on that sandbox we can see:

```
[2016-03-14 16:15:43,947: ERROR/MainProcess] consumer: Cannot connect to amqp://celery:**@127.0.0.1:5672//: [Errno 111] Connection refused.
Trying again in 4.00 seconds...

[2016-03-14 16:15:47,955: ERROR/MainProcess] consumer: Cannot connect to amqp://celery:**@127.0.0.1:5672//: [Errno 111] Connection refused.
Trying again in 6.00 seconds...

[2016-03-14 16:15:53,965: ERROR/MainProcess] consumer: Cannot connect to amqp://celery:**@127.0.0.1:5672//: [Errno 111] Connection refused.
Trying again in 8.00 seconds...

[2016-03-14 16:16:01,980: ERROR/MainProcess] consumer: Cannot connect to amqp://celery:**@127.0.0.1:5672//: [Errno 111] Connection refused.
Trying again in 10.00 seconds...
```

It turns out that rabbitmq is not running, in fact it is not even installed. This is because the `edx_sandbox.yml` playbook runs the `edxapp` role **before** the `rabbitmq` role, and the `edxapp` role errors out because rabbitmq is missing, so rabbitmq never gets installed.
#### Solution

Run the `rabbitmq` role **before** the `edxapp` role in `edx_sandbox.yml`.
