### PR TITLE
Make Hadoop more configurable

### DIFF
--- a/playbooks/roles/hadoop_common/defaults/main.yml
+++ b/playbooks/roles/hadoop_common/defaults/main.yml
@@ -67,6 +67,9 @@ MAPRED_SITE_DEFAULT_CONFIG:
 YARN_SITE_DEFAULT_CONFIG:
   yarn.nodemanager.aux-services: "mapreduce_shuffle"
   yarn.nodemanager.aux-services.mapreduce.shuffle.class: "org.apache.hadoop.mapred.ShuffleHandler"
+  yarn.log-aggregation-enable: true
+  # 24 hour log retention
+  yarn.log-aggregation.retain-seconds: 86400
 
 HADOOP_CORE_SITE_DEFAULT_CONFIG:
   fs.default.name: "hdfs://localhost:9000"
@@ -94,10 +97,6 @@ HDFS_SITE_DEFAULT_CONFIG:
 #   yarn.nodemanager.vmem-pmem-ratio: 2.1
 
 mapred_site_config: {}
-yarn_site_config:
-  yarn.log-aggregation-enable: true
-  # 24 hour log retention
-  yarn.log-aggregation.retain-seconds: 86400
-
+yarn_site_config: {}
 HADOOP_CORE_SITE_EXTRA_CONFIG: {}
 HDFS_SITE_EXTRA_CONFIG: {}

--- a/playbooks/roles/hadoop_common/defaults/main.yml
+++ b/playbooks/roles/hadoop_common/defaults/main.yml
@@ -61,6 +61,13 @@ hadoop_common_debian_pkgs:
 
 hadoop_common_redhat_pkgs: []
 
+#
+# Vars are used to fill in the following files:
+#     core-site.xml
+#     hdfs-site.xml
+#     mapred-site.xml
+#     yarn-site.xml
+#
 MAPRED_SITE_DEFAULT_CONFIG:
   mapreduce.framework.name: "yarn"
 

--- a/playbooks/roles/hadoop_common/defaults/main.yml
+++ b/playbooks/roles/hadoop_common/defaults/main.yml
@@ -61,6 +61,21 @@ hadoop_common_debian_pkgs:
 
 hadoop_common_redhat_pkgs: []
 
+MAPRED_SITE_DEFAULT_CONFIG:
+  mapreduce.framework.name: "yarn"
+
+YARN_SITE_DEFAULT_CONFIG:
+  yarn.nodemanager.aux-services: "mapreduce_shuffle"
+  yarn.nodemanager.aux-services.mapreduce.shuffle.class: "org.apache.hadoop.mapred.ShuffleHandler"
+
+HADOOP_CORE_SITE_DEFAULT_CONFIG:
+  fs.default.name: "hdfs://localhost:9000"
+
+HDFS_SITE_DEFAULT_CONFIG:
+  dfs.replication: "1"
+  dfs.namenode.name.dir: "file:{{ HADOOP_COMMON_DATA }}/namenode"
+  dfs.datanode.data.dir: "file:{{ HADOOP_COMMON_DATA }}/datanode"
+
 #
 # MapReduce/Yarn memory config (defaults for m1.medium)
 # http://docs.aws.amazon.com/ElasticMapReduce/latest/DeveloperGuide/TaskConfiguration_H2.html
@@ -84,3 +99,5 @@ yarn_site_config:
   # 24 hour log retention
   yarn.log-aggregation.retain-seconds: 86400
 
+HADOOP_CORE_SITE_EXTRA_CONFIG: {}
+HDFS_SITE_EXTRA_CONFIG: {}

--- a/playbooks/roles/hadoop_common/defaults/main.yml
+++ b/playbooks/roles/hadoop_common/defaults/main.yml
@@ -67,7 +67,7 @@ MAPRED_SITE_DEFAULT_CONFIG:
 YARN_SITE_DEFAULT_CONFIG:
   yarn.nodemanager.aux-services: "mapreduce_shuffle"
   yarn.nodemanager.aux-services.mapreduce.shuffle.class: "org.apache.hadoop.mapred.ShuffleHandler"
-  yarn.log-aggregation-enable: true
+  yarn.log-aggregation-enable: "true"
   # 24 hour log retention
   yarn.log-aggregation.retain-seconds: 86400
 

--- a/playbooks/roles/hadoop_common/defaults/main.yml
+++ b/playbooks/roles/hadoop_common/defaults/main.yml
@@ -96,6 +96,15 @@ HDFS_SITE_DEFAULT_CONFIG:
 #   yarn.nodemanager.resource.memory-mb: 2048
 #   yarn.nodemanager.vmem-pmem-ratio: 2.1
 
+#
+# Variables override the stock configuration for entry into
+# the following files. Ensure that you use unambiguous
+# string literals to avoid any confusion:
+#     core-site.xml
+#     hdfs-site.xml
+#     mapred-site.xml
+#     yarn-site.xml
+#
 mapred_site_config: {}
 yarn_site_config: {}
 HADOOP_CORE_SITE_EXTRA_CONFIG: {}

--- a/playbooks/roles/hadoop_common/templates/core-site.xml.j2
+++ b/playbooks/roles/hadoop_common/templates/core-site.xml.j2
@@ -1,16 +1,12 @@
 {% do HADOOP_CORE_SITE_DEFAULT_CONFIG.update(HADOOP_CORE_SITE_EXTRA_CONFIG) %}
 <?xml version="1.0"?>
 <?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
-
 <!-- Put site-specific property overrides in this file. -->
-
 <configuration>
-
 {% for key, value in HADOOP_CORE_SITE_DEFAULT_CONFIG.iteritems() %}
   <property>
     <name>{{ key }}</name>
     <value>{{ value }}</value>
   </property>
-
 {% endfor %}
 </configuration>

--- a/playbooks/roles/hadoop_common/templates/core-site.xml.j2
+++ b/playbooks/roles/hadoop_common/templates/core-site.xml.j2
@@ -1,11 +1,16 @@
+{% do HADOOP_CORE_SITE_DEFAULT_CONFIG.update(HADOOP_CORE_SITE_EXTRA_CONFIG) %}
 <?xml version="1.0"?>
 <?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
 
 <!-- Put site-specific property overrides in this file. -->
 
 <configuration>
+
+{% for key, value in HADOOP_CORE_SITE_DEFAULT_CONFIG.iteritems() %}
   <property>
-    <name>fs.default.name</name>
-    <value>hdfs://localhost:9000</value>
+    <name>{{ key }}</name>
+    <value>{{ value }}</value>
   </property>
+
+{% endfor %}
 </configuration>

--- a/playbooks/roles/hadoop_common/templates/hdfs-site.xml.j2
+++ b/playbooks/roles/hadoop_common/templates/hdfs-site.xml.j2
@@ -1,20 +1,14 @@
+{% do HDFS_SITE_DEFAULT_CONFIG.update(HDFS_SITE_EXTRA_CONFIG) %}
 <?xml version="1.0"?>
 <?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
 
 <configuration>
+
+{% for key, value in HDFS_SITE_DEFAULT_CONFIG.iteritems() %}
   <property>
-    <name>dfs.replication</name>
-    <value>1</value>
+    <name>{{ key }}</name>
+    <value>{{ value }}</value>
   </property>
 
-  <property>
-    <name>dfs.namenode.name.dir</name>
-    <value>file:{{ HADOOP_COMMON_DATA }}/namenode</value>
-  </property>
-
-  <property>
-    <name>dfs.datanode.data.dir</name>
-    <value>file:{{ HADOOP_COMMON_DATA }}/datanode</value>
-  </property>
-
+{% endfor %}
 </configuration>

--- a/playbooks/roles/hadoop_common/templates/hdfs-site.xml.j2
+++ b/playbooks/roles/hadoop_common/templates/hdfs-site.xml.j2
@@ -1,14 +1,11 @@
 {% do HDFS_SITE_DEFAULT_CONFIG.update(HDFS_SITE_EXTRA_CONFIG) %}
 <?xml version="1.0"?>
 <?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
-
 <configuration>
-
 {% for key, value in HDFS_SITE_DEFAULT_CONFIG.iteritems() %}
   <property>
     <name>{{ key }}</name>
     <value>{{ value }}</value>
   </property>
-
 {% endfor %}
 </configuration>

--- a/playbooks/roles/hadoop_common/templates/mapred-site.xml.j2
+++ b/playbooks/roles/hadoop_common/templates/mapred-site.xml.j2
@@ -1,5 +1,4 @@
 {% do MAPRED_SITE_DEFAULT_CONFIG.update(mapred_site_config) %}
-
 <?xml version="1.0"?>
 <?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
 

--- a/playbooks/roles/hadoop_common/templates/mapred-site.xml.j2
+++ b/playbooks/roles/hadoop_common/templates/mapred-site.xml.j2
@@ -1,19 +1,15 @@
+{% do MAPRED_SITE_DEFAULT_CONFIG.update(mapred_site_config) %}
+
 <?xml version="1.0"?>
 <?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
 
 <configuration>
-  <property>
-    <name>mapreduce.framework.name</name>
-    <value>yarn</value>
-  </property>
 
-{% if mapred_site_config is defined %}
-{% for key,value in mapred_site_config.iteritems() %}
+{% for key, value in MAPRED_SITE_DEFAULT_CONFIG.iteritems() %}
   <property>
     <name>{{ key }}</name>
     <value>{{ value }}</value>
   </property>
-{% endfor %}
-{% endif %}
 
+{% endfor %}
 </configuration>

--- a/playbooks/roles/hadoop_common/templates/mapred-site.xml.j2
+++ b/playbooks/roles/hadoop_common/templates/mapred-site.xml.j2
@@ -1,14 +1,11 @@
 {% do MAPRED_SITE_DEFAULT_CONFIG.update(mapred_site_config) %}
 <?xml version="1.0"?>
 <?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
-
 <configuration>
-
 {% for key, value in MAPRED_SITE_DEFAULT_CONFIG.iteritems() %}
   <property>
     <name>{{ key }}</name>
     <value>{{ value }}</value>
   </property>
-
 {% endfor %}
 </configuration>

--- a/playbooks/roles/hadoop_common/templates/yarn-site.xml.j2
+++ b/playbooks/roles/hadoop_common/templates/yarn-site.xml.j2
@@ -1,13 +1,10 @@
 {% do YARN_SITE_DEFAULT_CONFIG.update(yarn_site_config) %}
 <?xml version="1.0"?>
-
 <configuration>
-
 {% for key, value in YARN_SITE_DEFAULT_CONFIG.iteritems() %}
   <property>
     <name>{{ key }}</name>
     <value>{{ value }}</value>
   </property>
-
 {% endfor %}
 </configuration>

--- a/playbooks/roles/hadoop_common/templates/yarn-site.xml.j2
+++ b/playbooks/roles/hadoop_common/templates/yarn-site.xml.j2
@@ -1,5 +1,4 @@
 {% do YARN_SITE_DEFAULT_CONFIG.update(yarn_site_config) %}
-
 <?xml version="1.0"?>
 
 <configuration>

--- a/playbooks/roles/hadoop_common/templates/yarn-site.xml.j2
+++ b/playbooks/roles/hadoop_common/templates/yarn-site.xml.j2
@@ -1,23 +1,14 @@
+{% do YARN_SITE_DEFAULT_CONFIG.update(yarn_site_config) %}
+
 <?xml version="1.0"?>
 
 <configuration>
-  <property>
-    <name>yarn.nodemanager.aux-services</name>
-    <value>mapreduce_shuffle</value>
-  </property>
 
-  <property>
-    <name>yarn.nodemanager.aux-services.mapreduce.shuffle.class</name>
-    <value>org.apache.hadoop.mapred.ShuffleHandler</value>
-  </property>
-
-{% if yarn_site_config is defined %}
-{% for key,value in yarn_site_config.iteritems() %}
+{% for key, value in YARN_SITE_DEFAULT_CONFIG.iteritems() %}
   <property>
     <name>{{ key }}</name>
     <value>{{ value }}</value>
   </property>
-{% endfor %}
-{% endif %}
 
+{% endfor %}
 </configuration>

--- a/playbooks/roles/hive/defaults/main.yml
+++ b/playbooks/roles/hive/defaults/main.yml
@@ -30,6 +30,23 @@ HIVE_METASTORE_DATABASE:
   host: "{{ HIVE_METASTORE_DATABASE_HOST }}"
   port: "{{ HIVE_METASTORE_DATABASE_PORT }}"
 
+#
+# Vars are used to fill in the hive-site.xml file
+#
+HIVE_SITE_DEFAULT_CONFIG:
+  javax.jdo.option.ConnectionURL: "jdbc:mysql://{{ HIVE_METASTORE_DATABASE.host }}:{{ HIVE_METASTORE_DATABASE.port }}/{{ HIVE_METASTORE_DATABASE.name }}"
+  javax.jdo.option.ConnectionDriverName: "com.mysql.jdbc.Driver"
+  javax.jdo.option.ConnectionUserName: "{{ HIVE_METASTORE_DATABASE.user }}"
+  javax.jdo.option.ConnectionPassword: "{{ HIVE_METASTORE_DATABASE.password }}"
+  datanucleus.autoCreateSchema: "true"
+  hive.metastore.schema.verification: "true"
+
+#
+# Variables override the stock configuration for entry into
+# the hive-site.xml file. Ensure that you use unambiguous
+# string literals to avoid any confusion.
+#
+HIVE_SITE_EXTRA_CONFIG: {}
 
 #
 # vars are namespace with the module name.

--- a/playbooks/roles/hive/templates/hive-site.xml.j2
+++ b/playbooks/roles/hive/templates/hive-site.xml.j2
@@ -1,28 +1,15 @@
+{% do HIVE_SITE_DEFAULT_CONFIG.update(HIVE_SITE_EXTRA_CONFIG) %}
+
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+
 <configuration>
+
+{% for key, value in HIVE_SITE_DEFAULT_CONFIG.iteritems() %}
   <property>
-    <name>javax.jdo.option.ConnectionURL</name>  
-    <value>jdbc:mysql://{{ HIVE_METASTORE_DATABASE.host }}:{{ HIVE_METASTORE_DATABASE.port }}/{{ HIVE_METASTORE_DATABASE.name }}</value>
+    <name>{{ key }}</name>
+    <value>{{ value }}</value>
   </property>
-  <property>
-    <name>javax.jdo.option.ConnectionDriverName</name>  
-    <value>com.mysql.jdbc.Driver</value>
-  </property>
-  <property>
-    <name>javax.jdo.option.ConnectionUserName</name>  
-    <value>{{ HIVE_METASTORE_DATABASE.user }}</value>
-  </property>
-  <property>
-    <name>javax.jdo.option.ConnectionPassword</name>  
-    <value>{{ HIVE_METASTORE_DATABASE.password }}</value>
-  </property>
-  <property>
-    <name>datanucleus.autoCreateSchema</name>  
-    <value>true</value>
-  </property>
-  <property>
-    <name>hive.metastore.schema.verification</name>  
-    <value>true</value>
-  </property>
+
+{% endfor %}
 </configuration>

--- a/playbooks/roles/hive/templates/hive-site.xml.j2
+++ b/playbooks/roles/hive/templates/hive-site.xml.j2
@@ -1,14 +1,11 @@
 {% do HIVE_SITE_DEFAULT_CONFIG.update(HIVE_SITE_EXTRA_CONFIG) %}
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
-
 <configuration>
-
 {% for key, value in HIVE_SITE_DEFAULT_CONFIG.iteritems() %}
   <property>
     <name>{{ key }}</name>
     <value>{{ value }}</value>
   </property>
-
 {% endfor %}
 </configuration>

--- a/playbooks/roles/hive/templates/hive-site.xml.j2
+++ b/playbooks/roles/hive/templates/hive-site.xml.j2
@@ -1,5 +1,4 @@
 {% do HIVE_SITE_DEFAULT_CONFIG.update(HIVE_SITE_EXTRA_CONFIG) %}
-
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
 


### PR DESCRIPTION
This PR is designed to enhance the ability to configure Hadoop as part of the analytics stack more completely by allowing additional variables to `hdfs-site.xml`, `core-site.xml`, `yarn-site.xml`, `mapred-site.xml`, and `hive-site.xml`.

Some of these files already had some level of configurability, but had no deduplication, meaning that the templates could result in files with the same property multiple times.

**Dependencies**: None
**Testing instructions**:

1. Spin up a new VM running Ubuntu 12.04
2. SSH into said VM
3. Create an `override.yml` file with the following contents:
 ```yaml
role: "hive"
COMMON_APP_DIR: "/edx/app"
COMMON_BIN_DIR: "/edx/bin"
COMMON_DATA_DIR: "/edx/etc"
SQOOP_MYSQL_CONNECTOR_VERSION: "5.1.29"
HIVE_SITE_EXTRA_CONFIG:
  hive.auto.convert.join: "false"
yarn_site_config:
  yarn.nodemanager.vmem-check-enabled: "false"
  yarn.nodemanager.vmem-pmem-ratio: "4"
HDFS_SITE_EXTRA_CONFIG:
  dfs.heartbeat.interval: "1"
HADOOP_CORE_SITE_EXTRA_CONFIG:
  fs.trash.interval: "5"
mapred_site_config:
  mapreduce.map.memory_mb: "768"
```
4. Run the following commands (running as a shell script is fine):
```shell
#! /bin/bash
sudo apt-get update
sudo apt-get install -y git python-pip python-dev libmysqlclient-dev
sudo pip install virtualenv
echo 'create an "ansible" virtualenv and activate it'
virtualenv ansible
. ansible/bin/activate
git clone https://github.com/open-craft/configuration.git
cd configuration/
git checkout haikuginger/configure-hadoop-settings
pip install -r requirements.txt
cd playbooks/
sudo mkdir -p /edx/bin
sudo mkdir -p /edx/etc
sudo mkdir -p /edx/app
ansible-playbook -i localhost, -c local run_role.yml --extra-vars "@../../override.yml"
```
5. Check that the relevant configuration files have been created with both the default values and the values that you added:
    - `/edx/app/hadoop/hive/conf/hive-site.xml`
    - `/edx/app/hadoop/hadoop/etc/hadoop/core-site.xml`
    - `/edx/app/hadoop/hadoop/etc/hadoop/hdfs-site.xml`
    - `/edx/app/hadoop/hadoop/etc/hadoop/mapred-site.xml`
    - `/edx/app/hadoop/hadoop/etc/hadoop/yarn-site.xml`

**Author notes and concerns**:

1. The names for `yarn_site_config` and `mapred_site_config` don't match the others because they're existing variables for the purpose presented here.

**Reviewers**
- [ ] @pomegranited 
- [ ] edX reviewer[s] TBD

---

Make sure that the following steps are done before merging

  - [ ] @devops team member has commented with :+1:
  - [ ] are you adding any new default values that need to be overriden when this goes live?  
    - [ ] Open a ticket (DEVOPS) to make sure that they have been added to secure vars.
    - [ ] Add an entry to the CHANGELOG.