### PR TITLE
Improvements to django_admin.sh

### DIFF
--- a/util/jenkins/django-admin.sh
+++ b/util/jenkins/django-admin.sh
@@ -15,4 +15,5 @@ if [ "$help" = "true" ]; then
   manage="$manage help"
 fi
 
-$ansible "$manage $command $options --settings aws"
+echo "Running $ansible \"$manage $command $options\""
+$ansible "$manage $command $options"


### PR DESCRIPTION
- Echo the command to run before running (for post-mortem debugging)
- Stop adding "--settings aws" to the end of every command, even when it
  was added to $manage earlier
