### PR TITLE
Grant 'go' user sudo perms for /usr/local/bin/pip

### DIFF
--- a/docker/build/go-agent/Dockerfile
+++ b/docker/build/go-agent/Dockerfile
@@ -59,7 +59,7 @@ RUN /bin/bash /tmp/docker/docker_install.sh
 RUN usermod -aG docker go
 
 # Assign the go user root privlidges
-RUN printf "\ngo      ALL=(ALL:ALL) NOPASSWD: /usr/bin/pip\n" >> /etc/sudoers
+RUN printf "\ngo      ALL=(ALL:ALL) NOPASSWD: /usr/bin/pip, /usr/local/bin/pip\n" >> /etc/sudoers
 
 # Install AWS command-line interface - for AWS operations in a go-agent task.
 RUN pip install awscli


### PR DESCRIPTION
This change is required when upgrading the pip version via performing `pip install -r pre-requirements.txt` in configuration. The old `/usr/bin/pip` is still present but the new `/usr/local/bin/pip` is the pip executable from that point forward.

@edx/pipeline-team Please review.
