### PR TITLE
SOL-2037: Make sure ssh private keys are not leaked into the jenkins job logs

### DIFF
--- a/playbooks/roles/git_clone/tasks/main.yml
+++ b/playbooks/roles/git_clone/tasks/main.yml
@@ -24,6 +24,7 @@
   shell: git config --global fetch.prune true
   become_user: "{{ repo_owner }}"
   when: GIT_REPOS is defined
+  no_log: true
   tags:
     - install
     - install:code
@@ -33,6 +34,7 @@
     msg: '{{ GIT_REPOS.PROTOCOL }} must be "https" or "ssh"'
   when: (item.PROTOCOL != "https") and (item.PROTOCOL != "ssh") and GIT_REPOS is defined
   with_items: GIT_REPOS
+  no_log: true
   tags:
     - install
     - install:code
@@ -47,6 +49,7 @@
     mode: "0600"
   when: item.PROTOCOL == "ssh" and GIT_REPOS is defined
   with_items: GIT_REPOS
+  no_log: true
   tags:
     - install
     - install:code
@@ -62,6 +65,7 @@
   register: code_checkout
   when: item.PROTOCOL == "ssh" and GIT_REPOS is defined
   with_items: GIT_REPOS
+  no_log: true
   tags:
     - install
     - install:code
@@ -75,6 +79,7 @@
   register: code_checkout
   when: item.PROTOCOL == "https" and GIT_REPOS is defined
   with_items: GIT_REPOS
+  no_log: true
   tags:
     - install
     - install:code
@@ -85,6 +90,7 @@
     state: absent
   when: item.PROTOCOL == "ssh" and GIT_REPOS is defined
   with_items: GIT_REPOS
+  no_log: true
   tags:
     - install
     - install:code


### PR DESCRIPTION
## Configuration Pull Request

**Description:**
After the merge of sandbox-secure, setting a git ssh key for the themes role, it began leaking an ssh private key into the jenkins job logs. We're going to have to rotate this key now.

@mattdrayer , @jibsheet -- FYI

Make sure that the following steps are done before merging
- [x] @devops team member has commented with :+1:
- [ ] are you adding any new default values that need to be overriden when this goes live?  
  - [ ] Open a ticket (DEVOPS) to make sure that they have been added to secure vars.
  - [ ] Add an entry to the CHANGELOG.
