### PR TITLE
Sailthru support ecommerce_worker default values

### DIFF
--- a/playbooks/roles/ecomworker/defaults/main.yml
+++ b/playbooks/roles/ecomworker/defaults/main.yml
@@ -52,6 +52,47 @@ ECOMMERCE_WORKER_WORKER_ACCESS_TOKEN: 'your-secret-here'
 ECOMMERCE_WORKER_MAX_FULFILLMENT_RETRIES: 11
 # END ORDER FULFILLMENT
 
+# SAILTHRU INTEGRATION
+# Set to false to ignore Sailthru events
+#  Sailthru support in ecommerce_worker sends purchase/enroll events to the email
+#  marketing system Sailthru for tracking the efficacy of email marketing campaigns.  It does not
+#  have to be enabled for normal ecommerce operation.  If it is enabled, the waffle switch
+#  sailthru_enable should be set to on in ecommerce as well or ecommerce won't send
+#  purchase/enroll events to ecommerce_worker.
+ECOMMERCE_WORKER_SAILTHRU_ENABLE: false
+
+# Template used when user upgrades to verified
+ECOMMERCE_WORKER_SAILTHRU_UPGRADE_TEMPLATE: !!null
+
+# Template used with user purchases a course
+ECOMMERCE_WORKER_SAILTHRU_PURCHASE_TEMPLATE: !!null
+
+# Template used with user enrolls in a free course
+ECOMMERCE_WORKER_SAILTHRU_ENROLL_TEMPLATE: !!null
+
+# Abandoned cart template
+ECOMMERCE_WORKER_SAILTHRU_ABANDONED_CART_TEMPLATE: !!null
+
+# minutes to delay before abandoned cart message
+ECOMMERCE_WORKER_SAILTHRU_ABANDONED_CART_DELAY: 60
+
+# Sailthru key and secret required for integration
+#  Note: stage keys/secret should be taken from Sailthru Edx Dev account, prod should be from edX.org
+ECOMMERCE_WORKER_SAILTHRU_KEY: 'sailthru key here'
+ECOMMERCE_WORKER_SAILTHRU_SECRET: 'sailthru secret here'
+
+# Retry settings for Sailthru celery tasks
+ECOMMERCE_WORKER_SAILTHRU_RETRY_SECONDS: 3600
+ECOMMERCE_WORKER_SAILTHRU_RETRY_ATTEMPTS: 6
+
+# ttl for cached course content from Sailthru (in seconds)
+ECOMMERCE_WORKER_SAILTHRU_CACHE_TTL_SECONDS: 3600
+
+# dummy price for audit/honor (i.e., if cost = 0)
+#  Note: setting this value to 0 skips Sailthru calls for free transactions
+ECOMMERCE_WORKER_SAILTHRU_MINIMUM_COST: 100
+# END SAILTHRU INTEGRATION
+
 # Ecommerce Worker settings
 ECOMMERCE_WORKER_JWT_SECRET_KEY: 'insecure-secret-key'
 ECOMMERCE_WORKER_JWT_ISSUER: 'ecommerce_worker'
@@ -63,6 +104,19 @@ ECOMMERCE_WORKER_SERVICE_CONFIG:
   JWT_SECRET_KEY: '{{ ECOMMERCE_WORKER_JWT_SECRET_KEY }}'
   JWT_ISSUER: '{{ ECOMMERCE_WORKER_JWT_ISSUER }}'
   MAX_FULFILLMENT_RETRIES: '{{ ECOMMERCE_WORKER_MAX_FULFILLMENT_RETRIES }}'
+  SAILTHRU:
+    SAILTHRU_ENABLE: '{{ ECOMMERCE_WORKER_SAILTHRU_ENABLE }}'
+    SAILTHRU_UPGRADE_TEMPLATE: '{{ ECOMMERCE_WORKER_SAILTHRU_UPGRADE_TEMPLATE }}'
+    SAILTHRU_PURCHASE_TEMPLATE: '{{ ECOMMERCE_WORKER_SAILTHRU_PURCHASE_TEMPLATE }}'
+    SAILTHRU_ENROLL_TEMPLATE: '{{ ECOMMERCE_WORKER_SAILTHRU_ENROLL_TEMPLATE }}'
+    SAILTHRU_ABANDONED_CART_TEMPLATE: '{{ ECOMMERCE_WORKER_SAILTHRU_ABANDONED_CART_TEMPLATE }}'
+    SAILTHRU_ABANDONED_CART_DELAY: '{{ ECOMMERCE_WORKER_SAILTHRU_ABANDONED_CART_DELAY }}'
+    SAILTHRU_KEY: '{{ ECOMMERCE_WORKER_SAILTHRU_KEY }}'
+    SAILTHRU_SECRET: '{{ ECOMMERCE_WORKER_SAILTHRU_SECRET }}'
+    SAILTHRU_RETRY_SECONDS: '{{ ECOMMERCE_WORKER_SAILTHRU_RETRY_SECONDS }}'
+    SAILTHRU_RETRY_ATTEMPTS: '{{ ECOMMERCE_WORKER_SAILTHRU_RETRY_ATTEMPTS }}'
+    SAILTHRU_CACHE_TTL_SECONDS: '{{ ECOMMERCE_WORKER_SAILTHRU_CACHE_TTL_SECONDS }}'
+    SAILTHRU_MINIMUM_COST: '{{ ECOMMERCE_WORKER_SAILTHRU_MINIMUM_COST }}'
 
   # Site-specific configuration overrides.  Implemented as a dict of dicts with 'site_code' for keys.
   # Ecommerce worker will apply these settings instead of their corresponding default values.


### PR DESCRIPTION
ecommerce_worker default values for Sailthru support.  PR https://github.com/edx/configuration/pull/3275 also required to add queue to celery startup
