### PR TITLE
Ensure libjpeg-dev is available on Programs hosts

### DIFF
--- a/playbooks/roles/programs/defaults/main.yml
+++ b/playbooks/roles/programs/defaults/main.yml
@@ -170,6 +170,7 @@ programs_requirements:
 #
 
 programs_debian_pkgs:
+  - libjpeg-dev
   - libmysqlclient-dev
   - libssl-dev
 


### PR DESCRIPTION
I believe Pillow (PIL) will not work properly on without this package installed. h/t @rlucioni 

@edx/devops please review?
