### PR TITLE
Updated links to Devstack and Fullstack documentation.

### DIFF
--- a/vagrant/README.rst
+++ b/vagrant/README.rst
@@ -10,8 +10,8 @@ If you are a developer or designer, you should use the ``release`` stacks.
 
 For creating test edX instances, there are two versions of the stack:
 
-- ``fullstack`` is a production-like configuration running all the services on a single server.  https://github.com/edx/configuration/wiki/edX-Production-Stack
-- ``devstack`` is designed for local development. It uses the same system requirements as in production, but simplifies certain settings to make development more convenient.  https://github.com/edx/configuration/wiki/edX-Developer-Stack
+- ``fullstack`` is a production-like configuration running all the services on a single server.  https://openedx.atlassian.net/wiki/display/OpenOPS/Running+Fullstack
+- ``devstack`` is designed for local development. It uses the same system requirements as in production, but simplifies certain settings to make development more convenient.  https://openedx.atlassian.net/wiki/display/OpenOPS/Running+Devstack
 
 For testing Ansible playbooks and roles, there are two directories under the ``base`` directory:
 


### PR DESCRIPTION
@feanil and @fredsmith. I noticed that the link to Fullstack previously went to a Github link that no longer exists and the Devstack link went to a Github page that instructed the user to go to the documentation hosted on Confluence. Is there anyone else that I should tag on this PR?
