### PR TITLE
use Open edX in the motd, and delete unneeded variables

### DIFF
--- a/playbooks/roles/common_vars/defaults/main.yml
+++ b/playbooks/roles/common_vars/defaults/main.yml
@@ -68,7 +68,6 @@ COMMON_CUSTOM_DHCLIENT_CONFIG: false
 # uncomment and specifity your domains.
 # COMMON_DHCLIENT_DNS_SEARCH: ["ec2.internal","example.com"]
 
-COMMON_MOTD_TEMPLATE: "motd.tail.j2"
 COMMON_SSH_PASSWORD_AUTH: "no"
 
 COMMON_SECURITY_UPDATES: no

--- a/playbooks/roles/vhost/templates/etc/motd.tail.j2
+++ b/playbooks/roles/vhost/templates/etc/motd.tail.j2
@@ -1,12 +1,18 @@
 *******************************************************************
-*         _ __  __                                                *
-*   _   _| |\ \/ /  This system is for the use of authorized      *
-* / -_) _` | >  <   users only.  Usage of this system may be      *
-* \___\__,_|/_/\_\  monitored and recorded by system personnel.   *
+*     ___                         _ __  __                        *
+*    / _ \ _ __ ___ _ _    ___ __| |\ \/ / (R)                    *
+*   | |_| | '_ \ -_) ' \  / -_) _` | >  <                         *
+*    \___/| .__/___|_|_|  \___\__,_|/_/\_\                        *
+*         |_|                                                     *
+*                                                                 *
+* This system is for the use of authorized users only.  Usage of  *
+* this system may be monitored and recorded by system personnel.  *
 *                                                                 *
 * Anyone using this system expressly consents to such monitoring  *
 * and is advised that if such monitoring reveals possible         *
 * evidence of criminal activity, system personnel may provide the *
 * evidence from such monitoring to law enforcement officials.     *
+*                                                                 *
+* Need help? https://open.edx.org/getting-help                    *
 *                                                                 *
 *******************************************************************

--- a/playbooks/vagrant-analytics.yml
+++ b/playbooks/vagrant-analytics.yml
@@ -8,7 +8,6 @@
     disable_edx_services: true
     mongo_enable_journal: false
     EDXAPP_NO_PREREQ_INSTALL: 0
-    COMMON_MOTD_TEMPLATE: 'devstack_motd.tail.j2'
     COMMON_SSH_PASSWORD_AUTH: "yes"
     EDXAPP_LMS_BASE: 127.0.0.1:8000
     EDXAPP_OAUTH_ENFORCE_SECURE: false

--- a/playbooks/vagrant-devstack.yml
+++ b/playbooks/vagrant-devstack.yml
@@ -8,7 +8,6 @@
     disable_edx_services: true
     mongo_enable_journal: false
     EDXAPP_NO_PREREQ_INSTALL: 0
-    COMMON_MOTD_TEMPLATE: 'devstack_motd.tail.j2'
     COMMON_SSH_PASSWORD_AUTH: "yes"
     EDXAPP_LMS_BASE: 127.0.0.1:8000
     EDXAPP_OAUTH_ENFORCE_SECURE: false

--- a/playbooks/vagrant/vagrant-devstack-delta.yml
+++ b/playbooks/vagrant/vagrant-devstack-delta.yml
@@ -6,7 +6,6 @@
     devstack: true
     disable_edx_services: true
     mongo_enable_journal: false
-    COMMON_MOTD_TEMPLATE: 'devstack_motd.tail.j2'
     COMMON_SSH_PASSWORD_AUTH: "yes"
     EDXAPP_LMS_BASE: 127.0.0.1:8000
     EDXAPP_OAUTH_ENFORCE_SECURE: false

--- a/playbooks/vagrant/vagrant-fullstack-delta.yml
+++ b/playbooks/vagrant/vagrant-fullstack-delta.yml
@@ -5,7 +5,6 @@
   vars:
     disable_edx_services: true
     mongo_enable_journal: false
-    COMMON_MOTD_TEMPLATE: 'devstack_motd.tail.j2'
     COMMON_SSH_PASSWORD_AUTH: "yes"
     EDXAPP_LMS_BASE: 127.0.0.1:8000
     EDXAPP_OAUTH_ENFORCE_SECURE: false


### PR DESCRIPTION
The Open Stack PR from January got rid of different motd for different installations.  We should use "Open edX" as the broadest branding.  And we no longer need the COMMON_MOTD_TEMPLATE variables.
