### PR TITLE
Remove .npmrc from jenkins worker.

### DIFF
--- a/playbooks/roles/jenkins_worker/tasks/system.yml
+++ b/playbooks/roles/jenkins_worker/tasks/system.yml
@@ -51,14 +51,6 @@
   shell: sed -i -r 's/^127.0.0.1\s+.*$/127.0.0.1 localhost preview.localhost/' /etc/hosts
   become: yes
 
-# Npm registry must be pre-loaded or else setting it
-# with the Jenkins user will fail
-# See https://github.com/npm/npm/issues/3565
-- name: Set npm registry
-  template:
-    src=.npmrc.j2 dest={{ jenkins_home }}/.npmrc
-    owner={{ jenkins_user }} group={{ jenkins_group }} mode=0664
-
 # Set up configuration for pip-accel for caching python requirements
 - name: Create directory for pip-accel config file
   file: path={{ jenkins_home }}/.pip-accel state=directory

--- a/playbooks/roles/jenkins_worker/templates/.npmrc.j2
+++ b/playbooks/roles/jenkins_worker/templates/.npmrc.j2
@@ -1,1 +1,0 @@
-registry={{ COMMON_NPM_MIRROR_URL }}


### PR DESCRIPTION
Will resolve TE-1835.

Not posting full URL, but this was verified in our packer build 3869 tonight. (All builds are failing for packer, without this fix.)

Configuration Pull Request
---

Make sure that the following steps are done before merging

  - [x] @devops team member has commented with :+1:
  - [ ] are you adding any new default values that need to be overriden when this goes live?  
    - [ ] Open a ticket (DEVOPS) to make sure that they have been added to secure vars.
    - [ ] Add an entry to the CHANGELOG.

