### PR TITLE
fix the duplicate entry of rabbitmq_refresh

### DIFF
--- a/util/jenkins/ansible-provision.sh
+++ b/util/jenkins/ansible-provision.sh
@@ -318,7 +318,6 @@ instance_tags:
 root_ebs_size: $root_ebs_size
 name_tag: $name_tag
 dns_zone: $dns_zone
-rabbitmq_refresh: True
 elb: $elb
 EOF
 


### PR DESCRIPTION
@edx/devops, kindly review. Thanks

error track:

```
[WARNING]: While constructing a mapping from /var/tmp/extra-vars-18389.yml,
line 1, column 1, found a duplicate dict key (rabbitmq_refresh).  Using last
defined value only.
```

There were two entries in `util/jenkins/ansible-provision.sh`:

```
203:rabbitmq_refresh: True
321:rabbitmq_refresh: True
```
