### PR TITLE
Optionally allow user provisioning failures

### DIFF
--- a/playbooks/edx-east/manage_edxapp_users_and_groups.yml
+++ b/playbooks/edx-east/manage_edxapp_users_and_groups.yml
@@ -77,10 +77,12 @@
   vars:
     python_path: /edx/bin/python.edxapp
     manage_path: /edx/bin/manage.edxapp
+    ignore_user_creation_errors: no
+    deployment_settings: "{{ EDXAPP_SETTINGS | default('aws') }}"
   tasks:
     - name: Manage groups
       shell: >
-        {{ python_path }} {{ manage_path }} lms --settings=aws
+        {{ python_path }} {{ manage_path }} lms --settings={{ deployment_settings }}
         manage_group {{ item.name | quote }}
         {% if item.get('permissions', []) | length %}--permissions {{ item.permissions | default([]) | map('quote') | join(' ') }}{% endif %}
         {% if item.get('remove') %}--remove{% endif %}
@@ -88,7 +90,7 @@
 
     - name: Manage users
       shell: >
-        {{ python_path }} {{ manage_path }} lms --settings=aws
+        {{ python_path }} {{ manage_path }} lms --settings={{ deployment_settings }}
         manage_user {{ item.username | quote }} {{ item.email | quote }}
         {% if item.get('groups', []) | length %}--groups {{ item.groups | default([]) | map('quote') | join(' ') }}{% endif %}
         {% if item.get('remove') %}--remove{% endif %}
@@ -97,3 +99,5 @@
         {% if item.get('unusable_password') %}--unusable-password{% endif %}
         {% if item.get('initial_password_hash') %}--initial-password-hash {{ item.initial_password_hash | quote }}{% endif %}
       with_items: django_users
+      register: manage_users_result
+      failed_when: (manage_users_result | failed) and not (ignore_user_creation_errors | bool)


### PR DESCRIPTION
When using the user management playbook in the context of an OpenEdX instance with persistent databases stored on another server, we discovered that we may run into errors when managing users if the user's email address has been changed since the initial provisioning. Since this is expected, we'd like to optionally set a variable while provisioning that determines whether we fail at provisioning if user account creation fails.

In other words, if we have a persistent database that has previously been fully provisioned, then a failure of the management command is likely due to an acceptable reason, and we can safely ignore it.

**Dependencies**: None

**Partner information**: 3rd party-hosted open edX instance

**Testing instructions**:
1. On a devstack, pull this version of configuration.
2. Run the following command:
   
   `ansible-playbook -i "localhost," manage_edxapp_users_and_groups.yml --extra-vars '{"django_users":[{"username":"staff","email":"fake-staff@example.com"}, {"username":"honor","email":"honor@example.com"}], "django_groups":[], "deployment_settings":"devstack"}' -c local`
3. Observe that the playbook fails (ends with the message: "FATAL: all hosts have already failed -- aborting").
4. Run the following command:
   
   `ansible-playbook -i "localhost," manage_edxapp_users_and_groups.yml --extra-vars '{"django_users":[{"username":"staff","email":"fake-staff@example.com"}, {"username":"honor","email":"honor@example.com"}], "django_groups":[], "deployment_settings":"devstack", "ignore_user_creation_errors":"yes"}' -c local`
5. Observe that there is an "...ignoring" note under the failed play, and that the final report does not show any failures.

**Author notes and concerns**:
1. The previous version of the playbook was statically tied to `settings=aws`. To make testing this change in a devstack feasible, it was necessary to add a variable to change that to have an arbitrary value (e.g., `settings=devstack` or `settings=openstack`).
2. While it would have been nice to simply set a variable in `ignore_errors` on a single play, this does not appear to be possible with the current version of Ansible. As a result, it was necessary to create an additional play that fails if the user creation play failed AND `ignore_user_creation_errors` isn't True.

**Reviewers**
- [ ] @pomegranited 
- [ ] edX reviewer[s] TBD
