### PR TITLE
Add libffi to jenkins_worker and devstack

### DIFF
--- a/playbooks/roles/jenkins_worker/defaults/main.yml
+++ b/playbooks/roles/jenkins_worker/defaults/main.yml
@@ -12,6 +12,7 @@ jenkins_edx_platform_version: master
 jenkins_debian_pkgs:
     - nodejs
     - pkg-config
+    - libffi-dev
 
 # packer direct download URL
 packer_url: "https://releases.hashicorp.com/packer/0.8.6/packer_0.8.6_linux_amd64.zip"

--- a/playbooks/roles/local_dev/defaults/main.yml
+++ b/playbooks/roles/local_dev/defaults/main.yml
@@ -75,5 +75,6 @@ local_dev_pkgs:
     - emacs
     - xorg
     - openbox
+    - libffi-dev
 
 localdev_jscover_version: "1.0.2"


### PR DESCRIPTION
When adding a python dependency to Jenkins builds for edxapp, I found that libffi was installed in devstack (via the ecommerce role) but not on jenkins_workers.  It is a requirement of the new python package (which is only needed for testing purposes, not in prod).  This PR adds libffi to the jenkins_worker role,  and explicitly adds it to devstack in the local_dev role to avoid it depending on the ecommerce role.

I've created an AMI and tested that this fixes the pip install issues with my platform changes.
