### PR TITLE
Revert "Bump the sandbox version"

### DIFF
--- a/util/jenkins/ansible-provision.sh
+++ b/util/jenkins/ansible-provision.sh
@@ -127,7 +127,7 @@ fi
 
 if [[ -z $ami ]]; then
   if [[ $server_type == "full_edx_installation" ]]; then
-    ami="ami-42d9f255"
+    ami="ami-79a18c6e"
   elif [[ $server_type == "ubuntu_12.04" || $server_type == "full_edx_installation_from_scratch" ]]; then
     ami="ami-1fd6fb08"
   elif [[ $server_type == "ubuntu_14.04(experimental)" ]]; then


### PR DESCRIPTION
Reverts edx/configuration#3476

Go back to the old PPA on 12.04 in order to maintain backcompat with devstacks.
This has the side-effect of impacting sandboxes, since they're both 12.04.

https://github.com/edx/configuration/pull/3478