### PR TITLE
Fix all failing ansible syntax checks in roles when we move to Ansible 2.0

### DIFF
--- a/playbooks/roles/mongo_mms/tasks/main.yml
+++ b/playbooks/roles/mongo_mms/tasks/main.yml
@@ -6,7 +6,8 @@
 #   roles:
 #   - mongo_mms
 
-- fail: MMSAPIKEY is required
+- fail:
+    msg: "MMSAPIKEY is required"
   when: MMSAPIKEY is not defined 
 
 - name: download mongo mms agent

--- a/playbooks/roles/rbenv/tasks/main.yml
+++ b/playbooks/roles/rbenv/tasks/main.yml
@@ -25,13 +25,16 @@
 # with a number of changes.
 #
 
-- fail: rbenv_user required for role
+- fail:
+    msg: "rbenv_user required for role"
   when: rbenv_user is not defined
 
-- fail: rbenv_dir required for role
+- fail:
+    msg: "rbenv_dir required for role"
   when: rbenv_dir is not defined
 
-- fail: rbenv_ruby_version required for role
+- fail:
+    msg: "rbenv_ruby_version required for role"
   when: rbenv_ruby_version is not defined
 
 - name: create rbenv user {{ rbenv_user }}


### PR DESCRIPTION
There are still a lot of warnings that need to be fixed but these
were the only failures.

@edx/devops this is a small change that we should merge so that when we get to 2.0 this isn't broken.

Pulling this out of the more controversial PR https://github.com/edx/configuration/pull/3108
