### PR TITLE
Example of having security upgrades run during jenkins AMI building

### DIFF
--- a/playbooks/edx-east/jenkins_worker.yml
+++ b/playbooks/edx-east/jenkins_worker.yml
@@ -10,6 +10,7 @@
     mongo_enable_journal: False
     serial_count: 1
     platform_worker: True
+    SECURITY_UPGRADE_ON_ANSIBLE: true
   serial: "{{ serial_count }}"
   vars_files:
     - roles/edxapp/defaults/main.yml


### PR DESCRIPTION
@estute @benpatterson  quick example for https://openedx.atlassian.net/browse/TE-1794
