### PR TITLE
Use force instead of setting fetch.prune

### DIFF
--- a/playbooks/roles/git_clone/tasks/main.yml
+++ b/playbooks/roles/git_clone/tasks/main.yml
@@ -17,17 +17,6 @@
 # require in our default configuration.
 #
 #
-# Rewrite this task using the ansible git-config module once we'll migrate to Ansible 2.x
-# https://docs.ansible.com/ansible/git_config_module.html#git-config
-#
-- name: Set git fetch.prune to ignore deleted remote refs
-  shell: git config --global fetch.prune true
-  become_user: "{{ repo_owner }}"
-  when: GIT_REPOS is defined
-  tags:
-    - install
-    - install:code
-
 - name: Validate git protocol
   fail:
     msg: '{{ GIT_REPOS.PROTOCOL }} must be "https" or "ssh"'
@@ -58,6 +47,7 @@
     version: "{{ item.VERSION }}"
     accept_hostkey: yes
     key_file: "{{ git_home }}/.ssh/{{ item.REPO }}"
+    force: true
   become_user: "{{ repo_owner }}"
   register: code_checkout
   when: item.PROTOCOL == "ssh" and GIT_REPOS is defined
@@ -71,6 +61,7 @@
     repo: "https://{{ item.DOMAIN }}/{{ item.PATH }}/{{ item.REPO }}"
     dest: "{{ item.DESTINATION }}"
     version: "{{ item.VERSION }}"
+    force: true
   become_user: "{{ repo_owner }}"
   register: code_checkout
   when: item.PROTOCOL == "https" and GIT_REPOS is defined


### PR DESCRIPTION
Make sure that the following steps are done before merging
- [ ] @devops team member has commented with :+1:
  - [ ] Add an entry to the CHANGELOG.

We originally started setting fetch.prune because it would cause the git
module to fail if there were refs locally that were not on the remote
(because they got deleted). Based on the Ansible devs' response on
https://github.com/ansible/ansible-modules-core/issues/637,
we can safely replace this task with setting the "force: true" flag
wherever we use the git module.
