### PR TITLE
New base image that disables daily/boot apt updates

### DIFF
--- a/util/jenkins/ansible-provision.sh
+++ b/util/jenkins/ansible-provision.sh
@@ -127,7 +127,7 @@ fi
 
 if [[ -z $ami ]]; then
   if [[ $server_type == "full_edx_installation" ]]; then
-    ami="ami-8ca1459a"
+    ami="ami-75789e63"
   elif [[ $server_type == "ubuntu_16.04" || $server_type == "full_edx_installation_from_scratch" ]]; then
     ami="ami-9dcfdb8a"
   fi


### PR DESCRIPTION
The security role was not run on the base image, meaning that
these tasks were not disabled.  This was causing sandbox builds to fail
if a systemd timer task was also running (which is a bit
nondeterministic to predict unfortunately).

DEVOPS-5273

@edx/devops