### PR TITLE
Adds bootstrap python role, which installs python 2.7 using raw ansible

### DIFF
--- a/playbooks/edx-stateless.yml
+++ b/playbooks/edx-stateless.yml
@@ -3,6 +3,13 @@
 # Stateless app server configuration, designed to be used with external mysql,
 # mongo, rabbitmq, and elasticsearch services.
 
+- name: Bootstrap instance(s)
+  hosts: all
+  gather_facts: no
+  become: True
+  roles:
+    - python
+
 - name: Configure instance(s)
   hosts: all
   become: True

--- a/playbooks/edx_sandbox.yml
+++ b/playbooks/edx_sandbox.yml
@@ -4,6 +4,13 @@
 # for single server community
 # installs
 
+- name: Bootstrap instance(s)
+  hosts: all
+  gather_facts: no
+  become: True
+  roles:
+    - python
+
 - name: Configure instance(s)
   hosts: all
   become: True

--- a/playbooks/roles/python/defaults/main.yml
+++ b/playbooks/roles/python/defaults/main.yml
@@ -1,0 +1,4 @@
+# Install python2.7 + the /usr/bin/python symlink.
+
+python_packages:
+  - python-minimal

--- a/playbooks/roles/python/tasks/main.yml
+++ b/playbooks/roles/python/tasks/main.yml
@@ -1,0 +1,10 @@
+# Bootstrap packages must be installed with raw commands, because ubuntu
+# xenial+ cloud images don't have python2.7 installed, and ansible doesn't yet
+# support python3.
+
+- name: Update apt-get
+  raw: apt-get update -qq
+
+- name: Install packages
+  raw: "apt-get install -qq {{ item }}"
+  with_items: "{{ python_packages }}"


### PR DESCRIPTION
This PR adds a `python` role, which installs `python` using raw ansible commands.  This change is required because ansible currently cannot run commands on an unmodified xenial image.

The `python` role is run by `edx_sandbox.yml` and `edx-stateless.yml` as a separate, prefixed playbook, so that the main "Configure instance(s)" playbook can be left unmodified, with `gather_facts: yes`.

**JIRA ticket**: [OSPR-1647](https://openedx.atlassian.net/browse/OSPR-1647)

**Discussions**: ref: [edx-code post](https://groups.google.com/d/msg/openedx-ops/pIR1JFMxYSA/nDwygEpUDAAJ).

**Merge deadline**: ASAP - We'd like to get this into `open-release/ficus.master`. CC @nedbat

**Testing instructions**:

1. Create a VM using an unmodified xenial cloud image, e.g. https://cloud-images.ubuntu.com/xenial/current/
1. Clone this repo and branch, create a virtualenv, and run:

    ```
    make requirements
    cd playbooks
    ansible-playbook -i "instance_ip," -u ubuntu -e @path/to/your/vars.yml edx_sandbox.yml
    ```
1. Ensure that the playbook runs to completion.


To test using an [OpenCraft IM](https://github.com/open-craft/opencraft) devstack:

1. Set `OPENSTACK_SANDBOX_BASE_IMAGE` to point to a xenial cloud image, e.g. `'{"name": "xenial-server-cloudimg-amd64-disk1-unmodified-20161214"}'` is available on OpenCraft's dev OVH instance.
1. Run `make shell`, and these commands:

    ```python
    from instance.factories import instance_factory
    instance = instance_factory(name="xenial-dev", sub_domain="xenial.dev.sandbox",
        configuration_version="jill/xenial-bootstrap",
        configuration_source_repo_url="https://github.com/open-craft/configuration.git",
        edx_platform_commit="master",
        edx_platform_repository_url="https://github.com/edx/edx-platform.git",
        openedx_release="master"
    )
    instance.spawn_appserver()
    ``` 
1. Check the output to verify that the `python` role runs, and the "Configure instance(s)" playbook runs at least the first few roles ok.
1. Ok to cancel at this point, and run:

    ```python
    instance.shut_down()`.
    ```

**Author notes and concerns**:

1. We are aware that edX currently run the [ansible-bootstrap script](https://github.com/edx/configuration/blob/master/util/install/ansible-bootstrap.sh) on their new `xenial` instances, which installs `python`, among other things.  This change brings that one critical step into an`edx:configuration` role.

**Reviewers**
- [x] @bdero 

Configuration Pull Request
---

Make sure that the following steps are done before merging

  - [x] @devops team member has commented with :+1:
  - [ ] are you adding any new default values that need to be overridden when this goes live?   No.
    - [ ] Open a ticket (DEVOPS) to make sure that they have been added to secure vars.
    - [ ] Add an entry to the CHANGELOG.
