### PR TITLE
Upgrade edxapp node version to 6.9 LTS

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -639,7 +639,7 @@ edxapp_venv_dir: "{{ edxapp_venvs_dir }}/edxapp"
 edxapp_venv_bin: "{{ edxapp_venv_dir }}/bin"
 edxapp_nodeenv_dir: "{{ edxapp_app_dir }}/nodeenvs/edxapp"
 edxapp_nodeenv_bin: "{{ edxapp_nodeenv_dir }}/bin"
-edxapp_node_version: "6.9.1"
+edxapp_node_version: "6.9.2"
 # This is where node installs modules, not node itself
 edxapp_node_bin: "{{ edxapp_code_dir }}/node_modules/.bin"
 edxapp_user: edxapp

--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -639,7 +639,7 @@ edxapp_venv_dir: "{{ edxapp_venvs_dir }}/edxapp"
 edxapp_venv_bin: "{{ edxapp_venv_dir }}/bin"
 edxapp_nodeenv_dir: "{{ edxapp_app_dir }}/nodeenvs/edxapp"
 edxapp_nodeenv_bin: "{{ edxapp_nodeenv_dir }}/bin"
-edxapp_node_version: "0.10.37"
+edxapp_node_version: "6.9.1"
 # This is where node installs modules, not node itself
 edxapp_node_bin: "{{ edxapp_code_dir }}/node_modules/.bin"
 edxapp_user: edxapp


### PR DESCRIPTION
## Description:
[TNL-5521](https://openedx.atlassian.net/browse/TNL-5521). Upgrade to Node 6.

## Testing:

- [x] **Created a devstack**: I've been using it for the past few days without issue (update: Ari is now on Node 6 as well)
```
$> CONFIGURATION_VERSION=bjacobel/node6 vagrant up
[...]
$> vagrant ssh
[...]
vagrant@precise64:~$ sudo su edxapp
edxapp@precise64:~/edx-platform$ node --version
v6.9.1
edxapp@precise64:~/edx-platform$ npm --version
3.10.8
```
- [x] **Created a "normal" sandbox**: https://peerdeps-npm3.sandbox.edx.org
- [x] **Built an AMI**: succeeded (Job number 5766, build token kevin-prod-edx-edxapp-1480954987)
- [x] **Create a "from scratch" sandbox**: https://scratch-node-lts.sandbox.edx.org, [job](http://jenkins.edx.org:8080/view/Ansible/job/ansible-provision/10313/)
- [x] **Build Jenkins worker AMI**: [success](https://build.testeng.edx.org/view/packer/job/build-packer-ami/4246/)
- [x] **Jenkins worker AMI smoketests**: running [javascript](https://build.testeng.edx.org/view/All/job/edx-platform-pr-tests-special-worker/2/) and [bokchoy](https://build.testeng.edx.org/view/All/job/edx-platform-pr-tests-special-worker/3/)

## Reviewers;
- [x] @jibsheet 
- [ ] @benpatterson 
