### PR TITLE
Configurable timeouts for celery workers

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -599,6 +599,7 @@ edxapp_git_ssh: "/tmp/edxapp_git_ssh.sh"
 edxapp_legacy_course_data_dir: "{{ edxapp_app_dir }}/data"
 
 edxapp_workers: "{{ EDXAPP_CELERY_WORKERS }}"
+EDXAPP_WORKER_DEFAULT_STOPWAITSECS: 432000
 
 # setup for python codejail
 edxapp_sandbox_venv_dir:  '{{ edxapp_venvs_dir }}/edxapp-sandbox'

--- a/playbooks/roles/edxapp/templates/workers.conf.j2
+++ b/playbooks/roles/edxapp/templates/workers.conf.j2
@@ -10,7 +10,7 @@ stderr_logfile={{ supervisor_log_dir }}/%(program_name)s-stderr.log
 command={{ edxapp_venv_dir + '/bin/newrelic-admin run-program ' if w.monitor and COMMON_ENABLE_NEWRELIC_APP else ''}}{{ edxapp_venv_bin }}/python {{ edxapp_code_dir }}/manage.py {{ w.service_variant }} --settings=aws celery worker --loglevel=info --queues=edx.{{ w.service_variant }}.core.{{ w.queue }} --hostname=edx.{{ w.service_variant }}.core.{{ w.queue }}.%%h --concurrency={{ w.concurrency }} {{ '--maxtasksperchild ' + w.max_tasks_per_child|string if w.max_tasks_per_child is defined else '' }}
 killasgroup=true
 stopasgroup=true
-stopwaitsecs=432000
+stopwaitsecs={{ w.stopwaitsecs | default(EDXAPP_WORKER_DEFAULT_STOPWAITSECS) }}
 stopsignal=INT
 
 {% endfor %}


### PR DESCRIPTION
**Description:** This PR makes edxapp celery worker timeouts configurable (both global default and per-worker).
**Background:** Provisions often fail with 

```
2016-03-14 10:15:31-0700 | INFO | instance.models.instance  | instance=sandbox | TASK: [edxapp | ensure edxapp_workers has started] ****************************
2016-03-14 10:15:31-0700 | INFO | instance.models.instance  | instance=sandbox | failed: [149.202.174.205] => {"failed": true}
2016-03-14 10:15:31-0700 | INFO | instance.models.instance  | instance=sandbox | msg: edxapp_worker:cms_default_1: ERROR (abnormal termination)
2016-03-14 10:15:31-0700 | INFO | instance.models.instance  | instance=sandbox | 
2016-03-14 10:15:31-0700 | INFO | instance.models.instance  | instance=sandbox | 
2016-03-14 10:15:31-0700 | INFO | instance.models.instance  | instance=sandbox | FATAL: all hosts have already failed -- aborting
```

or just timeout around the same lines. Discoveries point out that `edxapp_worker:cms_default_1` fails to restart properly (or fails to signal supervisor that they are restarted). Unlike other approaches to fix this (listed below), lowering restart timeout seems to reliably fix/workaround the problem.
**Related:** 
First noticed: [comment thread](https://github.com/edx/configuration/pull/2527#issuecomment-161812463).
Previous attempts to fix the issue: #2557, #2871, #2875

**JIRA:** https://openedx.atlassian.net/browse/OSPR-1252
**EMail threads:** https://groups.google.com/forum/#!topic/openedx-ops/5hblv9LGeR8 - potentailly related.

**Author concerns:**

Major concern is that the problem this patch aims to fix/workaround was an intermittent one - about 50% builds succeeded without the patch. So it might be that probabilities aligned in my favor this time and all the deployments I did to verify the fix just never actually had a root cause expressed.
