### PR TITLE
Configure header_checks and sender_canonical_maps.

### DIFF
--- a/playbooks/roles/postfix_queue/defaults/main.yml
+++ b/playbooks/roles/postfix_queue/defaults/main.yml
@@ -15,11 +15,25 @@ POSTFIX_QUEUE_EXTERNAL_SMTP_PORT: 587
 POSTFIX_QUEUE_EXTERNAL_SMTP_USER: ''
 POSTFIX_QUEUE_EXTERNAL_SMTP_PASSWORD: ''
 
+# Set this to content of sender_canonical_maps postfix configuration file (optional).
+# Example:
+# POSTFIX_QUEUE_SENDER_CANONICAL_MAPS: |-
+#   @internal @external.com
+#   someuser@example.com otheruser@myschool.org
+POSTFIX_QUEUE_SENDER_CANONICAL_MAPS: ''
+
+# Set this to content of header_checks postfix configuration file (optional).
+# Example:
+# POSTFIX_QUEUE_HEADER_CHECKS: |-
+#  /^From:(.*)$/   PREPEND Reply-To:$1
+#  /^Subject:.*spam/   DISCARD
+POSTFIX_QUEUE_HEADER_CHECKS: ''
 
 # Internal vars:
 
 postfix_queue_password_file: "/etc/postfix/sasl/passwd"
-postfix_queue_password_file_hashed: "{{ postfix_queue_password_file }}.db"
+postfix_queue_sender_canonical_maps_file: "/etc/postfix/sender_canonical_maps"
+postfix_queue_header_checks_file: "/etc/postfix/header_checks"
 
 postfix_queue_smtp_sasl_auth_enable: "yes"
 postfix_queue_smtp_sasl_password_maps: "hash:{{ postfix_queue_password_file }}"

--- a/playbooks/roles/postfix_queue/handlers/main.yml
+++ b/playbooks/roles/postfix_queue/handlers/main.yml
@@ -1,9 +1,0 @@
----
-
-# postfix_queue: Configure a local postfix server to forward mail to an
-# external SMTP server. This way postfix acts as an outgoing mail queue, and
-# web apps can send mail instantly, while still taking advantage of an
-# external SMTP service.
-
-- name: restart postfix
-  service: name=postfix state=restarted

--- a/playbooks/roles/postfix_queue/tasks/main.yml
+++ b/playbooks/roles/postfix_queue/tasks/main.yml
@@ -23,12 +23,14 @@
     - "relayhost = {{ postfix_queue_relayhost }}"
     - "smtp_tls_security_level = {{ postfix_queue_smtp_tls_security_level }}"
     - "smtp_tls_mandatory_ciphers = {{ postfix_queue_smtp_tls_mandatory_ciphers }}"
+    - "sender_canonical_maps = hash:{{ postfix_queue_sender_canonical_maps_file }}"
+    - "header_checks = regexp:{{ postfix_queue_header_checks_file }}"
   notify: restart postfix
 
 - name: Explain postfix authentication
   lineinfile: >
     dest="{{ postfix_queue_password_file }}"
-    line="# configured by ansible:"
+    line="# Configured by Ansible:"
     create=yes
 
 - name: Set permissions of password file
@@ -38,10 +40,35 @@
   lineinfile: >
     dest="{{ postfix_queue_password_file }}"
     line="{{ postfix_queue_relayhost }}    {{ POSTFIX_QUEUE_EXTERNAL_SMTP_USER }}:{{ POSTFIX_QUEUE_EXTERNAL_SMTP_PASSWORD }}"
-    insertafter="# configured by ansible:"
+    insertafter="# Configured by Ansible:"
   register: postfix_queue_password
 
 - name: Hash postfix SASL password
   command: "postmap hash:{{ postfix_queue_password_file }}"
   when: postfix_queue_password.changed
+  notify: restart postfix
+
+- name: Configure postfix sender canonical maps
+  copy: >
+    dest="{{ postfix_queue_sender_canonical_maps_file }}"
+    content="# Configured by Ansible:\n{{ POSTFIX_QUEUE_SENDER_CANONICAL_MAPS }}"
+    force=true
+    owner=root
+    group=root
+    mode="0600"
+  register: postfix_queue_sender_canonical_maps
+
+- name: Hash postfix sender canonical maps file
+  command: "postmap hash:{{ postfix_queue_sender_canonical_maps_file }}"
+  when: postfix_queue_sender_canonical_maps.changed
+  notify: restart postfix
+
+- name: Configure postfix header checks
+  copy: >
+    dest="{{ postfix_queue_header_checks_file }}"
+    content="# Configured by Ansible:\n{{ POSTFIX_QUEUE_HEADER_CHECKS }}"
+    force=true
+    owner=root
+    group=root
+    mode="0600"
   notify: restart postfix

--- a/playbooks/roles/postfix_queue/tasks/main.yml
+++ b/playbooks/roles/postfix_queue/tasks/main.yml
@@ -25,50 +25,51 @@
     - "smtp_tls_mandatory_ciphers = {{ postfix_queue_smtp_tls_mandatory_ciphers }}"
     - "sender_canonical_maps = hash:{{ postfix_queue_sender_canonical_maps_file }}"
     - "header_checks = regexp:{{ postfix_queue_header_checks_file }}"
-  notify: restart postfix
 
 - name: Explain postfix authentication
-  lineinfile: >
-    dest="{{ postfix_queue_password_file }}"
-    line="# Configured by Ansible:"
-    create=yes
+  lineinfile:
+    dest: "{{ postfix_queue_password_file }}"
+    line: "# Configured by Ansible:"
+    create: yes
 
 - name: Set permissions of password file
   file: path="{{ postfix_queue_password_file }}" state=file mode="0600" owner=root group=root
 
 - name: Configure postfix authentication
-  lineinfile: >
-    dest="{{ postfix_queue_password_file }}"
-    line="{{ postfix_queue_relayhost }}    {{ POSTFIX_QUEUE_EXTERNAL_SMTP_USER }}:{{ POSTFIX_QUEUE_EXTERNAL_SMTP_PASSWORD }}"
-    insertafter="# Configured by Ansible:"
+  lineinfile:
+    dest: "{{ postfix_queue_password_file }}"
+    line: "{{ postfix_queue_relayhost }}    {{ POSTFIX_QUEUE_EXTERNAL_SMTP_USER }}:{{ POSTFIX_QUEUE_EXTERNAL_SMTP_PASSWORD }}"
+    insertafter: "# Configured by Ansible:"
   register: postfix_queue_password
 
 - name: Hash postfix SASL password
   command: "postmap hash:{{ postfix_queue_password_file }}"
   when: postfix_queue_password.changed
-  notify: restart postfix
 
 - name: Configure postfix sender canonical maps
-  copy: >
-    dest="{{ postfix_queue_sender_canonical_maps_file }}"
-    content="# Configured by Ansible:\n{{ POSTFIX_QUEUE_SENDER_CANONICAL_MAPS }}"
-    force=true
-    owner=root
-    group=root
-    mode="0600"
+  copy:
+    dest: "{{ postfix_queue_sender_canonical_maps_file }}"
+    content: "# Configured by Ansible:\n{{ POSTFIX_QUEUE_SENDER_CANONICAL_MAPS }}"
+    force: true
+    owner: root
+    group: root
+    mode: "0600"
   register: postfix_queue_sender_canonical_maps
 
 - name: Hash postfix sender canonical maps file
   command: "postmap hash:{{ postfix_queue_sender_canonical_maps_file }}"
   when: postfix_queue_sender_canonical_maps.changed
-  notify: restart postfix
 
 - name: Configure postfix header checks
-  copy: >
-    dest="{{ postfix_queue_header_checks_file }}"
-    content="# Configured by Ansible:\n{{ POSTFIX_QUEUE_HEADER_CHECKS }}"
-    force=true
-    owner=root
-    group=root
-    mode="0600"
-  notify: restart postfix
+  copy:
+    dest: "{{ postfix_queue_header_checks_file }}"
+    content: "# Configured by Ansible:\n{{ POSTFIX_QUEUE_HEADER_CHECKS }}"
+    force: true
+    owner: root
+    group: root
+    mode: "0600"
+
+- name: Restart Postfix
+  service:
+    name: postfix
+    state: restarted


### PR DESCRIPTION
#### Background

This patch modifies the postfix_queue role to add ability to configure postfix `header_checks` and `sender_canonical_maps`.

The contents of header_checks file is controlled by the `POSTFIX_QUEUE_HEADER_CHECKS` ansible variable and sender_canonical_maps by the `POSTFIX_QUEUE_SENDER_CANONICAL_MAPS` variable.
Both are optional and default to blank strings (empty configuration files).
#### Testing

Set `POSTFIX_QUEUE_HEADER_CHECKS` and `POSTFIX_QUEUE_SENDER_CANONICAL_MAPS` to desired values and run the `postfix_queue` role, for example:

```
ansible-playbook -i "<host-ip>," playbooks/run_role.yml -u ubuntu -e "role=postfix_queue" \
    -e '{"POSTFIX_QUEUE_HEADER_CHECKS": "/^From:(.*)$/   PREPEND Reply-To:$1"}' \
    -e '{"POSTFIX_QUEUE_SENDER_CANONICAL_MAPS": "user@email.com rewritten@email.com"}'
```

Check that `/etc/postfix/header_checks` and `/etc/postifx/sender_canonical_maps` on the target host contain expected content and that `/etc/postfix/main.cf` contains the following lines:

```
sender_canonical_maps = hash:/etc/postfix/sender_canonical_maps
header_checks = regexp:/etc/postfix/header_checks
```

Then run playbook again without setting the vars:

```
ansible-playbook -i "<host-ip>," playbooks/run_role.yml -u ubuntu -e "role=postfix_queue"
```

Check that `/etc/postfix/header_checks` and `/etc/postfix/sender_canonical_maps` files don't contain any configuration.

---

**JIRA ticket**: https://openedx.atlassian.net/browse/OSPR-1301
