### PR TITLE
MAYN-217: Enhance ansible provisioning script to support Otto Theming

### DIFF
--- a/playbooks/roles/ecommerce/tasks/main.yml
+++ b/playbooks/roles/ecommerce/tasks/main.yml
@@ -78,6 +78,16 @@
     - "'You already have countries in your database' not in command_result.stderr"
     - "command_result.rc != 0"
 
+- name: compile sass
+  shell: >
+    chdir={{ ecommerce_code_dir }}
+    {{ ecommerce_venv_dir }}/bin/python manage.py {{ item }}
+  sudo_user: "{{ ecommerce_user }}"
+  environment: "{{ ecommerce_environment }}"
+  with_items:
+    - "update_assets --skip-collect"
+  when: not devstack
+
 - name: run r.js optimizer
   shell: >
     chdir={{ ecommerce_code_dir }}


### PR DESCRIPTION
Hi @e0d , @arbabnazar , @mattdrayer 

Kindly review this PR, it contains ansible updates for ecommerce theming related to [PR#649](https://github.com/edx/ecommerce/pull/649). 

Here is a summary of the changes.
During provisioning and with offline compression enabled, We run `compress` management command for template compression after running `collectstatic`. After the changes introduced in  Otto Theming ( [PR#649](https://github.com/edx/ecommerce/pull/649)) we need to compile/collect theme and system sass before running `compress` command, so that the required css files are present and template compression does not error out.

I created a sandbox with '[saleem-latif/MAYN-217](https://github.com/edx/configuration/pull/2978)' branch of edx/configuration and '[saleem-latif/WL-330](https://github.com/edx/ecommerce/pull/649/files)' branch of edx/ecommerce to verify the change set. Here is the link of sandbox and links of applied themes.

Default Theme:
1. https://otto-theming.sandbox.edx.org (ecommerce: https://ecommerce-otto-theming.sandbox.edx.org/)

Red Theme:
2. https://red.sandbox.edx.org/ (ecommerce: https://ecommerce-red.sandbox.edx.org)

@clintonb , @jimabramson -- FYI
