### PR TITLE
Added unsuable_password option to manage_edxapp_users_and_groups.yml

### DIFF
--- a/playbooks/edx-east/manage_edxapp_users_and_groups.yml
+++ b/playbooks/edx-east/manage_edxapp_users_and_groups.yml
@@ -19,6 +19,7 @@
 #   - superuser (optional, bool)
 #   - staff (optional, bool)
 #   - remove (optional, bool): ensures the user does not exist
+#   - unusable_password (optional, bool): ensures the password is unusable
 #
 # Groups can have the following properties:
 #   - name (required, str)
@@ -41,6 +42,13 @@
 #   - username: smitty
 #     email: smitty@werbenmanjens.en
 #     groups: [group1]
+#
+#   - username: frank
+#     email: frank@bigcorp.com
+#     staff: false
+#     superuser: false
+#     unusable_password: true
+#     groups: []
 #
 # groups:
 #   - name: group3
@@ -82,4 +90,5 @@
         {% if item.get('remove') %}--remove{% endif %}
         {% if item.get('superuser') %}--superuser{% endif %}
         {% if item.get('staff') %}--staff{% endif %}
+        {% if item.get('unusable_password') %}--unusable-password{% endif %}
       with_items: django_users


### PR DESCRIPTION
This PR is necessary to reflect changes in https://github.com/edx/edx-platform/pull/12804 that will allow for an unusable password to be set for a user. @edx/devops when the next release is completed is it safe to assume that those changes will be pushed to prod? This option shouldn't be used until the changes are live.
