### PR TITLE
Update mariadb role and add groups capability

### DIFF
--- a/playbooks/roles/mariadb/defaults/main.yml
+++ b/playbooks/roles/mariadb/defaults/main.yml
@@ -31,15 +31,17 @@ MARIADB_LISTEN_ALL: false
 MARIADB_DATABASES:
   - "{{ EDXAPP_MYSQL_DB_NAME|default('edxapp') }}"
   - "{{ XQUEUE_MYSQL_DB_NAME|default('xqueue') }}"
-
-MARIADB_ANALYTICS_DATABASES:
-  - "{{ ANALYTICS_API_CONFIG['DATABASES']['default']['NAME']|default('analytics-api') }}"
-  - "{{ ANALYTICS_API_CONFIG['DATABASES']['reports']['NAME']|default('reports') }}"
+  - "{{ EDXAPP_MYSQL_CSMH_DB_NAME|default('edxapp_csmh') }}"
 
 MARIADB_USERS:
   - name: "{{ EDXAPP_MYSQL_USER|default('edxapp001') }}"
     pass: "{{ EDXAPP_MYSQL_PASSWORD|default('password') }}"
     priv: "{{ EDXAPP_MYSQL_DB_NAME|default('edxapp') }}.*:ALL"
+    host: "{{ MARIADB_HOST_PRIV }}"
+
+  - name: "{{ EDXAPP_MYSQL_USER|default('edxapp001') }}"
+    pass: "{{ EDXAPP_MYSQL_PASSWORD|default('password') }}"
+    priv: "{{ EDXAPP_MYSQL_CSMH_DB_NAME|default('edxapp_csmh') }}.*:ALL"
     host: "{{ MARIADB_HOST_PRIV }}"
 
   - name: "{{ XQUEUE_MYSQL_USER|default('xqueue001') }}"
@@ -50,6 +52,11 @@ MARIADB_USERS:
   - name: "{{ COMMON_MYSQL_MIGRATE_USER|default('migrate') }}"
     pass: "{{ COMMON_MYSQL_MIGRATE_PASSWORD|default('password') }}"
     priv: "{{ EDXAPP_MYSQL_DB_NAME|default('edxapp') }}.*:ALL"
+    host: "{{ MARIADB_HOST_PRIV }}"
+
+  - name: "{{ COMMON_MYSQL_MIGRATE_USER|default('migrate') }}"
+    pass: "{{ COMMON_MYSQL_MIGRATE_PASSWORD|default('password') }}"
+    priv: "{{ EDXAPP_MYSQL_CSMH_DB_NAME|default('edxapp_csmh') }}.*:ALL"
     host: "{{ MARIADB_HOST_PRIV }}"
 
   - name: "{{ COMMON_MYSQL_MIGRATE_USER|default('migrate') }}"
@@ -70,27 +77,6 @@ MARIADB_USERS:
   - name: "{{ EDX_NOTES_API_MYSQL_DB_USER|default('notes001') }}"
     pass: "{{ EDX_NOTES_API_MYSQL_DB_PASS|default('secret') }}"
     priv: "{{ EDX_NOTES_API_MYSQL_DB_NAME|default('edx-notes-api') }}.*:ALL"
-    host: "{{ MARIADB_HOST_PRIV }}"
-
-MARIADB_ANALYTICS_USERS:
-  - name: "{{ ANALYTICS_API_CONFIG['DATABASES']['default']['USER']|default('api001') }}"
-    pass: "{{ ANALYTICS_API_CONFIG['DATABASES']['default']['PASSWORD']|default('password') }}"
-    priv: "{{ ANALYTICS_API_CONFIG['DATABASES']['default']['NAME'] }}.*:ALL/reports.*:SELECT"
-    host: "{{ MARIADB_HOST_PRIV }}"
-
-  - name: "{{ ANALYTICS_API_CONFIG['DATABASES']['reports']['USER']|default('reports001') }}"
-    pass: "{{ ANALYTICS_API_CONFIG['DATABASES']['reports']['PASSWORD']|default('password') }}"
-    priv: "{{ ANALYTICS_API_CONFIG['DATABASES']['reports']['NAME'] }}.*:SELECT"
-    host: "{{ MARIADB_HOST_PRIV }}"
-
-  - name: "{{ COMMON_MYSQL_MIGRATE_USER|default('migrate') }}"
-    pass: "{{ COMMON_MYSQL_MIGRATE_PASSWORD|default('password') }}"
-    priv: "{{ ANALYTICS_API_CONFIG['DATABASES']['default']['NAME']|default('analytics-api') }}.*:ALL"
-    host: "{{ MARIADB_HOST_PRIV }}"
-
-  - name: "{{ COMMON_MYSQL_MIGRATE_USER|default('migrate') }}"
-    pass: "{{ COMMON_MYSQL_MIGRATE_PASSWORD|default('password') }}"
-    priv: "{{ ANALYTICS_API_CONFIG['DATABASES']['reports']['NAME']|default('reports') }}.*:ALL"
     host: "{{ MARIADB_HOST_PRIV }}"
 
 #

--- a/playbooks/roles/mariadb/tasks/cluster.yml
+++ b/playbooks/roles/mariadb/tasks/cluster.yml
@@ -17,9 +17,9 @@
 - name: setup bootstrap on primary
   lineinfile:
     dest: "/etc/mysql/conf.d/galera.cnf"
-    regexp: "^wsrep_cluster_address=gcomm://{{ hostvars.keys()|sort|join(',') }}$"
+    regexp: "^wsrep_cluster_address=gcomm://{{ groups[group_names[0]]|sort|join(',') }}$"
     line: "wsrep_cluster_address=gcomm://"
-  when: ansible_hostname == hostvars[hostvars.keys()[0]].ansible_hostname and not mariadb_bootstrap.stat.exists
+  when: ansible_hostname == hostvars[groups[group_names[0]][0]].ansible_hostname and not mariadb_bootstrap.stat.exists
 
 - name: fetch debian.cnf file so start-stop will work properly
   fetch:
@@ -27,7 +27,7 @@
     dest: /tmp/debian.cnf
     fail_on_missing: yes
     flat: yes
-  when: ansible_hostname == hostvars[hostvars.keys()[0]].ansible_hostname and not mariadb_bootstrap.stat.exists
+  when: ansible_hostname == hostvars[groups[group_names[0]][0]].ansible_hostname and not mariadb_bootstrap.stat.exists
   register: mariadb_new_debian_cnf
 
 - name: copy fetched file to other cluster members
@@ -52,6 +52,12 @@
 
 # This is needed for mysql-check in haproxy or other mysql monitor
 # scripts to prevent haproxy checks exceeding `max_connect_errors`.
+# It's better to use ansible mysql_user to avoid creation of user
+# on every node of the cluster
 - name: create haproxy monitor user
-  command: "mysql -e \"INSERT INTO mysql.user (Host,User) values ('{{ item }}','{{ MARIADB_HAPROXY_USER }}'); FLUSH PRIVILEGES;\""
+  mysql_user: >
+    name={{ MARIADB_HAPROXY_USER }}
+    host={{ item }}
+    password=""
+    state=present
   with_items: "{{ MARIADB_HAPROXY_HOSTS }}"

--- a/playbooks/roles/mariadb/tasks/main.yml
+++ b/playbooks/roles/mariadb/tasks/main.yml
@@ -65,14 +65,6 @@
   with_items: "{{ MARIADB_DATABASES }}"
   when: MARIADB_CREATE_DBS|bool
 
-- name: create all analytics dbs
-  mysql_db:
-    db: "{{ item }}"
-    state: present
-    encoding: utf8
-  with_items: "{{ MARIADB_ANALYTICS_DATABASES }}"
-  when: MARIADB_CREATE_DBS|bool and ANALYTICS_API_CONFIG is defined
-
 - name: create all users/privs
   mysql_user:
     name: "{{ item.name }}"
@@ -83,12 +75,3 @@
   with_items: "{{ MARIADB_USERS }}"
   when: MARIADB_CREATE_DBS|bool
 
-- name: create all analytics users/privs
-  mysql_user:
-    name: "{{ item.name }}"
-    password: "{{ item.pass }}"
-    priv: "{{ item.priv }}"
-    host: "{{ item.host }}"
-    append_privs: yes
-  with_items: "{{ MARIADB_ANALYTICS_USERS }}"
-  when: MARIADB_CREATE_DBS|bool and ANALYTICS_API_CONFIG is defined


### PR DESCRIPTION
Update mariadb role:
- Remove MARIADB_ANALYTICS_DATABASES and MARIADB_ANALYTICS_USERS. There's no need to create users and databases for analytics. Moreover ANALYTICS_API_CONFIG is not defined anymore
- Create database and users for EDXAPP_MYSQL_CSMH_DB_NAME
- Use ansible module mysql_user for creating haproxy monitor user. It's better to use ansible mysql_user to avoid creation of user on every node of the cluster and crash the installation
- Use groups[group_names[0]]| instead of hostvars.keys(). This add the capability to use different deploying solution that takes advantage of ansible groups. This fix is compatible with previous solution.