### PR TITLE
Switch to manage_user from create_user

### DIFF
--- a/playbooks/roles/demo/defaults/main.yml
+++ b/playbooks/roles/demo/defaults/main.yml
@@ -18,16 +18,20 @@ demo_code_dir: "{{ demo_app_dir }}/edx-demo-course"
 demo_repo: "https://{{ COMMON_GIT_MIRROR }}/edx/edx-demo-course.git"
 demo_course_id: 'course-v1:edX+DemoX+Demo_Course'
 demo_version: "master"
+demo_hashed_password: 'pbkdf2_sha256$20000$TjE34FJjc3vv$0B7GUmH8RwrOc/BvMoxjb5j8EgnWTt3sxorDANeF7Qw=' # edx
 demo_test_users:
   - email: 'honor@example.com'
+    username: honor
     mode: honor
-    password: edx
+    hashed_password: "{{ demo_hashed_password }}"
   - email: 'audit@example.com'
+    username: audit
     mode: audit
-    password: edx
+    hashed_password: "{{ demo_hashed_password }}"
   - email: 'verified@example.com'
+    username: verified
     mode: verified
-    password: edx
+    hashed_password: "{{ demo_hashed_password }}"
 
 demo_edxapp_user: 'edxapp'
 demo_edxapp_venv_bin: '{{ COMMON_APP_DIR }}/{{ demo_edxapp_user }}/venvs/{{demo_edxapp_user}}/bin'

--- a/playbooks/roles/demo/tasks/deploy.yml
+++ b/playbooks/roles/demo/tasks/deploy.yml
@@ -14,9 +14,9 @@
   become_user: "{{ common_web_user }}"
   when: demo_checkout.changed
 
-- name: create some test users and enroll them in the course
+- name: create some test users
   shell: >
-    {{ demo_edxapp_venv_bin }}/python ./manage.py lms --settings=aws --service-variant lms create_user -e {{ item.email }} -p {{ item.password }} -m {{ item.mode }} -c {{ demo_course_id }}
+    {{ demo_edxapp_venv_bin }}/python ./manage.py lms --settings=aws --service-variant lms manage_user {{ item.username}} {{ item.email }} --initial-password-hash {{ item.hashed_password | quote }}
     chdir={{ demo_edxapp_code_dir }}
   become_user: "{{ common_web_user }}"
   with_items: demo_test_users
@@ -24,12 +24,23 @@
 
 - name: create staff user
   shell: >
-    {{ demo_edxapp_venv_bin }}/python ./manage.py lms --settings=aws --service-variant lms create_user -e staff@example.com -p edx -s -c {{ demo_course_id }}
+    {{ demo_edxapp_venv_bin }}/python ./manage.py lms --settings=aws --service-variant lms manage_user staff staff@example.com --initial-password-hash {{ demo_hashed_password | quote }} --staff
     chdir={{ demo_edxapp_code_dir }}
   become_user: "{{ common_web_user }}"
   when:
     - demo_checkout.changed
     - DEMO_CREATE_STAFF_USER
+
+- name: enroll test users in the demo course
+  shell: >
+    {{ demo_edxapp_venv_bin }}/python ./manage.py lms --settings=aws --service-variant lms enroll_user_in_course -e {{ item.email }} -c {{ demo_course_id }}
+    chdir={{ demo_edxapp_code_dir }}
+  become_user: "{{ common_web_user }}"
+  with_items:
+      - "{{ demo_test_users }}"
+      - { email: 'staff@example.com' }
+  when: demo_checkout.changed
+
 
 - name: add test users to the certificate whitelist
   shell: >


### PR DESCRIPTION
manage_user doesn't try to create a new user, but it doesn't handle
enrollments, so we have to enroll the users in a separate task using
another management command.

Additionally, it takes only password hashes, not passwords, so we have
to provide a pre-salted and pre-generated database string.
