### PR TITLE
Uses proxy_set_header Host $http_host

### DIFF
--- a/playbooks/roles/jenkins_master/templates/etc/nginx/sites-available/jenkins.j2
+++ b/playbooks/roles/jenkins_master/templates/etc/nginx/sites-available/jenkins.j2
@@ -11,7 +11,7 @@ server {
     # The following settings from https://wiki.jenkins-ci.org/display/JENKINS/Running+Hudson+behind+Nginx
     sendfile off;
 
-    proxy_set_header        Host $host;
+    proxy_set_header        Host $http_host;
     proxy_set_header        X-Real-IP $remote_addr;
     proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_connect_timeout   150;


### PR DESCRIPTION
This change is required so that self-links in the proxied content can be rewritten correctly if `jenkins_nginx_port` is set to something other than the default port 80.

`$http_host` is the same as `$host`, except it also includes the port number if  present in the request.  Ref: http://stackoverflow.com/a/15414811

**JIRA tickets**: Discovered while deploying Jenkins to an OpenCraft client site ([OC--1561](https://tasks.opencraft.com/browse/OC-1561)).

**Related PRs**: 
#3025 , #3027

**Dependencies**:
- PR #3025 - workaround shown in Testing Instructions.

**Testing instructions**:

Build a `analytics-jenkins` vagrant instance: 

``` bash
git clone https://github.com/open-craft/configuration
cd configuration
git checkout jill/jenkins_master_http_host
mkvirtualenv analytics-jenkins
make requirements  # requires libmysqlclient-dev
vim ansible.yml   # see below
export VAGRANT_JENKINS_LOCAL_VARS_FILE=/path/to/ansible.yml
cd vagrant/base/analytics_jenkins
vim Vagrantfile  # see below

# should skip the final task that creates and runs AnalyticsSeedJob, but if it doesn't, don't worry about that final failure :)
ANSIBLE_ARGS='--skip-tags=jenkins-seed-job' vagrant up
```

`ansible.yml`:

``` yaml

---
JENKINS_ANALYTICS_AUTH_REALM: unix
JENKINS_ANALYTICS_USER_PASSWORD_PLAIN: password
jenkins_nginx_port: 8081
jenkins_server_name: localhost
```

Add to `vagrant/base/analytics_jenkins/Vagrantfile`:

```
...
  unless ENV['VAGRANT_NO_PORTS']
    config.vm.network :forwarded_port, guest: 8080, host: 8080  # Jenkins
    config.vm.network :forwarded_port, guest: 8081, host: 8081  # Jenkins proxied by nginx
  end
...
```

_Note:_ you'll need to manually apply the change from PR #3025 to the nginx config:

``` bash
vagrant ssh
sudo vim /etc/nginx/sites-enabled/jenkins   # comment out the line starting with proxy_redirect
sudo service nginx restart
```
1. Visit http://localhost:8081
2. Login as jenkins user
3. Note that clicking around works; proxied links are rewritten correctly to include port :8081.

To undo this change and watch it break:
1. Apply the diff for this PR to the vagrant instance's `/etc/nginx/sites-enabled/jenkins`
2. `sudo service nginx restart`
3. Try to login to jenkins.  You'll be redirected to locahost (without :8081).

**Reviewers**
- [x] @jbzdak  
- [ ] edX reviewer[s] TBD
