### PR TITLE
Update /playbooks/roles/hadoop_common/main.yml

### DIFF
--- a/playbooks/roles/hadoop_common/defaults/main.yml
+++ b/playbooks/roles/hadoop_common/defaults/main.yml
@@ -35,7 +35,7 @@ hadoop_common_dist:
   sha256sum: 3fad58b525a47cf74458d0996564a2151c5a28baa1f92383e7932774deef5023
 hadoop_common_protobuf_dist:
   filename: "protobuf-{{ HADOOP_COMMON_PROTOBUF_VERSION }}.tar.gz"
-  url: "https://protobuf.googlecode.com/files/protobuf-{{ HADOOP_COMMON_PROTOBUF_VERSION }}.tar.gz"
+  url: "https://github.com/google/protobuf/releases/download/v2.5.0/protobuf-{{ HADOOP_COMMON_PROTOBUF_VERSION }}.tar.gz"
   sha256sum: c55aa3dc538e6fd5eaf732f4eb6b98bdcb7cedb5b91d3b5bdcf29c98c293f58e
 hadoop_common_native_dist:
   filename: "release-{{ HADOOP_COMMON_VERSION }}.tar.gz"


### PR DESCRIPTION
The previous Pull request for this issue doesn't contain the direct URL. It rather query the base download directory containing all releases of protobuf. This one contains the direct download link.
