### PR TITLE
These are expanded in common.py, but too late

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -281,7 +281,7 @@ EDXAPP_TIME_ZONE: 'America/New_York'
 EDXAPP_LMS_DOC_LINK_BASE_URL: 'https://edx.readthedocs.io/projects/open-edx-learner-guide'
 EDXAPP_CMS_DOC_LINK_BASE_URL: 'https://edx.readthedocs.io/projects/open-edx-building-and-running-a-course'
 
-EDXAPP_RECALCULATE_GRADES_ROUTING_KEY: 'low'
+EDXAPP_RECALCULATE_GRADES_ROUTING_KEY: 'edx.lms.core.low'
 
 EDXAPP_TECH_SUPPORT_EMAIL: 'technical@example.com'
 EDXAPP_CONTACT_EMAIL: 'info@example.com'


### PR DESCRIPTION
We have to use the full name when overriding.

@edx/devops
@efischer19