### PR TITLE
Configurable jenkins nginx port

### DIFF
--- a/playbooks/roles/jenkins_master/defaults/main.yml
+++ b/playbooks/roles/jenkins_master/defaults/main.yml
@@ -3,6 +3,7 @@ jenkins_user: "jenkins"
 jenkins_group: "edx"
 jenkins_server_name: "jenkins.testeng.edx.org"
 jenkins_port: 8080
+jenkins_nginx_port: 80
 
 jenkins_version: "1.638"
 jenkins_deb_url: "http://pkg.jenkins-ci.org/debian/binary/jenkins_{{ jenkins_version }}_all.deb"

--- a/playbooks/roles/jenkins_master/templates/etc/nginx/sites-available/jenkins.j2
+++ b/playbooks/roles/jenkins_master/templates/etc/nginx/sites-available/jenkins.j2
@@ -1,5 +1,5 @@
 server {
-  listen 80;
+  listen {{ jenkins_nginx_port }};
   server_name {{ jenkins_server_name }};
 
   location / {


### PR DESCRIPTION
**Description:** Allow jenkins port to be overridden.
**Motivation:** Having dedicated VM for jenkins scheduler might be a bit too much, since it perfectly works alongside Insights. However, in such case, jenkins binds to 80 port first, blocking insights from default HTTP port. With this PR it becomes possible to override default jenkins port and allow Insights to listen on default HTTP port.
**JIRA:** [OSPR-1241](https://openedx.atlassian.net/browse/OSPR-1241)
**Related:** [PR on deprecated repo](https://github.com/edx/edx-analytics-configuration/pull/37)

**Testing instructions:**
1. Create file with override variables: `vars.yml`
2. Add `jenkins_nginx_port: 8080` to `vars.yml`
3. Run playbook with `ansible-playbook --extra-vars=@"/path/to/vars.yml"
4. Ensure Jenkins listens on specified port and port 80 is free.
