### PR TITLE
Pin the demo course whenever we install it

### DIFF
--- a/playbooks/vagrant-fullstack.yml
+++ b/playbooks/vagrant-fullstack.yml
@@ -13,6 +13,7 @@
     certs_version: '{{ OPENEDX_RELEASE | default("master") }}'
     forum_version: '{{ OPENEDX_RELEASE | default("master") }}'
     xqueue_version: '{{ OPENEDX_RELEASE | default("master") }}'
+    demo_version: '{{ OPENEDX_RELEASE | default("master") }}'
   roles:
     - common
     - vhost

--- a/util/install/sandbox.sh
+++ b/util/install/sandbox.sh
@@ -49,6 +49,7 @@ if [ -n "$OPENEDX_RELEASE" ]; then
     -e forum_version=$OPENEDX_RELEASE \
     -e xqueue_version=$OPENEDX_RELEASE \
     -e configuration_version=$OPENEDX_RELEASE \
+    -e demo_version=$OPENEDX_RELEASE \
     -e NOTIFIER_VERSION=$OPENEDX_RELEASE \
     -e INSIGHTS_VERSION=$OPENEDX_RELEASE \
     -e ANALYTICS_API_VERSION=$OPENEDX_RELEASE \

--- a/util/jenkins/ansible-provision.sh
+++ b/util/jenkins/ansible-provision.sh
@@ -168,6 +168,7 @@ xqueue_version: $xqueue_version
 xserver_version: $xserver_version
 certs_version: $certs_version
 configuration_version: $configuration_version
+demo_version: $demo_version
 
 edx_ansible_source_repo: ${configuration_source_repo}
 edx_platform_repo: ${edx_platform_repo}

--- a/util/vagrant/upgrade.sh
+++ b/util/vagrant/upgrade.sh
@@ -329,6 +329,7 @@ echo "edx_platform_version: $TARGET" > vars.yml
 echo "certs_version: $TARGET" >> vars.yml
 echo "forum_version: $TARGET" >> vars.yml
 echo "xqueue_version: $TARGET" >> vars.yml
+echo "demo_version: $TARGET" >> vars.yml
 echo "NOTIFIER_VERSION: $TARGET" >> vars.yml
 echo "ECOMMERCE_VERSION: $TARGET" >> vars.yml
 echo "ECOMMERCE_WORKER_VERSION: $TARGET" >> vars.yml

--- a/vagrant/base/analyticstack/Vagrantfile
+++ b/vagrant/base/analyticstack/Vagrantfile
@@ -76,6 +76,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         certs_version: ENV['OPENEDX_RELEASE'],
         forum_version: ENV['OPENEDX_RELEASE'],
         xqueue_version: ENV['OPENEDX_RELEASE'],
+        demo_version: ENV['OPENEDX_RELEASE'],
         ANALYTICS_API_VERSION: ENV['OPENEDX_RELEASE'],
         INSIGHTS_VERSION: ENV['OPENEDX_RELEASE'],
       }

--- a/vagrant/base/devstack/Vagrantfile
+++ b/vagrant/base/devstack/Vagrantfile
@@ -77,6 +77,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         certs_version: ENV['OPENEDX_RELEASE'],
         forum_version: ENV['OPENEDX_RELEASE'],
         xqueue_version: ENV['OPENEDX_RELEASE'],
+        demo_version: ENV['OPENEDX_RELEASE'],
         NOTIFIER_VERSION: ENV['OPENEDX_RELEASE'],
         ECOMMERCE_VERSION: ENV['OPENEDX_RELEASE'],
         ECOMMERCE_WORKER_VERSION: ENV['OPENEDX_RELEASE'],

--- a/vagrant/base/fullstack/Vagrantfile
+++ b/vagrant/base/fullstack/Vagrantfile
@@ -40,6 +40,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         certs_version: ENV['OPENEDX_RELEASE'],
         forum_version: ENV['OPENEDX_RELEASE'],
         xqueue_version: ENV['OPENEDX_RELEASE'],
+        demo_version: ENV['OPENEDX_RELEASE'],
       }
     end
   end

--- a/vagrant/release/analyticstack/Vagrantfile
+++ b/vagrant/release/analyticstack/Vagrantfile
@@ -24,6 +24,7 @@ if [ -n "$OPENEDX_RELEASE" ]; then
     -e certs_version=$OPENEDX_RELEASE \
     -e forum_version=$OPENEDX_RELEASE \
     -e xqueue_version=$OPENEDX_RELEASE \
+    -e demo_version=$OPENEDX_RELEASE \
     -e ANALYTICS_API_VERSION=$OPENEDX_RELEASE \
     -e INSIGHTS_VERSION=$OPENEDX_RELEASE \
   "

--- a/vagrant/release/devstack/Vagrantfile
+++ b/vagrant/release/devstack/Vagrantfile
@@ -24,6 +24,7 @@ if [ -n "$OPENEDX_RELEASE" ]; then
     -e certs_version=$OPENEDX_RELEASE \
     -e forum_version=$OPENEDX_RELEASE \
     -e xqueue_version=$OPENEDX_RELEASE \
+    -e demo_version=$OPENEDX_RELEASE \
     -e NOTIFIER_VERSION=$OPENEDX_RELEASE \
     -e ECOMMERCE_VERSION=$OPENEDX_RELEASE \
     -e ECOMMERCE_WORKER_VERSION=$OPENEDX_RELEASE \


### PR DESCRIPTION
The demo course was unpinned, which caused problems when the base devstack box and the devstack installation straddled a change to the demo course.  We need to make a change to how the demo course creates users so that devstack installs on master will work, but this change will make Eucalyptus work.
