### PR TITLE
Use unattended-upgrade to only take security updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -192,3 +192,7 @@
 
 - Role: discovery
   - Added `PUBLISHER_FROM_EMAIL` for sending emails to publisher app users.
+
+- Role: security
+  - Changed SECURITY_UPGRADE_ON_ANSIBLE to only apply security updates.  If you want to retain the behavior of running safe-upgrade,
+    you should switch to using SAFE_UPGRADE_ON_ANSIBLE.

--- a/playbooks/roles/security/defaults/main.yml
+++ b/playbooks/roles/security/defaults/main.yml
@@ -20,6 +20,8 @@ SECURITY_UNATTENDED_UPGRADES: false
 # set to true to upgrade all packages nightly.  false will only upgrade from security repo.
 SECURITY_UPDATE_ALL_PACKAGES: false
 # set to true to run aptitute safe-upgrade whenever ansible is run
+SAFE_UPGRADE_ON_ANSIBLE: false
+# set to true to run unattended-upgrade during ansible runs.  This is expected to only install security udpates.
 SECURITY_UPGRADE_ON_ANSIBLE: false
 
 

--- a/playbooks/roles/security/tasks/security-ubuntu.yml
+++ b/playbooks/roles/security/tasks/security-ubuntu.yml
@@ -11,7 +11,7 @@
 - name: Update all system packages
   apt:
     upgrade: safe
-  when: SECURITY_UPGRADE_ON_ANSIBLE
+  when: SAFE_UPGRADE_ON_ANSIBLE
 
 - name: Configure periodic unattended-upgrades
   template:
@@ -49,6 +49,14 @@
     path: "/etc/apt/apt.conf.d/20unattended-upgrade"
     state: absent
   when: SECURITY_UPDATE_ALL_PACKAGES or not SECURITY_UNATTENDED_UPGRADES
+
+# We dry-run because unattended-upgrade is quiet, and only had -d (debug) not -v (verbose)
+- name: "Take security updates during ansible runs"
+  command: "{{ item }}"
+  when: SECURITY_UPGRADE_ON_ANSIBLE
+  with_items:
+    - unattended-upgrade --dry-run
+    - unattended-upgrade
 
 #### Bash security vulnerability
 


### PR DESCRIPTION
This allows for security updates to be applied during artifact creation, but not applying other updates.
