### PR TITLE
We moved to using the same xqwatcher as everything else

### DIFF
--- a/playbooks/roles/xqwatcher/tasks/deploy_watcher.yml
+++ b/playbooks/roles/xqwatcher/tasks/deploy_watcher.yml
@@ -46,7 +46,6 @@
 - name: Restart xqwatcher
   supervisorctl:
     name: "{{ xqwatcher_service_name }}"
-    supervisorctl_path: "{{ xqwatcher_supervisor_ctl }}"
     config: "{{ xqwatcher_supervisor_app_dir }}/supervisord.conf"
     state: restarted
   when: not disable_edx_services


### PR DESCRIPTION
@edx/devops 

We moved to using the standard supervisorctl but forgot to update this config here for the restart.
