### PR TITLE
E0d/unbreak npm

### DIFF
--- a/playbooks/roles/ecommerce/defaults/main.yml
+++ b/playbooks/roles/ecommerce/defaults/main.yml
@@ -205,7 +205,7 @@ ecommerce_requirements:
 ecommerce_environment:
   DJANGO_SETTINGS_MODULE: "{{ ECOMMERCE_DJANGO_SETTINGS_MODULE }}"
   ECOMMERCE_CFG: "{{ COMMON_CFG_DIR }}/{{ ecommerce_service_name }}.yml"
-  PATH: "{{ ecommerce_venv_dir }}/bin:{{ ansible_env.PATH }}"
+  PATH: "{{ ecommerce_nodeenv_bin }}:{{ ecommerce_venv_dir }}/bin:{{ ansible_env.PATH }}"
 
 #
 # OS packages

--- a/playbooks/roles/ecommerce/tasks/main.yml
+++ b/playbooks/roles/ecommerce/tasks/main.yml
@@ -44,6 +44,7 @@
 - name: install node dependencies
   npm: executable={{ ecommerce_nodeenv_bin }}/npm path={{ ecommerce_code_dir }} production=yes
   sudo_user: "{{ ecommerce_user }}"
+  environment: "{{ ecommerce_environment }}"
 
 - name: install bower dependencies
   shell: >

--- a/playbooks/roles/insights/defaults/main.yml
+++ b/playbooks/roles/insights/defaults/main.yml
@@ -150,8 +150,11 @@ INSIGHTS_REPOS:
 insights_environment:
   DJANGO_SETTINGS_MODULE: "analytics_dashboard.settings.production"
   ANALYTICS_DASHBOARD_CFG: "{{ COMMON_CFG_DIR  }}/{{ insights_service_name }}.yml"
+  PATH: "{{ insights_nodeenv_bin }}:{{ insights_venv_dir }}/bin:{{ ansible_env.PATH }}"
 
+  
 insights_service_name: insights
+insights_venv_dir: "{{ insights_home }}/venvs/{{ insights_service_name }}"
 insights_user: "{{ insights_service_name }}"
 insights_app_dir: "{{ COMMON_APP_DIR }}/{{ insights_service_name }}"
 insights_home: "{{ COMMON_APP_DIR }}/{{ insights_service_name }}"

--- a/playbooks/roles/insights/tasks/main.yml
+++ b/playbooks/roles/insights/tasks/main.yml
@@ -35,7 +35,7 @@
 - name: install application requirements
   pip: >
     requirements="{{ insights_requirements_base }}/{{ item }}"
-    virtualenv="{{ insights_home }}/venvs/{{ insights_service_name }}" 
+    virtualenv="{{ insights_venv_dir }}" 
     state=present extra_args="--exists-action w"
   sudo_user: "{{ insights_user }}"
   with_items: insights_requirements
@@ -46,7 +46,7 @@
 - name: create nodeenv
   shell: >
     creates={{ insights_nodeenv_dir }}
-    {{ insights_home }}/venvs/{{ insights_service_name }}/bin/nodeenv {{ insights_nodeenv_dir }}  --prebuilt
+    {{ insights_venv_dir }}/bin/nodeenv {{ insights_nodeenv_dir }}  --prebuilt
   sudo_user: "{{ insights_user }}"
   tags:
     - install
@@ -58,6 +58,7 @@
   tags:
     - install
     - install:app-requirements
+  environment: "{{ insights_environment }}"
 
 - name: install bower dependencies
   shell: >
@@ -73,7 +74,7 @@
     chdir={{ insights_code_dir }}
     DB_MIGRATION_USER='{{ COMMON_MYSQL_MIGRATE_USER }}'
     DB_MIGRATION_PASS='{{ COMMON_MYSQL_MIGRATE_PASS }}'
-    {{ insights_home }}/venvs/{{ insights_service_name }}/bin/python {{ insights_manage }} migrate --noinput
+    {{ insights_venv_dir }}/bin/python {{ insights_manage }} migrate --noinput
   sudo_user: "{{ insights_user }}"
   environment: "{{ insights_environment }}"
   when: migrate_db is defined and migrate_db|lower == "yes"
@@ -93,7 +94,7 @@
 - name: run collectstatic
   shell: >
     chdir={{ insights_code_dir }}
-    {{ insights_home }}/venvs/{{ insights_service_name }}/bin/python {{ insights_manage }} {{ item }}
+    {{ insights_venv_dir }}/bin/python {{ insights_manage }} {{ item }}
   sudo_user: "{{ insights_user }}"
   environment: "{{ insights_environment }}"
   with_items:
@@ -106,7 +107,7 @@
 - name: compile translations
   shell: >
     chdir={{ insights_code_dir }}/analytics_dashboard
-    . {{ insights_home }}/venvs/{{ insights_service_name }}/bin/activate && i18n_tool generate -v
+    . {{ insights_venv_dir }}/bin/activate && i18n_tool generate -v
   sudo_user: "{{ insights_user }}"
   tags:
     - assets
@@ -150,7 +151,7 @@
 
 - name: create symlinks from the venv bin dir
   file: >
-    src="{{ insights_home }}/venvs/{{ insights_service_name }}/bin/{{ item }}"
+    src="{{ insights_venv_dir }}/bin/{{ item }}"
     dest="{{ COMMON_BIN_DIR }}/{{ item.split('.')[0] }}.{{ insights_service_name }}"
     state=link
   with_items:


### PR DESCRIPTION
@jibsheet @clintonb @feanil 

This essentially follows what was happening below for bower.  I'm assuming this issue was introduced by the fact that we are not pinning the version of the prebuilt package we are installing, sigh.

Older version of the npm wrapper start with

```
#!/bin/sh
// 2>/dev/null; exec "`dirname "$0"`/node" "$0" "$@"
```

New versions start with 

```
#!/usr/bin/env node
;(function () { // wrapper in case we're in module_context mode

  // windows: running "npm blah" in this folder will invoke WSH, not node.
  /*global WScript*/
```
