### PR TITLE
Sometimes abbey builds fail waiting on the status checks

### DIFF
--- a/util/vpc-tools/abbey.py
+++ b/util/vpc-tools/abbey.py
@@ -655,7 +655,7 @@ def launch_and_configure(ec2_args):
     system_start = time.time()
     for _ in xrange(EC2_STATUS_TIMEOUT):
         status = ec2.get_all_instance_status(inst.id)
-        if status[0].system_status.status == u'ok':
+        if status and status[0].system_status.status == u'ok':
             system_delta = time.time() - system_start
             run_summary.append(('EC2 Status Checks', system_delta))
             print "[ OK ] {:0>2.0f}:{:0>2.0f}".format(


### PR DESCRIPTION
They fail with

  Waiting for system status:               An error occurred building
  AMI for loadtest edx edxapp.  The Exception was IndexError('list index
  out of range',)

I'm guessing that it is this list index lookup, seems likely.  Hard
to test as it requires AWS slowness.  Normal builds continue unimpeded, but I've seen this particular list index error 3 or 4 times this week, so this seems like an ok guard to add.

@edx/devops 
