### PR TITLE
Get studio domain into programs' cors whitelist

### DIFF
--- a/playbooks/roles/programs/defaults/main.yml
+++ b/playbooks/roles/programs/defaults/main.yml
@@ -53,7 +53,9 @@ PROGRAMS_PLATFORM_NAME: 'Your Platform Name Here'
 
 # CORS
 # See: https://github.com/ottoyiu/django-cors-headers/.
-PROGRAMS_CORS_ORIGIN_WHITELIST: []
+# the whitelist should always contain the public hostname for Studio in the given environment.
+PROGRAMS_CORS_ORIGIN_WHITELIST:
+  - '127.0.0.1:8001'
 
 PROGRAMS_DATA_DIR: '{{ COMMON_DATA_DIR }}/{{ programs_service_name }}'
 PROGRAMS_MEDIA_ROOT: '{{ PROGRAMS_DATA_DIR }}/media'

--- a/util/jenkins/ansible-provision.sh
+++ b/util/jenkins/ansible-provision.sh
@@ -277,6 +277,8 @@ ECOMMERCE_SOCIAL_AUTH_REDIRECT_IS_HTTPS: true
 PROGRAMS_LMS_URL_ROOT: "https://${deploy_host}"
 PROGRAMS_URL_ROOT: "https://programs-${deploy_host}"
 PROGRAMS_SOCIAL_AUTH_REDIRECT_IS_HTTPS: true
+PROGRAMS_CORS_ORIGIN_WHITELIST:
+  - studio-${deploy_host}
 
 CREDENTIALS_LMS_URL_ROOT: "https://${deploy_host}"
 CREDENTIALS_DOMAIN: "credentials-${deploy_host}"


### PR DESCRIPTION
@edx/devops review requested.  The intent is to have the correct CORS origin whitelist for Programs IDA in sandboxes, without manual editing.  It needs to have the public url for Studio in it, instead of being empty.

CORS is already fine in edx.org prod/stage so this is just for sandboxes.

@schenedx FYI
