### PR TITLE
analyticstack enable yarn log retention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+- Role: hadoop_common
+  - Enable log retention by default to assist with debugging. Now YARN will retain stdout and stderr logs produced by map reduce tasks for 24 hours. They can be retrieved by running "yarn logs -applicationId YOUR_APPLICATION_ID".
+
 - Role: rabbitmq
   - Removed the RABBITMQ_CLUSTERED var and related tooling. The goal of the var was to be able to setup a cluster in the aws environment without having to know all the IPs of the cluster before hand.  It relied on the `hostvars` ansible varible to work correctly which it no longer does in 1.9.  This may get fixed in the future but for now, the "magic" setup doesn't work.
   - Changed `rabbitmq_clustered_hosts` to RABBITMQ_CLUSTERED_HOSTS.

--- a/playbooks/roles/hadoop_common/defaults/main.yml
+++ b/playbooks/roles/hadoop_common/defaults/main.yml
@@ -79,4 +79,8 @@ hadoop_common_redhat_pkgs: []
 #   yarn.nodemanager.vmem-pmem-ratio: 2.1
 
 mapred_site_config: {}
-yarn_site_config: {}
+yarn_site_config:
+  yarn.log-aggregation-enable: true
+  # 24 hour log retention
+  yarn.log-aggregation.retain-seconds: 86400
+


### PR DESCRIPTION
Description:

When running Hadoop jobs on the analytics devstack (and single-instance install), YARN does not retain the raw logs produced by the python processes that are actually running the map and reduce function in the yarn containers. This makes debugging very difficult since you cannot see the stack traces produced by your code.

Solution:

By enabling yarn log aggregation, you can run `yarn logs -applicationId <your application ID>` after the job completes and it will dump all of the logs to stdout. This allows you to grep through the logs to find the relevant errors. See [the hortonworks guide](http://hortonworks.com/blog/simplifying-user-logs-management-and-access-in-yarn/) for more information.

Reviewers:
- [x] @feanil 
- [x] @brianhw 

FYI:
- [ ] @renevatium - since I suspect you are overriding this in your setup
- [ ] @sanfordstudent 
- [ ] @HassanJaveed84 
