### PR TITLE
(WIP) Wait for rabbitmq queues to become available

### DIFF
--- a/playbooks/roles/rabbitmq/tasks/main.yml
+++ b/playbooks/roles/rabbitmq/tasks/main.yml
@@ -152,3 +152,6 @@
   file: >
     path=/usr/local/bin/rabbitmqadmin owner=root
     group=root mode=0655
+
+- name: ensure can connect to rabbitmq queues
+  wait_for: port={{ rabbitmq_port }} delay=2


### PR DESCRIPTION
**Description:** Theoretically fixes celery errors seen when provisioning instances.
**JIRA:** [OC-1475](https://tasks.opencraft.com/browse/OC-1475)
