### PR TITLE
let app home directories default to None if not defined

### DIFF
--- a/playbooks/roles/local_dev/defaults/main.yml
+++ b/playbooks/roles/local_dev/defaults/main.yml
@@ -43,28 +43,28 @@ localdev_accounts:
 
     - {
         user: "{{ analytics_api_user|default('None') }}",
-        home: "{{ analytics_api_home }}",
+        home: "{{ analytics_api_home|default('None') }}",
         env: "analytics_api_env",
         repo: "analytics_api"
       }
 
     - {
         user: "{{ insights_user|default('None') }}",
-        home: "{{ insights_home }}",
+        home: "{{ insights_home|default('None') }}",
         env: "insights_env",
         repo: "edx_analytics_dashboard"
       }
 
     - {
         user: "{{ programs_user|default('None') }}",
-        home: "{{ programs_home }}",
+        home: "{{ programs_home|default('None') }}",
         env: "programs_env",
         repo: "programs"
       }
 
     - {
         user: "{{ credentials_user|default('None') }}",
-        home: "{{ credentials_home }}",
+        home: "{{ credentials_home|default('None') }}",
         env: "credentials_env",
         repo: "credentials"
       }

--- a/playbooks/roles/oauth_client_setup/defaults/main.yml
+++ b/playbooks/roles/oauth_client_setup/defaults/main.yml
@@ -19,38 +19,38 @@ oauth_client_setup_role_name: oauth_client_setup
 oauth_client_setup_oauth2_clients:
     - {
         name: "{{ ecommerce_service_name | default('None') }}",
-        url_root: "{{ ECOMMERCE_ECOMMERCE_URL_ROOT }}",
-        id: "{{ ECOMMERCE_SOCIAL_AUTH_EDX_OIDC_KEY }}", 
-        secret: "{{ ECOMMERCE_SOCIAL_AUTH_EDX_OIDC_SECRET }}",
-        logout_uri: "{{ ECOMMERCE_LOGOUT_URL }}"
+        url_root: "{{ ECOMMERCE_ECOMMERCE_URL_ROOT | default('None') }}",
+        id: "{{ ECOMMERCE_SOCIAL_AUTH_EDX_OIDC_KEY | default('None') }}",
+        secret: "{{ ECOMMERCE_SOCIAL_AUTH_EDX_OIDC_SECRET | default('None') }}",
+        logout_uri: "{{ ECOMMERCE_LOGOUT_URL | default('None') }}"
       }
     - {
         name: "{{ INSIGHTS_OAUTH2_APP_CLIENT_NAME | default('None') }}",
-        url_root: "{{ INSIGHTS_BASE_URL }}",
-        id: "{{ INSIGHTS_OAUTH2_KEY }}",
-        secret: "{{ INSIGHTS_OAUTH2_SECRET }}",
-        logout_uri: "{{ INSIGHTS_LOGOUT_URL }}"
+        url_root: "{{ INSIGHTS_BASE_URL | default('None') }}",
+        id: "{{ INSIGHTS_OAUTH2_KEY | default('None') }}",
+        secret: "{{ INSIGHTS_OAUTH2_SECRET | default('None') }}",
+        logout_uri: "{{ INSIGHTS_LOGOUT_URL | default('None') }}"
       }
     - {
         name: "{{ programs_service_name | default('None') }}",
-        url_root: "{{ PROGRAMS_URL_ROOT }}",
-        id: "{{ PROGRAMS_SOCIAL_AUTH_EDX_OIDC_KEY }}",
-        secret: "{{ PROGRAMS_SOCIAL_AUTH_EDX_OIDC_SECRET }}",
-        logout_uri: "{{ PROGRAMS_LOGOUT_URL }}"
+        url_root: "{{ PROGRAMS_URL_ROOT | default('None') }}",
+        id: "{{ PROGRAMS_SOCIAL_AUTH_EDX_OIDC_KEY | default('None') }}",
+        secret: "{{ PROGRAMS_SOCIAL_AUTH_EDX_OIDC_SECRET | default('None') }}",
+        logout_uri: "{{ PROGRAMS_LOGOUT_URL | default('None') }}"
       }
     - {
         name: "{{ credentials_service_name | default('None') }}",
-        url_root: "{{ CREDENTIALS_URL_ROOT }}",
-        id: "{{ CREDENTIALS_SOCIAL_AUTH_EDX_OIDC_KEY }}",
-        secret: "{{ CREDENTIALS_SOCIAL_AUTH_EDX_OIDC_SECRET }}",
-        logout_uri: "{{ CREDENTIALS_LOGOUT_URL }}"
+        url_root: "{{ CREDENTIALS_URL_ROOT | default('None') }}",
+        id: "{{ CREDENTIALS_SOCIAL_AUTH_EDX_OIDC_KEY | default('None') }}",
+        secret: "{{ CREDENTIALS_SOCIAL_AUTH_EDX_OIDC_SECRET | default('None') }}",
+        logout_uri: "{{ CREDENTIALS_LOGOUT_URL | default('None') }}"
       }
     - {
         name: "{{ discovery_service_name | default('None') }}",
-        url_root: "{{ DISCOVERY_URL_ROOT }}",
-        id: "{{ DISCOVERY_SOCIAL_AUTH_EDX_OIDC_KEY }}",
-        secret: "{{ DISCOVERY_SOCIAL_AUTH_EDX_OIDC_SECRET }}",
-        logout_uri: "{{ DISCOVERY_LOGOUT_URL }}"
+        url_root: "{{ DISCOVERY_URL_ROOT | default('None') }}",
+        id: "{{ DISCOVERY_SOCIAL_AUTH_EDX_OIDC_KEY | default('None') }}",
+        secret: "{{ DISCOVERY_SOCIAL_AUTH_EDX_OIDC_SECRET | default('None') }}",
+        logout_uri: "{{ DISCOVERY_LOGOUT_URL | default('None') }}"
       }
 
 #


### PR DESCRIPTION
@feanil if these apps are not included in devstack not having the home directory defined will cause an error during: https://github.com/edx/configuration/blob/6b2945fbf98c927c1a492c463bcde702a25139c7/playbooks/roles/local_dev/tasks/main.yml#L10-L15

I've set them to a default of None here. Is this ok or do you have some other juju you would like to work with this?