### PR TITLE
fix the Failed to set permissions on the temporary files in Ansible

### DIFF
--- a/playbooks/roles/common_vars/defaults/main.yml
+++ b/playbooks/roles/common_vars/defaults/main.yml
@@ -102,8 +102,10 @@ common_redhat_pkgs:
   - rsyslog
   - git
   - unzip
+  - acl
 common_debian_pkgs:
   - ntp
+  - acl
   - lynx-cur
   - logrotate
   - rsyslog


### PR DESCRIPTION
@edx/devops kindly review. Thanks

getting this error while setting permission on the tmp file:

`fatal: [x.x.x.x]: FAILED! => {"failed": true, "msg": "Failed to set permissions on the temporary files Ansible needs to create when becoming an unprivileged user. For information on working around this, see https://docs.ansible.com/ansible/become.html#becoming-an-unprivileged-user"}`

I was testing the roles with Ansible 2.1, after installing the `acl` package everything work and behind the scenes this package make sure those temporary files are handled securely and silently.
