### PR TITLE
Add a version override here so it's easy to update.

### DIFF
--- a/docker/build/analytics_api/ansible_overrides.yml
+++ b/docker/build/analytics_api/ansible_overrides.yml
@@ -19,3 +19,6 @@ ANALYTICS_API_DATABASES:
     PASSWORD: 'password'
     HOST: "db.{{ DOCKER_TLD  }}"
     PORT: '3306'
+
+# Change this if you want to build a specific version of the ANALYTICS_API
+ANALYTICS_API_VERSION: 'master'


### PR DESCRIPTION
Analytics-Api will generally need to be built from a tag so that Insights
tests can run with that version.  Adding this line here to make it easier
to update when that process occurs.

@edx/devops 