### PR TITLE
Revert "Revert "New payment processor configuration format""

### DIFF
--- a/playbooks/roles/ecommerce/defaults/main.yml
+++ b/playbooks/roles/ecommerce/defaults/main.yml
@@ -80,6 +80,7 @@ ECOMMERCE_PAYPAL_CANCEL_URL: '{{ ECOMMERCE_LMS_URL_ROOT }}/commerce/checkout/can
 ECOMMERCE_PAYPAL_ERROR_URL: '{{ ECOMMERCE_LMS_URL_ROOT }}/commerce/checkout/error/'
 
 ECOMMERCE_PAYMENT_PROCESSOR_CONFIG:
+  edx:
     cybersource:
       profile_id: '{{ ECOMMERCE_CYBERSOURCE_PROFILE_ID }}'
       merchant_id: '{{ ECOMMERCE_CYBERSOURCE_MERCHANT_ID }}'


### PR DESCRIPTION
**Reverts:** #2922 
**Restores:** #2886

This reverts commit d5c7e72ddc5a7222a0feab52764396f2d756f79b
This restores commit 7278bd07a38cfae0faca2ef72aceed5bf7f33518

**Explanation:** 
- edx/ecommerce#630 introduced changes to payment processor configurations format in `ecommerce` app and added startup validation for SiteConfiguration models.
- #2886 propagated payment processor configuration changes to `configuration`.
- Startup validation turned out to be broken and prevented new ecommerce VM instances to be created, so entire changeset was reverted in edx/ecommerce#651, as a side effect `configuration` changes made in #2886 become out of sync with the code.
- In #2922, `configuration` changes was reverted.
- edx/ecommerce#654 added back multitenant payment processor configuration to `ecommerce`, so `configuration` needs changes added in #2886 and reverted in #2922 back as well.
