### PR TITLE
OPS-1601 As an operator, I want my Ansible callback plugins upgraded

### DIFF
--- a/playbooks/callback_plugins/datadog_tasks_timing.py
+++ b/playbooks/callback_plugins/datadog_tasks_timing.py
@@ -38,11 +38,6 @@ class CallbackModule(object):
     def clean_tag_value(self, value):
         return value.replace(" | ", ".").replace(" ", "-").lower()
 
-    def playbook_on_play_start(self, pattern):
-            self.playbook_name, _ = os.path.splitext(
-                os.path.basename(self.play.playbook.filename)
-            )
-
     def playbook_on_task_start(self, name, is_conditional):
         """
         Logs the start of each task


### PR DESCRIPTION
@edx/devops Kindly review. Thanks

By remove `playbook_on_play_start`, it will work for both Ansible 1.9 and 2.x, once we'll migrate to Ansible 2.x, we'll modify it further using Ansible 2.x API.
