### PR TITLE
The downloads-distro.mongodb.org URL only has 2.6 packages?

### DIFF
--- a/playbooks/roles/ad_hoc_reporting/defaults/main.yml
+++ b/playbooks/roles/ad_hoc_reporting/defaults/main.yml
@@ -43,7 +43,7 @@ ad_hoc_reporting_pip_pkgs:
 
 MONGODB_APT_KEY: "7F0CEB10"
 MONGODB_APT_KEYSERVER: "keyserver.ubuntu.com"
-MONGODB_REPO: "deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen"
+MONGODB_REPO: "deb http://repo.mongodb.org/apt/ubuntu precise/mongodb-org/3.0 multiverse"
 mongo_version: 3.0.8
 
 


### PR DESCRIPTION
This worked at one time, but stopped.  I've updated the URL to be
consistent with their current docs (and what we do in the mongo_3 role).
