### PR TITLE
Update shell prompt to show database name

### DIFF
--- a/playbooks/roles/ad_hoc_reporting/templates/etc/mongorc.js.j2
+++ b/playbooks/roles/ad_hoc_reporting/templates/etc/mongorc.js.j2
@@ -1,2 +1,7 @@
 // we only ever connect to secondaries, avoid people needing to remember to type this
 rs.slaveOk();
+
+// This uses the DB name rather than the replica set, which I think is more useful
+var prompt = function() {
+    return db.getName() + "> ";
+}


### PR DESCRIPTION
We use the same replica set for forums and edxapp, so showing that is
confusing.  Instead, show the DB.

@edx/devops
