### PR TITLE
temporarily install google chrome stable

### DIFF
--- a/playbooks/roles/browsers/defaults/main.yml
+++ b/playbooks/roles/browsers/defaults/main.yml
@@ -12,11 +12,11 @@ browser_deb_pkgs:
 # Both Chrome and FireFox update their apt repos with the latest version,
 # which often causes spurious acceptance test failures.
 browser_s3_deb_pkgs:
-    - { name: "google-chrome-stable_30.0.1599.114-1_amd64.deb", url: "https://s3.amazonaws.com/vagrant.testeng.edx.org/google-chrome-stable_30.0.1599.114-1_amd64.deb" }
     - { name: "firefox-mozilla-build_42.0-0ubuntu1_amd64.deb", url: "https://s3.amazonaws.com/vagrant.testeng.edx.org/firefox-mozilla-build_42.0-0ubuntu1_amd64.deb" }
+    - { name: "google-chrome-stable_55.0.2883.87-1_amd64.deb", url: "https://s3.amazonaws.com/vagrant.testeng.edx.org/google-chrome-stable_55.0.2883.87-1_amd64.deb" }
 
-# Chrome and ChromeDriver
-chromedriver_version: 2.6
+# ChromeDriver
+chromedriver_version: 2.27
 chromedriver_url: "http://chromedriver.storage.googleapis.com/{{ chromedriver_version }}/chromedriver_linux64.zip"
 
 # PhantomJS

--- a/playbooks/roles/browsers/tasks/main.yml
+++ b/playbooks/roles/browsers/tasks/main.yml
@@ -71,9 +71,42 @@
 - assert:
     that: "phantomjs.stat.exists"
 
-- name: create xvfb upstart script
-  template: src=xvfb.conf.j2 dest=/etc/init/xvfb.conf owner=root group=root
+- name: create xvfb upstart script for Precise and Trusty (12.04 and 14.04)
+  template:
+    src: xvfb.conf.j2
+    dest: /etc/init/xvfb.conf
+    owner: root
+    group: root
+  when: ansible_distribution_release == 'precise' or ansible_distribution_release == 'trusty'
+  tags:
+    - install
+    - install:configuration
 
-- name: start xvfb
+- name: start xvfb upstart script for Precise and Trusty (12.04 and 14.04)
   shell: start xvfb
   ignore_errors: yes
+  when: ansible_distribution_release == 'precise' or ansible_distribution_release == 'trusty'
+  tags:
+    - install
+    - install:configuration
+
+- name: create xvfb systemd service for Xenial (16.04)
+  template:
+    src: xvfb.service.j2
+    dest: /etc/systemd/system/xvfb.service
+    owner: root
+    group: root
+  when: ansible_distribution_release == 'xenial'
+  tags:
+    - install
+    - install:configuration
+
+- name: enable and start xvfb systemd service for Xenial (16.04)
+  systemd:
+    name: xvfb
+    enabled: yes
+    state: started
+  when: ansible_distribution_release == 'xenial'
+  tags:
+    - install
+    - install:configuration

--- a/playbooks/roles/browsers/templates/xvfb.service.j2
+++ b/playbooks/roles/browsers/templates/xvfb.service.j2
@@ -1,0 +1,9 @@
+[Unit]
+Description=Xvfb X Server
+After=network.target
+
+[Service] 
+ExecStart=/usr/bin/Xvfb {{ browser_xvfb_display }} -screen 0 1024x768x24
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
[TE-1923](https://openedx.atlassian.net/browse/TE-1923)
This fixes the failing packer jobs, which were failing due to lettuce tests, which failed because they couldn't get a chrome instance up. The jobs began failing on Jan 4, due to a security flaw that was patched in libnss3. The patch was incompatible with our pinned version of chrome, and newer versions of chrome no longer support 12.04, so let's just go to the future and use Xenial.
 
@benpatterson @jzoldak 
2 things to be concerned with here:
* I used the google-chrome-stable package as opposed to a pinned version, but I see the rationale for using a pinned version in a testing environment. I would love your input.
* Regardless of if I pinned it or used the version in the apt-repo, the current version of chrome is notoriously slow (see [sitespeed update](http://support.speedcurve.com/testing-process/chrome-55-variability)) and since google doesn't believe in distributing older versions, we have to use it. As soon as 56 is released and deemed stable, let's use that.

@feanil @gsong 
This tackles part of [jenkins-16.04](https://github.com/edx/configuration/tree/feanil/jenkins-16.04), but for the sake of fixing our scripts, just wanted to focus on chrome. I know there is a separate Firefox issue.