### PR TITLE
Docker workaround for ansible provisioning.

### DIFF
--- a/util/jenkins/ansible-provision.sh
+++ b/util/jenkins/ansible-provision.sh
@@ -22,6 +22,13 @@ env
 export PYTHONUNBUFFERED=1
 export BOTO_CONFIG=/var/lib/jenkins/${aws_account}.boto
 
+# docker on OS-X includes your Mac's home directory in the socket path
+# that SSH/Ansible uses for the control socket, pushing you over
+# the 108 character limit.
+if [ -f /.dockerenv ]; then
+    export ANSIBLE_SSH_CONTROL_PATH=/tmp/%%C
+fi
+
 run_ansible() {
   if [[ "$VERBOSE" == "true" ]]; then
     verbose_arg='-vvv'


### PR DESCRIPTION
Because /var/home_jenkins on our jenkins test containers is mounted from
~/path/to/git/repo/.docker_volumes/jenkins_home you end up with an ssh
socket for ansible which is way past the 108 character unix limit for
filenames of sockets.

@edx/devops
