### PR TITLE
Disable ATOMIC_REQUESTS for discovery

### DIFF
--- a/playbooks/roles/discovery/defaults/main.yml
+++ b/playbooks/roles/discovery/defaults/main.yml
@@ -34,7 +34,7 @@ DISCOVERY_DATABASES:
     PASSWORD: '{{ DISCOVERY_MYSQL_PASSWORD }}'
     HOST: '{{ DISCOVERY_MYSQL }}'
     PORT: '3306'
-    ATOMIC_REQUESTS: true
+    ATOMIC_REQUESTS: false
     CONN_MAX_AGE: 60
 
 # Using SSL? See https://www.elastic.co/guide/en/shield/current/ssl-tls.html.


### PR DESCRIPTION
Turns out Django disables [`ATOMIC_REQUESTS`](https://docs.djangoproject.com/en/1.10/ref/settings/#std:setting-DATABASE-ATOMIC_REQUESTS) by default for good reason. We first used this setting in the early days of the ecommerce service (https://github.com/edx/configuration/pull/1934) in an effort to prevent dirty data from being written to the database. From there, it spread to the cookiecutter Django service and eventually made it into discovery.

Two years later, it's safe to say that our use of this setting has brought us nothing but trouble. It's always a surprise to learn that view code has been executing in a transaction. Every time. This setting invisibly adds transactions around every view. That leads to situations where developers are writing code without realizing that all changes will be rolled back if an exception is raised and not handled properly. Opening a transaction for every view isn't free, either, but that's besides the point.

```python
>>> import this
The Zen of Python, by Tim Peters

...
Explicit is better than implicit.
...
```

Explicit is better than implicit. You should be thinking about whether your code requires atomicity. If it does, you should be explicitly controlling any transactions using `transaction.atomic()`.

@edx/ecommerce @edx/devops I'd like to start by disabling this for discovery. Assuming this is merged, I'll file a ticket to change the value in secure config and see about making similar changes in other projects.