### PR TITLE
Be more careful about what env we log in ansible-provision

### DIFF
--- a/util/jenkins/ansible-provision.sh
+++ b/util/jenkins/ansible-provision.sh
@@ -18,7 +18,10 @@
 # - environment
 # - name_tag
 set -x
-env
+
+# Seeing the environment is fine, spewing secrets to the log isn't ok
+env | grep -v AWS | grep -v ARN
+
 export PYTHONUNBUFFERED=1
 export BOTO_CONFIG=/var/lib/jenkins/${aws_account}.boto
 


### PR DESCRIPTION
Now that it can use AWS tokens for auth, we need to be careful about
just dumping env into logs (and thus into splunk).

@edx/devops
