### PR TITLE
Install libmysqlclient-dev on go-agent docker so edx/configuration can be instaled

### DIFF
--- a/docker/build/go-agent/Dockerfile
+++ b/docker/build/go-agent/Dockerfile
@@ -23,7 +23,8 @@ RUN apt-get update && apt-get install -y -q \
     python \
     python-dev \
     python-distribute \
-    python-pip
+    python-pip \
+    libmysqlclient-dev
 
 # TODO: repalce this with a pip install command so we can version this properly
 RUN git clone https://github.com/edx/tubular.git /opt/tubular


### PR DESCRIPTION
@feanil @doctoryes PTAL.

This will unblock running pip install -r /configuration/requirements.txt on the go agent machine so we can build AMIs.
