### PR TITLE
This breaks when you add a new person, but a previous person removed a key.

### DIFF
--- a/playbooks/roles/user/tasks/main.yml
+++ b/playbooks/roles/user/tasks/main.yml
@@ -121,7 +121,7 @@
   with_items: "{{ user_info }}"
   register: github_users_return
 
-- fail:
+- debug:
     msg: "User {{ item.item.name }} doesn't have an SSH key associated with their account"
   with_items: "{{ github_users_return.results | default([]) }}"
   # We skip users in the previous task, and they end up with no content_length


### PR DESCRIPTION
Other than removing that user you have no recourse to add the new user.

We need a better warning mechanism for this, but we need to stop
failing.

@edx/devops
