### PR TITLE
instruct nginx to add a X-Queue-Start header

### DIFF
--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/analytics_api.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/analytics_api.j2
@@ -48,6 +48,10 @@ location @proxy_to_app {
     proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
     proxy_set_header X-Forwarded-Port $http_x_forwarded_port;
     proxy_set_header X-Forwarded-For $http_x_forwarded_for;
+
+    # newrelic-specific header records the time when nginx handles a request.
+    proxy_set_header X-Queue-Start "t=${msec}";
+
     proxy_set_header Host $http_host;
 
     proxy_redirect off;

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/cms.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/cms.j2
@@ -94,6 +94,10 @@ error_page {{ k }} {{ v }};
     proxy_set_header X-Forwarded-Port $http_x_forwarded_port;
     proxy_set_header X-Forwarded-For $http_x_forwarded_for;
     {% endif %}
+
+    # newrelic-specific header records the time when nginx handles a request.
+    proxy_set_header X-Queue-Start "t=${msec}";
+
     proxy_set_header Host $http_host;
 
     proxy_redirect off;

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/credentials.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/credentials.j2
@@ -56,6 +56,10 @@ location @proxy_to_app {
     proxy_set_header X-Forwarded-Port $http_x_forwarded_port;
     proxy_set_header X-Forwarded-For $http_x_forwarded_for;
     {% endif %}
+
+    # newrelic-specific header records the time when nginx handles a request.
+    proxy_set_header X-Queue-Start "t=${msec}";
+
     proxy_set_header Host $http_host;
 
     proxy_redirect off;

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/ecommerce.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/ecommerce.j2
@@ -86,6 +86,10 @@ location @proxy_to_app {
     proxy_set_header X-Forwarded-Port $http_x_forwarded_port;
     proxy_set_header X-Forwarded-For $http_x_forwarded_for;
     {% endif %}
+
+    # newrelic-specific header records the time when nginx handles a request.
+    proxy_set_header X-Queue-Start "t=${msec}";
+
     proxy_set_header Host $http_host;
 
     proxy_redirect off;

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/edx_notes_api.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/edx_notes_api.j2
@@ -46,6 +46,10 @@ location @proxy_to_app {
     proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
     proxy_set_header X-Forwarded-Port $http_x_forwarded_port;
     proxy_set_header X-Forwarded-For $http_x_forwarded_for;
+
+    # newrelic-specific header records the time when nginx handles a request.
+    proxy_set_header X-Queue-Start "t=${msec}";
+
     proxy_set_header Host $http_host;
 
     proxy_redirect off;

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/forum.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/forum.j2
@@ -52,6 +52,10 @@ location @proxy_to_app {
     proxy_set_header X-Forwarded-Port $http_x_forwarded_port;
     proxy_set_header X-Forwarded-For $http_x_forwarded_for;
     {% endif %}
+
+    # newrelic-specific header records the time when nginx handles a request.
+    proxy_set_header X-Queue-Start "t=${msec}";
+
     proxy_set_header Host $http_host;
 
     proxy_redirect off;

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/insights.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/insights.j2
@@ -36,6 +36,10 @@ location @proxy_to_app {
     proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
     proxy_set_header X-Forwarded-Port $http_x_forwarded_port;
     proxy_set_header X-Forwarded-For $http_x_forwarded_for;
+
+    # newrelic-specific header records the time when nginx handles a request.
+    proxy_set_header X-Queue-Start "t=${msec}";
+
     proxy_set_header Host $http_host;
 
     proxy_redirect off;

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms-preview.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms-preview.j2
@@ -30,6 +30,10 @@ server {
     proxy_set_header X-Forwarded-Port $http_x_forwarded_port;
     proxy_set_header X-Forwarded-For $http_x_forwarded_for;
     {% endif %}
+
+    # newrelic-specific header records the time when nginx handles a request.
+    proxy_set_header X-Queue-Start "t=${msec}";
+
     proxy_set_header Host $http_host;
 
     proxy_redirect off;

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
@@ -123,6 +123,10 @@ error_page {{ k }} {{ v }};
     proxy_set_header X-Forwarded-Port $http_x_forwarded_port;
     proxy_set_header X-Forwarded-For $http_x_forwarded_for;
     {% endif %}
+
+    # newrelic-specific header records the time when nginx handles a request.
+    proxy_set_header X-Queue-Start "t=${msec}";
+
     proxy_set_header Host $http_host;
 
     proxy_redirect off;

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/programs.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/programs.j2
@@ -102,6 +102,10 @@ location @proxy_to_app {
     proxy_set_header X-Forwarded-Port $http_x_forwarded_port;
     proxy_set_header X-Forwarded-For $http_x_forwarded_for;
     {% endif %}
+
+    # newrelic-specific header records the time when nginx handles a request.
+    proxy_set_header X-Queue-Start "t=${msec}";
+
     proxy_set_header Host $http_host;
 
     proxy_redirect off;

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/xqueue.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/xqueue.j2
@@ -25,6 +25,10 @@ location @proxy_to_app {
     proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
     proxy_set_header X-Forwarded-Port $http_x_forwarded_port;
     proxy_set_header X-Forwarded-For $http_x_forwarded_for;
+
+    # newrelic-specific header records the time when nginx handles a request.
+    proxy_set_header X-Queue-Start "t=${msec}";
+
     proxy_set_header Host $http_host;
 
     proxy_redirect off;

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/xserver.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/xserver.j2
@@ -29,6 +29,10 @@ server {
     proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
     proxy_set_header X-Forwarded-Port $http_x_forwarded_port;
     proxy_set_header X-Forwarded-For $http_x_forwarded_for;
+
+    # newrelic-specific header records the time when nginx handles a request.
+    proxy_set_header X-Queue-Start "t=${msec}";
+
     proxy_set_header Host $http_host;
 
     proxy_redirect off;


### PR DESCRIPTION
## Configuration Pull Request

Make sure that the following steps are done before merging
- [x] @devops team member has commented with :+1:
- [ ] are you adding any new default values that need to be overriden when this goes live?  
  - [ ] Open a ticket (DEVOPS) to make sure that they have been added to secure vars.
  - [ ] Add an entry to the CHANGELOG.

This header gets added to requests proxied by nginx to various edx apps.
The New Relic agent, if there is one, reads this header to calculate the
time each request spends between the web server (nginx) and the
application server (django or some other cms).

The specific intention of this commit is to measure the time requests
spend queued at the gunicorn layer.

This work is part of PERF-372.
## Testing

I created a NR-enabled sandbox using this branch, and drove LMS load using locust.  By varying the number of locust clients, I was able to fill the gunicorn request queue:

[![2016-10-14-152240_1040x396_scrot](https://cloud.githubusercontent.com/assets/85151/19400540/ad55af90-9224-11e6-8db7-31fc8de5b66a.png)](https://rpm.newrelic.com/accounts/1391042/notes/6311)

In particular, pay attention to the new layer "Request Queuing", and how it suddenly increases (then plateaus) when the one gunicorn worker cannot handle the increased simultaneous requests without queuing.
