### PR TITLE
Add LMS_ROOT_URL to django settings.

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -819,6 +819,7 @@ generic_env_config:  &edxapp_generic_env
   STATIC_ROOT_BASE: "{{ edxapp_staticfile_dir }}"
   LMS_BASE: "{{ EDXAPP_LMS_BASE }}"
   CMS_BASE: "{{ EDXAPP_CMS_BASE }}"
+  LMS_ROOT_URL: "{{ EDXAPP_LMS_ROOT_URL }}"
   BOOK_URL:  "{{ EDXAPP_BOOK_URL }}"
   PARTNER_SUPPORT_EMAIL: "{{ EDXAPP_PARTNER_SUPPORT_EMAIL }}"
   PLATFORM_NAME: "{{ EDXAPP_PLATFORM_NAME }}"


### PR DESCRIPTION
## Description

LMS_BASE hides information about the URL protocol that then gets reconstructed with unfortunate assumptions throughout the CMS.  We should instead surface an LMS_ROOT_URL setting that explicitly communicates the URL scheme.

For instance:

```
 LMS_BASE = 'courses.edx.org'
```

should be accompanied by an LMS_ROOT_URL like:

```
 LMS_BASE = 'courses.edx.org'
 LMS_ROOT_URL = 'https://courses.edx.org'
```

Adding the setting to ENV_TOKENS here will allow us to surface that information in the CMS and LMS settings.
## Reviewers
- [x] @feanil 
- [x] @nasthagiri

FYI: @wajeeha-khalid 
## Related to

[MA-2536: Server - Retrieve the URL for the course about page](https://openedx.atlassian.net/browse/MA-2536)
