### PR TITLE
Enable and forward query logs for neo4j.

### DIFF
--- a/playbooks/edx-east/neo4j.yml
+++ b/playbooks/edx-east/neo4j.yml
@@ -4,6 +4,13 @@
   gather_facts: True
   vars:
     CLUSTER_NAME: 'coursegraph'
+    SPLUNKFORWARDER_LOG_ITEMS:
+      - source: '/etc/neo4j/log/query.log'
+        recursive: true
+        index: 'testeng'
+        sourcetype: coursegraph_query
+        followSymlink: false
+
   roles:
     - role: nginx
       nginx_template_dir: "../roles/neo4j/templates/edx/app/nginx/sites-available"
@@ -13,3 +20,5 @@
         - coursegraph
 #    - aws
     - neo4j
+    - role: splunkforwarder
+      when: COMMON_ENABLE_SPLUNKFORWARDER

--- a/playbooks/roles/neo4j/defaults/main.yml
+++ b/playbooks/roles/neo4j/defaults/main.yml
@@ -29,3 +29,4 @@ neo4j_listen_address: "0.0.0.0"
 # Properties file settings
 neo4j_https_settings_key: "dbms.connector.https.address"
 neo4j_http_settings_key: "dbms.connector.http.address"
+neo4j_enable_query_logging_key: "dbms.logs.query.enabled"

--- a/playbooks/roles/neo4j/tasks/main.yml
+++ b/playbooks/roles/neo4j/tasks/main.yml
@@ -63,9 +63,18 @@
     - install
     - install:configuration
 
+- name: turn on logging for queries
+  lineinfile:
+    dest: "{{ neo4j_server_config_file }}"
+    regexp: "{{ neo4j_enable_query_logging_key }}="
+    line: "{{ neo4j_enable_query_logging_key }}=true"
+  tags:
+    - install
+    - install:configuration
+
 - name: restart neo4j
-  service: 
-    name: neo4j 
+  service:
+    name: neo4j
     state: restarted
   tags:
     - manage


### PR DESCRIPTION
This will help us gather important metrics related to adoption and usage. Knowledge base reference [here](https://neo4j.com/developer/kb/how-do-i-log-parameter-values-into-the-query-log-file/).

When deploying this, we'll need to enable the splunk forwarder (e.g., set `COMMON_ENABLE_SPLUNKFORWARDER`).

Configuration Pull Request
---

Make sure that the following steps are done before merging

  - [ ] @devops team member has commented with :+1:
  - [ ] are you adding any new default values that need to be overridden when this goes live?  
    - [ ] Open a ticket (DEVOPS) to make sure that they have been added to secure vars.
    - [ ] Add an entry to the CHANGELOG.
