### PR TITLE
ECOM-4904 fix the broken configuration book where nodeenv was not deleted cleanly

### DIFF
--- a/playbooks/roles/programs/defaults/main.yml
+++ b/playbooks/roles/programs/defaults/main.yml
@@ -169,7 +169,7 @@ programs_code_dir: "{{ programs_home }}/{{ programs_service_name }}"
 programs_environment:
   DJANGO_SETTINGS_MODULE: "{{ PROGRAMS_DJANGO_SETTINGS_MODULE }}"
   PROGRAMS_CFG: "{{ COMMON_CFG_DIR }}/{{ programs_service_name }}.yml"
-  PATH: "{{ programs_nodeenv_bin }}:{{ programs_venv_dir }}/bin:{{ ansible_env.PATH }}"
+  PATH: "{{ programs_venv_dir }}/bin:{{ ansible_env.PATH }}"
 
 programs_gunicorn_host: "127.0.0.1"
 programs_gunicorn_port: 8140


### PR DESCRIPTION
@rlucioni @nedbat Please review this bug fix.
