### PR TITLE
Sigh

### DIFF
--- a/playbooks/roles/splunkforwarder/tasks/main.yml
+++ b/playbooks/roles/splunkforwarder/tasks/main.yml
@@ -104,7 +104,7 @@
     dest: "/opt/splunkforwarder/etc/system/local/{{ item }}.conf"
     owner: splunk
     group: splunk
-    mode: 644
+    mode: "0644"
   with_items:
     - inputs
     - outputs


### PR DESCRIPTION
@jibsheet @douglashall @mattdrayer @arbabnazar @fredsmith 

Working theory here is that converting a task to use with_items caused the modes to be interpolated in a strange way.  Note that @arbabnazar 's PR did not change how we were expressing the mode, but dryed out the tasks file by using with_items.

On the server the mode is clearly not correct

```
sudo stat -c "%a %n" /opt/splunkforwarder/etc/system/local/inputs.conf 
1204 /opt/splunkforwarder/etc/system/local/inputs.conf
```

With my change:

```
sudo stat -c "%a %n" /opt/splunkforwarder/etc/system/local/inputs.conf
644 /opt/splunkforwarder/etc/system/local/inputs.conf
```
