### PR TITLE
Update to how git client is installed in the go-agent docker

### DIFF
--- a/docker/build/go-agent/Dockerfile
+++ b/docker/build/go-agent/Dockerfile
@@ -8,7 +8,6 @@ LABEL version="0.02" \
 RUN \
   echo oracle-java7-installer shared/accepted-oracle-license-v1-1 select true | debconf-set-selections && \
   add-apt-repository -y ppa:webupd8team/java && \
-  add-apt-repository -y ppa:git-core/ppa && \
   apt-get update
 
 # Install Java 7
@@ -18,7 +17,9 @@ RUN \
   rm -rf /var/cache/oracle-jdk7-installer
 
 # Install a modern git client
-RUN sudo apt-get -y install git
+RUN add-apt-repository -y ppa:git-core/ppa && \
+    apt-get update && \
+    apt-get -y install git
 
 # Define working directory.
 WORKDIR /data


### PR DESCRIPTION
@feanil @doctoryes Update to PR #3000. Unfortunately apt-get was not correctly updating when 2 repositories were added at the same time. This update corrects the issue.
