### PR TITLE
SOL-2032: Theming broken for "From Scratch" AMI builds

### DIFF
--- a/playbooks/roles/ecommerce/meta/main.yml
+++ b/playbooks/roles/ecommerce/meta/main.yml
@@ -25,8 +25,6 @@ dependencies:
   - role: edx_themes
     theme_users:
       - "{{ ecommerce_user }}"
-    additional_theme_dirs:
-      - "{{ ECOMMERCE_COMPREHENSIVE_THEME_DIRS }}"
     when: "{{ ECOMMERCE_ENABLE_COMPREHENSIVE_THEMING }}"
 
   - oraclejdk

--- a/playbooks/roles/edx_themes/defaults/main.yml
+++ b/playbooks/roles/edx_themes/defaults/main.yml
@@ -13,7 +13,7 @@
 
 themes_service_name: "edx-themes"
 themes_user: "{{ themes_service_name }}"
-themes_group: "{{ themes_user }}"
+themes_group: "www-data"
 themes_home: "{{ COMMON_DATA_DIR }}/{{ themes_service_name }}"
 
 THEMES_CODE_DIR: "{{ themes_home }}/{{ themes_service_name }}"

--- a/playbooks/roles/edx_themes/tasks/main.yml
+++ b/playbooks/roles/edx_themes/tasks/main.yml
@@ -28,8 +28,6 @@
 #     theme_users:
 #       - ecommerce
 #       - edxapp
-#     additional_theme_dirs:
-#      - /edx/app/ecommerce/ecommerce/ecommerce/themes
 #     when do_setup_themes
 #
 
@@ -42,19 +40,6 @@
     owner: "{{ themes_user }}"
     group: "{{ themes_group }}"
     mode: "g+rw"
-  tags:
-    - install
-    - install:base
-
-- name: assign theme's group to all theme's directories
-  file:
-    path: "{{ item }}"
-    state: directory
-    recurse: yes
-    group: "{{ themes_group }}"
-    mode: "g+rw"
-  with_items: additional_theme_dirs
-  when: additional_theme_dirs is defined
   tags:
     - install
     - install:base

--- a/playbooks/roles/edxapp/meta/main.yml
+++ b/playbooks/roles/edxapp/meta/main.yml
@@ -7,6 +7,4 @@ dependencies:
   - role: edx_themes
     theme_users:
       - "{{ edxapp_user }}"
-    additional_theme_dirs:
-      - "{{ EDXAPP_COMPREHENSIVE_THEME_DIRS }}"
     when: "{{ EDXAPP_ENABLE_COMPREHENSIVE_THEMING }}"


### PR DESCRIPTION
## Configuration Pull Request

**Description of the issue:**
There appears to be an issue with the theming framework when constructing edxapp / edx-platform AMI builds in the "from scratch" configuration. 
The log from Ansible is: https://gist.github.com/maxrothman/5f457577517f7d6f12b3c78d2562f1ef
Here's what Max Rothman determined (from the release HipChat room):

> In secure config, EDXAPP_COMPREHENSIVE_THEME_DIRS is set to ["{{ edxapp_code_dir }}/themes", "{{ THEMES_CODE_DIR }}/edx-platform"]
> thus when then "assign theme's group to all theme's directories" task in edx_themes runs, {{ edxapp_code_dir }}/themes is created
> this takes place before the edx_platform role runs because it depends on the edx_themes role
> then when edx_platform attempts to check out the edx_platform repo to {{ edxapp_code_dir }} it fails because that themes dir is already there.

**Problem:**
edx-themes role assigns 'edx-themes' group to all the directories related to theming, if a directory does not exist it is created (default behavior of ansible). 'edx-themes' group is then used grant read/write access to theme's users like edxapp, ecommerce etc. Since, edx_themes is a dependency of edxapp, it runs before edxapp. The Problem is that one theme directory is present inside edx-platform repo and when the task runs it creates that directory. This happens before edxapp role could clone edx-platform repo.

**Solution:**
We can leave the assignment  of 'edx-themes' group to the directory present inside edx-platform repo because edxapp will already have read/write permissions for this directory. That is why we are excluding this directory from `ECOMMERCE_COMPREHENSIVE_THEME_DIRS` before passing to the edx_themes role.

Make sure that the following steps are done before merging
- [x] @devops team member has commented with :+1:
- [ ] are you adding any new default values that need to be overriden when this goes live?  
  - [ ] Open a ticket (DEVOPS) to make sure that they have been added to secure vars.
  - [ ] Add an entry to the CHANGELOG.
