### PR TITLE
Insights: Use py venv in bower install for sassc

### DIFF
--- a/playbooks/roles/insights/tasks/main.yml
+++ b/playbooks/roles/insights/tasks/main.yml
@@ -63,6 +63,7 @@
 - name: install bower dependencies
   shell: >
     chdir={{ insights_code_dir }}
+    . {{ insights_venv_dir }}/bin/activate &&
     . {{ insights_nodeenv_bin }}/activate && {{ insights_node_bin }}/bower install --production --config.interactive=false
   become_user: "{{ insights_user }}"
   tags:


### PR DESCRIPTION
## Configuration Pull Request

Make sure that the following steps are done before merging
- [x] @devops team member has commented with :+1:
- ~~[ ] are you adding any new default values that need to be overriden when this goes live?~~ No.
  - ~~[ ] Open a ticket (DEVOPS) to make sure that they have been added to secure vars.~~
  - ~~[ ] Add an entry to the CHANGELOG.~~

We added a bower post-install task that pre-compiles the edX pattern library in insights. This requires the executable sassc which is installed in python-libsass. It was already being installed in a previous ansible task (install application requirements), but we weren't sourcing the python virtualenv where it was installed for the bower install task.

With @macdiesel's help, I tested this change on a copy of the stage-edx-insights pipeline and it looks like it worked: https://gocd.tools.edx.org/go/pipelines/thallada-stage-edx-insights/1/run_play/1

@edx/devops @dsjen @mulby 
