### PR TITLE
Make sure Ansible notices migration errors.

### DIFF
--- a/playbooks/roles/edxapp/templates/edx/bin/edxapp-migrate-cms.j2
+++ b/playbooks/roles/edxapp/templates/edx/bin/edxapp-migrate-cms.j2
@@ -1,11 +1,11 @@
 {% include "edxapp_common.j2" %}
 
-if [[ -z "$NO_EDXAPP_SUDO" ]]; then
+if [[ -z "${NO_EDXAPP_SUDO:-}" ]]; then
     SUDO='sudo -E -u {{ edxapp_user }} env "PATH=$PATH"'
 fi
 
 {% for db in cms_auth_config.DATABASES.keys() %}
   {%- if db != 'read_replica' %}
-$SUDO {{ edxapp_venv_bin}}/python manage.py cms migrate --database {{ db }} --noinput --settings $EDX_PLATFORM_SETTINGS $@
+${SUDO:-} {{ edxapp_venv_bin }}/python manage.py cms migrate --database {{ db }} --noinput --settings $EDX_PLATFORM_SETTINGS $@
   {% endif %}
 {% endfor %}

--- a/playbooks/roles/edxapp/templates/edx/bin/edxapp-migrate-lms.j2
+++ b/playbooks/roles/edxapp/templates/edx/bin/edxapp-migrate-lms.j2
@@ -1,11 +1,11 @@
 {% include "edxapp_common.j2" %}
 
-if [[ -z "$NO_EDXAPP_SUDO" ]]; then
+if [[ -z "${NO_EDXAPP_SUDO:-}" ]]; then
     SUDO='sudo -E -u {{ edxapp_user }} env "PATH=$PATH"'
 fi
 
 {% for db in lms_auth_config.DATABASES.keys() %}
   {%- if db != 'read_replica' %}
-$SUDO {{ edxapp_venv_bin}}/python manage.py lms migrate --database {{ db }} --noinput --settings $EDX_PLATFORM_SETTINGS $@
+${SUDO:-} {{ edxapp_venv_bin }}/python manage.py lms migrate --database {{ db }} --noinput --settings $EDX_PLATFORM_SETTINGS $@
   {% endif %}
 {% endfor %}

--- a/playbooks/roles/edxapp/templates/edx/bin/edxapp_common.j2
+++ b/playbooks/roles/edxapp/templates/edx/bin/edxapp_common.j2
@@ -1,11 +1,15 @@
 #!/bin/bash
+
+# Error out when any command fails.  For the migration scripts migrating multiple
+# databases this ensure migration errors for any database will be seen by Ansible.
+set -euo pipefail
+
 cd {{ edxapp_code_dir }}
 source {{ edxapp_app_dir }}/edxapp_env
 
 # The default settings set in edxapp_env can be overridden
 # using the var $EDX_PLATFORM_SETTINGS_OVERRIDE
 
-if [[ -n "$EDX_PLATFORM_SETTINGS_OVERRIDE" ]]; then
+if [[ -n "${EDX_PLATFORM_SETTINGS_OVERRIDE:-}" ]]; then
     export EDX_PLATFORM_SETTINGS="$EDX_PLATFORM_SETTINGS_OVERRIDE"
 fi
-


### PR DESCRIPTION
The edxapp-migrate{lms,cms} script call `./manage.py migrate` for each database alias (for our instances, this means once for `default` and once for `student_module_history`).  However, Ansible is only seeing the return code of the script, which is the return code of the last command in the script.  If one of the earlier migration commands fails, but the last one succeeds, Ansible will silently ignore the error, and not even show it in the logs.

This change configures the shell to error out as soon as any of the migration commands fails, so Ansible will actually notice something went wrong.

- - -

Make sure that the following steps are done before merging

  - [ ] @devops team member has commented with :+1:
  - [ ] are you adding any new default values that need to be overriden when this goes live?  
    - [ ] Open a ticket (DEVOPS) to make sure that they have been added to secure vars.
    - [ ] Add an entry to the CHANGELOG.

