### PR TITLE
Restore ecommerce roles to analytics devstack

### DIFF
--- a/playbooks/vagrant-analytics.yml
+++ b/playbooks/vagrant-analytics.yml
@@ -14,6 +14,7 @@
     EDXAPP_LMS_BASE: 127.0.0.1:8000
     EDXAPP_OAUTH_ENFORCE_SECURE: false
     EDXAPP_LMS_BASE_SCHEME: http
+    ECOMMERCE_DJANGO_SETTINGS_MODULE: "ecommerce.settings.devstack"
   roles:
     - common
     - vhost
@@ -25,6 +26,8 @@
     - oraclejdk
     - elasticsearch
     - forum
+    - ecommerce
+    - ecomworker
     - { role: 'rabbitmq', rabbitmq_ip: '127.0.0.1' }
     - analytics_api
     - insights

--- a/vagrant/base/analyticstack/Vagrantfile
+++ b/vagrant/base/analyticstack/Vagrantfile
@@ -26,6 +26,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   if not ENV['VAGRANT_NO_PORTS']
     config.vm.network :forwarded_port, guest: 8000, host: 8000  # LMS
     config.vm.network :forwarded_port, guest: 8001, host: 8001  # Studio
+    config.vm.network :forwarded_port, guest: 8002, host: 8002  # Ecommerce
     config.vm.network :forwarded_port, guest: 8003, host: 8003  # LMS for Bok Choy
     config.vm.network :forwarded_port, guest: 8031, host: 8031  # Studio for Bok Choy
     config.vm.network :forwarded_port, guest: 8120, host: 8120  # edX Notes Service
@@ -82,6 +83,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     end
     if ENV['EDX_PLATFORM_VERSION']
       ansible.extra_vars['edx_platform_version'] = ENV['EDX_PLATFORM_VERSION']
+    end
+    if ENV['ECOMMERCE_VERSION']
+      ansible.extra_vars['ECOMMERCE_VERSION'] = ENV['ECOMMERCE_VERSION']
     end
   end
 end

--- a/vagrant/release/analyticstack/Vagrantfile
+++ b/vagrant/release/analyticstack/Vagrantfile
@@ -44,6 +44,8 @@ MOUNT_DIRS = {
   :edx_platform => {:repo => "edx-platform", :local => "/edx/app/edxapp/edx-platform", :owner => "edxapp"},
   :themes => {:repo => "themes", :local => "/edx/app/edxapp/themes", :owner => "edxapp"},
   :forum => {:repo => "cs_comments_service", :local => "/edx/app/forum/cs_comments_service", :owner => "forum"},
+  :ecommerce => {:repo => "ecommerce", :local => "/edx/app/ecommerce/ecommerce", :owner => "ecommerce"},
+  :ecommerce_worker => {:repo => "ecommerce-worker", :local => "/edx/app/ecommerce_worker/ecommerce_worker", :owner => "ecommerce_worker"},
   :insights => {:repo => "insights", :local => "/edx/app/insights/edx_analytics_dashboard", :owner => "insights"},
   :analytics_api => {:repo => "analytics_api", :local => "/edx/app/analytics_api/analytics_api", :owner => "analytics_api"},
   :analytics_pipeline => {:repo => "edx-analytics-pipeline", :local => "/edx/app/analytics_pipeline/analytics_pipeline", :owner => "hadoop"},
@@ -85,6 +87,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   if not ENV['VAGRANT_NO_PORTS']
     config.vm.network :forwarded_port, guest: 8000, host: 8000  # LMS
     config.vm.network :forwarded_port, guest: 8001, host: 8001  # Studio
+    config.vm.network :forwarded_port, guest: 8002, host: 8002  # Ecommerce
     config.vm.network :forwarded_port, guest: 8003, host: 8003  # LMS for Bok Choy
     config.vm.network :forwarded_port, guest: 8031, host: 8031  # Studio for Bok Choy
     config.vm.network :forwarded_port, guest: 8120, host: 8120  # edX Notes Service


### PR DESCRIPTION
In 48f79b673c1fd358232c5d68b06399ef0dc4100a we removed `ecommerce` from a default analytics stack installation, at my suggestion, but I think that was a mistake. Lately everyone on my team has had to locally revert that change since we've been working on eCommerce+analytics.

This is a simple proposed change to add Otto/ecommerce to future analytics devstacks.
