### PR TITLE
Allow specification of an aws_region

### DIFF
--- a/playbooks/roles/minos/defaults/main.yml
+++ b/playbooks/roles/minos/defaults/main.yml
@@ -14,10 +14,12 @@ MINOS_GIT_IDENTITY: !!null
 
 MINOS_SERVICE_CONFIG:
   aws_profile: !!null
+  aws_region: "{{ MINOS_AWS_REGION }}"
   s3_bucket: "{{ COMMON_AWS_SYNC_BUCKET }}"
   bucket_path: lifecycle/minos
   voter_conf_d: "{{ minos_voter_cfg }}"
 
+MINOS_AWS_REGION: 'us-east-1'
 #
 # vars are namespace with the module name.
 #


### PR DESCRIPTION
We need to be able to override this to run outside us-east-1
@edx/devops 
