### PR TITLE
Remove occurrences of ANSIBLE_REPO/VERSION.

### DIFF
--- a/docker/build/precise-common/Dockerfile
+++ b/docker/build/precise-common/Dockerfile
@@ -1,5 +1,5 @@
-FROM ubuntu:precise 
-MAINTAINER edxops 
+FROM ubuntu:precise
+MAINTAINER edxops
 
 # Set locale to UTF-8 which is not the default for docker.
 # See the links for details:
@@ -8,7 +8,6 @@ MAINTAINER edxops
 # https://github.com/docker-library/python/pull/14/files
 ENV LANG C.UTF-8
 
-ENV ANSIBLE_REPO="https://github.com/edx/ansible"
 ENV CONFIGURATION_REPO="https://github.com/edx/configuration.git"
 ENV CONFIGURATION_VERSION="master"
 

--- a/docker/build/trusty-common/Dockerfile
+++ b/docker/build/trusty-common/Dockerfile
@@ -1,6 +1,5 @@
 FROM ubuntu:trusty
-MAINTAINER edxops 
-ENV ANSIBLE_REPO="https://github.com/edx/ansible"
+MAINTAINER edxops
 ENV CONFIGURATION_REPO="https://github.com/edx/configuration.git"
 ENV CONFIGURATION_VERSION="master"
 

--- a/docker/build/xenial-common/Dockerfile
+++ b/docker/build/xenial-common/Dockerfile
@@ -1,5 +1,5 @@
 FROM ubuntu:xenial
-MAINTAINER edxops 
+MAINTAINER edxops
 
 # Set locale to UTF-8 which is not the default for docker.
 # See the links for details:
@@ -8,7 +8,6 @@ MAINTAINER edxops
 # https://github.com/docker-library/python/pull/14/files
 ENV LANG C.UTF-8
 
-ENV ANSIBLE_REPO="https://github.com/edx/ansible"
 ENV CONFIGURATION_REPO="https://github.com/edx/configuration.git"
 ENV CONFIGURATION_VERSION="master"
 

--- a/util/install/ansible-bootstrap.sh
+++ b/util/install/ansible-bootstrap.sh
@@ -13,14 +13,6 @@
 
 set -xe
 
-if [[ -z "${ANSIBLE_REPO}" ]]; then
-  ANSIBLE_REPO="https://github.com/edx/ansible.git"
-fi
-
-if [[ -z "${ANSIBLE_VERSION}" ]]; then
-  ANSIBLE_VERSION="master"
-fi
-
 if [[ -z "${CONFIGURATION_REPO}" ]]; then
   CONFIGURATION_REPO="https://github.com/edx/configuration.git"
 fi
@@ -56,8 +48,6 @@ cat << EOF
 
 Running the edx_ansible bootstrap script with the following arguments:
 
-ANSIBLE_REPO="${ANSIBLE_REPO}"
-ANSIBLE_VERSION="${ANSIBLE_VERSION}"
 CONFIGURATION_REPO="${CONFIGURATION_REPO}"
 CONFIGURATION_VERSION="${CONFIGURATION_VERSION}"
 

--- a/util/vpc-tools/abbey.py
+++ b/util/vpc-tools/abbey.py
@@ -304,14 +304,6 @@ export HIPCHAT_MSG_COLOR DATADOG_API_KEY
 
 
 #################################### Lifted from ansible-bootstrap.sh
-if [[ -z "$ANSIBLE_REPO" ]]; then
-  ANSIBLE_REPO="https://github.com/edx/ansible.git"
-fi
-
-if [[ -z "$ANSIBLE_VERSION" ]]; then
-  ANSIBLE_VERSION="master"
-fi
-
 if [[ -z "$CONFIGURATION_REPO" ]]; then
   CONFIGURATION_REPO="https://github.com/edx/configuration.git"
 fi
@@ -339,8 +331,6 @@ cat << EOF
 
 Running the abbey with the following arguments:
 
-ANSIBLE_REPO="$ANSIBLE_REPO"
-ANSIBLE_VERSION="$ANSIBLE_VERSION"
 CONFIGURATION_REPO="$CONFIGURATION_REPO"
 CONFIGURATION_VERSION="$CONFIGURATION_VERSION"
 


### PR DESCRIPTION
@feanil When looking at something unrelated today, I noticed references to the Ansible fork, which we've now abandoned with the Ansible 2.2 upgrade, correct? Are the changes in this PR then appropriate?

Make sure that the following steps are done before merging

  - [ ] @devops team member has commented with :+1:
  - [ ] are you adding any new default values that need to be overriden when this goes live?  
    - [ ] Open a ticket (DEVOPS) to make sure that they have been added to secure vars.
    - [ ] Add an entry to the CHANGELOG.
