### PR TITLE
Update mongo 3.0 play to use our two new roles

### DIFF
--- a/playbooks/edx-east/mongo_3_0.yml
+++ b/playbooks/edx-east/mongo_3_0.yml
@@ -16,6 +16,7 @@
   gather_facts: True
   roles:
     - aws
+    - enhanced_networking
     - mongo_3_0
     - munin_node
     - role: datadog

--- a/playbooks/roles/mongo_3_0/defaults/main.yml
+++ b/playbooks/roles/mongo_3_0/defaults/main.yml
@@ -51,6 +51,13 @@ MONGO_RS_CONFIG:
 # Storage engine options in 3.0: "mmapv1" or "wiredTiger" 
 MONGO_STORAGE_ENGINE: "mmapv1"
 
+# List of dictionaries as described in the mount_ebs role's default
+# for the volumes.
+# Useful if you want to store your mongo data and/or journal on separate
+# disks from the root volume.  By default, they will end up mongo_data_dir
+# on the root disk.
+MONGO_VOLUMES: []
+
 # WiredTiger takes a number of optional configuration settings
 # which can be defined as a yaml structure in your secure configuration.
 MONGO_STORAGE_ENGINE_OPTIONS: !!null

--- a/playbooks/roles/mongo_3_0/meta/main.yml
+++ b/playbooks/roles/mongo_3_0/meta/main.yml
@@ -1,3 +1,5 @@
 ---
 dependencies:
   - common
+  - role: mount_ebs
+    volumes: "{{ MONGO_VOLUMES }}"


### PR DESCRIPTION
This moves functionality from cloud_migrations into the ansible
role so that we can build machines from their scratch 'terraformed' state.

@edx/devops
