### PR TITLE
Instead of hardcoding a bucket name, use the common sync bucket

### DIFF
--- a/playbooks/roles/minos/defaults/main.yml
+++ b/playbooks/roles/minos/defaults/main.yml
@@ -14,7 +14,7 @@ MINOS_GIT_IDENTITY: !!null
 
 MINOS_SERVICE_CONFIG:
   aws_profile: !!null
-  s3_bucket: edx-{{ COMMON_ENVIRONMENT }}-{{ COMMON_DEPLOYMENT }}
+  s3_bucket: "{{ COMMON_AWS_SYNC_BUCKET }}"
   bucket_path: lifecycle/minos
   voter_conf_d: "{{ minos_voter_cfg }}"
 


### PR DESCRIPTION
This var is already properly used in things like TrackingLogVoter.yml.j2

@edx-ops/devops
