### PR TITLE
motd.tail support for Xenial

### DIFF
--- a/playbooks/roles/vhost/tasks/main.yml
+++ b/playbooks/roles/vhost/tasks/main.yml
@@ -54,6 +54,16 @@
     group: root
     mode: '755'
 
+- name: Add motd.tail support for 16.04
+  copy:
+    dest: "/etc/update-motd.d/75-motd-tail"
+    content: "#!/bin/sh\necho\ncat /etc/motd.tail\n"
+    force: true
+    owner: root
+    group: root
+    mode: "0755"
+  when: ansible_distribution_release == 'xenial'
+
 - name: Update sshd logging to VERBOSE
   lineinfile:
     dest: /etc/ssh/sshd_config


### PR DESCRIPTION
motd.tail isn't a thing in Ubuntu 14.04 and beyond.  The simplest way to keep it working is to add a file to /etc/update-motd.d that displays /etc/motd.tail

@e0d there was some thought that your xenial branch had a fix for this, but I didn't see it.

Make sure that the following steps are done before merging

  - [ ] @devops team member has commented with :+1:
  - [ ] are you adding any new default values that need to be overridden when this goes live?  
    - [ ] Open a ticket (DEVOPS) to make sure that they have been added to secure vars.
    - [ ] Add an entry to the CHANGELOG.
