### PR TITLE
Prevent invalid display courseware in IE 10+ with high privacy settings

### DIFF
--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/cms.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/cms.j2
@@ -42,6 +42,9 @@ error_page {{ k }} {{ v }};
   add_header Strict-Transport-Security "max-age=31536000; includeSubDomains";
   {% endif %}
 
+  # Prevent invalid display courseware in IE 10+ with high privacy settings
+  add_header P3P 'CP="Open EdX does not have a P3P policy."';
+
   # Nginx does not support nested condition or or conditions so
   # there is an unfortunate mix of conditonals here.
   {% if NGINX_REDIRECT_TO_HTTPS %}

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
@@ -62,6 +62,10 @@ error_page {{ k }} {{ v }};
   add_header Strict-Transport-Security "max-age=31536000; includeSubDomains";
   {% endif %}
 
+  # Prevent invalid display courseware in IE 10+ with high privacy settings
+  add_header P3P 'CP="Open EdX does not have a P3P policy."';
+
+
   # Nginx does not support nested condition or or conditions so
   # there is an unfortunate mix of conditonals here.
   {% if NGINX_REDIRECT_TO_HTTPS %}


### PR DESCRIPTION
The problem reproduced only in IE browser with high privacy settings.
JS couldn't get Cookie for the CSRF protection and sends always `null`.
So because of this users can't login, get the course problems and make other actions connected with CSRF protection.
![high_privaci_issue_in_ie](https://cloud.githubusercontent.com/assets/1876893/13854122/06896d36-ec7b-11e5-8624-14c2f0b2e8cd.jpg)
![high_privaci_issue_in_ie2](https://cloud.githubusercontent.com/assets/1876893/13854128/10c186ee-ec7b-11e5-89e5-8d1d41c8725b.jpg)
So as you can see from the screenshots for every request server returns HTTP 403.
As we found it is connected with the cookie-restricting privacy feature called P3P. More details can be found here: http://blogs.msdn.com/b/ieinternals/archive/2013/09/17/simple-introduction-to-p3p-cookie-blocking-frame.aspx
and here:
http://stackoverflow.com/questions/8048306/what-is-the-most-broad-p3p-header-that-will-work-with-ie
As we found out adding P3P HTTP header solve this issue:

```
P3P: CP="Open EdX does not have a P3P policy."
```
