### PR TITLE
Make basic auth exceptions an overridable list

### DIFF
--- a/playbooks/roles/common_vars/defaults/main.yml
+++ b/playbooks/roles/common_vars/defaults/main.yml
@@ -7,6 +7,10 @@
 COMMON_ENABLE_BASIC_AUTH: False
 COMMON_HTPASSWD_USER: edx
 COMMON_HTPASSWD_PASS: edx
+COMMON_BASIC_AUTH_EXCEPTIONS:
+  - 192.168.0.0/16
+  - 172.16.0.0/12
+
 # Turn on syncing logs on rotation for edx
 # application and tracking logs, must also
 # have the AWS role installed

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/basic-auth.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/basic-auth.j2
@@ -2,13 +2,10 @@
      satisfy any;
 
      allow 127.0.0.1;
-     allow 192.168.0.0/16;
-     allow 172.16.0.0/12;
 
-     allow 10.3.110.0/24;
-     allow 10.3.120.0/24;
-     allow 10.8.110.0/24;
-     allow 10.8.120.0/24;     
+     {% for cidr in COMMON_BASIC_AUTH_EXCEPTIONS %}
+         allow {{ cidr }};
+     {% endfor %}
 
      deny all;
 


### PR DESCRIPTION
Allow for overriding the default list of exception CIDRs when http auth is turned on for nginx.
