### PR TITLE
Make Vagrantfiles less hard-coded, and more uniformly configurable

### DIFF
--- a/vagrant/base/devstack/Vagrantfile
+++ b/vagrant/base/devstack/Vagrantfile
@@ -13,6 +13,22 @@ if ENV["VAGRANT_GUEST_IP"]
   vm_guest_ip = ENV["VAGRANT_GUEST_IP"]
 end
 
+# These are versioning variables in the roles. Each can be overridden, first
+# with OPENEDX_RELEASE, and then with a specific environment variable of the
+# same name but upper-cased.
+VERSION_VARS = [
+    'edx_platform_version',
+    'configuration_version',
+    'certs_version',
+    'forum_version',
+    'xqueue_version',
+    'demo_version',
+    'NOTIFIER_VERSION',
+    'ECOMMERCE_VERSION',
+    'ECOMMERCE_WORKER_VERSION',
+    'PROGRAMS_VERSION',
+]
+
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   # Creates a devstack from a base Ubuntu 12.04 image for virtualbox
@@ -70,34 +86,15 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     ansible.verbose = "vvvv"
 
     ansible.extra_vars = {}
-    if ENV['OPENEDX_RELEASE']
-      ansible.extra_vars = {
-        edx_platform_version: ENV['OPENEDX_RELEASE'],
-        configuration_version: ENV['OPENEDX_RELEASE'],
-        certs_version: ENV['OPENEDX_RELEASE'],
-        forum_version: ENV['OPENEDX_RELEASE'],
-        xqueue_version: ENV['OPENEDX_RELEASE'],
-        demo_version: ENV['OPENEDX_RELEASE'],
-        NOTIFIER_VERSION: ENV['OPENEDX_RELEASE'],
-        ECOMMERCE_VERSION: ENV['OPENEDX_RELEASE'],
-        ECOMMERCE_WORKER_VERSION: ENV['OPENEDX_RELEASE'],
-        PROGRAMS_VERSION: ENV['OPENEDX_RELEASE'],
-      }
+    VERSION_VARS.each do |var|
+      if ENV['OPENEDX_RELEASE']
+        ansible.extra_vars[var] = ENV['OPENEDX_RELEASE']
+      end
+      env_var = var.upcase
+      if ENV[env_var]
+        ansible.extra_vars[var] = ENV[env_var]
+      end
     end
-    if ENV['CONFIGURATION_VERSION']
-      ansible.extra_vars['configuration_version'] = ENV['CONFIGURATION_VERSION']
-    end
-    if ENV['EDX_PLATFORM_VERSION']
-      ansible.extra_vars['edx_platform_version'] = ENV['EDX_PLATFORM_VERSION']
-    end
-    if ENV['ECOMMERCE_VERSION']
-      ansible.extra_vars['ECOMMERCE_VERSION'] = ENV['ECOMMERCE_VERSION']
-    end
-    if ENV['ECOMMERCE_WORKER_VERSION']
-      ansible.extra_vars['ECOMMERCE_WORKER_VERSION'] = ENV['ECOMMERCE_WORKER_VERSION']
-    end
-    if ENV['PROGRAMS_VERSION']
-      ansible.extra_vars['PROGRAMS_VERSION'] = ENV['PROGRAMS_VERSION']
-    end
+
   end
 end

--- a/vagrant/release/devstack/Vagrantfile
+++ b/vagrant/release/devstack/Vagrantfile
@@ -66,11 +66,12 @@ openedx_releases = {
 }
 openedx_releases.default = "eucalyptus-devstack-2016-09-01"
 
-rel = ENV['OPENEDX_RELEASE']
+openedx_release = ENV['OPENEDX_RELEASE']
 
 extra_vars_lines = ""
-if rel
-  VERSION_VARS.each do |var|
+VERSION_VARS.each do |var|
+  rel = ENV[var.upcase] || openedx_release
+  if rel
     extra_vars_lines += "-e #{var}=#{rel} \\\n"
   end
 end
@@ -85,7 +86,7 @@ source /edx/app/edx_ansible/venvs/edx_ansible/bin/activate
 cd /edx/app/edx_ansible/edx_ansible/playbooks
 
 EXTRA_VARS="#{extra_vars_lines}"
-CONFIG_VER="#{rel || 'master'}"
+CONFIG_VER="#{openedx_release || 'master'}"
 
 ansible-playbook -i localhost, -c local run_role.yml -e role=edx_ansible -e configuration_version=$CONFIG_VER $EXTRA_VARS
 ansible-playbook -i localhost, -c local vagrant-devstack.yml -e configuration_version=$CONFIG_VER $EXTRA_VARS
@@ -94,10 +95,10 @@ SCRIPT
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
-  reldata = openedx_releases[rel]
+  reldata = openedx_releases[openedx_release]
   if Hash == reldata.class
-    boxname = openedx_releases[rel][:name]
-    boxfile = openedx_releases[rel].fetch(:file, "#{boxname}.box")
+    boxname = openedx_releases[openedx_release][:name]
+    boxfile = openedx_releases[openedx_release].fetch(:file, "#{boxname}.box")
   else
     boxname = reldata
     boxfile = "#{boxname}.box"

--- a/vagrant/release/devstack/Vagrantfile
+++ b/vagrant/release/devstack/Vagrantfile
@@ -68,6 +68,7 @@ openedx_releases.default = "eucalyptus-devstack-2016-09-01"
 
 openedx_release = ENV['OPENEDX_RELEASE']
 
+# Build -e override lines for each overridable variable.
 extra_vars_lines = ""
 VERSION_VARS.each do |var|
   rel = ENV[var.upcase] || openedx_release
@@ -86,7 +87,7 @@ source /edx/app/edx_ansible/venvs/edx_ansible/bin/activate
 cd /edx/app/edx_ansible/edx_ansible/playbooks
 
 EXTRA_VARS="#{extra_vars_lines}"
-CONFIG_VER="#{openedx_release || 'master'}"
+CONFIG_VER="#{ENV['CONFIGURATION_VERSION'] || openedx_release || 'master'}"
 
 ansible-playbook -i localhost, -c local run_role.yml -e role=edx_ansible -e configuration_version=$CONFIG_VER $EXTRA_VARS
 ansible-playbook -i localhost, -c local vagrant-devstack.yml -e configuration_version=$CONFIG_VER $EXTRA_VARS

--- a/vagrant/release/devstack/Vagrantfile
+++ b/vagrant/release/devstack/Vagrantfile
@@ -8,37 +8,21 @@ VAGRANTFILE_API_VERSION = "2"
 MEMORY = 4096
 CPU_COUNT = 2
 
-$script = <<SCRIPT
-if [ ! -d /edx/app/edx_ansible ]; then
-    echo "Error: Base box is missing provisioning scripts." 1>&2
-    exit 1
-fi
-OPENEDX_RELEASE=$1
-export PYTHONUNBUFFERED=1
-source /edx/app/edx_ansible/venvs/edx_ansible/bin/activate
-cd /edx/app/edx_ansible/edx_ansible/playbooks
-
-# Did we specify an openedx release?
-if [ -n "$OPENEDX_RELEASE" ]; then
-  EXTRA_VARS="-e edx_platform_version=$OPENEDX_RELEASE \
-    -e certs_version=$OPENEDX_RELEASE \
-    -e forum_version=$OPENEDX_RELEASE \
-    -e xqueue_version=$OPENEDX_RELEASE \
-    -e demo_version=$OPENEDX_RELEASE \
-    -e NOTIFIER_VERSION=$OPENEDX_RELEASE \
-    -e ECOMMERCE_VERSION=$OPENEDX_RELEASE \
-    -e ECOMMERCE_WORKER_VERSION=$OPENEDX_RELEASE \
-    -e PROGRAMS_VERSION=$OPENEDX_RELEASE \
-  "
-  CONFIG_VER=$OPENEDX_RELEASE
-else
-  CONFIG_VER="master"
-fi
-
-ansible-playbook -i localhost, -c local run_role.yml -e role=edx_ansible -e configuration_version=$CONFIG_VER $EXTRA_VARS
-ansible-playbook -i localhost, -c local vagrant-devstack.yml -e configuration_version=$CONFIG_VER $EXTRA_VARS
-
-SCRIPT
+# These are versioning variables in the roles. Each can be overridden, first
+# with OPENEDX_RELEASE, and then with a specific environment variable of the
+# same name but upper-cased.
+VERSION_VARS = [
+    'edx_platform_version',
+    'configuration_version',
+    'certs_version',
+    'forum_version',
+    'xqueue_version',
+    'demo_version',
+    'NOTIFIER_VERSION',
+    'ECOMMERCE_VERSION',
+    'ECOMMERCE_WORKER_VERSION',
+    'PROGRAMS_VERSION',
+]
 
 MOUNT_DIRS = {
   :edx_platform => {:repo => "edx-platform", :local => "/edx/app/edxapp/edx-platform", :owner => "edxapp"},
@@ -83,6 +67,30 @@ openedx_releases = {
 openedx_releases.default = "eucalyptus-devstack-2016-09-01"
 
 rel = ENV['OPENEDX_RELEASE']
+
+extra_vars_lines = ""
+if rel
+  VERSION_VARS.each do |var|
+    extra_vars_lines += "-e #{var}=#{rel} \\\n"
+  end
+end
+
+$script = <<SCRIPT
+if [ ! -d /edx/app/edx_ansible ]; then
+    echo "Error: Base box is missing provisioning scripts." 1>&2
+    exit 1
+fi
+export PYTHONUNBUFFERED=1
+source /edx/app/edx_ansible/venvs/edx_ansible/bin/activate
+cd /edx/app/edx_ansible/edx_ansible/playbooks
+
+EXTRA_VARS="#{extra_vars_lines}"
+CONFIG_VER="#{rel || 'master'}"
+
+ansible-playbook -i localhost, -c local run_role.yml -e role=edx_ansible -e configuration_version=$CONFIG_VER $EXTRA_VARS
+ansible-playbook -i localhost, -c local vagrant-devstack.yml -e configuration_version=$CONFIG_VER $EXTRA_VARS
+
+SCRIPT
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
@@ -153,5 +161,5 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   # Assume that the base box has the edx_ansible role installed
   # We can then tell the Vagrant instance to update itself.
-  config.vm.provision "shell", inline: $script, args: rel
+  config.vm.provision "shell", inline: $script
 end


### PR DESCRIPTION
I needed to test a fix in the notifier repo, but could not because NOTIFIER_VERSION was not available in the Vagrantfile.  This makes all the version variables overridable, with less repetition.