### PR TITLE
use search_regex and shorter delay

### DIFF
--- a/playbooks/roles/launch_ec2/tasks/main.yml
+++ b/playbooks/roles/launch_ec2/tasks/main.yml
@@ -91,8 +91,7 @@
   local_action:
     module: wait_for
     host: "{{ item.public_dns_name }}"
-    state: started
+    search_regex: OpenSSH
     port: 22
-    delay: 60
-    timeout: 320
+    delay: 10
   with_items: ec2.instances


### PR DESCRIPTION
@edx/devops kindly review. Thanks

Without this change:

```
ansible.callback_plugins.datadog_tasks_timing:launch_ec2 | Wait for SSH to come up ---------- 89.17s
```

With this change:

```
ansible.callback_plugins.datadog_tasks_timing:launch_ec2 | Wait for SSH to come up---------- 68.96s
```
