### PR TITLE
Backport fixes from e0d/xenial that enable the automated dockerfile

### DIFF
--- a/docker/build/automated/Dockerfile
+++ b/docker/build/automated/Dockerfile
@@ -1,5 +1,4 @@
-#FROM edxops/trusty-common:v3
-FROM hacking/edxapp
+FROM edxops/precise-common:latest
 MAINTAINER edxops
 
 ADD . /edx/app/edx_ansible/edx_ansible

--- a/docker/build/automated/ansible_overrides.yml
+++ b/docker/build/automated/ansible_overrides.yml
@@ -1,16 +1,12 @@
 ---
 FLOCK_TLD: "edx"
 
-AUTOMATED_USER: "ecom3"
-AUTOMATED_RBASH_LINKS: ['/usr/bin/python']
-
-AUTOMATED_SUDO_COMMANDS:
-  - command: "/edx/app/edxapp/venvs/edxapp/bin/python /edx/app/edxapp/edx-platform/manage.py lms migrate --list --settings=aws"
-    sudo_user: "edxapp"
-  - command: "/edx/app/edxapp/venvs/edxapp/bin/python /edx/app/edxapp/edx-platform/manage.py cms migrate --list --settings=aws"
-    sudo_user: "edxapp"
-
-AUTOMATED_SUDOERS_TEMPLATE: "roles/automated/templates/99-sample.j2"
 AUTOMATED_AUTHORIZED_KEYS: ['ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCx+OpJ6787GWnSo5FcwNPjiM7yqjXKi0FPkfpx8Dd3Oqts5PnJV/xokMP4vJTfXu6Zezh+/NvofgMlnxhnIwC3YIoGkLRhW5vKTZfohPjhyIRu0TyQOgmdocYk2o7xMQ1/fcrQh1sQMQqz79mv1ENKc47dVv7qfdBz803M5gschi4RjMYNMN97AA5rByz/AHJnrxQMWEndOZU+H2X9KRUn1TsWe8s99alILwFrNF1dZzF20r2zMErx48f4zfaczQnLOm+pJ1VrruPI8tQzS9X/kfy8GpBTbTX7X80SuM1Npuazr5sJAalXSZ2ccBVa1fKRwa6PmET21gdxOd2ZUsFYL5wZsPIF2f2ij5XwQxKco2lHH6QsvBzapY1BI5PZ/+mQzoaDO7w6WaaDvSDVxyuG/Sw0kOpA9uVEp3qTs8WT6CUYFmnBd+E8YnH6OwqbS9gfBkSNY9pwq1EpR+DCXVFuzWfYoSGQjxpTFbe7YsShB2Jyf/rZyA7NaS4lEkF8eABG6siEwckWvMOV5Z0lGGLTia1DCOZ3c6X09Te3xY4weYS1c0/Nx15C0rmYsMUeDYDonJWujBbvlOBNpx2opG2KPkSE9PAKWyS/mc4SrW0urJBxjAommVq9//dPTxo7IBmiCNWEcOuhXsQYp5tpDmj32Dh8nvNrkvOFYxb9SxuZgQ== automated@example.com']
-SUDO_USER: 
-edxapp_venv_dir: "/usr"
+
+AUTOMATED_USERS:
+  testing:
+    sudo_commands:
+      - command: "/usr/bin/ls"
+        sudo_user: "ubuntu"
+        job_name: "ls"
+    authorized_keys: "{{ AUTOMATED_AUTHORIZED_KEYS }}"

--- a/util/parsefiles_config.yml
+++ b/util/parsefiles_config.yml
@@ -20,3 +20,4 @@ weights:
   - precise-common: 4
   - ecommerce: 6 
   - rabbitmq: 2
+  - automated: 1


### PR DESCRIPTION
Without this, if a role change triggers a rebuild of the automated role,
travis will a) file because you have no weight for automated b) the automated
dockerfile doesn't build (invalid base image, invalid ansible overrides)
