### PR TITLE
Restart nginx after copying the configuration.

### DIFF
--- a/playbooks/roles/nginx/tasks/main.yml
+++ b/playbooks/roles/nginx/tasks/main.yml
@@ -310,6 +310,17 @@
     - install
     - install:configuration
 
+# nginx is started during package installation, before any of the configuration files are in place.
+# The handler that reloads the configuration would be run only at the very end of the playbook, so
+# none of the local services would be available in the meantime, e.g. causing certs to error out
+# since it can't reach xqueue on the its nginx port.  For this reason, we flush the handlers here
+# to ensure the nginx configuration is reloaded when necessary.
+- name: Restart or reload nginx if necessary
+  meta: flush_handlers
+  tags:
+    - install
+    - install:configuration
+
 # If tasks that notify restart nginx don't change the state of the remote system
 # their corresponding notifications don't get run.  If nginx has been stopped for
 # any reason, this will ensure that it is started up again.


### PR DESCRIPTION
Nginx is started during package installation, before any of its configuration files are in place, so it only listens on port 80 at first.  The handler that reloads the configuration is run only at the very end of the playbook, so none of the local services are available in the meantime.  This causes the "certs" service to error out since it can't reach xqueue on its nginx port.  For this reason, this patch flushes the handlers at the end of the nginx roles to ensure the nginx is restarted at that point if necessary, which fixes the problem for us.

**Jira**: [OSPR-1248](https://openedx.atlassian.net/browse/OSPR-1248)

(See also the discussion on #2772.)
