### PR TITLE
Installing libmemcached-dev for the discovery service

### DIFF
--- a/playbooks/roles/discovery/defaults/main.yml
+++ b/playbooks/roles/discovery/defaults/main.yml
@@ -47,7 +47,7 @@ DISCOVERY_MEMCACHE: [ 'memcache' ]
 
 DISCOVERY_CACHES:
   default:
-    BACKEND:  'django.core.cache.backends.memcached.MemcachedCache'
+    BACKEND:  'django.core.cache.backends.memcached.PyLibMCCache'
     KEY_PREFIX: '{{ discovery_service_name }}'
     LOCATION: '{{ DISCOVERY_MEMCACHE }}'
 
@@ -178,5 +178,6 @@ discovery_debian_pkgs:
   - libmysqlclient-dev
   - libssl-dev
   - libffi-dev  # Needed to install the Python cryptography library for asymmetric JWT signing
+  - libmemcached-dev # Needed for pylibmc
 
 discovery_redhat_pkgs: []


### PR DESCRIPTION
This is a requirement for installing the pylibmc pip package, necessary for interfacing with memcached.

ECOM-4370
