### PR TITLE
install cached android emu on jenkins workers

### DIFF
--- a/playbooks/roles/android_sdk/defaults/main.yml
+++ b/playbooks/roles/android_sdk/defaults/main.yml
@@ -20,8 +20,10 @@ android_tools:
     - { package: 'extra-google-m2repository', android_test_path: 'extras/google/m2repository' }
     - { package: 'extra-android-m2repository', android_test_path: 'extras/android/m2repository' }
     - { package: 'sys-img-armeabi-v7a-android-21', android_test_path: 'system-images/android-21/default/armeabi-v7a/' }
-    - { package: 'sys-img-armeabi-v7a-android-23', android_test_path: 'system-images/android-23/default/armeabi-v7a/' }
+#    - { package: 'sys-img-armeabi-v7a-android-23', android_test_path: 'system-images/android-23/default/armeabi-v7a/' }
 # libraries needed for avd(android virtual device) emulation
 android_apt_libraries:
     - libstdc++6:i386
     - lib32z1
+android_sys_image_url: https://s3.amazonaws.com/edx-testeng-tools/android/android-sysimage-23.tar.gz
+android_sys_image_checksum: a111ad559000e91e1d8d9d76df83a6341cc8cbfc3608077380ab15f17b5d0033

--- a/playbooks/roles/android_sdk/tasks/main.yml
+++ b/playbooks/roles/android_sdk/tasks/main.yml
@@ -65,6 +65,10 @@
     state: link
     owner: "{{ android_user }}"
     group: "{{ android_group }}"
+# TEMPORARY FIX TO https://code.google.com/p/android/issues/detail?id=228113
+# The version of the Android ARM system image used by the mobile team for screenshot
+# testing is currently unavailable. In the meantime, download a cached version on
+# s3.
 # Download cached version of Android Sys image, because it is no longer available
 # via the Android SDK
 - name: Download cached version of Android Sys Image 23 from s3

--- a/playbooks/roles/android_sdk/tasks/main.yml
+++ b/playbooks/roles/android_sdk/tasks/main.yml
@@ -65,3 +65,21 @@
     state: link
     owner: "{{ android_user }}"
     group: "{{ android_group }}"
+# Download cached version of Android Sys image, because it is no longer available
+# via the Android SDK
+- name: Download cached version of Android Sys Image 23 from s3
+  shell: "curl -L {{ android_sys_image_url }} -o /var/tmp/android-sysimage-23.tar.gz"
+  args:
+    creates: /var/tmp/android-sysimage-23.tar.gz
+- name: Verify checksum of downloaded android tarball
+  shell: "sha256sum /var/tmp/android-sysimage-23.tar.gz"
+  register: android_sys_image_download_checksum
+- assert:
+    that:
+        "'{{ android_sys_image_checksum }}' in android_sys_image_download_checksum.stdout"
+- name: Unzip Android system image
+  unarchive:
+    src: /var/tmp/android-sysimage-23.tar.gz
+    dest: "{{ android_home }}/system-images"
+    creates: "{{ android_home }}/system-images/android-23"
+    copy: no

--- a/playbooks/roles/jenkins_worker/meta/main.yml
+++ b/playbooks/roles/jenkins_worker/meta/main.yml
@@ -40,7 +40,7 @@ dependencies:
       - { package: 'extra-google-m2repository', android_test_path: 'extras/google/m2repository' }
       - { package: 'extra-android-m2repository', android_test_path: 'extras/android/m2repository' }
       - { package: 'sys-img-armeabi-v7a-android-21', android_test_path: 'system-images/android-21/default/armeabi-v7a/' }
-      - { package: 'sys-img-armeabi-v7a-android-23', android_test_path: 'system-images/android-23/default/armeabi-v7a/' }
+    #  - { package: 'sys-img-armeabi-v7a-android-23', android_test_path: 'system-images/android-23/default/armeabi-v7a/' }
     # libraries needed for avd(android virtual device) emulation
     android_apt_libraries:
       - libstdc++6:i386

--- a/playbooks/roles/jenkins_worker/tasks/test_android_worker.yml
+++ b/playbooks/roles/jenkins_worker/tasks/test_android_worker.yml
@@ -37,3 +37,11 @@
   assert:
     that:
       - "item.stat.exists == True"
+# TEMP: until we either change to using a different system image OR google hosts
+# the android 23 image again
+- name: Verify that cached Android sys image is installed
+  shell: "stat {{ android_home }}/system-images/android-23"
+  register: android_23_stat
+- assert:
+    that:
+        - "android_23_stat.rc == 0"


### PR DESCRIPTION
@jzoldak @benpatterson PTAL
@jibsheet 

this is a *hopefully* temporary fix for https://code.google.com/p/android/issues/detail?id=228113. I pulled the emulator off of my machine and hosted it on s3. 