### PR TITLE
Support configuration of tracking log rotation frequency

### DIFF
--- a/playbooks/roles/common/templates/etc/logrotate.d/hourly/edx_logrotate_tracking_log.j2
+++ b/playbooks/roles/common/templates/etc/logrotate.d/hourly/edx_logrotate_tracking_log.j2
@@ -1,4 +1,7 @@
 {{ COMMON_LOG_DIR }}/tracking/tracking.log {
+  {% for config in COMMON_TRACKING_LOG_ROTATION %}
+  {{ config }}
+  {% endfor %}
   compress
   create
   dateext
@@ -7,7 +10,6 @@
   nodelaycompress
   notifempty
   rotate 16000
-  size 1M
   postrotate
     /usr/bin/killall -HUP rsyslogd
   endscript

--- a/playbooks/roles/common_vars/defaults/main.yml
+++ b/playbooks/roles/common_vars/defaults/main.yml
@@ -171,3 +171,6 @@ common_close_all_caches: |
         cache = django_cache.cache
         if hasattr(cache, 'close'):
             cache.close()
+
+COMMON_TRACKING_LOG_ROTATION:
+  - size 1M


### PR DESCRIPTION
@e0d - as discussed in passing, this change can enable us to change the behavior of logrotate for our different environments for tracking log files.

I would like to set this variable to different values in different environments. Environments that don't get as much traffic might want to set this variable to "hourly" to ensure that logs are rotated once per hour regardless of the size.

Reviewers:
- [ ] @e0d 
- [x] @feanil 
- [x] @brianhw 
