### PR TITLE
Feanil/test sandbox build

### DIFF
--- a/docker/plays/ansible.cfg
+++ b/docker/plays/ansible.cfg
@@ -4,3 +4,5 @@ jinja2_extensions=jinja2.ext.do
 roles_path=../plays:../../playbooks/roles
 library=../../playbooks/library
 
+[ssh_connection]
+ssh_args='-o ControlMaster=auto -o ControlPersist=60s -o ControlPath="~/.ansible/tmp/ansible-ssh-%h-%p-%r" -o ServerAliveInterval=30'

--- a/docker/plays/ansible.cfg
+++ b/docker/plays/ansible.cfg
@@ -5,4 +5,4 @@ roles_path=../plays:../../playbooks/roles
 library=../../playbooks/library
 
 [ssh_connection]
-ssh_args='-o ControlMaster=auto -o ControlPersist=60s -o ControlPath="~/.ansible/tmp/ansible-ssh-%h-%p-%r" -o ServerAliveInterval=30'
+ssh_args=-o ControlMaster=auto -o ControlPersist=60s -o ControlPath="~/.ansible/tmp/ansible-ssh-%h-%p-%r" -o ServerAliveInterval=30

--- a/playbooks/ansible.cfg
+++ b/playbooks/ansible.cfg
@@ -8,3 +8,6 @@ jinja2_extensions=jinja2.ext.do
 host_key_checking = False
 roles_path=../../ansible-roles/roles:../../ansible-private/roles:../../ansible-roles/
 ansible_managed=This file is created and updated by ansible, edit at your peril
+
+[ssh_connection]
+ssh_args='-o ControlMaster=auto -o ControlPersist=60s -o ControlPath="~/.ansible/tmp/ansible-ssh-%h-%p-%r" -o ServerAliveInterval=30'

--- a/playbooks/ansible.cfg
+++ b/playbooks/ansible.cfg
@@ -10,4 +10,4 @@ roles_path=../../ansible-roles/roles:../../ansible-private/roles:../../ansible-r
 ansible_managed=This file is created and updated by ansible, edit at your peril
 
 [ssh_connection]
-ssh_args='-o ControlMaster=auto -o ControlPersist=60s -o ControlPath="~/.ansible/tmp/ansible-ssh-%h-%p-%r" -o ServerAliveInterval=30'
+ssh_args=-o ControlMaster=auto -o ControlPersist=60s -o ControlPath="~/.ansible/tmp/ansible-ssh-%h-%p-%r" -o ServerAliveInterval=30

--- a/playbooks/continuous_delivery/ansible.cfg
+++ b/playbooks/continuous_delivery/ansible.cfg
@@ -8,9 +8,7 @@ jinja2_extensions=jinja2.ext.do
 host_key_checking=False
 roles_path=../../../ansible-roles/roles:../../../ansible-private/roles:../../../ansible-roles/
 library=../library/
-
-# ControlPersist keeps the socket ssh creates open to the target. Increasing this timeout decreases
-# some of the ssh overhead with all the ssh connections ansible makes by allowing it to just reuse the
-# socket for each ssh session. This should improve performance since we are now running ansible remotely.
-ssh_args = -o ControlMaster=auto -o ControlPersist=30m -o StrictHostKeyChecking=no
 ansible_managed=This file is created and updated by ansible, edit at your peril
+
+[ssh_connection]
+ssh_args='-o ControlMaster=auto -o ControlPersist=60s -o ControlPath="~/.ansible/tmp/ansible-ssh-%h-%p-%r" -o ServerAliveInterval=30'

--- a/playbooks/continuous_delivery/ansible.cfg
+++ b/playbooks/continuous_delivery/ansible.cfg
@@ -11,4 +11,4 @@ library=../library/
 ansible_managed=This file is created and updated by ansible, edit at your peril
 
 [ssh_connection]
-ssh_args='-o ControlMaster=auto -o ControlPersist=60s -o ControlPath="~/.ansible/tmp/ansible-ssh-%h-%p-%r" -o ServerAliveInterval=30'
+ssh_args=-o ControlMaster=auto -o ControlPersist=60s -o ControlPath="~/.ansible/tmp/ansible-ssh-%h-%p-%r" -o ServerAliveInterval=30

--- a/playbooks/edx-east/ansible.cfg
+++ b/playbooks/edx-east/ansible.cfg
@@ -8,3 +8,6 @@ jinja2_extensions=jinja2.ext.do
 host_key_checking=False
 roles_path=../../../ansible-roles/roles:../../../ansible-private/roles:../../../ansible-roles/
 ansible_managed=This file is created and updated by ansible, edit at your peril
+
+[ssh_connection]
+ssh_args='-o ControlMaster=auto -o ControlPersist=60s -o ControlPath="~/.ansible/tmp/ansible-ssh-%h-%p-%r" -o ServerAliveInterval=30'

--- a/playbooks/edx-east/ansible.cfg
+++ b/playbooks/edx-east/ansible.cfg
@@ -10,4 +10,4 @@ roles_path=../../../ansible-roles/roles:../../../ansible-private/roles:../../../
 ansible_managed=This file is created and updated by ansible, edit at your peril
 
 [ssh_connection]
-ssh_args='-o ControlMaster=auto -o ControlPersist=60s -o ControlPath="~/.ansible/tmp/ansible-ssh-%h-%p-%r" -o ServerAliveInterval=30'
+ssh_args=-o ControlMaster=auto -o ControlPersist=60s -o ControlPath="~/.ansible/tmp/ansible-ssh-%h-%p-%r" -o ServerAliveInterval=30

--- a/playbooks/vagrant/ansible.cfg
+++ b/playbooks/vagrant/ansible.cfg
@@ -6,3 +6,6 @@ library=../library
 roles_path=../roles
 callback_plugins=../callback_plugins
 ansible_managed=This file is created and updated by ansible, edit at your peril
+
+[ssh_connection]
+ssh_args='-o ControlMaster=auto -o ControlPersist=60s -o ControlPath="~/.ansible/tmp/ansible-ssh-%h-%p-%r" -o ServerAliveInterval=30'

--- a/playbooks/vagrant/ansible.cfg
+++ b/playbooks/vagrant/ansible.cfg
@@ -8,4 +8,4 @@ callback_plugins=../callback_plugins
 ansible_managed=This file is created and updated by ansible, edit at your peril
 
 [ssh_connection]
-ssh_args='-o ControlMaster=auto -o ControlPersist=60s -o ControlPath="~/.ansible/tmp/ansible-ssh-%h-%p-%r" -o ServerAliveInterval=30'
+ssh_args=-o ControlMaster=auto -o ControlPersist=60s -o ControlPath="~/.ansible/tmp/ansible-ssh-%h-%p-%r" -o ServerAliveInterval=30

--- a/util/jenkins/ansible-provision.sh
+++ b/util/jenkins/ansible-provision.sh
@@ -24,6 +24,7 @@ env | grep -v AWS | grep -v ARN
 
 export PYTHONUNBUFFERED=1
 export BOTO_CONFIG=/var/lib/jenkins/${aws_account}.boto
+export ANSIBLE_SSH_ARGS='-o ControlMaster=auto -o ControlPersist=60s -o ControlPath="~/.ansible/tmp/ansible-ssh-%h-%p-%r" -o ServerAliveInterval=30'
 
 # docker on OS-X includes your Mac's home directory in the socket path
 # that SSH/Ansible uses for the control socket, pushing you over

--- a/util/jenkins/ansible-provision.sh
+++ b/util/jenkins/ansible-provision.sh
@@ -24,7 +24,6 @@ env | grep -v AWS | grep -v ARN
 
 export PYTHONUNBUFFERED=1
 export BOTO_CONFIG=/var/lib/jenkins/${aws_account}.boto
-export ANSIBLE_SSH_ARGS='-o ControlMaster=auto -o ControlPersist=60s -o ControlPath="~/.ansible/tmp/ansible-ssh-%h-%p-%r" -o ServerAliveInterval=30'
 
 # docker on OS-X includes your Mac's home directory in the socket path
 # that SSH/Ansible uses for the control socket, pushing you over

--- a/vagrant/base/cluster/ansible.cfg
+++ b/vagrant/base/cluster/ansible.cfg
@@ -9,4 +9,4 @@ host_key_checking = False
 roles_path=../../ansible-roles/roles:../../ansible-private/roles:../../ansible-roles/
 
 [ssh_connection]
-ssh_args='-o ControlMaster=auto -o ControlPersist=60s -o ControlPath="~/.ansible/tmp/ansible-ssh-%h-%p-%r" -o ServerAliveInterval=30'
+ssh_args=-o ControlMaster=auto -o ControlPersist=60s -o ControlPath="~/.ansible/tmp/ansible-ssh-%h-%p-%r" -o ServerAliveInterval=30

--- a/vagrant/base/cluster/ansible.cfg
+++ b/vagrant/base/cluster/ansible.cfg
@@ -7,3 +7,6 @@
 jinja2_extensions=jinja2.ext.do
 host_key_checking = False
 roles_path=../../ansible-roles/roles:../../ansible-private/roles:../../ansible-roles/
+
+[ssh_connection]
+ssh_args='-o ControlMaster=auto -o ControlPersist=60s -o ControlPath="~/.ansible/tmp/ansible-ssh-%h-%p-%r" -o ServerAliveInterval=30'

--- a/vagrant/base/test_playbook/ansible.cfg
+++ b/vagrant/base/test_playbook/ansible.cfg
@@ -8,3 +8,6 @@ jinja2_extensions=jinja2.ext.do
 host_key_checking = False
 roles_path=../../ansible-roles/roles:../../ansible-private/roles:../../ansible-roles/
 ansible_managed=This file is created and updated by ansible, edit at your peril
+
+[ssh_connection]
+ssh_args='-o ControlMaster=auto -o ControlPersist=60s -o ControlPath="~/.ansible/tmp/ansible-ssh-%h-%p-%r" -o ServerAliveInterval=30'

--- a/vagrant/base/test_playbook/ansible.cfg
+++ b/vagrant/base/test_playbook/ansible.cfg
@@ -10,4 +10,4 @@ roles_path=../../ansible-roles/roles:../../ansible-private/roles:../../ansible-r
 ansible_managed=This file is created and updated by ansible, edit at your peril
 
 [ssh_connection]
-ssh_args='-o ControlMaster=auto -o ControlPersist=60s -o ControlPath="~/.ansible/tmp/ansible-ssh-%h-%p-%r" -o ServerAliveInterval=30'
+ssh_args=-o ControlMaster=auto -o ControlPersist=60s -o ControlPath="~/.ansible/tmp/ansible-ssh-%h-%p-%r" -o ServerAliveInterval=30


### PR DESCRIPTION
Configuration Pull Request

---

Make sure that the following steps are done before merging

  - [x] @devops team member has commented with :+1:
  - [x] Sandbox Build Works from New Jenkins
  - [x] Sandbox Build works from Old Jenkins
  - [x] AMIs Still Build correctly
  - [x] AMIs still build correctly from scratch

When ansible is going over a NAT Gateway or other intermdiate
network devices, the connection can time out if that device has
its own timeout setting for no traffic.  Setting the ServerAliveInterval
will ensure that there is data sent over the wire ever 30 seconds so the
connection does not get closed while running ansible tasks that take
over 5 minutes.

