### PR TITLE
Add vim configuration for devstack

### DIFF
--- a/playbooks/roles/local_dev/files/ftplugin-python.vim
+++ b/playbooks/roles/local_dev/files/ftplugin-python.vim
@@ -1,0 +1,13 @@
+" Python specific syntax handling
+
+" indent according to pep-8 rules (4 char, all spaces)
+setlocal tabstop=8 
+setlocal expandtab 
+setlocal shiftwidth=4 
+setlocal softtabstop=4
+setlocal smarttab
+setlocal smartindent 
+setlocal cinwords=if,elif,else,for,while,with,try,except,finally,def,class
+
+" Don't auto-align block comments to column 1
+inoremap # X#

--- a/playbooks/roles/local_dev/files/vimrc
+++ b/playbooks/roles/local_dev/files/vimrc
@@ -1,0 +1,33 @@
+set nocompatible
+
+" Turn on syntax highlighting
+syntax on
+
+" Handle filetypes 
+filetype on
+
+" Handle filetype-based plugins and indentation rules
+filetype plugin indent on
+
+" Highlight matching delimiters (brackets, braces, quotes, etc.)
+set showmatch
+
+" Show the following replacement characters on :set list
+set listchars=tab:→\ ,trail:·,nbsp:¤,precedes:«,extends:»,eol:↲
+
+" Never autocomplete filenames that match the following
+set wildignore+=*.pyc,*.pyo
+
+" Silence error bells
+set noerrorbells visualbell
+
+" Standard indentation rules:
+
+" - A tab character is 8 spaces wide
+set tabstop=8
+" - a block indents four spaces
+set shiftwidth=4
+" - Pressing the tab key indents by four spaces
+set softtabstop=4
+" - Always render indentation as spaces
+set expandtab

--- a/playbooks/roles/local_dev/tasks/main.yml
+++ b/playbooks/roles/local_dev/tasks/main.yml
@@ -64,10 +64,41 @@
     src: paver_autocomplete
     dest: "{{ item.home }}/.paver_autocomplete"
     owner: "{{ item.user }}"
+    group: "{{ common_web_group }}"
     mode: 0755
   with_items: localdev_accounts
   when: item.user != 'None'
   ignore_errors: yes
+
+# Add useful vimrc files 
+- name: create .vim/plugin directory
+  file:
+    path: "{{ item.home }}/.vim/ftplugin"
+    owner: "{{ item.user }}"
+    group: "{{ common_web_group }}"
+    state: directory
+  with_items: localdev_accounts
+  when: item.user != 'None'
+
+- name: add .vimrc file
+  copy:
+    src: vimrc
+    dest: "{{ item.home }}/.vimrc"
+    owner: "{{ item.user }}"
+    group: "{{ common_web_group }}"
+    mode: 0644
+  with_items: localdev_accounts
+  when: item.user != 'None'
+
+- name: add python.vim ftplugin file
+  copy:
+    src: ftplugin-python.vim
+    dest: "{{ item.home }}/.vim/ftplugin/python.vim"
+    owner: "{{ item.user }}"
+    group: "{{ common_web_group }}"
+    mode: 0644
+  with_items: localdev_accounts
+  when: item.user != 'None'
 
 # Edit the /etc/hosts file so that the Preview button will work in Studio
 - name: add preview.localhost to /etc/hosts


### PR DESCRIPTION
Trying to edit code on devstacks is hindered by lack of decent vim configuration (indentation is by tab characters, and syntax highlighting is missing, for instance.)
### Open Questions
- Is local_dev the right playbook for this?  I think so, but I'm happy to put it somewhere else
- Is there anything else we want in our vim configuration?
### Testing
- [x] Create devstack with playbook.  Make sure it works good.
### Reviewers:
- [x] @edx/devops 
- [x] @efischer19 
### Pre-merge
- [ ] Squash commits
