### PR TITLE
Replace nginx redirect method from rewrite to return for speeding up

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -52,3 +52,4 @@ Dan Powell <dan@abakas.com>
 Omar Al-Ithawi <oithawi@qrf.org>
 David Adams<dcadams@stanford.edu>
 Florian Haas <florian@hastexo.com>
+Shohei Maeda <s.maeda@gacco.co.jp>

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/analytics_api.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/analytics_api.j2
@@ -29,7 +29,7 @@ server {
   # Execute the actual redirect
   if ($do_redirect_to_https = "true")
   {
-  rewrite ^ https://$host$request_uri? permanent;
+  return 301 https://$host$request_uri;
   }
   {% endif %}
   

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/cms.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/cms.j2
@@ -64,7 +64,7 @@ error_page {{ k }} {{ v }};
   # Execute the actual redirect
   if ($do_redirect_to_https = "true")
   {
-  rewrite ^ https://$host$request_uri? permanent;
+  return 301 https://$host$request_uri;
   }
   {% endif %}
 

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/credentials.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/credentials.j2
@@ -80,7 +80,7 @@ location @proxy_to_app {
   # Execute the actual redirect
   if ($do_redirect_to_https = "true")
   {
-  rewrite ^ https://$host$request_uri? permanent;
+  return 301 https://$host$request_uri;
   }
   {% endif %}
 }

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/ecommerce.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/ecommerce.j2
@@ -50,7 +50,7 @@ server {
   # Execute the actual redirect
   if ($do_redirect_to_https = "true")
   {
-  rewrite ^ https://$host$request_uri? permanent;
+  return 301 https://$host$request_uri;
   }
   {% endif %}
 

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/edx_notes_api.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/edx_notes_api.j2
@@ -29,7 +29,7 @@ server {
   # Execute the actual redirect
   if ($do_redirect_to_https = "true")
   {
-  rewrite ^ https://$host$request_uri? permanent;
+  return 301 https://$host$request_uri;
   }
   {% endif %}
   

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/insights.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/insights.j2
@@ -55,7 +55,7 @@ location @proxy_to_app {
   # Execute the actual redirect
   if ($do_redirect_to_https = "true")
   {
-  rewrite ^ https://$host$request_uri? permanent;
+  return 301 https://$host$request_uri;
   }
   {% endif %}
 }

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/kibana.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/kibana.j2
@@ -45,7 +45,7 @@ server {
   # Execute the actual redirect
   if ($do_redirect_to_https = "true")
   {
-  rewrite ^ https://$host$request_uri? permanent;
+  return 301 https://$host$request_uri;
   }
   {% endif %}
   

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms-preview.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms-preview.j2
@@ -98,7 +98,7 @@ server {
   # Execute the actual redirect
   if ($do_redirect_to_https = "true")
   {
-  rewrite ^ https://$host$request_uri? permanent;
+  return 301 https://$host$request_uri;
   }
   {% endif %}
 

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
@@ -84,7 +84,7 @@ error_page {{ k }} {{ v }};
   # Execute the actual redirect
   if ($do_redirect_to_https = "true")
   {
-  rewrite ^ https://$host$request_uri? permanent;
+  return 301 https://$host$request_uri;
   }
   {% endif %}
   
@@ -118,7 +118,7 @@ error_page {{ k }} {{ v }};
     {% include "basic-auth.j2" %}
     {% if NGINX_EDXAPP_EMBARGO_CIDRS -%}
     if ( $embargo ) {
-      rewrite ^ /embargo;
+      return 302 /embargo;
     }
     {% endif -%}
     try_files $uri @proxy_to_lms_app;

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/programs.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/programs.j2
@@ -53,7 +53,7 @@ server {
   # Execute the actual redirect
   if ($do_redirect_to_https = "true")
   {
-  rewrite ^ https://$host$request_uri? permanent;
+  return 301 https://$host$request_uri;
   }
   {% endif %}
 


### PR DESCRIPTION
Nginx "rewrite" method is slower than "return" method.
So we should use "return" method if we do not need to specify regular expression rules.

[Additional]
- [Official doc](http://wiki.nginx.org/Pitfalls#Taxing_Rewrites)

As you know regexes are expensive. "rewrite" will start a new rewrite search.
But do not need expensive options for the simple case like just convert protocol from http to https.
This is very tiny improvement.
So difficult to measure and feel differences but it is definitely improvement of performance.
