### PR TITLE
add default configuration for neo4j

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -187,6 +187,16 @@ EDXAPP_ENABLE_READING_FROM_MULTIPLE_HISTORY_TABLES: True
 EDXAPP_GIT_REPO_DIR: '/edx/var/edxapp/course_repos'
 EDXAPP_GIT_REPO_EXPORT_DIR: '/edx/var/edxapp/export_course_repos'
 
+EDXAPP_NEO4J_CONFIG: !!null
+  # Setting this to null as a default. Here's what an example configuration
+  # would look like:
+  # bolt: True
+  # password: 'password'
+  # user: 'neo4j'
+  # https_port: 7473
+  # host: 'localhost'
+  # secure: True
+
 EDXAPP_ONLOAD_BEACON_SAMPLE_RATE: 0.0
 
 EDXAPP_FINANCIAL_REPORTS:
@@ -683,7 +693,7 @@ edxapp_generic_doc_store_config: &edxapp_generic_default_docstore
   socketTimeoutMS: 3000 # default is never timeout while the connection is open, this means it needs to explicitly close raising pymongo.errors.NetworkTimeout
   connectTimeoutMS: 2000 # default is 20000, I believe raises pymongo.errors.ConnectionFailure
   # Not setting waitQueueTimeoutMS and waitQueueMultiple since pymongo defaults to nobody being allowed to wait
-  
+
 
 EDXAPP_LMS_DRAFT_DOC_STORE_CONFIG:
   <<: *edxapp_generic_default_docstore
@@ -973,6 +983,7 @@ lms_auth_config:
                 render_template: 'edxmako.shortcuts.render_to_string'
   PROCTORING_BACKEND_PROVIDER: "{{ EDXAPP_PROCTORING_BACKEND_PROVIDER }}"
   SOCIAL_AUTH_OAUTH_SECRETS: "{{ EDXAPP_SOCIAL_AUTH_OAUTH_SECRETS }}"
+  NEO4J_CONFIG: "{{ EDXAPP_NEO4J_CONFIG }}"
 
 
 lms_env_config:


### PR DESCRIPTION
@fredsmith , here's the default configuration for neo4j. I'll file a devops ticket to add the real configuration to secure.

@Qubad786 

associated platform PR: https://github.com/edx/edx-platform/pull/13103
## Configuration Pull Request

Make sure that the following steps are done before merging
- [ ] @devops team member has commented with :+1:
- [x] are you adding any new default values that need to be overriden when this goes live?  
  - [x] Open a ticket ([DEVOPS-4701](https://openedx.atlassian.net/browse/DEVOPS-4701)) to make sure that they have been added to secure vars.
  - [ ] Add an entry to the CHANGELOG.

@fredsmith , I looked into adding to the changelog, but it doesn't look like the changelog has any organizational rule. There are many entries for each given role, and it's unclear if new entries should go on the top or bottom of the file. In fact, people seem to have done both: https://github.com/edx/configuration/blame/adam%2Fneo4j-config/CHANGELOG.md. What's the right move?
