### PR TITLE
We don't want to recreate these files

### DIFF
--- a/playbooks/roles/rabbitmq/templates/etc/logrotate.d/rabbitmq.j2
+++ b/playbooks/roles/rabbitmq/templates/etc/logrotate.d/rabbitmq.j2
@@ -7,4 +7,5 @@
   missingok
   daily
   rotate 3
+  nocreate
 }


### PR DESCRIPTION
Rabbit's logs go to /var/log/rabbitmq/ these files are our internal
queue monitoring logs and they will be recreated by
/edx/app/rabbitmq/log-rabbitmq-queues.sh

Without this, we end up with > 10K empty files which makes logrotate and
splunk sad.

@edx/devops