### PR TITLE
Removed broken/unnecessary call to make target

### DIFF
--- a/playbooks/roles/discovery/tasks/main.yml
+++ b/playbooks/roles/discovery/tasks/main.yml
@@ -102,16 +102,6 @@
     - install
     - install:app-requirements
 
-- name: install js requirements
-  command: make requirement.js
-  args:
-    chdir: "{{ discovery_code_dir }}"
-  become_user: "{{ discovery_user }}"
-  environment: "{{ discovery_environment }}"
-  tags:
-    - install
-    - install:app-requirements
-
 - name: migrate database
   command: make migrate
   args:


### PR DESCRIPTION
There is no need to call requirments.js since we are already installing the node/bower dependencies.

ECOM-5129
