### PR TITLE
The apt syntax which handles urls in deb: wasn't added until 2.1

### DIFF
--- a/playbooks/roles/jenkins_master/tasks/main.yml
+++ b/playbooks/roles/jenkins_master/tasks/main.yml
@@ -37,9 +37,13 @@
     owner: "{{ jenkins_user }}"
     group: "{{ jenkins_group }}"
 
-- name: Install Jenkins package from the internet
+# TODO in Ansible 2.1 we can do apt: deb="{{ jenkins_deb_url }}"
+- name: download Jenkins package
+  get_url: url="{{ jenkins_deb_url }}" dest="/tmp/{{ jenkins_deb }}"
+
+- name: install Jenkins package
   apt:
-    deb: "{{ jenkins_deb_url }}"
+    deb: "/tmp/{{ jenkins_deb }}"
 
 - name: Stop Jenkins
   service:


### PR DESCRIPTION
This reverts and then cleans up a bit the jenkins_master role to run on 1.9

@edx/devops
