### PR TITLE
Builds are failling because ffi.h is not installed

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -1069,6 +1069,8 @@ edxapp_debian_pkgs:
   - ntp
   # matplotlib needs libfreetype6-dev
   - libfreetype6-dev
+  # cffi needs libffi-dev
+  - libffi-dev
 
 # Deploy Specific Vars
 edxapp_lms_variant: lms


### PR DESCRIPTION
We're not yet sure what changed, but something between Friday morning's
patchset release and this afternoon's rc cut.

@ormsbee
@edx/devops
