### PR TITLE
Add all two new dependencies needed for Ansible 2.x

### DIFF
--- a/docker/build/go-agent/Dockerfile
+++ b/docker/build/go-agent/Dockerfile
@@ -42,8 +42,8 @@ RUN apt-get update && apt-get install -y \
     php5-common \
     php5-cli
 
-# Install libffi-dev - a dependency for Ansible 2.x
-RUN apt-get update && apt-get install -y libffi-dev
+# Install dependencies needed for Ansible 2.x
+RUN apt-get update && apt-get install -y libffi-dev libssl-dev
 
 # Install drush (drupal shell) for access to Drupal commands/Acquia
 RUN php -r "readfile('http://files.drush.org/drush.phar');" > drush && \


### PR DESCRIPTION
I'm confident these dependencies are all of the new ones needed - because I started a local go-agent Docker container and installed all Python modules from tubular/configuration successfully after adding these two dependencies.

@macdiesel @feanil Please review.
@edx/devops FYI
