### PR TITLE
Add role to create initial LMS users.

### DIFF
--- a/playbooks/roles/create_lms_users/defaults/main.yml
+++ b/playbooks/roles/create_lms_users/defaults/main.yml
@@ -1,0 +1,41 @@
+---
+#
+# edX Configuration
+#
+# github:     https://github.com/edx/configuration
+# wiki:       https://openedx.atlassian.net/wiki/display/OpenOPS
+# code style: https://openedx.atlassian.net/wiki/display/OpenOPS/Ansible+Code+Conventions
+# license:    https://github.com/edx/configuration/blob/master/LICENSE.TXT
+#
+##
+# Defaults for role create_lms_users
+# 
+
+#
+# vars are namespaced with the module name.
+#
+create_lms_users_role_name: create_lms_users
+
+#
+# OS packages
+#
+
+create_lms_users_debian_pkgs: []
+
+create_lms_users_redhat_pkgs: []
+
+# The list of users to create.  Example:
+# CREATE_LMS_USERS:
+#   - email: martha@example.com
+#     name: Martha Jones
+#     username: martha
+#     password: 'pbkdf2_sha256$20000$TCWPsU7v6LEl$B+Rk8O1Sw4/lxAsnpYpNN2vtL/RAoL/G/+OFBNlolBI='
+#     password_hash: true
+#     is_staff: true
+#   - email: john@example.com
+#     name: John Smith
+#     username: john
+#     password: edx
+#     password_hash: false
+#     is_staff: false
+CREATE_LMS_USERS: []

--- a/playbooks/roles/create_lms_users/meta/main.yml
+++ b/playbooks/roles/create_lms_users/meta/main.yml
@@ -1,0 +1,14 @@
+---
+#
+# edX Configuration
+#
+# github:     https://github.com/edx/configuration
+# wiki:       https://openedx.atlassian.net/wiki/display/OpenOPS
+# code style: https://openedx.atlassian.net/wiki/display/OpenOPS/Ansible+Code+Conventions
+# license:    https://github.com/edx/configuration/blob/master/LICENSE.TXT
+#
+##
+# Role includes for role create_lms_users
+
+dependencies:
+  - common_vars

--- a/playbooks/roles/create_lms_users/tasks/deploy.yml
+++ b/playbooks/roles/create_lms_users/tasks/deploy.yml
@@ -1,0 +1,10 @@
+- name: create LMS users
+  # It's important to use "command" here instead of "shell", since otherwise we would have to
+  # escape the special characters in the password (or other fields) for the shell.
+  command: >
+    {{ COMMON_APP_DIR }}/edxapp/venvs/edxapp/bin/python ./manage.py lms --settings=aws
+    create_user -e {{ item.email }} -n {{ item.name }} -u {{ item.username }} -p {{ item.password }}
+    {{ "-s" if item.is_staff else "" }} {{ "--password-hash" if item.password_hash else "" }}
+    chdir={{ COMMON_APP_DIR }}/edxapp/edx-platform
+  sudo_user: "{{ common_web_user }}"
+  with_items: CREATE_LMS_USERS

--- a/playbooks/roles/create_lms_users/tasks/main.yml
+++ b/playbooks/roles/create_lms_users/tasks/main.yml
@@ -1,0 +1,24 @@
+---
+#
+# edX Configuration
+#
+# github:     https://github.com/edx/configuration
+# wiki:       https://openedx.atlassian.net/wiki/display/OpenOPS
+# code style: https://openedx.atlassian.net/wiki/display/OpenOPS/Ansible+Code+Conventions
+# license:    https://github.com/edx/configuration/blob/master/LICENSE.TXT
+#
+#
+#
+# Tasks for role create_lms_users
+# 
+# Overview:
+# 
+#
+# Dependencies:
+#
+# 
+# Example play:
+#
+#
+
+- include: deploy.yml tags=deploy


### PR DESCRIPTION
This role can be used to create LMS users on an Open edX instance.  It can be run using the `run_role.yml` playbook, and can be used on any readily provisioned instance.

For testing, create a file `vars.yml` with these contents:

```
role: create_lms_users

CREATE_LMS_USERS:
  - email: john@example.com
    name: John Smith
    username: john
    password: edx
    password_hash: false
    is_staff: false
```

and run it against any sandbox with edxapp installed

```
ansible-playbook ./run_role.yml -i "sandbox.domain," -u username_on_sandbox -e @vars.yml
```

**JIRA Ticket**: [OSPR-1282](https://openedx.atlassian.net/browse/OSPR-1282)
**Dependencies**: edx/edx-platform#12519 (if you want to use `password_hash: true` and to ensure idempotency)
