### PR TITLE
This needs to be installed on the servers not locally.

### DIFF
--- a/playbooks/roles/common_vars/defaults/main.yml
+++ b/playbooks/roles/common_vars/defaults/main.yml
@@ -118,8 +118,6 @@ common_pip_pkgs:
   - setuptools==18.3.2
   - virtualenv==13.1.2
   - virtualenvwrapper==4.7.1
-  # This is needed for the uri module to work correctly.
-  - httplib2==0.9.2
 
 common_web_user: www-data
 common_web_group: www-data

--- a/playbooks/roles/common_vars/defaults/main.yml
+++ b/playbooks/roles/common_vars/defaults/main.yml
@@ -118,6 +118,8 @@ common_pip_pkgs:
   - setuptools==18.3.2
   - virtualenv==13.1.2
   - virtualenvwrapper==4.7.1
+  # This is needed for the uri module to work correctly.
+  - httplib2==0.9.2
 
 common_web_user: www-data
 common_web_group: www-data

--- a/playbooks/roles/user/defaults/main.yml
+++ b/playbooks/roles/user/defaults/main.yml
@@ -35,3 +35,6 @@ user_rbash_links:
 # will take precedence over the paramter
 user_info: []
 
+user_debian_pkgs:
+  # This is needed for the uri module to work correctly.
+  - python-httplib2

--- a/playbooks/roles/user/tasks/main.yml
+++ b/playbooks/roles/user/tasks/main.yml
@@ -70,6 +70,14 @@
 # want to provide more binaries add them to user_rbash_links
 # which can be passed in as a parameter to the role.
 #
+- name: Install debian packages user role needs
+  apt:
+    name: "{{ item }}"
+    instal_recommends: yes
+    state: present
+    update_cache: yes
+  with_items: "{{ user_debian_pkgs }}"
+  when: ansible_distribution in common_debian_variants
 
 - debug: 
     var: user_info

--- a/playbooks/roles/user/tasks/main.yml
+++ b/playbooks/roles/user/tasks/main.yml
@@ -73,7 +73,7 @@
 - name: Install debian packages user role needs
   apt:
     name: "{{ item }}"
-    instal_recommends: yes
+    install_recommends: yes
     state: present
     update_cache: yes
   with_items: "{{ user_debian_pkgs }}"

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,9 +14,6 @@ awscli==1.10.28
 requests==2.9.1
 datadog==0.8.0
 
-# Needed to fetch github keys when deploying instances
-httplib2==0.9.2
-
 # Needed for the mongo_* modules (playbooks/library/mongo_*)
 pymongo==3.1
 


### PR DESCRIPTION
This change is needed because we recently moved from the get_url module to the uri module.

@edx/devops 
