### PR TITLE
upgrading packer to 0.9.0

### DIFF
--- a/playbooks/roles/jenkins_worker/defaults/main.yml
+++ b/playbooks/roles/jenkins_worker/defaults/main.yml
@@ -17,7 +17,8 @@ jenkins_debian_pkgs:
     - libsqlite3-dev
 
 # packer direct download URL
-packer_url: "https://releases.hashicorp.com/packer/0.8.6/packer_0.8.6_linux_amd64.zip"
+packer_url: "https://s3.amazonaws.com/edx-testeng-tools/packer/packer_0.9.0-rc2_linux_amd64.zip"
+packer_checksum: "13befc52f23861277eafbae99c65b193232c7432e1ff49c371b3c5029675a58c"
 
 # custom firefox
 custom_firefox_version: 42.0

--- a/playbooks/roles/jenkins_worker/tasks/packer.yml
+++ b/playbooks/roles/jenkins_worker/tasks/packer.yml
@@ -3,6 +3,11 @@
   shell: "curl -L {{ packer_url }} -o /var/tmp/packer.zip"
   args:
       creates: /var/tmp/packer.zip
-
+- name: Verify checksum of downloaded packer zip
+  shell: "sha256sum /var/tmp/packer.zip"
+  register: packer_download_checksum
+- assert:
+    that:
+      "'{{ packer_checksum }}' in packer_download_checksum.stdout"
 - name: Unzip packer
   unarchive: src=/var/tmp/packer.zip dest=/usr/local/bin copy=no


### PR DESCRIPTION
Updgrading packer to 0.9.0, which introduces the remote ansible provisioner, which will allow us to run the bootstrap script and kick of plays without copying them over.
## @jzoldak @benpatterson @jibsheet 

Make sure that the following steps are done before merging
- [ ] @devops team member has commented with :+1:
- [ ] are you adding any new default values that need to be overriden when this goes live?  
  - [ ] Open a ticket (DEVOPS) to make sure that they have been added to secure vars.
  - [ ] Add an entry to the CHANGELOG.
