### PR TITLE
Changed COMMON_EDX_PPA_KEY_SERVER value

### DIFF
--- a/playbooks/roles/common_vars/defaults/main.yml
+++ b/playbooks/roles/common_vars/defaults/main.yml
@@ -51,7 +51,7 @@ COMMON_NPM_MIRROR_URL: 'https://registry.npmjs.org'
 COMMON_UBUNTU_APT_KEYSERVER: "http://keyserver.ubuntu.com/pks/lookup?op=get&fingerprint=on&search="
 
 COMMON_EDX_PPA: "deb http://ppa.edx.org {{ ansible_distribution_release }} main"
-COMMON_EDX_PPA_KEY_SERVER: "keyserver.ubuntu.com"
+COMMON_EDX_PPA_KEY_SERVER: "hkp://keyserver.ubuntu.com:80"
 COMMON_EDX_PPA_KEY_ID: "69464050"
 
 #The git checkout url in most roles is constructed from these values


### PR DESCRIPTION
In [playbooks/roles/common/tasks/main.yml](https://github.com/edx/configuration/blob/1aefd20ac1b2d609ca8fe71fe44dac6a85de8856/playbooks/roles/common/tasks/main.yml),  under "add edx ppa apt key" (line 56), keyserver value is assigned the [COMMON_EDX_PPA_KEY_SERVER](https://github.com/edx/configuration/blob/1aefd20ac1b2d609ca8fe71fe44dac6a85de8856/playbooks/roles/common/tasks/main.yml) variable that points to 

> keyserver.ubuntu.com

Problem in this case, is that the instance executing the playbook tries to make an outgoing call over port 11371 which is blocked in most instances. For example, in my case, I was running this in AWS and given that I hadn't explicitly allowed outbound traffic on port 11371, playbook execution failed. 
The recommended fix is to use port 80 instead since that's typically open in most cases. In short, this PR changes the variable in [playbooks/roles/common_vars/defaults/main.yml](https://github.com/edx/configuration/blob/1a75f791c918abbb17d2e39bf85953ac5f43d292/playbooks/roles/common_vars/defaults/main.yml) from:

`COMMON_EDX_PPA_KEY_SERVER: "keyserver.ubuntu.com"`
to
`COMMON_EDX_PPA_KEY_SERVER: "hkp://keyserver.ubuntu.com:80"`

Configuration Pull Request
---
Make sure that the following steps are done before merging

  - [ ] @devops team member has commented with :+1:
  - [ ] are you adding any new default values that need to be overriden when this goes live?  
    - [ ] Open a ticket (DEVOPS) to make sure that they have been added to secure vars.
    - [ ] Add an entry to the CHANGELOG.