### PR TITLE
Upgrade to 3.0.14

### DIFF
--- a/playbooks/edx-east/mongo_rolling_upgrade.yml
+++ b/playbooks/edx-east/mongo_rolling_upgrade.yml
@@ -103,7 +103,7 @@
         install_recommends: yes
         force: yes
         update_cache: yes
-      with_items: mongodb_debian_pkgs
+      with_items: "{{ mongodb_debian_pkgs }}"
     - name: wait for mongo server to start
       wait_for:
         port: 27017
@@ -138,7 +138,7 @@
         install_recommends: yes
         force: yes
         update_cache: yes
-      with_items: mongodb_debian_pkgs
+      with_items: "{{ mongodb_debian_pkgs }}"
     - name: wait for mongo server to start
       wait_for:
         port: 27017

--- a/playbooks/roles/ad_hoc_reporting/defaults/main.yml
+++ b/playbooks/roles/ad_hoc_reporting/defaults/main.yml
@@ -44,7 +44,7 @@ ad_hoc_reporting_pip_pkgs:
 MONGODB_APT_KEY: "7F0CEB10"
 MONGODB_APT_KEYSERVER: "keyserver.ubuntu.com"
 MONGODB_REPO: "deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen"
-mongo_version: 3.0.12
+mongo_version: 3.0.14
 
 # AD_HOC_REPORTING_REPLICA_DB_HOSTS:
 #   - db_host: "{{ EDXAPP_MYSQL_REPLICA_HOST }}"

--- a/playbooks/roles/mongo_3_0/defaults/main.yml
+++ b/playbooks/roles/mongo_3_0/defaults/main.yml
@@ -3,7 +3,7 @@ mongo_logappend: true
 #This way, when mongod receives a SIGUSR1, it'll close and reopen its log file handle
 mongo_logrotate: reopen
 
-mongo_version: 3.0.12
+mongo_version: 3.0.14
 mongo_port: "27017"
 mongo_extra_conf: ''
 mongo_key_file: '/etc/mongodb_key'


### PR DESCRIPTION
3.0.14 was a bugfix release to 3.0.13
Changelog here, nothing particularly relevant to us, just the normal
march of progress and bugfixes.

https://docs.mongodb.com/v3.2/release-notes/3.0-changelog/#id1

@edx/devops
Pave the way to start upgrading mongo on all the things.