### PR TITLE
Adds COMMON_EDXAPP_SETTINGS

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -54,3 +54,4 @@ David Adams<dcadams@stanford.edu>
 Florian Haas <florian@hastexo.com>
 Shohei Maeda <s.maeda@gacco.co.jp>
 Bill DeRusha <bill@edx.org>
+Jillian Vogel <jill@opencraft.com>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
   - Renamed `COMMON_AWS_SYNC_BUCKET` to `COMMON_OBJECT_STORE_LOG_SYNC_BUCKET`
   - Renamed `COMMON_AWS_S3_SYNC_SCRIPT` to `COMMON_OBJECT_STORE_LOG_SYNC_SCRIPT`
   - Added `COMMON_OBJECT_STORE_LOG_SYNC_PREFIX`. Default: `logs/tracking/`
+  - Added `COMMON_EDXAPP_SETTINGS`. Default: `aws`
 - Role: aws
   - Removed `AWS_S3_LOGS`
   - Added `vhost` role as dependency

--- a/playbooks/roles/common_vars/defaults/main.yml
+++ b/playbooks/roles/common_vars/defaults/main.yml
@@ -11,6 +11,9 @@ COMMON_BASIC_AUTH_EXCEPTIONS:
   - 192.168.0.0/16
   - 172.16.0.0/12
 
+# Settings to use for calls to edxapp manage.py
+COMMON_EDXAPP_SETTINGS: 'aws'
+
 # Turn on syncing logs on rotation for edx
 # application and tracking logs, must also
 # have the aws or openstack role installed

--- a/playbooks/roles/demo/defaults/main.yml
+++ b/playbooks/roles/demo/defaults/main.yml
@@ -34,6 +34,7 @@ demo_test_users:
     hashed_password: "{{ demo_hashed_password }}"
 
 demo_edxapp_user: 'edxapp'
+demo_edxapp_settings: '{{ COMMON_EDXAPP_SETTINGS }}'
 demo_edxapp_venv_bin: '{{ COMMON_APP_DIR }}/{{ demo_edxapp_user }}/venvs/{{demo_edxapp_user}}/bin'
 demo_edxapp_course_data_dir: '{{ COMMON_DATA_DIR }}/{{ demo_edxapp_user }}/data'
 demo_edxapp_code_dir: '{{ COMMON_APP_DIR }}/{{ demo_edxapp_user }}/edx-platform'

--- a/playbooks/roles/demo/tasks/deploy.yml
+++ b/playbooks/roles/demo/tasks/deploy.yml
@@ -10,14 +10,14 @@
   register: demo_checkout
 
 - name: import demo course
-  shell: "{{ demo_edxapp_venv_bin }}/python ./manage.py cms --settings=aws import {{ demo_edxapp_course_data_dir }} {{ demo_code_dir }}"
+  shell: "{{ demo_edxapp_venv_bin }}/python ./manage.py cms --settings={{ demo_edxapp_settings }} import {{ demo_edxapp_course_data_dir }} {{ demo_code_dir }}"
   args:
     chdir: "{{ demo_edxapp_code_dir }}"
   become_user: "{{ common_web_user }}"
   when: demo_checkout.changed
 
 - name: create some test users
-  shell: "{{ demo_edxapp_venv_bin }}/python ./manage.py lms --settings=aws --service-variant lms manage_user {{ item.username}} {{ item.email }} --initial-password-hash {{ item.hashed_password | quote }}"
+  shell: "{{ demo_edxapp_venv_bin }}/python ./manage.py lms --settings={{ demo_edxapp_settings }} --service-variant lms manage_user {{ item.username}} {{ item.email }} --initial-password-hash {{ item.hashed_password | quote }}"
   args:
     chdir: "{{ demo_edxapp_code_dir }}"
   become_user: "{{ common_web_user }}"
@@ -25,7 +25,7 @@
   when: demo_checkout.changed
 
 - name: create staff user
-  shell: "{{ demo_edxapp_venv_bin }}/python ./manage.py lms --settings=aws --service-variant lms manage_user staff staff@example.com --initial-password-hash {{ demo_hashed_password | quote }} --staff"
+  shell: "{{ demo_edxapp_venv_bin }}/python ./manage.py lms --settings={{ demo_edxapp_settings }} --service-variant lms manage_user staff staff@example.com --initial-password-hash {{ demo_hashed_password | quote }} --staff"
   args:
     chdir: "{{ demo_edxapp_code_dir }}"
   become_user: "{{ common_web_user }}"
@@ -34,7 +34,7 @@
     - DEMO_CREATE_STAFF_USER
 
 - name: enroll test users in the demo course
-  shell: "{{ demo_edxapp_venv_bin }}/python ./manage.py lms --settings=aws --service-variant lms enroll_user_in_course -e {{ item.email }} -c {{ demo_course_id }}"
+  shell: "{{ demo_edxapp_venv_bin }}/python ./manage.py lms --settings={{ demo_edxapp_settings }} --service-variant lms enroll_user_in_course -e {{ item.email }} -c {{ demo_course_id }}"
   args:
     chdir: "{{ demo_edxapp_code_dir }}"
   become_user: "{{ common_web_user }}"
@@ -45,14 +45,14 @@
 
 
 - name: add test users to the certificate whitelist
-  shell: "{{ demo_edxapp_venv_bin }}/python ./manage.py lms --settings=aws --service-variant lms cert_whitelist -a {{ item.email }} -c {{ demo_course_id }}"
+  shell: "{{ demo_edxapp_venv_bin }}/python ./manage.py lms --settings={{ demo_edxapp_settings }} --service-variant lms cert_whitelist -a {{ item.email }} -c {{ demo_course_id }}"
   args:
     chdir: "{{ demo_edxapp_code_dir }}"
   with_items: "{{ demo_test_users }}"
   when: demo_checkout.changed
 
 - name: seed the forums for the demo course
-  shell: "{{ demo_edxapp_venv_bin }}/python ./manage.py lms --settings=aws seed_permissions_roles {{ demo_course_id }}"
+  shell: "{{ demo_edxapp_venv_bin }}/python ./manage.py lms --settings={{ demo_edxapp_settings }} seed_permissions_roles {{ demo_course_id }}"
   args:
     chdir: "{{ demo_edxapp_code_dir }}"
   with_items: "{{ demo_test_users }}"

--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -97,7 +97,7 @@ EDXAPP_ELASTIC_SEARCH_CONFIG:
     - host: "localhost"
       port: 9200
 
-EDXAPP_SETTINGS: 'aws'
+EDXAPP_SETTINGS: '{{ COMMON_EDXAPP_SETTINGS }}'
 
 EDXAPP_LMS_ENV: 'lms.envs.{{ EDXAPP_SETTINGS }}'
 EDXAPP_CMS_ENV: 'cms.envs.{{ EDXAPP_SETTINGS }}'
@@ -368,7 +368,7 @@ EDXAPP_SANDBOX_ENFORCE: true
 EDXAPP_AUTOMATED_USERS:
   automated_user:
     sudo_commands:
-      - command: "{{ edxapp_venv_bin }}/python {{ edxapp_code_dir }}/manage.py lms migrate --list --settings=aws"
+      - command: "{{ edxapp_venv_bin }}/python {{ edxapp_code_dir }}/manage.py lms migrate --list --settings={{ edxapp_settings }}"
         sudo_user: "edxapp"
     authorized_keys:
       - "SSH authorized key"
@@ -642,6 +642,7 @@ edxapp_venv_dir: "{{ edxapp_venvs_dir }}/edxapp"
 edxapp_venv_bin: "{{ edxapp_venv_dir }}/bin"
 edxapp_nodeenv_dir: "{{ edxapp_app_dir }}/nodeenvs/edxapp"
 edxapp_nodeenv_bin: "{{ edxapp_nodeenv_dir }}/bin"
+edxapp_settings: '{{ EDXAPP_SETTINGS }}'
 edxapp_node_version: "6.9.2"
 # This is where node installs modules, not node itself
 edxapp_node_bin: "{{ edxapp_code_dir }}/node_modules/.bin"

--- a/playbooks/roles/gitreload/defaults/main.yml
+++ b/playbooks/roles/gitreload/defaults/main.yml
@@ -36,12 +36,10 @@ gitreload_venv_bin: "{{ gitreload_venv }}/bin"
 gitreload_gunicorn_workers: 1
 gitreload_gunicorn_host: "127.0.0.1"
 
-gitreload_edxapp_django_settings: "aws"
-
 gitreload_env:
   REPODIR: "{{ GITRELOAD_REPODIR }}"
   LOG_LEVEL: "{{ GITRELOAD_LOG_LEVEL }}"
   NUM_THREADS: "{{ GITRELOAD_NUM_THREADS }}"
   VIRTUAL_ENV: "{{ edxapp_venv_dir }}"
   EDX_PLATFORM: "{{ edxapp_code_dir }}"
-  DJANGO_SETTINGS: "{{ gitreload_edxapp_django_settings }}"
+  DJANGO_SETTINGS: "{{ edxapp_settings }}"

--- a/playbooks/roles/gitreload/tasks/course_pull.yml
+++ b/playbooks/roles/gitreload/tasks/course_pull.yml
@@ -6,7 +6,7 @@
   with_items: "{{ GITRELOAD_REPOS }}"
 
 - name: do import of courses
-  shell: "SERVICE_VARIANT=lms {{ edxapp_venv_bin }}/python manage.py lms --settings=aws git_add_course {{ item.url }} {{ GITRELOAD_REPODIR }}/{{ item.name }}"
+  shell: "SERVICE_VARIANT=lms {{ edxapp_venv_bin }}/python manage.py lms --settings={{ edxapp_settings }} git_add_course {{ item.url }} {{ GITRELOAD_REPODIR }}/{{ item.name }}"
   args:
     executable: "/bin/bash"
     chdir: "{{ edxapp_code_dir }}"

--- a/playbooks/roles/oauth_client_setup/tasks/main.yml
+++ b/playbooks/roles/oauth_client_setup/tasks/main.yml
@@ -23,7 +23,7 @@
 
 - name: create OAuth2 Clients
   shell: >
-    {{ COMMON_BIN_DIR }}/python.edxapp {{ COMMON_BIN_DIR }}/manage.edxapp lms --settings=aws
+    {{ COMMON_BIN_DIR }}/python.edxapp {{ COMMON_BIN_DIR }}/manage.edxapp lms --settings={{ COMMON_EDXAPP_SETTINGS }}
     create_oauth2_client
     {{ item.url_root }}
     "{{ item.url_root }}/complete/edx-oidc/"

--- a/playbooks/roles/testcourses/tasks/deploy.yml
+++ b/playbooks/roles/testcourses/tasks/deploy.yml
@@ -1,12 +1,12 @@
 ---
 - name: import the test courses from github
-  shell: "{{ demo_edxapp_venv_bin }}/python /edx/bin/manage.edxapp lms git_add_course --settings=aws \"{{ item.github_url }}\""
+  shell: "{{ demo_edxapp_venv_bin }}/python /edx/bin/manage.edxapp lms git_add_course --settings={{ demo_edxapp_settings }} \"{{ item.github_url }}\""
   become_user: "{{ common_web_user }}"
   when: item.install == True
   with_items: "{{ TESTCOURSES_EXPORTS }}"
 
 - name: enroll test users in the testcourses
-  shell: "{{ demo_edxapp_venv_bin }}/python ./manage.py lms --settings=aws --service-variant lms enroll_user_in_course -e {{ item[0].email }} -c {{ item[1].course_id }}"
+  shell: "{{ demo_edxapp_venv_bin }}/python ./manage.py lms --settings={{ demo_edxapp_settings }} --service-variant lms enroll_user_in_course -e {{ item[0].email }} -c {{ item[1].course_id }}"
   args:
     chdir: "{{ demo_edxapp_code_dir }}"
   become_user: "{{ common_web_user }}"


### PR DESCRIPTION
This change allows us to use the `openstack` or other settings files when ansible runs `manage.py` tasks, e.g. by setting:

```yaml
COMMON_EDXAPP_SETTINGS: 'openstack'
```

* Default value is 'aws' (unchanged)
* Used by `EDXAPP_SETTINGS`, `gitreload_env.DJANGO_SETTINGS`, and `demo_edxapp_settings` variables

**JIRA tickets**: [OSPR-1642](https://openedx.atlassian.net/browse/OSPR-1642)

**Sandbox URL**: 

* LMS: http://ficus.sandbox.opencraft.hosting/
* Studio: http://studio.ficus.sandbox.opencraft.hosting/

This sandbox was configured using the [open-craft:jill/ficus.rc1](https://github.com/edx/configuration/compare/master...open-craft:jill/ficus.rc1) branch, which contains the changes from this PR.

**Merge deadline**: ASAP - we'd like to get this into the ficus RC1 cut.  CC @nedbat 

Configuration Pull Request
---

Make sure that the following steps are done before merging

  - [x] @mtyaka has commented with :+1:
  - [ ] @devops team member has commented with :+1:
  - [-] are you adding any new default values that need to be overridden when this goes live?  
    - [ ] Open a ticket (DEVOPS) to make sure that they have been added to secure vars.
    - [ ] Add an entry to the CHANGELOG.
