### PR TITLE
Add another region to ec2.py

### DIFF
--- a/playbooks/ec2.ini
+++ b/playbooks/ec2.ini
@@ -11,7 +11,7 @@
 # AWS regions to make calls to. Set this to 'all' to make request to all regions
 # in AWS and merge the results together. Alternatively, set this to a comma
 # separated list of regions. E.g. 'us-east-1,us-west-1,us-west-2'
-regions = us-east-1
+regions = us-east-1,eu-west-1
 regions_exclude = us-gov-west-1
 
 # When generating inventory, Ansible needs to know how to address a server.


### PR DESCRIPTION
This appears to be the only way to ask it to look in multiple regions
since it doesn't support AWS_REGION or --region.
Alternately, we could start having independent .ini files for deploys.

@edx/devops
