### PR TITLE
Ecommerce and Programs need to play along with OPENEDX_RELEASE

### DIFF
--- a/vagrant/base/devstack/Vagrantfile
+++ b/vagrant/base/devstack/Vagrantfile
@@ -77,6 +77,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         certs_version: ENV['OPENEDX_RELEASE'],
         forum_version: ENV['OPENEDX_RELEASE'],
         xqueue_version: ENV['OPENEDX_RELEASE'],
+        ECOMMERCE_VERSION: ENV['OPENEDX_RELEASE'],
+        PROGRAMS_VERSION: ENV['OPENEDX_RELEASE'],
       }
     end
     if ENV['CONFIGURATION_VERSION']


### PR DESCRIPTION
Eucalyptus devstack won't install without these lines, because ecommerce and programs are unpinned to the release, and so will install master, which won't work with a Eucalyptus configuration repo.
