### PR TITLE
Jibsheet/disable automated upgrade 16.04

### DIFF
--- a/playbooks/roles/security/tasks/security-ubuntu.yml
+++ b/playbooks/roles/security/tasks/security-ubuntu.yml
@@ -22,6 +22,13 @@
     mode: "0644"
   when: SECURITY_UNATTENDED_UPGRADES
 
+- name: Disable unattended-upgrades if Xenial (16.04)
+  command: "{{ item }}"
+  when: ansible_distribution_release == 'xenial' and not SECURITY_UNATTENDED_UPGRADES
+  with_items:
+    - "systemctl disable apt-daily.service"
+    - "systemctl disable apt-daily.timer"
+
 - name: Disable unattended-upgrades
   file:
     path: "/etc/apt/apt.conf.d/10periodic"

--- a/playbooks/roles/xqwatcher/tasks/code_jail.yml
+++ b/playbooks/roles/xqwatcher/tasks/code_jail.yml
@@ -15,6 +15,8 @@
 # Do this first so symlinks can be resolved in the next step
 - name: Create jail virtualenv
   shell: "/usr/local/bin/virtualenv --python={{ item.PYTHON_EXECUTABLE }} --no-site-packages {{ xqwatcher_app_dir }}/venvs/{{ item.QUEUE_CONFIG.HANDLERS[0].CODEJAIL.name }}"
+  args:
+    creates: "{{ xqwatcher_app_dir }}/venvs/{{ item.QUEUE_CONFIG.HANDLERS[0].CODEJAIL.name }}/bin/pip"
   with_items: "{{ XQWATCHER_COURSES }}"
   tags:
     - install


### PR DESCRIPTION
Two parts.

Run systemctl disable-timers to turn off running apt-get update/upgrade on boot and at 0600, 1800.
http://www.hiroom2.com/2016/05/18/ubuntu-16-04-auto-apt-update-and-apt-upgrade/

This is similar to what we do earlier in this file for 12.04 and 14.04

Additional bugfix.  It was impossible to build xqwatcher from an existing xqwatcher AMI because it tried to make the virtualenv every time.

I've tested this by building
xqwatcher from scratcher
xqwatcher from that AMI

edxapp from scratch and from existing (12.04)
discovery from scratch and from existing (14.04)

@edx/devops 
