### PR TITLE
SEC-220: actually block /login?next=/favicon.ico

### DIFF
--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
@@ -166,7 +166,7 @@ error_page {{ k }} {{ v }};
       {% include "basic-auth.j2" %}
     {% endif %}
 
-    if ( $arg_next = "favicon.ico" ) {
+    if ( $arg_next ~* "favicon.ico" ) {
       return 403;
     }
 


### PR DESCRIPTION
Configuration Pull Request
---

Make sure that the following steps are done before merging

  - [ ] @devops team member has commented with :+1:
  - [ ] are you adding any new default values that need to be overriden when this goes live?  
    - [ ] Open a ticket (DEVOPS) to make sure that they have been added to secure vars.
    - [ ] Add an entry to the CHANGELOG.

Previously we only blocked exact matches to "next=favicon.ico". Now,
we'll also block "next=/favicon.ico" and any other variations.