### PR TITLE
Use logrotate to clean up from the log-queue-lenghts (sic) job

### DIFF
--- a/docker/build/rabbitmq/Dockerfile
+++ b/docker/build/rabbitmq/Dockerfile
@@ -1,0 +1,14 @@
+FROM edxops/precise-common:latest
+MAINTAINER edxops
+
+USER root
+ADD . /edx/app/edx_ansible/edx_ansible
+WORKDIR /edx/app/edx_ansible/edx_ansible/docker/plays
+
+# Role is currently untagged
+RUN /edx/app/edx_ansible/venvs/edx_ansible/bin/ansible-playbook rabbitmq.yml -c local \
+   -i '127.0.0.1,'
+
+USER rabbitmq
+# TBD what we want to run rabbit under
+EXPOSE 15672 5672

--- a/docker/plays/rabbitmq.yml
+++ b/docker/plays/rabbitmq.yml
@@ -1,0 +1,11 @@
+- name: Deploy rabbitmq
+  hosts: all
+  sudo: True
+  gather_facts: True
+  vars:
+    serial_count: 1
+  serial: "{{ serial_count }}"
+  roles:
+    - common_vars
+    - docker
+    - rabbitmq

--- a/playbooks/roles/rabbitmq/tasks/main.yml
+++ b/playbooks/roles/rabbitmq/tasks/main.yml
@@ -54,6 +54,15 @@
     name: "log-queue-lenghts"
     job: "{{ rabbitmq_app_dir }}/log-rabbitmq-queues.sh >/dev/null 2>&1"
 
+- name: install logrotate configuration
+  template:
+    src: etc/logrotate.d/rabbitmq.j2
+    dest: /etc/logrotate.d/rabbitmq
+  tags:
+    - "install"
+    - "install:configuration"
+    - "logrotate"
+
 # Defaulting to /var/lib/rabbitmq
 - name: create cookie directory
   file: >

--- a/playbooks/roles/rabbitmq/templates/etc/logrotate.d/rabbitmq.j2
+++ b/playbooks/roles/rabbitmq/templates/etc/logrotate.d/rabbitmq.j2
@@ -1,0 +1,10 @@
+# We want to hit the top level queues and any vhost queues
+# such as notifier and fulfillment
+{{ rabbitmq_log_dir }}/*.log {{ rabbitmq_log_dir }}/*/*.log {
+  compress
+  dateext
+  dateformat -%Y%m%d-%s
+  missingok
+  daily
+  rotate 3
+}


### PR DESCRIPTION
Right now these files never go away, and some are a million lines long.
This means splunk eats all the disk IO if we ever restart.
