### PR TITLE
Adjustments to browsers role for devstack

### DIFF
--- a/playbooks/roles/browsers/defaults/main.yml
+++ b/playbooks/roles/browsers/defaults/main.yml
@@ -1,22 +1,17 @@
 browser_deb_pkgs:
-    - xvfb
     - dbus-x11
-    - libgconf2-4
-    - libxss1
-    - libnss3-1d
+    - firefox=45.0.2+build1-0ubuntu1
+    - google-chrome-stable
     - libcurl3
+    - libgconf2-4
+    - libnss3-1d
+    - libxss1
     - xdg-utils
-    - gdebi
-
-# Debian packages we host in S3 to ensure correct browser version
-# Both Chrome and FireFox update their apt repos with the latest version,
-# which often causes spurious acceptance test failures.
-browser_s3_deb_pkgs:
-    - { name: "google-chrome-stable_30.0.1599.114-1_amd64.deb", url: "https://s3.amazonaws.com/vagrant.testeng.edx.org/google-chrome-stable_30.0.1599.114-1_amd64.deb" }
-    - { name: "firefox-mozilla-build_42.0-0ubuntu1_amd64.deb", url: "https://s3.amazonaws.com/vagrant.testeng.edx.org/firefox-mozilla-build_42.0-0ubuntu1_amd64.deb" }
+    - xvfb
 
 # Chrome and ChromeDriver
-chromedriver_version: 2.6
+chrome_repo: "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main"
+chromedriver_version: 2.25
 chromedriver_url: "http://chromedriver.storage.googleapis.com/{{ chromedriver_version }}/chromedriver_linux64.zip"
 
 # PhantomJS

--- a/playbooks/roles/browsers/tasks/main.yml
+++ b/playbooks/roles/browsers/tasks/main.yml
@@ -64,9 +64,11 @@
 - assert:
     that: "phantomjs.stat.exists"
 
-- name: create xvfb upstart script
-  template: src=xvfb.conf.j2 dest=/etc/init/xvfb.conf owner=root group=root
+- name: create xvfb systemd service
+  template: src=xvfb.service.j2 dest=/etc/systemd/system/xvfb.service owner=root group=root
+
+- name: register xvfb systemd service
+  shell: systemctl enable /etc/systemd/system/xvfb.service
 
 - name: start xvfb
-  shell: start xvfb
-  ignore_errors: yes
+  service: name=xvfb state=started

--- a/playbooks/roles/browsers/tasks/main.yml
+++ b/playbooks/roles/browsers/tasks/main.yml
@@ -1,26 +1,19 @@
 # Install browsers required to run the JavaScript
 # and acceptance test suite locally without a display
 ---
+- name: install Google public key for apt
+  apt_key:
+    url: "https://dl-ssl.google.com/linux/linux_signing_key.pub"
+    state: present
+
+- name: add Google Chrome repo to the sources list
+  apt_repository:
+    repo: "{{ chrome_repo }}"
+    state: present
+
 - name: install system packages
   apt: pkg={{','.join(browser_deb_pkgs)}}
        state=present update_cache=yes
-
-- name: download browser debian packages from S3
-  get_url: dest="/tmp/{{ item.name }}" url="{{ item.url }}"
-  register: download_deb
-  with_items: browser_s3_deb_pkgs
-
-- name: install browser debian packages
-  shell: gdebi -nq /tmp/{{ item.name }}
-  when: download_deb.changed
-  with_items: browser_s3_deb_pkgs
-
-# Because the source location has been deprecated, we need to
-# ensure it does not interfere with subsequent apt commands
-- name: remove google chrome debian source list
-  file:
-    path: /etc/apt/sources.list.d/google-chrome.list
-    state: absent
 
 - name: download ChromeDriver
   get_url:

--- a/playbooks/roles/browsers/templates/xvfb.conf.j2
+++ b/playbooks/roles/browsers/templates/xvfb.conf.j2
@@ -1,6 +1,0 @@
-description     "Xvfb X Server"
-start on (net-device-up and local-filesystems and runlevel [2345])
-stop on runlevel [016]
-exec /usr/bin/Xvfb {{ browser_xvfb_display }} -screen 0 1024x768x24
-respawn
-respawn limit 15 5

--- a/playbooks/roles/browsers/templates/xvfb.service.j2
+++ b/playbooks/roles/browsers/templates/xvfb.service.j2
@@ -1,0 +1,9 @@
+[Unit]
+Description=X Virtual Frame Buffer Service
+After=network.target
+
+[Service] 
+ExecStart=/usr/bin/Xvfb {{ browser_xvfb_display }} -screen 0 1024x768x24
+
+[Install]
+WantedBy=multi-user.target

--- a/vagrant/base/devstack/Vagrantfile
+++ b/vagrant/base/devstack/Vagrantfile
@@ -16,7 +16,7 @@ end
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   # Creates a devstack from a base Ubuntu 16.04 image for virtualbox
-  config.vm.box = "ubuntu/xenial64"
+  config.vm.box = "boxcutter/ubuntu1604"
 
   config.vm.network :private_network, ip: vm_guest_ip
 


### PR DESCRIPTION
* Switch base box from `ubuntu/xenial64` to `boxcutter/ubuntu1604`
* Update to Firefox 45 which comes from the official package repo (verified to be compatible with Selenium 2.53.1)
* Install latest stable Chrome using Google's PPA (verified to be compatible with Selenium 2.53.1)
* Upgrade chromedriver from 2.6 to 2.25 (current release, verified to be compatible with Selenium 2.53.1)
* Manage `xvfb` via systemd rather than upstart

Address #3487.

/cc @nedbat @benpatterson @jibsheet 

Make sure that the following steps are done before merging

  - [x] Verify successful [Vagrant box build](https://openedx.atlassian.net/wiki/display/COMM/Process+to+Create+an+Open+edX+Release#ProcesstoCreateanOpenedXRelease-MakeVagrantboxes) (@gsong)
  - [ ] Verify successful `paver test` (@gsong)
  - [ ] @devops team member has commented with :+1: