### PR TITLE
disable auto apt updates in xenial

### DIFF
--- a/util/install/ansible-bootstrap.sh
+++ b/util/install/ansible-bootstrap.sh
@@ -92,6 +92,17 @@ fi
 
 EDX_PPA="deb http://ppa.edx.org ${SHORT_DIST} main"
 
+# Temporarily turn off the automatic updates for Xenial (16.04) to avoid 
+# conflicts with this script
+if [ $SHORT_DIST == "xenial" ]; then
+    systemctl stop apt-daily.service
+    systemctl kill --kill-who=all apt-daily.service
+    while lsof |grep -q /var/lib/dpkg/lock; do
+        echo "Waiting for apt to release the dpkg lock..."
+        sleep 5
+    done
+fi
+
 # Upgrade the OS
 apt-get update -y
 apt-key update -y


### PR DESCRIPTION
Since I started using a Xenial ami in our packer builds nearly all of our builds were failing (perhaps the only ones that succeeded beat the automatic updates race). 
@feanil @jibsheet for the devops approval
@benpatterson @jzoldak just to let you know