### PR TITLE
Allows JENKINS_ANALYTICS_AUTH_REALM: none

### DIFF
--- a/playbooks/roles/jenkins_analytics/defaults/main.yml
+++ b/playbooks/roles/jenkins_analytics/defaults/main.yml
@@ -149,11 +149,15 @@ jenkins_admin_users:
   - "{{ jenkins_user }}"
 
 jenkins_auth_realms_available:
+  none:
+    name: none
+    cli_auth: ''
   unix:
     name: unix
     service: su
     plain_password: "{{ JENKINS_ANALYTICS_USER_PASSWORD_PLAIN }}"
     username: "{{ jenkins_user }}"
+    cli_auth: '-i {{ jenkins_private_keyfile }}'
   github_oauth:
     name: github_oauth
     webUri: "{{ JENKINS_ANALYTICS_GITHUB_OAUTH_WEB_URI }}"
@@ -161,6 +165,7 @@ jenkins_auth_realms_available:
     clientId: "{{ JENKINS_ANALYTICS_GITHUB_OAUTH_CLIENT_ID }}"
     clientSecret: "{{ JENKINS_ANALYTICS_GITHUB_OAUTH_CLIENT_SECRET }}"
     oauthScopes: "{{ JENKINS_ANALYTICS_GITHUB_OAUTH_SCOPES }}"
+    cli_auth: '-i {{ jenkins_private_keyfile }}'
 
 jenkins_auth_realm: "{{ jenkins_auth_realms_available[JENKINS_ANALYTICS_AUTH_REALM] }}"
 

--- a/playbooks/roles/jenkins_analytics/tasks/execute_jenkins_cli.yaml
+++ b/playbooks/roles/jenkins_analytics/tasks/execute_jenkins_cli.yaml
@@ -15,7 +15,7 @@
     return_content: yes
     status_code: 200,403
   register: result
-  until: (result.status is defined) and ((result.status == 403) or (results.status == 200))
+  until: (result.status is defined) and ((result.status == 403) or (result.status == 200))
   retries: "{{ jenkins_connection_retries }}"
   delay: "{{ jenkins_connection_delay }}"
   changed_when: false
@@ -28,7 +28,7 @@
 - name: execute command
   shell: >
     {{ jenkins_command_prefix|default('') }} java -jar {{ jenkins_cli_jar }} -s http://localhost:{{ jenkins_port }}
-    -i {{ jenkins_private_keyfile }}
+    {{ jenkins_auth_realm.cli_auth }}
     {{ jenkins_command_string }}
   register: jenkins_command_output
   ignore_errors: "{{ jenkins_ignore_cli_errors|default (False) }}"

--- a/playbooks/roles/jenkins_analytics/tasks/main.yml
+++ b/playbooks/roles/jenkins_analytics/tasks/main.yml
@@ -15,11 +15,6 @@
 
 # Jenkins authentication/authorization
 
-- fail: msg="invalid auth realm {{ jenkins_auth_realm.name }}"
-  when: jenkins_auth_realm.name != "unix" and jenkins_auth_realm.name != "github_oauth"
-  tags:
-    - jenkins-auth
-
 - fail: msg="Please change default password for jenkins user"
   when: jenkins_auth_realm.name == "unix" and jenkins_auth_realm.plain_password == jenkins_auth_realm.username
   tags:

--- a/playbooks/roles/jenkins_analytics/templates/jenkins.config.main.xml
+++ b/playbooks/roles/jenkins_analytics/templates/jenkins.config.main.xml
@@ -5,6 +5,10 @@
   <numExecutors>{{ JENKINS_ANALYTICS_CONCURRENT_JOBS_COUNT }}</numExecutors>
   <mode>NORMAL</mode>
   <useSecurity>true</useSecurity>
+  {% if jenkins_auth_realm.name == "none" %}
+  <authorizationStrategy class="hudson.security.AuthorizationStrategy$Unsecured"/>
+  <securityRealm class="hudson.security.SecurityRealm$None"/>
+  {% else %}
   <authorizationStrategy class="hudson.security.GlobalMatrixAuthorizationStrategy">
   {% for permission_group, permissions in jenkins_auth_permissions.iteritems() %}
     {% for permission in permissions %}
@@ -26,6 +30,7 @@
     <clientSecret>{{ jenkins_auth_realm.clientSecret }}</clientSecret>
     <oauthScopes>{{ jenkins_auth_realm.oauthScopes|join(',') }}</oauthScopes>
   </securityRealm>
+  {% endif %}
   {% endif %}
   <disableRememberMe>false</disableRememberMe>
   <projectNamingStrategy class="jenkins.model.ProjectNamingStrategy$DefaultProjectNamingStrategy"/>


### PR DESCRIPTION
Useful for Jenkins installations which are secured via other means, e.g. firewall rules.
- Adds an authentication realm option which disables Jenkins authentication.
- Configures CLI authentication for existing auth realms
- Fixes a typo in execute_jenkins_cli.yml "Wait for Jenkins CLI"

**JIRA tickets**: Discovered while deploying Jenkins to an OpenCraft client site ([OC-1561](https://tasks.opencraft.com/browse/OC-1561)).

**Related PRs**: 
#3025 , #3026

**Dependencies**:
- PR #3025 - workaround shown in Testing Instructions.

**Testing instructions**:

Build a `analytics-jenkins` vagrant instance: 

``` bash
git clone https://github.com/open-craft/configuration
cd configuration
git checkout jill/jenkins_analytics_no_auth
mkvirtualenv analytics-jenkins
make requirements  # requires libmysqlclient-dev
vim ansible.yml   # see below
export VAGRANT_JENKINS_LOCAL_VARS_FILE=/path/to/ansible.yml
cd vagrant/base/analytics_jenkins

# should skip the final task that creates and runs AnalyticsSeedJob, but if it doesn't, don't worry about that final failure :)
ANSIBLE_ARGS='--skip-tags=jenkins-seed-job' vagrant up
```

ansible.yml:

``` yaml

---
JENKINS_ANALYTICS_AUTH_REALM: none
jenkins_server_name: localhost
```

_Note:_ you'll need to manually apply the change from PR #3025 to the nginx config:

``` bash
vagrant ssh
sudo vim /etc/nginx/sites-enabled/jenkins   # comment out the line starting with proxy_redirect
sudo service nginx restart
```
1. Visit http://localhost:8080
2. Note that you don't have to login to use or administer Jenkins.

**Reviewers**
- [x] @jbzdak  
- [ ] edX reviewer[s] TBD
