### PR TITLE
Revert "Update devstack base box" 

### DIFF
--- a/vagrant/release/devstack/Vagrantfile
+++ b/vagrant/release/devstack/Vagrantfile
@@ -82,7 +82,7 @@ openedx_releases = {
   # },
 }
 openedx_releases.default = {
-  :name => "devstack-periodic-2016-08-19", :file => "devstack-periodic-2016-08-19.box",
+  :name => "devstack-periodic-2016-05-16", :file => "devstack-periodic-2016-05-16.box",
 }
 rel = ENV['OPENEDX_RELEASE']
 


### PR DESCRIPTION
Revert the ruby upgrade.  The new version has memory issues.
