### PR TITLE
Remove node ppa for jenkins-worker.

### DIFF
--- a/playbooks/roles/jenkins_worker/defaults/main.yml
+++ b/playbooks/roles/jenkins_worker/defaults/main.yml
@@ -3,14 +3,10 @@ jenkins_user: "jenkins"
 jenkins_group: "jenkins"
 jenkins_home: /home/jenkins
 
-# repo for nodejs
-jenkins_chrislea_ppa: "ppa:chris-lea/node.js"
-
 jenkins_edx_platform_version: master
 
 # System packages
 jenkins_debian_pkgs:
-    - nodejs
     - pkg-config
     - libffi-dev
     - python-dev

--- a/playbooks/roles/jenkins_worker/tasks/system.yml
+++ b/playbooks/roles/jenkins_worker/tasks/system.yml
@@ -26,10 +26,6 @@
     owner={{ jenkins_user }} group={{ jenkins_group }} mode=400
   ignore_errors: yes
 
-# adding chris-lea nodejs repo
-- name: add ppas for current versions of nodejs
-  apt_repository: repo="{{ jenkins_chrislea_ppa }}"
-
 - name: Install system packages
   apt: pkg={{','.join(jenkins_debian_pkgs)}}
        state=present update_cache=yes


### PR DESCRIPTION
Platform is now using nodeenv so we do not need node installed globally on
jenkins-workers.

Configuration Pull Request
---

Make sure that the following steps are done before merging

  - [x] @devops team member has commented with :+1:
  - [ ] are you adding any new default values that need to be overriden when this goes live?  
    - [ ] Open a ticket (DEVOPS) to make sure that they have been added to secure vars.
    - [ ] Add an entry to the CHANGELOG.

