### PR TITLE
Fix MOTD link

### DIFF
--- a/playbooks/roles/vhost/templates/etc/devstack_motd.tail.j2
+++ b/playbooks/roles/vhost/templates/etc/devstack_motd.tail.j2
@@ -6,5 +6,5 @@
 *       |_|                                                                *
 *                                                                          *
 *  Instructions and troubleshooting:                                       *
-*  https://openedx.atlassian.net/wiki/display/OpenOPS/edX-Developer-Stack  *
+*  https://openedx.atlassian.net/wiki/display/OpenOPS/Running+Devstack     *
 ****************************************************************************


### PR DESCRIPTION
The old MOTD link was pointing to a non-existing page.
