### PR TITLE
Clean up /edx/var/edxapp/staticfiles before paver runs

### DIFF
--- a/playbooks/roles/edxapp/tasks/service_variant_config.yml
+++ b/playbooks/roles/edxapp/tasks/service_variant_config.yml
@@ -126,6 +126,24 @@
   tags:
     - migrate
 
+# There are problems with django collectstatic copying files.  It doesn't retain
+# last modified timestamps, but relies on those same timestamps to know if a new file
+# should be recopied.  While collectstatic --clear exists, it only clears some of the
+# files in edxapp_staticfile_dir, it leaves postprocessed or otherwise hashed files.
+# This ensures we have a totally clean directory.
+- name: Remove and recreate the staticfiles directory so nothing stale can exist
+  file:
+      path: "{{ edxapp_staticfile_dir }}"
+      state: "{{ item }}"
+      owner: "{{ edxapp_user }}"
+      group: "{{ common_web_group }}"
+      mode:  0755
+  when: celery_worker is not defined and not devstack
+  with_items: ['absent', 'directory']
+  tags:
+    - gather_static_assets
+    - assets
+
 # Gather assets using paver if possible
 - name: "gather {{ item }} static assets with paver"
   command: "{{ COMMON_BIN_DIR }}/edxapp-update-assets-{{ item }}"


### PR DESCRIPTION
When running on a dirty image (such as a sandbox base image or an AMI
build) this clears static files so that collectstatic will copy
everything.

Django's collectstatic copies files and doesn't preserve timestamps,
then only copies "newer modified files".  This leads to a condition
where old static files are in /edx/var/edxapp/staticfiles with a
timestamp of Yesterday, and we add a new dep which comes down from npm
with a timestamp of last week.  Collectstatic will not copy those.

This does not clean out on devstacks or for people running /edx/bin/edxapp-update-assets-lms directly, only for those using /edx/bin/update on sandboxes and during AMI builds.  If we're concerned about that limitation, we should figure out how to address it.

Waiting for
http://jenkins.edx.org:8080/job/ansible-provision/7406/console
http://jenkins.edx.org:8080/job/ansible-provision/7407/console
to finish, and have grabbed manual testers for next week on Thursday morning so we can test,
unless folks are comfortable going out in the primary release while I'm away.

@edx/devops 
FYI @andy-armstrong 
