### PR TITLE
Add dependency on "common" role to the elasticsearch role.

### DIFF
--- a/playbooks/roles/elasticsearch/meta/main.yml
+++ b/playbooks/roles/elasticsearch/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - common


### PR DESCRIPTION
The role makes use of some variables from common_vars (notably COMMON_*_DIR), so it should depend on the "common" role.  With this change applied, it's possible to run the elasticsearch role using the run_role.yml playbook, which is sometimes convenient.
