### PR TITLE
Go back to the default method of stopping workers

### DIFF
--- a/playbooks/roles/edxapp/templates/workers.conf.j2
+++ b/playbooks/roles/edxapp/templates/workers.conf.j2
@@ -9,9 +9,7 @@ stderr_logfile={{ supervisor_log_dir }}/%(program_name)s-stderr.log
 
 command={{ edxapp_venv_dir + '/bin/newrelic-admin run-program ' if w.monitor and COMMON_ENABLE_NEWRELIC_APP else ''}}{{ edxapp_venv_bin }}/python {{ edxapp_code_dir }}/manage.py {{ w.service_variant }} --settings={{ worker_django_settings_module }} celery worker --loglevel=info --queues=edx.{{ w.service_variant }}.core.{{ w.queue }} --hostname=edx.{{ w.service_variant }}.core.{{ w.queue }}.%%h --concurrency={{ w.concurrency }} {{ '--maxtasksperchild ' + w.max_tasks_per_child|string if w.max_tasks_per_child is defined else '' }}
 killasgroup=true
-stopasgroup=true
 stopwaitsecs={{ w.stopwaitsecs | default(EDXAPP_WORKER_DEFAULT_STOPWAITSECS) }}
-stopsignal=INT
 
 {% endfor %}
 


### PR DESCRIPTION
We had a persistent problem of workers getting stuck when trying to stop
during 12.04 native installation.  This fixes the problem, while still
allowing active tasks to complete.

This reverts pull request #2133, and removes the stopasgroup setting that
was causing the trouble.
