### PR TITLE
fix error on zero rate limited agents

### DIFF
--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
@@ -216,7 +216,10 @@ error_page {{ k }} {{ v }};
     {%- if EDXAPP_ENABLE_RATE_LIMITING -%}
     # Set Limit
     limit_req zone=cookies burst={{ EDXAPP_COURSES_REQUEST_BURST_RATE }};
+
+    {%- if EDXAPP_RATE_LIMITED_USER_AGENTS|length > 0 %}
     limit_req zone=agents burst={{ EDXAPP_COURSES_USER_AGENT_BURST_RATE }};
+    {%- endif %}
     error_page  503 = /server/rate-limit.html;
     {%- endif -%}
 


### PR DESCRIPTION
if EDXAPP_RATE_LIMITED_USER_AGENTS is empty, nginx fails to start with this error:

```
nginx: [emerg] zero size shared memory zone "agents"
```
