### PR TITLE
Make sure user has correct associated group

### DIFF
--- a/playbooks/roles/add_user/tasks/main.yml
+++ b/playbooks/roles/add_user/tasks/main.yml
@@ -34,6 +34,7 @@
   user:
     name: "{{ user_name }}"
     home: "{{ user_home }}"
+    group: "{{ group_name }}"
     createhome: yes
     shell: /bin/false
     generate_ssh_key: yes

--- a/playbooks/roles/edx_themes/tasks/main.yml
+++ b/playbooks/roles/edx_themes/tasks/main.yml
@@ -52,3 +52,9 @@
     append: yes
   with_items: theme_users
   when: theme_users is defined
+
+- name: update .bashrc to set umask value
+  lineinfile:
+    dest: "{{ themes_home }}/.bashrc"
+    line: "umask 002"
+    state: present


### PR DESCRIPTION
## Configuration Pull Request

Hi @mattdrayer , @jibsheet , @fredsmith 

Kindly review these changes, this PR fixes the issue of invalid groups for edx-themes user, issue was discussed in DEVOPS-4749.

**Problem Description:**
On sandbox we are facing an issue that whenever a new theme is added to edx-themes and is updated via `git pull`, the new directories will have a group `users` instead of `www-themes`. 

After digging around the problem, I found that `user` module of ansible is assigning a default group `users` to any newly created users that does not explicitly defines a group, which differs from previously observed default behavior. Previously, ansible used to assign a default group with name same as the new user's username.

Although the sandbox problem can be avoided by using the preferred workflow of updating themes i.e. using `/edx/bin/update` command instead of manually updating git repo. It would still be a good idea to assign `www-data` as the default group for `edx-themes` user on sandbox.

**Description of changes:**
In this PR, I have updated `add_user` to pass in (while calling ansible module `user`) a default group for the new user, this group passed in as `group_name` argument would sometimes have same value as `user_name` argument but it can have any other value e.g. for `edx-themes` user we use `www-data` as user's primary group.

Make sure that the following steps are done before merging
- [x] Have completed [Ops ansible testing checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)
- [x] @devops team member has commented with :+1:
- [ ] are you adding any new default values that need to be overriden when this goes live?  
  - [ ] Open a ticket (DEVOPS) to make sure that they have been added to secure vars.
  - [ ] Add an entry to the CHANGELOG.
