### PR TITLE
Add an install:app-configuration that only generates yml/json

### DIFF
--- a/playbooks/roles/edx_service/tasks/main.yml
+++ b/playbooks/roles/edx_service/tasks/main.yml
@@ -99,6 +99,7 @@
   tags:
     - install
     - install:configuration
+    - install:app-configuration
   
 - name: Install a bunch of system packages on which edx_service relies
   apt:

--- a/playbooks/roles/edxapp/tasks/service_variant_config.yml
+++ b/playbooks/roles/edxapp/tasks/service_variant_config.yml
@@ -10,7 +10,8 @@
   tags:
     - install
     - install:configuration
-    - edxapp_cfg
+    - install:app-configuration
+    - edxapp_cfg # Old deprecated tag, will remove when possible
 
 - name: create auth and application yaml config
   template:
@@ -23,7 +24,8 @@
   tags:
     - install
     - install:configuration
-    - edxapp_cfg
+    - install:app-configuration
+    - edxapp_cfg # Old deprecated tag, will remove when possible
 
 # write the supervisor scripts for the service variants
 - name: "writing {{ item }} supervisor script"


### PR DESCRIPTION
This is helpful for uses that want to generate just config for
edxapp or any of our IDAs