### PR TITLE
Remove references to xconsole

### DIFF
--- a/playbooks/roles/common/templates/edx_rsyslog.j2
+++ b/playbooks/roles/common/templates/edx_rsyslog.j2
@@ -77,17 +77,3 @@ news.notice                     -/var/log/news/news.notice
 #       news.=crit;news.=err;news.=notice;\
 #       *.=debug;*.=info;\
 #       *.=notice;*.=warn       /dev/tty8
-
-# The named pipe /dev/xconsole is for the `xconsole' utility.  To use it,
-# you must invoke `xconsole' with the `-file' option:
-#
-#    $ xconsole -file /dev/xconsole [...]
-#
-# NOTE: adjust the list below, or you'll go crazy if you have a reasonably
-#      busy site..
-#
-daemon.*;mail.*;\
-        news.err;\
-        *.=debug;*.=info;\
-        *.=notice;*.=warn       |/dev/xconsole
-


### PR DESCRIPTION
FYI @clintonb @macdiesel 

This was recommended by [rsyslogd's docs](http://kb.monitorware.com/kbeventdb-detail-id-6904.html).
