### PR TITLE
Make the configuration dir if it's not there already.

### DIFF
--- a/util/install/ansible-bootstrap.sh
+++ b/util/install/ansible-bootstrap.sh
@@ -142,6 +142,7 @@ PATH="${PYTHON_BIN}":${PATH}
 
 # Install the configuration repository to install 
 # edx_ansible role
+mkdir -p ${CONFIGURATION_DIR}
 git clone ${CONFIGURATION_REPO} ${CONFIGURATION_DIR}
 cd ${CONFIGURATION_DIR}
 git checkout ${CONFIGURATION_VERSION}


### PR DESCRIPTION
Configuration Pull Request
---

Make sure that the following steps are done before merging

  - [ ] @devops team member has commented with :+1:
  - [ ] are you adding any new default values that need to be overriden when this goes live?  
    - [ ] Open a ticket (DEVOPS) to make sure that they have been added to secure vars.
    - [ ] Add an entry to the CHANGELOG.

Text of PR:

I encountered the following error on a Xenial box which came with git 2.7.4 installed.

```
+ PATH=/tmp/bootstrap/bin:/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin
+ git clone /tmp/configuration
fatal: repository '/tmp/configuration' does not exist
```

This change ensures that does not happen.