### PR TITLE
Specify a socket timeout for pymongo and lower the connect timeout.

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -681,6 +681,11 @@ edxapp_generic_doc_store_config: &edxapp_generic_default_docstore
   user: "{{ EDXAPP_MONGO_USER }}"
   collection:  'modulestore'
   ssl: "{{ EDXAPP_MONGO_USE_SSL }}"
+  # https://api.mongodb.com/python/2.9.1/api/pymongo/mongo_client.html#module-pymongo.mongo_client
+  socketTimeoutMS: 3000 # default is never timeout while the connection is open, this means it needs to explicitly close raising pymongo.errors.NetworkTimeout
+  connectTimeoutMS: 2000 # default is 20000, I believe raises pymongo.errors.ConnectionFailure
+  # Not setting waitQueueTimeoutMS and waitQueueMultiple since pymongo defaults to nobody being allowed to wait
+  
 
 EDXAPP_LMS_DRAFT_DOC_STORE_CONFIG:
   <<: *edxapp_generic_default_docstore


### PR DESCRIPTION
Based on the work in https://openedx.atlassian.net/browse/PLAT-1014

@ormsbee Do you buy my argument in the comments, you get 3 seconds for a query to complete, 2 seconds to connect?  We don't get many slow queries from the modulestore, and most of them are from the read replica.  This 3 second timeout is mongo-is-silent from me reading the doc, so even if it takes time to stream us a 5mb document, we should be fine as long as querying the document and BSONing it doesn't take 3 seconds.

Willing to go lower, but wanted to find somewhere to start.

@doctoryes FYI since this would cause us to throw a new exception pymongo.errors.NetworkTimeout which we may want to handle explicitly in the platform, we don't seem to do so right now.
