### PR TITLE
adding httplib2 as a requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,9 @@ awscli==1.10.28
 requests==2.9.1
 datadog==0.8.0
 
+# Needed to fetch github keys when deploying instances
+httplib2==0.9.2
+
 # Needed for the mongo_* modules (playbooks/library/mongo_*)
 pymongo==3.1
 


### PR DESCRIPTION
This is needed to fetch github keys during deployment.
