### PR TITLE
Conditionally adds postfix_queue role to edx_sandbox.yml

### DIFF
--- a/playbooks/edx_sandbox.yml
+++ b/playbooks/edx_sandbox.yml
@@ -65,3 +65,5 @@
       when: COMMON_ENABLE_SPLUNKFORWARDER
     - role: newrelic
       when: COMMON_ENABLE_NEWRELIC
+    - role: postfix_queue
+      when: POSTFIX_QUEUE_EXTERNAL_SMTP_HOST != ''


### PR DESCRIPTION
This change ensures that `edx_sandbox.yml` playbook runs the `postfix_queue` role if `POSTFIX_QUEUE_EXTERNAL_SMTP_HOST` is set.

**JIRA tickets**: [OSPR-1643](https://openedx.atlassian.net/browse/OSPR-1643)

**Sandbox URL**: 

* LMS: http://ficus.sandbox.opencraft.hosting/
* Studio: http://studio.ficus.sandbox.opencraft.hosting/

This sandbox was configured using the [open-craft:jill/ficus.rc1](https://github.com/edx/configuration/compare/master...open-craft:jill/ficus.rc1) branch, which contains the changes from this PR.

**Merge deadline**: ASAP -  we'd like to get this into the ficus RC1 cut.  CC @nedbat 

**Author notes and concerns**:

1. We are moving towards using the `edx-stateless.yml` playbook which already includes `postfix-queue`, but we haven't changed over yet.

Configuration Pull Request
---

Make sure that the following steps are done before merging

  - [x] @mtyaka has commented with 👍 
  - [ ] @devops team member has commented with :+1:
  - [ ] are you adding any new default values that need to be overridden when this goes live?  
    - [ ] Open a ticket (DEVOPS) to make sure that they have been added to secure vars.
    - [ ] Add an entry to the CHANGELOG.
