### PR TITLE
update ansible-role templates to use correct variable

### DIFF
--- a/playbooks/roles/ansible-role/templates/defaults/main.yml.j2
+++ b/playbooks/roles/ansible-role/templates/defaults/main.yml.j2
@@ -1,18 +1,18 @@
 ---
 {% include 'roles/ansible-role/templates/header.j2' %}
 #
-# Defaults for role {{ role_name }}
+# Defaults for role {{ my_role_name }}
 # 
 
 #
 # vars are namespaced with the module name.
 #
-{{ role_name }}_role_name: {{ role_name }}
+{{ my_role_name }}_role_name: {{ my_role_name }}
 
 #
 # OS packages
 #
 
-{{ role_name }}_debian_pkgs: []
+{{ my_role_name }}_debian_pkgs: []
 
-{{ role_name }}_redhat_pkgs: []
+{{ my_role_name }}_redhat_pkgs: []

--- a/playbooks/roles/ansible-role/templates/meta/main.yml.j2
+++ b/playbooks/roles/ansible-role/templates/meta/main.yml.j2
@@ -1,7 +1,7 @@
 ---
 {% include 'roles/ansible-role/templates/header.j2' %}
 #
-# Role includes for role {{ role_name }}
+# Role includes for role {{ my_role_name }}
 # 
 # Example:
 #

--- a/playbooks/roles/ansible-role/templates/tasks/main.yml.j2
+++ b/playbooks/roles/ansible-role/templates/tasks/main.yml.j2
@@ -2,7 +2,7 @@
 {% include 'roles/ansible-role/templates/header.j2' %}
 
 #
-# Tasks for role {{ role_name }}
+# Tasks for role {{ my_role_name }}
 # 
 # Overview:
 # 


### PR DESCRIPTION
It looks like the tasks for the `ansible-role` role were updated to use the variable `my_role_name` in: https://github.com/edx/configuration/commit/49dac787dcbac0aa7454085927bb4d8200f31025

but the templates for the same role weren't updated. 
