### PR TITLE
fix error - found a duplicate dict key (when).  Using last defined value only

### DIFF
--- a/playbooks/roles/aws/tasks/main.yml
+++ b/playbooks/roles/aws/tasks/main.yml
@@ -153,13 +153,11 @@
     name: ssh
     state: restarted
   become: True
-  when: sshd_config.changed
-  when: ansible_distribution in common_debian_variants
+  when: sshd_config.changed and ansible_distribution in common_debian_variants
 
 - name: Restart ssh
   service:
     name: sshd
     state: restarted
   become: True
-  when: sshd_config.changed
-  when: ansible_distribution in common_redhat_variants
+  when: sshd_config.changed and ansible_distribution in common_redhat_variants


### PR DESCRIPTION
@edx/devops kindly review. Thanks

Fix those error with this change in Ansible 2.x:

```
[WARNING]: While constructing a mapping from git-repos/edx/configuration/playbooks/roles/aws/tasks/main.yml,
line 151, column 3, found a duplicate dict key (when).  Using last defined value only.

 [WARNING]: While constructing a mapping from git-repos/edx/configuration/playbooks/roles/aws/tasks/main.yml,
line 159, column 3, found a duplicate dict key (when).  Using last defined value only.
```
