### PR TITLE
Do not force the password or config creation if exists.

### DIFF
--- a/playbooks/roles/go-server/tasks/main.yml
+++ b/playbooks/roles/go-server/tasks/main.yml
@@ -91,6 +91,7 @@
     mode: 0600
     owner: "{{ GO_SERVER_USER }}"
     group: "{{ GO_SERVER_GROUP }}"
+    force: no
   when: GO_SERVER_ADMIN_PASSWORD and GO_SERVER_BACKUP_PASSWORD
 
 - name: install go-server configuration
@@ -100,6 +101,7 @@
     mode: 0600
     owner: "{{ GO_SERVER_USER }}"
     group: "{{ GO_SERVER_GROUP }}"
+    force: no
 
 # If a GoCD restore file is specified, attempt to download and restore it.
 - include: download_backup.yml


### PR DESCRIPTION
@feanil This change, along with `GO_SERVER_BACKUP_S3_BUCKET` and `GO_SERVER_BACKUP_S3_OBJECT` not being set will leave a currently configured go-server undisturbed.

@macdiesel FYI.
