### PR TITLE
mattdrayer/ecommerce-worker-multisite: Add site-specific overrides

### DIFF
--- a/playbooks/roles/ecomworker/defaults/main.yml
+++ b/playbooks/roles/ecomworker/defaults/main.yml
@@ -52,9 +52,10 @@ ECOMMERCE_WORKER_WORKER_ACCESS_TOKEN: 'your-secret-here'
 ECOMMERCE_WORKER_MAX_FULFILLMENT_RETRIES: 11
 # END ORDER FULFILLMENT
 
-# Ecommerce Worker settings 
+# Ecommerce Worker settings
 ECOMMERCE_WORKER_JWT_SECRET_KEY: 'insecure-secret-key'
 ECOMMERCE_WORKER_JWT_ISSUER: 'ecommerce_worker'
+ECOMMERCE_WORKER_SITE_OVERRIDES: !!null
 
 ECOMMERCE_WORKER_SERVICE_CONFIG:
   BROKER_URL: '{{ ECOMMERCE_WORKER_BROKER_URL }}'
@@ -62,6 +63,21 @@ ECOMMERCE_WORKER_SERVICE_CONFIG:
   JWT_SECRET_KEY: '{{ ECOMMERCE_WORKER_JWT_SECRET_KEY }}'
   JWT_ISSUER: '{{ ECOMMERCE_WORKER_JWT_ISSUER }}'
   MAX_FULFILLMENT_RETRIES: '{{ ECOMMERCE_WORKER_MAX_FULFILLMENT_RETRIES }}'
+
+  # Site-specific configuration overrides.  Implemented as a dict of dicts with 'site_code' for keys.
+  # Ecommerce worker will apply these settings instead of their corresponding default values.
+  # For example:
+  # SITE_OVERRIDES: {
+  #   "site1": {
+  #      "ECOMMERCE_API_ROOT": "http://ecommerce-subdomain.domain.com"
+  #   },
+  #   "site2": {
+  #      "JWT_SECRET_KEY": "site2-secret-key",
+  #      "JWT_ISSUER": "site2-worker"
+  #   }
+  # }
+  SITE_OVERRIDES: '{{ ECOMMERCE_WORKER_SITE_OVERRIDES }}'
+
 
 ecommerce_worker_environment:
   WORKER_CONFIGURATION_MODULE: 'ecommerce_worker.configuration.production'


### PR DESCRIPTION
@fredsmith @rlucioni -- FYI, this is the third part of the solution to enable site-specific configuration overrides for the ecommerce-worker service.  Pretty sure I'm missing something here.  If you can take a look and let me know what else needs to be changed that would be great.

Ref: 
- edx/ecommerce-worker#16
- edx/ecommerce#751
