### PR TITLE
(WL-435): Add configuration variable DEFAULT_SITE_THEME for setting default site theme

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -555,6 +555,10 @@ EDXAPP_PROCTORING_BACKEND_PROVIDER:
 # Comprehensive Theming
 # Full path to the comprehensive theme directory
 EDXAPP_COMPREHENSIVE_THEME_DIR: ""
+
+# Name of the default site theme
+EDXAPP_DEFAULT_SITE_THEME: ""
+
 # Git repo for the comprehensive theme (if using a comprehensive theme
 # other than the ones bundled with edx/platform)
 EDXAPP_COMPREHENSIVE_THEME_SOURCE_REPO: ""
@@ -853,6 +857,7 @@ generic_env_config:  &edxapp_generic_env
   XBLOCK_SETTINGS: "{{ EDXAPP_XBLOCK_SETTINGS }}"
   EDXMKTG_USER_INFO_COOKIE_NAME: "{{ EDXAPP_EDXMKTG_USER_INFO_COOKIE_NAME }}"
   COMPREHENSIVE_THEME_DIR: "{{ EDXAPP_COMPREHENSIVE_THEME_DIR }}"
+  DEFAULT_SITE_THEME: "{{ EDXAPP_DEFAULT_SITE_THEME }}"
   SESSION_SAVE_EVERY_REQUEST: "{{ EDXAPP_SESSION_SAVE_EVERY_REQUEST }}"
   SOCIAL_SHARING_SETTINGS: "{{ EDXAPP_SOCIAL_SHARING_SETTINGS }}"
   SESSION_COOKIE_SECURE: "{{ EDXAPP_SESSION_COOKIE_SECURE }}"


### PR DESCRIPTION
Hi @arbabnazar , @mattdrayer 

This PR contains addition of a new variable `DEFAULT_SITE_THEME` that can be used to set a default site theme for openedx instance, Kindly, review the changes and let me know if changes look good.

Note: default value for `COMPREHENSIVE_THEME_DIR` also needs to be updated, but I think those default values are set somewhere other that 'edx/configuration'. @arbabnazar can you share your thoughts on this ?
