### PR TITLE
Change migrate --list to showmigrations in pre_supervisor_checks

### DIFF
--- a/playbooks/roles/supervisor/files/pre_supervisor_checks.py
+++ b/playbooks/roles/supervisor/files/pre_supervisor_checks.py
@@ -14,12 +14,12 @@ MIGRATION_COMMANDS = {
         'lms':     "/edx/bin/edxapp-migrate-lms --noinput --list",
         'cms':     "/edx/bin/edxapp-migrate-cms --noinput --list",
         'xqueue':  "SERVICE_VARIANT=xqueue sudo -E -u xqueue {python} {code_dir}/manage.py migrate --noinput --list --settings=xqueue.aws_settings",
-        'ecommerce':     ". {env_file}; sudo -E -u ecommerce {python} {code_dir}/manage.py migrate --noinput --list",
-        'programs':      ". {env_file}; sudo -E -u programs {python} {code_dir}/manage.py migrate --noinput --list",
-        'insights':      ". {env_file}; sudo -E -u insights {python} {code_dir}/manage.py migrate --noinput --list",
-        'analytics_api': ". {env_file}; sudo -E -u analytics_api {python} {code_dir}/manage.py migrate --noinput --list",
-        'credentials':   ". {env_file}; sudo -E -u credentials {python} {code_dir}/manage.py migrate --noinput --list",
-        'discovery':     ". {env_file}; sudo -E -u discovery {python} {code_dir}/manage.py migrate --noinput --list",
+        'ecommerce':     ". {env_file}; sudo -E -u ecommerce {python} {code_dir}/manage.py showmigrations",
+        'programs':      ". {env_file}; sudo -E -u programs {python} {code_dir}/manage.py showmigrations",
+        'insights':      ". {env_file}; sudo -E -u insights {python} {code_dir}/manage.py showmigrations",
+        'analytics_api': ". {env_file}; sudo -E -u analytics_api {python} {code_dir}/manage.py showmigrations",
+        'credentials':   ". {env_file}; sudo -E -u credentials {python} {code_dir}/manage.py showmigrations",
+        'discovery':     ". {env_file}; sudo -E -u discovery {python} {code_dir}/manage.py showmigrations",
     }
 HIPCHAT_USER = "PreSupervisor"
 


### PR DESCRIPTION
Django removed `migrate --list` in version 1.10 in place of `showmigrations` which has the same output format.

We're unable to deploy the Analytics API because we updated to 1.10 and the `migrate --list` command fails.

All the other services listed have Django 1.8 or later so I switched them too (Django 1.8 added showmigrations). But, I didn't want to touch LMS, CMS, or xqueue since they seem to have their own special ways of checking for migrations that I didn't want to break.

Configuration Pull Request
---

Make sure that the following steps are done before merging

  - [x] @devops team member has commented with :+1:
  - are you adding any new default values that need to be overriden when this goes live?  I don't think so?

FYI: @dsjen @kevin @doctoryes 