### PR TITLE
We don't want to use a file, we have an ssh agent

### DIFF
--- a/util/jenkins/ansible-provision.sh
+++ b/util/jenkins/ansible-provision.sh
@@ -160,7 +160,6 @@ ssh-keygen -f "/var/lib/jenkins/.ssh/known_hosts" -R "$deploy_host"
 cd playbooks/edx-east
 
 cat << EOF > $extra_vars_file
-ansible_ssh_private_key_file: /var/lib/jenkins/${keypair}.pem
 edx_platform_version: $edxapp_version
 forum_version: $forum_version
 notifier_version: $notifier_version


### PR DESCRIPTION
Also, this file/path won't exist later on sandboxes which also
source this file when running /edx/bin/update

@feanil 

Built a sandbox plain and from scratch to test
http://jenkins.edx.org:8080/job/ansible-provision/8857/consoleFull
http://jenkins.edx.org:8080/job/ansible-provision/8860/console
