### PR TITLE
Install python3.5 for tools-jenkins

### DIFF
--- a/playbooks/roles/tools_jenkins/defaults/main.yml
+++ b/playbooks/roles/tools_jenkins/defaults/main.yml
@@ -44,7 +44,3 @@ jenkins_tools_plugins:
   - { name: "github-oauth", version: "0.24" }
   - { name: "gradle", version: "1.25" }
   - { name: "credentials-binding", version: "1.9" }
-
-jenkins_tools_debian_pkgs:
-  # Necessary until we switch to 16.04.
-  - python3.5

--- a/playbooks/roles/tools_jenkins/tasks/main.yml
+++ b/playbooks/roles/tools_jenkins/tasks/main.yml
@@ -31,11 +31,23 @@
   notify:
     - restart Jenkins
 
-- name: Install system packages
+# The deadsnakes PPA is required to install python3.5 on Precise and Trusty.
+# Xenial comes with python3.5 installed.
+- name: add deadsnakes repository
+  apt_repository:
+    repo: "ppa:fkrull/deadsnakes"
+  when: ansible_distribution_release == 'precise' or ansible_distribution_release == 'trusty'
+  tags:
+    - install
+    - install:system-requirements
+
+- name: install python3.5
   apt:
     name: "{{ item }}"
-    state: present
-  with_items: "{{ jenkins_tools_debian_pkgs }}"
+  with_items:
+    - python3.5
+    - python3.5-dev
+  when: ansible_distribution_release == 'precise' or ansible_distribution_release == 'trusty'
   tags:
     - install
     - install:system-requirements


### PR DESCRIPTION
Installation of python3.5 on Precise and Trusty requires adding the deadsnakes repository.

@jibsheet please review. @edx/ecommerce FYI.