### PR TITLE
Restoring this role for possible use with tools automation

### DIFF
--- a/docker/build/automated/Dockerfile
+++ b/docker/build/automated/Dockerfile
@@ -1,0 +1,11 @@
+#FROM edxops/trusty-common:v3
+FROM hacking/edxapp
+MAINTAINER edxops
+
+ADD . /edx/app/edx_ansible/edx_ansible
+COPY docker/build/automated/ansible_overrides.yml /
+WORKDIR /edx/app/edx_ansible/edx_ansible/docker/plays
+RUN /edx/app/edx_ansible/venvs/edx_ansible/bin/ansible-playbook -vvvv automated.yml \
+    -i '127.0.0.1,' -c local \
+    -e@/ansible_overrides.yml
+WORKDIR /edx/app

--- a/docker/build/automated/ansible_overrides.yml
+++ b/docker/build/automated/ansible_overrides.yml
@@ -1,0 +1,16 @@
+---
+FLOCK_TLD: "edx"
+
+AUTOMATED_USER: "ecom3"
+AUTOMATED_RBASH_LINKS: ['/usr/bin/python']
+
+AUTOMATED_SUDO_COMMANDS:
+  - command: "/edx/app/edxapp/venvs/edxapp/bin/python /edx/app/edxapp/edx-platform/manage.py lms migrate --list --settings=aws"
+    sudo_user: "edxapp"
+  - command: "/edx/app/edxapp/venvs/edxapp/bin/python /edx/app/edxapp/edx-platform/manage.py cms migrate --list --settings=aws"
+    sudo_user: "edxapp"
+
+AUTOMATED_SUDOERS_TEMPLATE: "roles/automated/templates/99-sample.j2"
+AUTOMATED_AUTHORIZED_KEYS: ['ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCx+OpJ6787GWnSo5FcwNPjiM7yqjXKi0FPkfpx8Dd3Oqts5PnJV/xokMP4vJTfXu6Zezh+/NvofgMlnxhnIwC3YIoGkLRhW5vKTZfohPjhyIRu0TyQOgmdocYk2o7xMQ1/fcrQh1sQMQqz79mv1ENKc47dVv7qfdBz803M5gschi4RjMYNMN97AA5rByz/AHJnrxQMWEndOZU+H2X9KRUn1TsWe8s99alILwFrNF1dZzF20r2zMErx48f4zfaczQnLOm+pJ1VrruPI8tQzS9X/kfy8GpBTbTX7X80SuM1Npuazr5sJAalXSZ2ccBVa1fKRwa6PmET21gdxOd2ZUsFYL5wZsPIF2f2ij5XwQxKco2lHH6QsvBzapY1BI5PZ/+mQzoaDO7w6WaaDvSDVxyuG/Sw0kOpA9uVEp3qTs8WT6CUYFmnBd+E8YnH6OwqbS9gfBkSNY9pwq1EpR+DCXVFuzWfYoSGQjxpTFbe7YsShB2Jyf/rZyA7NaS4lEkF8eABG6siEwckWvMOV5Z0lGGLTia1DCOZ3c6X09Te3xY4weYS1c0/Nx15C0rmYsMUeDYDonJWujBbvlOBNpx2opG2KPkSE9PAKWyS/mc4SrW0urJBxjAommVq9//dPTxo7IBmiCNWEcOuhXsQYp5tpDmj32Dh8nvNrkvOFYxb9SxuZgQ== automated@example.com']
+SUDO_USER: 
+edxapp_venv_dir: "/usr"

--- a/docker/plays/automated.yml
+++ b/docker/plays/automated.yml
@@ -1,0 +1,8 @@
+- name: Deploy autom
+  hosts: all
+  sudo: True
+  gather_facts: True
+  roles:
+    - common_vars
+    - docker
+    - automated

--- a/playbooks/edx-east/automated.yml
+++ b/playbooks/edx-east/automated.yml
@@ -1,0 +1,13 @@
+- name: Deploy automated role
+  hosts: all
+  sudo: True
+  gather_facts: True
+  roles:
+#    - aws
+    - automated
+    - role: datadog
+      when: COMMON_ENABLE_DATADOG
+    - role: splunkforwarder
+      when: COMMON_ENABLE_SPLUNKFORWARDER
+    - role: newrelic
+      when: COMMON_ENABLE_NEWRELIC

--- a/playbooks/roles/automated/defaults/main.yml
+++ b/playbooks/roles/automated/defaults/main.yml
@@ -1,0 +1,24 @@
+---
+#
+# edX Configuration
+#
+# github:     https://github.com/edx/configuration
+# wiki:       https://github.com/edx/configuration/wiki
+# code style: https://github.com/edx/configuration/wiki/Ansible-Coding-Conventions
+# license:    https://github.com/edx/configuration/blob/master/LICENSE.TXT
+#
+#
+# Vars for role automated
+#
+
+automated_role_name: automated
+AUTOMATED_USER: "changeme"
+automated_sudoers_template: "roles/automated/templates/99-automated.j2"
+
+#
+# OS packages
+#
+
+automated_debian_pkgs: []
+
+automated_redhat_pkgs: []

--- a/playbooks/roles/automated/tasks/main.yml
+++ b/playbooks/roles/automated/tasks/main.yml
@@ -1,0 +1,92 @@
+---
+#
+# edX Configuration
+#
+# github:     https://github.com/edx/configuration
+# wiki:       https://github.com/edx/configuration/wiki
+# code style: https://github.com/edx/configuration/wiki/Ansible-Coding-Conventions
+# license:    https://github.com/edx/configuration/blob/master/LICENSE.TXT
+#
+# Tasks for role automated
+#
+# Overview:
+#
+# This role is included as a dependency by other roles which provide
+# automated jobs.  Automation occurs over ssh.  The automator user is
+# is allowed to run explicitly listed commands via sudo.
+#
+# Dependencies:
+#
+# This role depends upon variables provided by an including role
+# via the my_role/meta/main.yml file.  Includes take the following forms:
+#
+# For example, the edxapp role might designate that ecom and analytics users
+# are allowed to run specific management commands on edxapp instancs.
+#
+# EDXAPP_AUTOMATED_USERS:
+#   ecom:
+#     sudo_commands:
+#       - command: "/edx/app/edxapp/venvs/edxapp/bin/python /edx/app/edxapp/edx-platform/manage.py lms migrate --list --settings=aws"
+#         sudo_user: "edxapp"
+#       - command: "/edx/app/edxapp/venvs/edxapp/bin/python /edx/app/edxapp/edx-platform/manage.py cms migrate --list --settings=aws"
+#         sudo_user: "edxapp"
+#     authorized_keys:
+#       - 'ssh-rsa <REDACTED> ecom+admin@example.com'
+#       - 'ssh-rsa <REDACTED> ecom+devel@example.com'
+#   analytics:
+#     sudo_commands:
+#       - command: "/edx/app/edxapp/venvs/edxapp/bin/python /edx/app/edxapp/edx-platform/manage.py lms help --settings=aws"
+#         sudo_user: "edxapp"
+#     authorized_keys: ['ssh-rsa <REDACTED> analytics@example.com']
+#
+# The play for the role enabling automation should include the role like so
+#
+#  - role: automated
+#    AUTOMATED_USERS: "{{ EDXAPP_AUTOMATED_USERS | default({}) }}"
+#
+
+- name: Create automated user
+  user:
+    name: "{{ item.key }}"
+    state: present
+    shell: "/bin/bash"
+    createhome: yes
+  with_dict: "{{ AUTOMATED_USERS }}"
+
+- name: Create sudoers file from template
+  template:
+    dest: "/etc/sudoers.d/99-{{ item.key }}"
+    src: "{{ automated_sudoers_template }}"
+    owner: "root"
+    group: "root"
+    mode: "0440"
+    validate: 'visudo -cf %s'
+  when: automated_sudoers_template
+  with_dict: "{{ AUTOMATED_USERS }}"
+  
+- name: Create .ssh directory
+  file:
+    path: "/home/{{ item.key }}/.ssh"
+    state: "directory"
+    mode: "0700"
+    owner: "{{ item.key }}"
+    group: "{{ item.key }}"
+  with_dict: "{{ AUTOMATED_USERS }}"
+    
+- name: Build authorized_keys file
+  template:
+    src: "home/automator/.ssh/authorized_keys.j2"
+    dest: "/home/{{ item.key }}/.ssh/authorized_keys"
+    mode: "0600"
+    owner: "{{ item.key }}"
+    group: "{{ item.key }}"
+  with_dict: "{{ AUTOMATED_USERS }}"
+    
+- name: Build known_hosts file
+  file:
+    path: "/home/{{ item.key }}/.ssh/known_hosts"
+    state: "touch"
+    mode: "0755"
+    owner: "{{ item.key }}"
+    group: "{{ item.key }}"
+  with_dict: "{{ AUTOMATED_USERS }}"

--- a/playbooks/roles/automated/templates/99-automated.j2
+++ b/playbooks/roles/automated/templates/99-automated.j2
@@ -1,0 +1,3 @@
+{% for command in item.value.sudo_commands %}
+{{ item.key }} ALL=({{ command.sudo_user }}) SETENV:NOPASSWD:{{ command.command }}
+{% endfor %}

--- a/playbooks/roles/automated/templates/home/automator/.ssh/authorized_keys.j2
+++ b/playbooks/roles/automated/templates/home/automator/.ssh/authorized_keys.j2
@@ -1,0 +1,5 @@
+# {{ ansible_managed }}
+
+{% for line in item.value.authorized_keys -%}
+{{ line }}
+{% endfor %}


### PR DESCRIPTION
@edx/devops The PR restores a role I wrote ages ago and that was removed as we were not actively using it.  I think it's directionally a good pattern for allowing jobs on a shared Jenkins box to run remote automation, but apply least privilege and give control over application to the teams.

Even if we decide it's not a a good pattern, we can kick off the conversation because we'll need something like this for opening tools automation up.

@rlucioni FYI
