### PR TITLE
Prevent programs tasks from attempting asset compression

### DIFF
--- a/playbooks/roles/programs/tasks/main.yml
+++ b/playbooks/roles/programs/tasks/main.yml
@@ -46,16 +46,12 @@
   environment: "{{ programs_environment }}"
   when: migrate_db is defined and migrate_db|lower == "yes"
 
-
 - name: run collectstatic
   shell: >
     chdir={{ programs_code_dir }}
-    {{ programs_venv_dir }}/bin/python manage.py {{ item }}
+    {{ programs_venv_dir }}/bin/python manage.py collectstatic --noinput
   become_user: "{{ programs_user }}"
   environment: "{{ programs_environment }}"
-  with_items:
-    - "collectstatic --noinput"
-    - "compress"
   when: not devstack
 
 # NOTE this isn't used or needed when s3 is used for PROGRAMS_MEDIA_STORAGE_BACKEND


### PR DESCRIPTION
There are no longer any templates in programs, let alone any with 'compress' tags in them. This should resolve ongoing failures observed at http://jenkins.edx.org:8080/job/ansible-provision-continuous-integration/30006/console.

@jibsheet @schenedx @mikedikan 
