### PR TITLE
Adds rebuild to the default plugins

### DIFF
--- a/playbooks/roles/jenkins_master/defaults/main.yml
+++ b/playbooks/roles/jenkins_master/defaults/main.yml
@@ -62,6 +62,7 @@ jenkins_plugins:
     - { name: "postbuild-task", version: "1.8" }
     - { name: "plain-credentials", version: "1.1" }
     - { name: "PrioritySorter", version: "2.9" }
+    - { name: "rebuild", version: "1.25" }
     - { name: "sauce-ondemand", version: "1.61" }
     - { name: "scm-api", version: "0.2" }
     - { name: "script-security", version: "1.12" }


### PR DESCRIPTION
I always miss this when we don't have it.

We turn it on manually in tools/admin jenkins' roles.  It isn't used in build jenkins, but that role passes an override of the plugin list anyway.  This would impact the jenkins_worker builds, which may be a reason not to do it (@benpatterson thoughts?  I'm running a packer rebuild and won't merge if it causes any issues https://build.testeng.edx.org/view/packer/job/build-packer-ami/1263/console)
