### PR TITLE
Fix openstack requirements installation

### DIFF
--- a/playbooks/roles/edxapp/meta/main.yml
+++ b/playbooks/roles/edxapp/meta/main.yml
@@ -8,3 +8,5 @@ dependencies:
     theme_users:
       - "{{ edxapp_user }}"
     when: "{{ EDXAPP_ENABLE_COMPREHENSIVE_THEMING }}"
+  - role: openstack
+    when: "{{ EDXAPP_USE_SWIFT_STORAGE }}"

--- a/playbooks/roles/openstack/tasks/main.yml
+++ b/playbooks/roles/openstack/tasks/main.yml
@@ -50,17 +50,8 @@
     dest: "{{ COMMON_OBJECT_STORE_LOG_SYNC_SCRIPT }}"
   when: COMMON_OBJECT_STORE_LOG_SYNC
 
-# Install openstack python requirements into {{ edxapp_venv_dir }}
-- name : Install python requirements
-  # Need to use command rather than pip so that we can maintain the context of our current working directory;
-  # some requirements are pathed relative to the edx-platform repo.
-  # Using the pip from inside the virtual environment implicitly installs everything into that virtual environment.
-  command: >
-    {{ edxapp_venv_dir }}/bin/pip install {{ COMMON_PIP_VERBOSITY }} -i {{ COMMON_PYPI_MIRROR_URL }} --exists-action w -r {{ openstack_requirements_file }}
-    chdir={{ edxapp_code_dir }}
-  sudo_user: "{{ edxapp_user }}"
-  environment: "{{ edxapp_environment }}"
-  when: edxapp_code_dir is defined
-  tags:
-    - install
-    - install:app-requirements
+# We want to ensure that OpenStack requirements are installed at the same time as edxapp
+# requirements so that they're available during the initial migration.
+- name: make sure Openstack Python requirements get installed
+  set_fact:
+    edxapp_requirements_files: "{{ edxapp_requirements_files + [openstack_requirements_file] }}"


### PR DESCRIPTION
We discovered that due to a timing issue, the previous Swift storage role didn't work properly with Eucalyptus. There was a migration that required storage to be available, whereas the Swift package wasn't installed until later. This configuration change results in the Swift package being installed while other OpenEdX requirements are installed, meaning that storage is immediately available, and all migrations work properly.

**Dependencies**: None

**Sandbox URL**: http://swift-pr-testing.stage.opencraft.hosting/

**Testing instructions**:
1. Using the sandbox, which is provisioned with Swift storage, upload an image to the forums for the demo course. Observe that the image is embedded correctly, with an accurate path, pointing to a Swift storage location, and that viewing the forum once posted shows that image inline.
2. Using the sandbox, enroll in the demo course and answer some questions. Then, log into the admin panel for that course, and observe that CSV analytics files can be downloaded from Swift storage.

**Reviewers**
- [ ] @itsjeyd 
- [ ] edX reviewer[s] TBD
