### PR TITLE
Allow make to run locally without throwing errors.

### DIFF
--- a/docker.mk
+++ b/docker.mk
@@ -4,7 +4,8 @@ SHARD=0
 SHARDS=1
 
 dockerfiles:=$(shell ls docker/build/*/Dockerfile)
-images:=$(shell git diff --name-only $(TRAVIS_COMMIT_RANGE) | python util/parsefiles.py)
+all_images:=$(patsubst docker/build/%/Dockerfile,%,$(dockerfiles))
+images:=$(if $(TRAVIS_COMMIT_RANGE),$(shell git diff --name-only $(TRAVIS_COMMIT_RANGE) | python util/parsefiles.py),$(all_images))
 
 docker_build=docker.build.
 docker_test=docker.test.

--- a/test.mk
+++ b/test.mk
@@ -2,7 +2,7 @@
 yml_files:=$(shell find . -name "*.yml")
 json_files:=$(shell find . -name "*.json")
 jinja_files:=$(shell find . -name "*.j2")
-images = $(shell git diff --name-only $(TRAVIS_COMMIT_RANGE) | python util/parsefiles.py)
+images = $(if $(TRAVIS_COMMIT_RANGE), $(shell git diff --name-only $(TRAVIS_COMMIT_RANGE) | python util/parsefiles.py), $(all_images))
 
 test: test.syntax test.edx_east_roles
 

--- a/util/balancecontainers.py
+++ b/util/balancecontainers.py
@@ -7,7 +7,7 @@ import argparse
 import logging
 import docker_images
 
-TRAVIS_BUILD_DIR = os.environ.get("TRAVIS_BUILD_DIR")
+TRAVIS_BUILD_DIR = os.environ.get("TRAVIS_BUILD_DIR", "")
 CONFIG_FILE_PATH = pathlib2.Path(TRAVIS_BUILD_DIR, "util", "parsefiles_config.yml")
 LOGGER = logging.getLogger(__name__)
 

--- a/util/docker_images.py
+++ b/util/docker_images.py
@@ -4,7 +4,7 @@ import pathlib2
 import itertools
 import sys
 
-TRAVIS_BUILD_DIR = os.environ.get("TRAVIS_BUILD_DIR")
+TRAVIS_BUILD_DIR = os.environ.get("TRAVIS_BUILD_DIR", "")
 CONFIG_FILE_PATH = pathlib2.Path(TRAVIS_BUILD_DIR, "util", "parsefiles_config.yml")
 
 def get_used_images(images):


### PR DESCRIPTION
Configuration Pull Request
---

Make sure that the following steps are done before merging

  - [ ] @devops team member has commented with :+1:

It wasn't fully broken but was throwing exceptions anytime you
ran any make command because the errors happened during variable
interpolation.