### PR TITLE
14.04 doesn't install httplib2 by default (12.04 does)

### DIFF
--- a/util/vpc-tools/abbey.py
+++ b/util/vpc-tools/abbey.py
@@ -296,7 +296,7 @@ if [[ ! -x /usr/bin/git || ! -x /usr/bin/pip ]]; then
     /usr/bin/apt-get update
     /usr/bin/apt-get install -y git python-pip python-apt \\
         git-core build-essential python-dev libxml2-dev \\
-        libxslt-dev curl libmysqlclient-dev --force-yes
+        python-httplib2 libxslt-dev curl libmysqlclient-dev --force-yes
 fi
 
 # upgrade setuptools early to avoid no distributin errors


### PR DESCRIPTION
Our user play now uses uri which requires httplib2. 
Fixes https://github.com/edx/configuration/pull/3144
