### PR TITLE
configure worker settings via worker_django_settings_module

### DIFF
--- a/playbooks/roles/edxapp/templates/workers.conf.j2
+++ b/playbooks/roles/edxapp/templates/workers.conf.j2
@@ -1,13 +1,13 @@
 {% for w in edxapp_workers %}
 [program:{{ w.service_variant }}_{{ w.queue }}_{{ w.concurrency }}]
 
-environment={% if COMMON_ENABLE_NEWRELIC_APP %}NEW_RELIC_APP_NAME={{ EDXAPP_NEWRELIC_WORKERS_APPNAME }},NEW_RELIC_LICENSE_KEY={{ NEWRELIC_LICENSE_KEY }},{% endif -%}CONCURRENCY={{ w.concurrency }},LOGLEVEL=info,DJANGO_SETTINGS_MODULE=aws,PYTHONPATH={{ edxapp_code_dir }},SERVICE_VARIANT={{ w.service_variant }}
+environment={% if COMMON_ENABLE_NEWRELIC_APP %}NEW_RELIC_APP_NAME={{ EDXAPP_NEWRELIC_WORKERS_APPNAME }},NEW_RELIC_LICENSE_KEY={{ NEWRELIC_LICENSE_KEY }},{% endif -%}CONCURRENCY={{ w.concurrency }},LOGLEVEL=info,DJANGO_SETTINGS_MODULE={{ worker_django_settings_module }},PYTHONPATH={{ edxapp_code_dir }},SERVICE_VARIANT={{ w.service_variant }}
 user={{ common_web_user }}
 directory={{ edxapp_code_dir }}
 stdout_logfile={{ supervisor_log_dir }}/%(program_name)s-stdout.log
 stderr_logfile={{ supervisor_log_dir }}/%(program_name)s-stderr.log
 
-command={{ edxapp_venv_dir + '/bin/newrelic-admin run-program ' if w.monitor and COMMON_ENABLE_NEWRELIC_APP else ''}}{{ edxapp_venv_bin }}/python {{ edxapp_code_dir }}/manage.py {{ w.service_variant }} --settings=aws celery worker --loglevel=info --queues=edx.{{ w.service_variant }}.core.{{ w.queue }} --hostname=edx.{{ w.service_variant }}.core.{{ w.queue }}.%%h --concurrency={{ w.concurrency }} {{ '--maxtasksperchild ' + w.max_tasks_per_child|string if w.max_tasks_per_child is defined else '' }}
+command={{ edxapp_venv_dir + '/bin/newrelic-admin run-program ' if w.monitor and COMMON_ENABLE_NEWRELIC_APP else ''}}{{ edxapp_venv_bin }}/python {{ edxapp_code_dir }}/manage.py {{ w.service_variant }} --settings={{ worker_django_settings_module }} celery worker --loglevel=info --queues=edx.{{ w.service_variant }}.core.{{ w.queue }} --hostname=edx.{{ w.service_variant }}.core.{{ w.queue }}.%%h --concurrency={{ w.concurrency }} {{ '--maxtasksperchild ' + w.max_tasks_per_child|string if w.max_tasks_per_child is defined else '' }}
 killasgroup=true
 stopasgroup=true
 stopwaitsecs={{ w.stopwaitsecs | default(EDXAPP_WORKER_DEFAULT_STOPWAITSECS) }}


### PR DESCRIPTION
We run a custom Django settings module in production. We can easily set this for the LMS and Studio via these two Ansible vars:

https://github.com/edx/configuration/blob/e9ad371e3c618893abd5e646fe83aa544861d071/playbooks/roles/edxapp/defaults/main.yml#L89-L90

which create the correct Supervisor conf scripts:
- https://github.com/edx/configuration/blob/e9ad371e3c618893abd5e646fe83aa544861d071/playbooks/roles/edxapp/templates/lms.conf.j2#L13
- https://github.com/edx/configuration/blob/e9ad371e3c618893abd5e646fe83aa544861d071/playbooks/roles/edxapp/templates/cms.conf.j2#L13

but there's no equivalant for the Celery worker processes because `--settings=aws` is hardcoded in the Supervisor conf template:
- https://github.com/edx/configuration/blob/e9ad371e3c618893abd5e646fe83aa544861d071/playbooks/roles/edxapp/templates/workers.conf.j2#L4
- https://github.com/edx/configuration/blob/e9ad371e3c618893abd5e646fe83aa544861d071/playbooks/roles/edxapp/templates/workers.conf.j2#L10

There's an unused variable in `roles/edxapp/defaults/main.yml` named `worker_django_settings_module`. By its name, I'm guessing that variable was meant to fit the bill. Does all of this sound reasonable? 
