### PR TITLE
Change to wiredTiger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -196,3 +196,7 @@
 - Role: security
   - Changed SECURITY_UPGRADE_ON_ANSIBLE to only apply security updates.  If you want to retain the behavior of running safe-upgrade,
     you should switch to using SAFE_UPGRADE_ON_ANSIBLE.
+
+- Role: mongo_3_0
+  - Changed MONGO_STORAGE_ENGINE to default to wiredTiger which is the default in 3.2 and 3.4 and what edX suggests be used even on 3.0.
+    If you have a mmapv1 3.0 install, override MONGO_STORAGE_ENGINE to be mmapv1 which was the old default.

--- a/playbooks/roles/mongo_3_0/defaults/main.yml
+++ b/playbooks/roles/mongo_3_0/defaults/main.yml
@@ -49,7 +49,8 @@ MONGO_RS_CONFIG:
   members: []
 
 # Storage engine options in 3.0: "mmapv1" or "wiredTiger" 
-MONGO_STORAGE_ENGINE: "mmapv1"
+# As 3.2 and 3.4 default to wiredTiger, our 3.0 play will help future-proof
+MONGO_STORAGE_ENGINE: "wiredTiger"
 
 # List of dictionaries as described in the mount_ebs role's default
 # for the volumes.


### PR DESCRIPTION
If this play is being run against an existing mmapv1 mongo 3.0 install,
make sure MONGO_STORAGE_ENGINE is overridden.

This will facilitate shipping 3.0 with newer release.

@edx/devops
We're not using this role on sandboxes/devstacks so this only impacts deployers (such as us).