### PR TITLE
XQWatcher user doesn't have permissions to update supervisor or restart it.

### DIFF
--- a/playbooks/roles/xqwatcher/tasks/deploy.yml
+++ b/playbooks/roles/xqwatcher/tasks/deploy.yml
@@ -7,6 +7,7 @@
     mode: "0600"
   when: XQWATCHER_GIT_IDENTITY != 'none'
   tags:
+    - deploy
     - install
     - install:code
     
@@ -19,6 +20,7 @@
     group: "{{ xqwatcher_user }}"
     mode: "0644" 
   tags:
+    - deploy
     - install
     - install:configuration
     

--- a/playbooks/roles/xqwatcher/tasks/deploy_watcher.yml
+++ b/playbooks/roles/xqwatcher/tasks/deploy_watcher.yml
@@ -50,7 +50,7 @@
     config: "{{ supervisor_cfg }}"
     state: restarted
   when: not disable_edx_services
-  become_user: "{{ xqwatcher_user }}"
+  become_user: "{{ common_web_user }}"
   tags:
     - manage
     - manage:update

--- a/playbooks/roles/xqwatcher/tasks/main.yml
+++ b/playbooks/roles/xqwatcher/tasks/main.yml
@@ -115,5 +115,3 @@
 - include: code_jail.yml CODE_JAIL_COMPLAIN=false
 
 - include: deploy.yml
-  tags:
-    - deploy


### PR DESCRIPTION
Configuration Pull Request
---

@edx/devops 

I believe this breakage occurred when we moved from a dedicated XQWatcher to the shared supervisor.  We see it now due to a change in the way tagging for includes works.  Previously it would not propagate recursively through includes but now it does.