### PR TITLE
psmisc isn't on precise docker images and the jenkins roles want it.

### DIFF
--- a/playbooks/roles/jenkins_master/defaults/main.yml
+++ b/playbooks/roles/jenkins_master/defaults/main.yml
@@ -100,6 +100,7 @@ jenkins_debian_pkgs:
     - maven
     - daemon
     - python-pycurl
+    - psmisc
 
 # Extra packages need for a specific jenkins instance.
 JENKINS_EXTRA_PKGS: []


### PR DESCRIPTION
It is part of the default AWS AMI though, which is why we haven't noticed.

@edx/devops 
