### PR TITLE
Adds jenkins_protocol_https variable

### DIFF
--- a/playbooks/roles/jenkins_master/defaults/main.yml
+++ b/playbooks/roles/jenkins_master/defaults/main.yml
@@ -4,6 +4,7 @@ jenkins_group: "edx"
 jenkins_server_name: "jenkins.testeng.edx.org"
 jenkins_port: 8080
 jenkins_nginx_port: 80
+jenkins_protocol_https: true
 
 jenkins_version: "1.638"
 jenkins_deb_url: "http://pkg.jenkins-ci.org/debian/binary/jenkins_{{ jenkins_version }}_all.deb"

--- a/playbooks/roles/jenkins_master/templates/etc/nginx/sites-available/jenkins.j2
+++ b/playbooks/roles/jenkins_master/templates/etc/nginx/sites-available/jenkins.j2
@@ -5,8 +5,10 @@ server {
   location / {
     proxy_pass              http://localhost:{{ jenkins_port }};
 
+    {% if jenkins_protocol_https %}
     # Rewrite HTTPS requests from WAN to HTTP requests on LAN
     proxy_redirect http:// https://;
+    {% endif %}
 
     # The following settings from https://wiki.jenkins-ci.org/display/JENKINS/Running+Hudson+behind+Nginx
     sendfile off;


### PR DESCRIPTION
When 'jenkins_protocol_https: true' (default value), this configures nginx with `proxy_redirect` from `http:` to `https:`.  Ref [edx-analytics-configuration jenkins.j2](https://github.com/edx/edx-analytics-configuration/blob/master/roles/jenkins/templates/etc/nginx/sites-available/jenkins.j2#L8-L11).

This change maintains the default behaviour, but makes the `proxy_redirect` config optional.

**JIRA tickets**: Discovered while deploying Jenkins to an OpenCraft client site ([OC-1561](https://tasks.opencraft.com/browse/OC-1561)).

**Related PRs**: 
#3026 , #3027

**Testing instructions**:

Build a `analytics-jenkins` vagrant instance: 

``` bash
git clone https://github.com/open-craft/configuration
cd configuration
git checkout jill/jenkins_master_protocol
mkvirtualenv analytics-jenkins
make requirements  # requires libmysqlclient-dev
vim ansible.yml   # see below
export VAGRANT_JENKINS_LOCAL_VARS_FILE=/path/to/ansible.yml
cd vagrant/base/analytics_jenkins
vim Vagrantfile  # see below

# should skip the final task that creates and runs AnalyticsSeedJob, but if it doesn't, don't worry about that final failure :)
ANSIBLE_ARGS='--skip-tags=jenkins-seed-job' vagrant up 
```

`ansible.yml`:

``` yaml

---
JENKINS_ANALYTICS_AUTH_REALM: unix
JENKINS_ANALYTICS_USER_PASSWORD_PLAIN: password
jenkins_protocol_https: false
jenkins_server_name: localhost
```

Add to `vagrant/base/analytics_jenkins/Vagrantfile`:

```
...
  unless ENV['VAGRANT_NO_PORTS']
    config.vm.network :forwarded_port, guest: 8080, host: 8080  # Jenkins
    config.vm.network :forwarded_port, guest: 80, host: 80  # Jenkins proxied by nginx
  end
...
```
1. Visit http://localhost
2. Login as jenkins user
3. Note that you're not redirected to https.

To undo this change and watch it break:
1. Add `proxy_redirect http: https:` to the vagrant instance's `/etc/nginx/sites-enabled/jenkins`
2. `sudo service nginx restart`
3. Logout of jenkins, and try to log back in.  See it redirect to https.

**Reviewers**
- [x] @jbzdak  
- [ ] edX reviewer[s] TBD
