### PR TITLE
No need to list 5000 lines of compileall

### DIFF
--- a/playbooks/roles/edxapp/tasks/deploy.yml
+++ b/playbooks/roles/edxapp/tasks/deploy.yml
@@ -325,7 +325,7 @@
   - install:app-requirements
 
 - name: compiling all py files in the edx-platform repo
-  shell: "{{ edxapp_venv_bin }}/python -m compileall -x .git/.* {{ edxapp_code_dir }}"
+  shell: "{{ edxapp_venv_bin }}/python -m compileall -q -x .git/.* {{ edxapp_code_dir }}"
   sudo_user: "{{ edxapp_user }}"
   tags:
     - install


### PR DESCRIPTION
When compileall fails (as it does with devstack with a Windows host,
because we inexplicably have a .py file that is a symlink, why!?!), this
step shows its whole output, which is >5000 lines of everything it did.
We don't need all that.
