### PR TITLE
add fb and tw accounts to generic_env_config

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -965,6 +965,8 @@ generic_env_config:  &edxapp_generic_env
     user: '{{ edxapp_sandbox_user }}'
   AFFILIATE_COOKIE_NAME: "{{ EDXAPP_AFFILIATE_COOKIE_NAME }}"
   ELASTIC_SEARCH_CONFIG: "{{ EDXAPP_ELASTIC_SEARCH_CONFIG }}"
+  PLATFORM_TWITTER_ACCOUNT: "{{ EDXAPP_PLATFORM_TWITTER_ACCOUNT }}"
+  PLATFORM_FACEBOOK_ACCOUNT: "{{ EDXAPP_PLATFORM_FACEBOOK_ACCOUNT }}"
 
 lms_auth_config:
   <<: *edxapp_generic_auth


### PR DESCRIPTION
This PR is a small bugfix, in the role `edxapp` there are two variables for override:
```
EDXAPP_PLATFORM_TWITTER_ACCOUNT: '@YourPlatformTwitterAccount'
EDXAPP_PLATFORM_FACEBOOK_ACCOUNT: 'http://www.facebook.com/YourPlatformFacebookAccount'
```
but both variables are not being included in the `generic_env_config` being, so aren't being populated in the lms.env.json file.

How to test the Fix:
* Override the `EDXAPP_PLATFORM_TWITTER_ACCOUNT` and `EDXAPP_PLATFORM_FACEBOOK_ACCOUNT` in your configuration variables.
* Run the `edxapp` role (you can use `-t edxapp_cfg` since the change only affects configuration)
* Open the `/edx/app/edxapp/lms.env.json` file and look for the `PLATFORM_TWITTER_ACCOUNT` and `PLATFORM_FACEBOOK_ACCOUNT`, they must exists and be with the proper values.

