### PR TITLE
go user may now execute the pip command as root.

### DIFF
--- a/docker/build/go-agent/Dockerfile
+++ b/docker/build/go-agent/Dockerfile
@@ -30,6 +30,9 @@ RUN apt-get update && apt-get install -y -q \
 COPY docker/build/go-agent/files/docker_install.sh /tmp/docker/
 RUN /bin/bash /tmp/docker/docker_install.sh
 
+# Assign the go user root privlidges
+RUN printf "\ngo      ALL=(ALL:ALL) NOPASSWD: /usr/bin/pip\n" >> /etc/sudoers
+
 # Install AWS command-line interface - for AWS operations in a go-agent task.
 RUN pip install awscli
 


### PR DESCRIPTION
@doctoryes @feanil PTAL. This will allow the go user on the go-agent containers to run pip as root.
