### PR TITLE
Need to point to library for custom modules

### DIFF
--- a/playbooks/vagrant/ansible.cfg
+++ b/playbooks/vagrant/ansible.cfg
@@ -2,6 +2,7 @@
 
 jinja2_extensions=jinja2.ext.do
 host_key_checking = False
+library=../library
 roles_path=../roles
 callback_plugins=../callback_plugins
 ansible_managed=This file is created and updated by ansible, edit at your peril


### PR DESCRIPTION
Upgrading from Cypress to Dogwood.2 failed because the playbooks in playbooks/vagrant couldn't find the git_2_0_1 module.  I'll cherry-pick this onto named-release/dogwood.rc
