### PR TITLE
Whitelisting future_builtins.so for matplotlib

### DIFF
--- a/playbooks/roles/edxapp/templates/code.sandbox.j2
+++ b/playbooks/roles/edxapp/templates/code.sandbox.j2
@@ -20,6 +20,7 @@
     /usr/lib/python2.7/lib-dynload/datetime.so mr,
     /usr/lib/python2.7/lib-dynload/_elementtree.so mr,
     /usr/lib/python2.7/lib-dynload/pyexpat.so mr,
+    /usr/lib/python2.7/lib-dynload/future_builtins.so mr,
 
     # Matplot lib  needs a place for temp caches
     {{ edxapp_sandbox_venv_dir }}/.config/ wrix,


### PR DESCRIPTION
Ticket: https://openedx.atlassian.net/browse/DEVOPS-4285

The purpose of this PR is to fix the following error which we were facing upon creation of python based capa problem.

```
Problem block-v1:edX+DemoX+Demo_Course+type@problem+block@2c916394980f4ca2a5ba43b9e00913d7 has an error:
cannot create LoncapaProblem block-v1:edX+DemoX+Demo_Course+type@problem+block@2c916394980f4ca2a5ba43b9e00913d7: 
Error while executing script code: Couldn't execute jailed code: stdout: '', stderr: 'Traceback (most recent call last):\n File "jailed_code", line 15, in &lt;module>\n exec code in g_dict\n File "&lt;string>", line 62, in &lt;module>\n File "/edx/app/edxapp/venvs/edxapp-sandbox/local/lib/python2.7/site-packages/matplotlib/__init__.py", line 156, in &lt;module>\n 
from matplotlib.cbook import is_string_like\n File "/edx/app/edxapp/venvs/edxapp-sandbox/local/lib/python2.7/site-packages/matplotlib/cbook.py", line 28, in &lt;module>\n
import numpy as np\n File "/edx/app/edxapp/venvs/edxapp-sandbox/local/lib/python2.7/site-packages/numpy/__init__.py", line 180, in &lt;module>\n from . import add_newdocs\n
File "/edx/app/edxapp/venvs/edxapp-sandbox/local/lib/python2.7/site-packages/numpy/add_newdocs.py", line 13, in &lt;module>\n from numpy.lib import add_newdoc\n File "/edx/app/edxapp/venvs/edxapp-sandbox/local/lib/python2.7/site-packages/numpy/lib/__init__.py", line 22, in &lt;module>\n from .npyio import *\n File "/edx/app/edxapp/venvs/edxapp-sandbox/local/lib/python2.7/site-packages/numpy/lib/npyio.py", line 29, in &lt;module>\n from future_builtins import map\n

**ImportError: /edx/app/edxapp/venvs/edxapp-sandbox/lib/python2.7/lib-dynload/future_builtins.so: failed to map segment from shared object: Permission denied\n'** with status code: 1
```
