### PR TITLE
Remove nonexistent reference

### DIFF
--- a/playbooks/roles/ecommerce/defaults/main.yml
+++ b/playbooks/roles/ecommerce/defaults/main.yml
@@ -220,7 +220,6 @@ ecommerce_log_dir: "{{ COMMON_LOG_DIR }}/{{ ecommerce_service_name }}"
 ecommerce_requirements_base: "{{ ecommerce_code_dir }}/requirements"
 ecommerce_requirements:
   - production.txt
-  - optional.txt
 
 ecommerce_environment:
   DJANGO_SETTINGS_MODULE: "{{ ECOMMERCE_DJANGO_SETTINGS_MODULE }}"

--- a/playbooks/roles/ecomworker/defaults/main.yml
+++ b/playbooks/roles/ecomworker/defaults/main.yml
@@ -147,7 +147,6 @@ ecommerce_worker_log_dir: '{{ COMMON_LOG_DIR }}/{{ ecommerce_worker_service_name
 ecommerce_worker_requirements_base: '{{ ecommerce_worker_code_dir }}/requirements'
 ecommerce_worker_requirements:
   - production.txt
-  - optional.txt
 
 # OS packages
 ecommerce_worker_debian_pkgs: []


### PR DESCRIPTION
@clintonb I just ran into an error setting up my devstack because `optional.txt` was removed in https://github.com/edx/ecommerce/commit/c38644712891a9753df3da4fde08a9478141cf56. I think this is the only thing we need to clean up to fix it, can you advise?

```
==> default: TASK: [ecommerce | Install application requirements] ************************** 
==> default: changed: [localhost] => (item=production.txt)
==> default: failed: [localhost] => (item=optional.txt) => {"cmd": "/edx/app/ecommerce/venvs/ecommerce/bin/pip install -r /edx/app/ecommerce/ecommerce/requirements/optional.txt", "failed": true, "item": "optional.txt"}
==> default: msg: 
==> default: :stderr: Could not open requirements file: [Errno 2] No such file or directory: '/edx/app/ecommerce/ecommerce/requirements/optional.txt'
==> default: You are using pip version 7.1.2, however version 9.0.1 is available.
==> default: You should consider upgrading via the 'pip install --upgrade pip' command.
==> default: 
==> default: FATAL: all hosts have already failed -- aborting
```

