### PR TITLE
Change nginx old listen parameter from default to default_server

### DIFF
--- a/playbooks/roles/ansible-role-django-ida/templates/templates/edx/app/nginx/sites-available/ROLE_NAME.j2
+++ b/playbooks/roles/ansible-role-django-ida/templates/templates/edx/app/nginx/sites-available/ROLE_NAME.j2
@@ -4,7 +4,7 @@
 
 
 {{ '{%' }} if nginx_default_sites is defined and "{{ role_name }}" in nginx_default_sites {{ '%}' }}
-  {{ '{%' }} set default_site = "default" {{ '%}' }}
+  {{ '{%' }} set default_site = "default_server" {{ '%}' }}
 {{ '{%' }} else {{ '%}' }}
   {{ '{%' }} set default_site = "" {{ '%}' }}
 {{ '{%' }} endif {{ '%}' }}

--- a/playbooks/roles/credentials/templates/edx/app/nginx/sites-available/credentials.j2
+++ b/playbooks/roles/credentials/templates/edx/app/nginx/sites-available/credentials.j2
@@ -4,7 +4,7 @@
 
 
 {% if nginx_default_sites is defined and "credentials" in nginx_default_sites %}
-  {% set default_site = "default" %}
+  {% set default_site = "default_server" %}
 {% else %}
   {% set default_site = "" %}
 {% endif %}

--- a/playbooks/roles/discovery/templates/edx/app/nginx/sites-available/discovery.j2
+++ b/playbooks/roles/discovery/templates/edx/app/nginx/sites-available/discovery.j2
@@ -4,7 +4,7 @@
 
 
 {% if nginx_default_sites is defined and "discovery" in nginx_default_sites %}
-  {% set default_site = "default" %}
+  {% set default_site = "default_server" %}
 {% else %}
   {% set default_site = "" %}
 {% endif %}

--- a/playbooks/roles/harstorage/templates/edx/app/nginx/sites-available/harstorage.j2
+++ b/playbooks/roles/harstorage/templates/edx/app/nginx/sites-available/harstorage.j2
@@ -4,7 +4,7 @@
 
 
 {% if nginx_default_sites is defined and "harstorage" in nginx_default_sites %}
-  {% set default_site = "default" %}
+  {% set default_site = "default_server" %}
 {% else %}
   {% set default_site = "" %}
 {% endif %}

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/cms.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/cms.j2
@@ -1,5 +1,5 @@
 {%- if "cms" in nginx_default_sites -%}
-  {%- set default_site = "default" -%}
+  {%- set default_site = "default_server" -%}
 {%- else -%}
   {%- set default_site = "" -%}
 {%- endif -%}

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/credentials.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/credentials.j2
@@ -4,7 +4,7 @@
 
 
 {% if "credentials" in nginx_default_sites %}
-  {% set default_site = "default" %}
+  {% set default_site = "default_server" %}
 {% else %}
   {% set default_site = "" %}
 {% endif %}

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/ecommerce.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/ecommerce.j2
@@ -4,7 +4,7 @@
 
 
 {% if "ecommerce" in nginx_default_sites %}
-  {% set default_site = "default" %}
+  {% set default_site = "default_server" %}
 {% else %}
   {% set default_site = "" %}
 {% endif %}

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/forum.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/forum.j2
@@ -10,7 +10,7 @@
 {% endraw %}
 
 {%- if "forum" in nginx_default_sites -%}
-  {%- set default_site = "default" -%}
+  {%- set default_site = "default_server" -%}
 {%- else -%}
   {%- set default_site = "" -%}
 {%- endif -%}

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/harstorage.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/harstorage.j2
@@ -4,7 +4,7 @@
 
 
 {% if nginx_default_sites is defined and "harstorage" in nginx_default_sites %}
-  {% set default_site = "default" %}
+  {% set default_site = "default_server" %}
 {% else %}
   {% set default_site = "" %}
 {% endif %}

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/kibana.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/kibana.j2
@@ -1,5 +1,5 @@
 {%- if "kibana" in nginx_default_sites -%}
-  {%- set default_site = "default" -%}
+  {%- set default_site = "default_server" -%}
 {%- else -%}
   {%- set default_site = "" -%}
 {%- endif -%}

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
@@ -1,5 +1,5 @@
 {%- if "lms" in nginx_default_sites -%}
-  {%- set default_site = "default" -%}
+  {%- set default_site = "default_server" -%}
 {%- else -%}
   {%- set default_site = "" -%}
 {%- endif -%}

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/nginx_redirect.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/nginx_redirect.j2
@@ -1,5 +1,5 @@
 {%- if "default" in item.value -%}
-  {%- set default_site = "default" -%}
+  {%- set default_site = "default_server" -%}
 {%- else -%}
   {%- set default_site = "" -%}
 {%- endif -%}

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/programs.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/programs.j2
@@ -4,7 +4,7 @@
 
 
 {% if "programs" in nginx_default_sites %}
-  {% set default_site = "default" %}
+  {% set default_site = "default_server" %}
 {% else %}
   {% set default_site = "" %}
 {% endif %}


### PR DESCRIPTION
Nginx document said:

```
The default_server parameter has been available since version 0.8.21.
In earlier versions the default parameter should be used instead.
```

ref. http://nginx.org/en/docs/http/request_processing.html
ref. http://nginx.org/en/docs/http/ngx_http_core_module.html#listen

So, we do not need to use this old parameter anymore.
