### PR TITLE
Update nltk URLs

### DIFF
--- a/playbooks/roles/nltk/defaults/main.yml
+++ b/playbooks/roles/nltk/defaults/main.yml
@@ -6,8 +6,8 @@ NLTK_DATA_DIR: "/usr/local/share/nltk_data"
 # your own version of the files with the version appended to the filename.
 NLTK_DATA:
   - { path: "taggers/maxent_treebank_pos_tagger",
-      url: "http://nltk.github.com/nltk_data/packages/taggers/maxent_treebank_pos_tagger.zip" }
+      url: "http://nltk.github.io/nltk_data/packages/taggers/maxent_treebank_pos_tagger.zip" }
   - { path: "corpora/stopwords",
-      url: "http://nltk.github.com/nltk_data/packages/corpora/stopwords.zip" }
+      url: "http://nltk.github.io/nltk_data/packages/corpora/stopwords.zip" }
   - { path: "corpora/wordnet",
-      url: "http://nltk.github.com/nltk_data/packages/corpora/wordnet.zip" }
+      url: "http://nltk.github.io/nltk_data/packages/corpora/wordnet.zip" }


### PR DESCRIPTION
The old ones were returning 301s pointing to the updated URL

This unbreaks CI.

This was the response from the old URLs:

```
HTTP/1.1 301 Moved Permanently
Server: GitHub.com
Content-Type: text/html
Location: http://nltk.github.io/nltk_data/packages/corpora/wordnet.zip
```
