### PR TITLE
Adds the aws role to edx_sandbox.yml if edxapp is using aws settings

### DIFF
--- a/playbooks/edx_sandbox.yml
+++ b/playbooks/edx_sandbox.yml
@@ -40,6 +40,8 @@
     - role: mongo
       when: "'localhost' in EDXAPP_MONGO_HOSTS"
     - { role: 'rabbitmq', rabbitmq_ip: '127.0.0.1' }
+    - role: aws
+      when: EDXAPP_SETTINGS == 'aws'
     - { role: 'edxapp', celery_worker: True }
     - edxapp
     - role: ecommerce


### PR DESCRIPTION
Tracking logs on our AWS instances provisioned with `edx_sandbox.yml` are currently not being synced to S3, and so aren't available for analytics processing.

This PR adds the adds the aws role for instances that use `aws` settings.  This role installs scripts and log rotation hooks which handle the transfer of rotated tracking log files to the configured S3 bucket.

This change complements [edx#3370 edx_sandbox.yml R43](https://github.com/edx/configuration/pull/3370/files#diff-9c10813c1a99cbfd58b6a8a7784245caR43), which ensures proper setup of `openstack` instances.

**JIRA tickets**: [OSPR-1510](https://openedx.atlassian.net/browse/OSPR-1510) 

**Partner information**: 3rd party-hosted open edX instance

**Testing instructions**:

This is difficult to test without spinning up a new AWS instance, but we've tested it on two of our clients using:

```
ansible-playbook -i <instance ip>, -e @vars.yml --user=ubuntu --private-key=key.pem edx_sandbox.yml 
```

Where `vars.yml` contains at least:

``` yaml
COMMON_OBJECT_STORE_LOG_SYNC: true
COMMON_OBJECT_STORE_LOG_SYNC_BUCKET: 'x-edxapp-tracking-logs'
AWS_S3_LOGS_ACCESS_KEY_ID: 'x'
AWS_S3_LOGS_SECRET_KEY: 'x'
AWS_S3_LOGS_NOTIFY_EMAIL: 'ops@example.com'
AWS_S3_LOGS_FROM_EMAIL: 's3logsync@myinstance.org'
```

**Steps before merge**
- [x] @itsjeyd has commented with :+1:
- [ ] @devops team member has commented with :+1:
- [-] are you adding any new default values that need to be overridden when this goes live?  
  - [-] Open a ticket (DEVOPS) to make sure that they have been added to secure vars.
  - [-] Add an entry to the CHANGELOG.
