### PR TITLE
Update devstack from a nightly DEVOPS-3949

### DIFF
--- a/vagrant/release/devstack/Vagrantfile
+++ b/vagrant/release/devstack/Vagrantfile
@@ -81,7 +81,7 @@ openedx_releases = {
   # },
 }
 openedx_releases.default = {
-  :name => "devstack-periodic-2016-03-08", :file => "devstack-periodic-2016-03-08.box",
+  :name => "devstack-periodic-2016-04-04", :file => "devstack-periodic-2016-04-04.box",
 }
 rel = ENV['OPENEDX_RELEASE']
 


### PR DESCRIPTION
This fixes the uninstall/reinstall oauth-toolkit shenanigans

@edx/devops 
@jcdyer you should be able to curl down the Vagrantfile from this branch and build a devstack to confirm the fix.
