### PR TITLE
Add parens to fix backup script.

### DIFF
--- a/playbooks/roles/go-server/templates/gocd_backup.j2
+++ b/playbooks/roles/go-server/templates/gocd_backup.j2
@@ -60,7 +60,7 @@ tar zcvf "$gocd_backup_location" -C "$(dirname "$backup_path")" "${backup_dir_na
 dated_backup_filename="${gocd_backup_base}-${backup_dir_name}.tgz"
 
 # Transfer tarball to S3 with datetime'd filename.
-aws_output=$(/usr/local/bin/aws s3 cp "${gocd_backup_location}" "s3://${s3_backup_bucket}/${dated_backup_filename}" 2>&1) || echo $aws_output && exit
+aws_output=$(/usr/local/bin/aws s3 cp "${gocd_backup_location}" "s3://${s3_backup_bucket}/${dated_backup_filename}" 2>&1) || (echo $aws_output && exit)
 case $aws_output in
 *failed*)
   echo "Backup transfer failed: $aws_output"
@@ -72,7 +72,7 @@ case $aws_output in
 esac
 
 # Transfer tarball to S3 with official backup filename.
-aws_output=$(/usr/local/bin/aws s3 cp "${gocd_backup_location}" "s3://${s3_backup_bucket}" 2>&1) || echo $aws_output && exit
+aws_output=$(/usr/local/bin/aws s3 cp "${gocd_backup_location}" "s3://${s3_backup_bucket}" 2>&1) || (echo $aws_output && exit)
 case $aws_output in
 *failed*)
   echo "Backup transfer failed: $aws_output"


### PR DESCRIPTION
A silly bash logic bug is now fixed - GoCD backups will now successfully upload and report to the snitch.

@edx/pipeline-team Please review.
