### PR TITLE
hide the log for ssl key

### DIFF
--- a/playbooks/roles/nginx/tasks/main.yml
+++ b/playbooks/roles/nginx/tasks/main.yml
@@ -276,6 +276,7 @@
     group: root
     mode: 0640
   when: ssl_key.stat.exists and NGINX_ENABLE_SSL and NGINX_SSL_KEY != 'ssl-cert-snakeoil.key'
+  no_log: True
   tags:
     - install
     - install:configuration


### PR DESCRIPTION
@edx/devops kindly review. Thanks

The idea is to hide the ssl private key to be print on the jenkins console output.
