### PR TITLE
Fix default edx-themes user on edxapp role

### DIFF
--- a/playbooks/roles/edxapp/meta/main.yml
+++ b/playbooks/roles/edxapp/meta/main.yml
@@ -12,8 +12,8 @@ dependencies:
         authorized_keys: "{{ EDXAPP_AUTOMATOR_AUTHORIZED_KEYS }}"
     when: EDXAPP_AUTOMATOR_AUTHORIZED_KEYS|length != 0
   - role: edx_themes
-    theme_users:
-      - "{{ edxapp_user }}"
+    themes_user: "{{ edxapp_user }}"
+    themes_group: "{{ common_web_group }}"
     additional_theme_dirs:
       - "{{ EDXAPP_COMPREHENSIVE_THEME_DIRS }}"
     when: "{{ EDXAPP_ENABLE_COMPREHENSIVE_THEMING }}"


### PR DESCRIPTION
This fixes a problem with the default "themes_user" in
edxapp/meta/main.yml. The bug's main symptom would be failure to git
clone a theme configured via THEMES_REPOS.
