### PR TITLE
Remove old / unlisted ssh keys

### DIFF
--- a/playbooks/roles/user/tasks/main.yml
+++ b/playbooks/roles/user/tasks/main.yml
@@ -138,6 +138,7 @@
 - name: Get github key(s) and update the authorized_keys file
   authorized_key:
     user: "{{ item.name }}"
+    exclusive: yes
     key: "https://github.com/{{ item.name }}.keys"
   when: item.github is defined and item.get('state', 'present') == 'present'
   with_items: "{{ user_info }}"


### PR DESCRIPTION
Without this, we leave your old ssh keys behind when adding the new keys from GitHub.

@edx/devops