### PR TITLE
Entrypoint can't be overridden, it should not be used this way.

### DIFF
--- a/docker/build/ecommerce/Dockerfile
+++ b/docker/build/ecommerce/Dockerfile
@@ -4,11 +4,11 @@ MAINTAINER edxops
 RUN apt-get update
 
 ADD . /edx/app/edx_ansible/edx_ansible
-COPY docker/build/ecommerce/ansible_overrides.yml /
 WORKDIR /edx/app/edx_ansible/edx_ansible/docker/plays
 
 COPY docker/build/ecommerce/ansible_overrides.yml /
 RUN /edx/app/edx_ansible/venvs/edx_ansible/bin/ansible-playbook ecommerce.yml -i '127.0.0.1,' -c local -t "install:base,install:system-requirements,install:configuration,install:app-requirements,install:code" -e@/ansible_overrides.yml
-COPY docker/build/xqueue/docker-run.sh /
-ENTRYPOINT ["/docker-run.sh"]
+COPY docker/build/ecommerce/docker-run.sh /
+
+CMD ["/docker-run.sh"]
 EXPOSE 8130


### PR DESCRIPTION
Configuration Pull Request
---

Make sure that the following steps are done before merging

  - [ ] @devops team member has commented with :+1:
  - [ ] are you adding any new default values that need to be overriden when this goes live?  
    - [ ] Open a ticket (DEVOPS) to make sure that they have been added to secure vars.
    - [ ] Add an entry to the CHANGELOG.

