### PR TITLE
Install Python 3.5 for tools-edx-jenkins

### DIFF
--- a/playbooks/roles/tools_jenkins/defaults/main.yml
+++ b/playbooks/roles/tools_jenkins/defaults/main.yml
@@ -44,3 +44,7 @@ jenkins_tools_plugins:
   - { name: "github-oauth", version: "0.24" }
   - { name: "gradle", version: "1.25" }
   - { name: "credentials-binding", version: "1.9" }
+
+jenkins_tools_debian_pkgs:
+  # Necessary until we switch to 16.04.
+  - python3.5

--- a/playbooks/roles/tools_jenkins/tasks/main.yml
+++ b/playbooks/roles/tools_jenkins/tasks/main.yml
@@ -30,3 +30,12 @@
   when: jpi_files
   notify:
     - restart Jenkins
+
+- name: Install system packages
+  apt:
+    name: "{{ item }}"
+    state: present
+  with_items: "{{ jenkins_tools_debian_pkgs }}"
+  tags:
+    - install
+    - install:system-requirements


### PR DESCRIPTION
New ecom team scripts are written in Python 3. If we want to run them with tools-jenkins, we need Python 3 available.

ECOM-5658

@jibsheet as discussed. FYI @edx/devops @edx/ecommerce.