### PR TITLE
Add P3P headers to the IDAs

### DIFF
--- a/playbooks/roles/ansible-role-django-ida/templates/templates/edx/app/nginx/sites-available/ROLE_NAME.j2
+++ b/playbooks/roles/ansible-role-django-ida/templates/templates/edx/app/nginx/sites-available/ROLE_NAME.j2
@@ -63,6 +63,9 @@ server {
     proxy_redirect off;
     proxy_pass http://{{ role_name }}_app_server;
   }
+
+# Prevent invalid display courseware in IE 10+ with high privacy settings
+  add_header P3P {{ '{{' }} NGINX_P3P_MESSAGE {{ '}}' }}
   
   # Nginx does not support nested condition or or conditions so
   # there is an unfortunate mix of conditonals here.

--- a/playbooks/roles/nginx/defaults/main.yml
+++ b/playbooks/roles/nginx/defaults/main.yml
@@ -127,3 +127,4 @@ nginx_cfg:
 
 NGINX_ROBOT_RULES: [ ]
 NGINX_EDXAPP_EMBARGO_CIDRS: []
+NGINX_P3P_MESSAGE: 'CP="Open edX does not have a P3P policy."'

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/cms.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/cms.j2
@@ -43,7 +43,7 @@ error_page {{ k }} {{ v }};
   {% endif %}
 
   # Prevent invalid display courseware in IE 10+ with high privacy settings
-  add_header P3P 'CP="Open EdX does not have a P3P policy."';
+  add_header P3P '{{ NGINX_P3P_MESSAGE }}';
 
   # Nginx does not support nested condition or or conditions so
   # there is an unfortunate mix of conditonals here.

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/credentials.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/credentials.j2
@@ -32,6 +32,9 @@ server {
   listen {{ CREDENTIALS_NGINX_PORT }} {{ default_site }};
   {% endif %}
 
+  # Prevent invalid display courseware in IE 10+ with high privacy settings
+  add_header P3P '{{ NGINX_P3P_MESSAGE }}';
+
   location ~ ^/static/(?P<file>.*) {
     root {{ COMMON_DATA_DIR }}/{{ credentials_service_name }};
     try_files /staticfiles/$file =404;

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/ecommerce.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/ecommerce.j2
@@ -30,6 +30,9 @@ server {
   add_header Strict-Transport-Security "max-age=31536000; includeSubDomains";
   {% endif %}
 
+  # Prevent invalid display courseware in IE 10+ with high privacy settings
+  add_header P3P '{{ NGINX_P3P_MESSAGE }}';
+
   # Nginx does not support nested condition or or conditions so
   # there is an unfortunate mix of conditonals here.
   {% if NGINX_REDIRECT_TO_HTTPS %}

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/edx_notes_api.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/edx_notes_api.j2
@@ -7,6 +7,9 @@ upstream {{ edx_notes_api_service_name }}_app_server {
 server {
   listen {{ edx_notes_api_nginx_port }} default_server;
 
+  # Prevent invalid display courseware in IE 10+ with high privacy settings
+  add_header P3P '{{ NGINX_P3P_MESSAGE }}';
+
   # Nginx does not support nested condition or or conditions so
   # there is an unfortunate mix of conditonals here.
   {% if NGINX_REDIRECT_TO_HTTPS %}

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/insights.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/insights.j2
@@ -32,6 +32,9 @@ location @proxy_to_app {
     proxy_redirect off;
     proxy_pass http://insights_app_server;
   }
+
+  # Prevent invalid display courseware in IE 10+ with high privacy settings
+  add_header P3P '{{ NGINX_P3P_MESSAGE }}';
   
   # Nginx does not support nested condition or or conditions so
   # there is an unfortunate mix of conditonals here.

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
@@ -63,7 +63,7 @@ error_page {{ k }} {{ v }};
   {% endif %}
 
   # Prevent invalid display courseware in IE 10+ with high privacy settings
-  add_header P3P 'CP="Open EdX does not have a P3P policy."';
+  add_header P3P '{{ NGINX_P3P_MESSAGE }}';
 
 
   # Nginx does not support nested condition or or conditions so


### PR DESCRIPTION
make it a variable so that you can override it for your
installation.

Extends the OSPR work from https://github.com/edx/configuration/pull/2876 so that the header is set in other user-facing IDAs, and is overridable in our secure vars.
