### PR TITLE
edx_sandbox.yml: Run edxlocal role only if edxapp db is on localhost

### DIFF
--- a/playbooks/edx_sandbox.yml
+++ b/playbooks/edx_sandbox.yml
@@ -34,9 +34,10 @@
       nginx_sites:
       - ecommerce
       when: SANDBOX_ENABLE_ECOMMERCE
-    - role: mysql
+    - role: edxlocal
       when: EDXAPP_MYSQL_HOST == 'localhost'
-    - edxlocal
+    - role: memcache
+      when: "'localhost' in ' '.join(EDXAPP_MEMCACHE)"
     - role: mongo
       when: "'localhost' in EDXAPP_MONGO_HOSTS"
     - { role: 'rabbitmq', rabbitmq_ip: '127.0.0.1' }

--- a/playbooks/roles/edxlocal/meta/main.yml
+++ b/playbooks/roles/edxlocal/meta/main.yml
@@ -1,3 +1,4 @@
 ---
 dependencies:
   - common
+  - mysql

--- a/playbooks/roles/edxlocal/tasks/main.yml
+++ b/playbooks/roles/edxlocal/tasks/main.yml
@@ -74,7 +74,3 @@
     name={{ COMMON_MYSQL_ADMIN_USER }}
     password={{ COMMON_MYSQL_ADMIN_PASS }}
     priv='*.*:CREATE USER'
-
-
-- name: install memcached
-  apt: pkg=memcached state=present

--- a/playbooks/roles/memcache/tasks/main.yml
+++ b/playbooks/roles/memcache/tasks/main.yml
@@ -1,0 +1,7 @@
+# Installs memcached
+
+- name: install memcached
+  apt: pkg=memcached state=present update_cache=yes
+  tags:
+    - install
+    - install:memcache


### PR DESCRIPTION
This change updates the `edx_sandbox.yml` playbook to run the `edxlocal` role only if the edxapp database is hosted on localhost, and makes the `mysql` role a dependency of `edxlocal`.

It also moves the `memcached` package installation out of `edxlocal` and into the `edxapp` role, and installs it if `EDXAPP_MEMCACHE` contains `localhost`.

Previously, the `mysql` role was run only if the edxapp database was hosted on localhost, and `edxlocal` had no such check.  So if the edxapp DB was not local, the subsequent `edxlocal` role would fail due to missing dependencies.

**Sandboxes**

`EDXAPP_MYSQL_HOST == 'localhost'`:
- LMS: http://pr12539.sandbox.opencraft.com
- Studio: http://studio.pr12539.sandbox.opencraft.com

`EDXAPP_MYSQL_HOST == 'pr12539.sandbox.opencraft.com`:
- LMS: http://pr12539-remote.sandbox.opencraft.com
- Studio: http://studio.pr12539-remote.sandbox.opencraft.com

**Reviewers**
- [x] @mtyaka 
- [x] e0d
- [x] fredsmith
- [x] feanil
