### PR TITLE
Add affiliate cookie setting in all environments.

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -891,6 +891,7 @@ generic_env_config:  &edxapp_generic_env
     python_bin: '{% if EDXAPP_PYTHON_SANDBOX %}{{ edxapp_sandbox_venv_dir }}/bin/python{% endif %}'
     limits: "{{ EDXAPP_CODE_JAIL_LIMITS }}"
     user: '{{ edxapp_sandbox_user }}'
+  AFFILIATE_COOKIE_NAME: "{{ EDXAPP_AFFILIATE_COOKIE_NAME }}"
 
 lms_auth_config:
   <<: *edxapp_generic_auth
@@ -961,7 +962,6 @@ lms_env_config:
   API_ACCESS_FROM_EMAIL: "{{ EDXAPP_API_ACCESS_FROM_EMAIL }}"
   API_DOCUMENTATION_URL: "{{ EDXAPP_API_DOCUMENTATION_URL }}"
   AUTH_DOCUMENTATION_URL: "{{ EDXAPP_AUTH_DOCUMENTATION_URL }}"
-  AFFILIATE_COOKIE_NAME: "{{ EDXAPP_AFFILIATE_COOKIE_NAME }}"
 
 cms_auth_config:
   <<: *edxapp_generic_auth


### PR DESCRIPTION
FYI @clintonb @bderusha I should have caught this earlier, but the setting override should be in both LMS and CMS environments since the code is being used in common/djangoapps and could run under either settings.
