### PR TITLE
Feanil/credentials 16.04

### DIFF
--- a/docker/build/credentials/Dockerfile
+++ b/docker/build/credentials/Dockerfile
@@ -7,7 +7,7 @@
 # This allows the dockerfile to update /edx/app/edx_ansible/edx_ansible
 # with the currently checked-out configuration repo.
 
-FROM edxops/trusty-common:latest
+FROM edxops/xenial-common:latest
 MAINTAINER edxops
 
 ARG CREDENTIALS_VERSION=master

--- a/playbooks/roles/credentials/templates/edx/app/credentials/devstack.sh.j2
+++ b/playbooks/roles/credentials/templates/edx/app/credentials/devstack.sh.j2
@@ -11,11 +11,25 @@ case $COMMAND in
 
         {{ supervisor_venv_bin }}/supervisord --configuration {{ supervisor_cfg }}
 
+	# Needed to run bower as root. See explaination around 'discovery_user=root'
+	echo '{ "allow_root": true }' > /root/.bowerrc
+
         cd /edx/app/edx_ansible/edx_ansible/docker/plays
         /edx/app/edx_ansible/venvs/edx_ansible/bin/ansible-playbook credentials.yml -c local -i '127.0.0.1,' \
-            -t 'install:app-requirements,assets:gather,devstack,migrate,manage:start' \
+            -t 'install:app-requirements,assets:gather,devstack,migrate' \
             --extra-vars="migrate_db=yes" \
-            --extra-vars="@/ansible_overrides.yml"
+            --extra-vars="@/ansible_overrides.yml" \
+	    --extra-vars="credentials_user=root"  # Needed when sharing the volume with the host machine because node/bower drops
+						  # everything in the code directory by default.  So we get issues with permissions
+						  # on folders owned by the developer.
+
+
+	# Need to start supervisord and nginx manually because systemd is hard to run on docker
+	# http://developers.redhat.com/blog/2014/05/05/running-systemd-within-docker-container/
+	# Both daemon by default
+	nginx
+	/edx/app/supervisor/venvs/supervisor/bin/supervisord --configuration /edx/app/supervisor/supervisord.conf
+
 
         # Docker requires an active foreground task. Tail the logs to appease Docker and
         # provide useful output for development.


### PR DESCRIPTION
@rlucioni @clintonb corresponding updates to the base docker image.  Once this merges I'll push up this container and then update the test branch(https://github.com/edx/credentials/pull/148) to use the latest image.

I verified locally that this is still needed to keep the dev environment unbroken in 16.04