### PR TITLE
Adds INSIGHTS_LEARNER_API_LIST_DOWNLOAD_FIELDS

### DIFF
--- a/playbooks/roles/insights/defaults/main.yml
+++ b/playbooks/roles/insights/defaults/main.yml
@@ -54,6 +54,11 @@ INSIGHTS_THEME_SCSS: 'sass/themes/open-edx.scss'
 INSIGHTS_RESEARCH_URL: 'https://www.edx.org/research-pedagogy'
 INSIGHTS_OPEN_SOURCE_URL: 'http://set-me-please'
 
+# Comma-delimited list of field names to include in the Learner List CSV download
+# e.g., "username,segments,cohort,engagements.videos_viewed,last_updated"
+# Default (null) includes all available fields, in alphabetical order
+INSIGHTS_LEARNER_API_LIST_DOWNLOAD_FIELDS: !!null
+
 INSIGHTS_DATABASE_NAME: 'dashboard'
 
 INSIGHTS_DATABASES:
@@ -126,6 +131,7 @@ INSIGHTS_CONFIG:
   CSRF_COOKIE_NAME: "{{ INSIGHTS_CSRF_COOKIE_NAME | default('insights_csrftoken') }}"
   LANGUAGE_COOKIE_NAME: "{{ INSIGHTS_LANGUAGE_COOKIE_NAME | default('insights_language') }}"
   CMS_COURSE_SHORTCUT_BASE_URL: "{{ INSIGHTS_CMS_COURSE_SHORTCUT_BASE_URL }}"
+  LEARNER_API_LIST_DOWNLOAD_FIELDS: "{{ INSIGHTS_LEARNER_API_LIST_DOWNLOAD_FIELDS }}"
 
 INSIGHTS_NEWRELIC_APPNAME: "{{ COMMON_ENVIRONMENT }}-{{ COMMON_DEPLOYMENT }}-analytics-api"
 INSIGHTS_PIP_EXTRA_ARGS: "-i {{ COMMON_PYPI_MIRROR_URL }}"


### PR DESCRIPTION
This variable is used by the Learner List view's "Download CSV" button to determine the fields to include in the downloaded report, and their sort order.

The default value shows all fields, in the order they're defined in the Learner Roster Record.

**Discussions**: Part of the Learner Profile reports to be downloadable from Insights.  Architecture discussed extensively with @mulby and the analytics team.

**Dependencies**: Used by [edx-analytics-dashboard PR #533](https://github.com/edx/edx-analytics-dashboard/pull/533)

**Partner information**: 3rd party-hosted open edX instance
1. See [edx-analytics-dashboard PR #533](https://github.com/edx/edx-analytics-dashboard/pull/533) for testing setup instructions.
2. Checkout this PR branch on your vagrant instance under `/edx/app/edx_ansible`
3. Create an extra-vars.yml file containing some overrides for the variables in this PR, and any others you want to preserve, e.g.
   
   ``` yaml
   INSIGHTS_LEARNER_API_LIST_DOWNLOAD_FIELDS: username,name,email,cohort,language,year_of_birth,gender,level_of_education,mailing_address,goals,city,country,first_enrollment_date,last_updated
   
   INSIGHTS_DATA_API_AUTH_TOKEN: token
   ```
4. Re-run the updated `insights` role:
   
   ```
   ssh vagrant
   source /edx/app/edx_ansible/venvs/edx_ansible/bin/activate
   cd /edx/app/edx_ansible/edx_ansible/playbooks
   ansible-playbook -i localhost, -c local run_role.yml -e role=insights --extra-vars=@/path/to/extra-vars.yml
   ```
5. Note changes written to `/edx/etc/insights.yml`.
6. Confirm changes by restarting Insights, and checking the downloaded the Learner List CSV.

**Author Notes & Concerns:**
1. The example field list uses the full list of fields available once [edx-analytics-data-api#129](https://github.com/edx/edx-analytics-data-api/pull/129) is merged.  Until then, only these fields will be returned: `username,name,email,cohort,first_enrollment_date,last_updated`.  However, it will not cause an error.

**Reviewers**
- [x] @bradenmacdonald 
- [x] @feanil 
- [x] @fredsmith
