### PR TITLE
Conditionally kill the `apt-daily.service` if running

### DIFF
--- a/util/install/ansible-bootstrap.sh
+++ b/util/install/ansible-bootstrap.sh
@@ -92,11 +92,14 @@ fi
 
 EDX_PPA="deb http://ppa.edx.org ${SHORT_DIST} main"
 
-# Temporarily turn off the automatic updates for Xenial (16.04) to avoid 
+# Temporarily turn off the automatic updates for Xenial (16.04) to avoid
 # conflicts with this script
 if [ $SHORT_DIST == "xenial" ]; then
-    systemctl stop apt-daily.service
-    systemctl kill --kill-who=all apt-daily.service
+    APT_DAILY=apt-daily.service
+    if systemctl --state=active | grep -q $APT_DAILY; then
+        systemctl stop $APT_DAILY
+        systemctl kill --kill-who=all $APT_DAILY
+    fi
     while lsof |grep -q /var/lib/dpkg/lock; do
         echo "Waiting for apt to release the dpkg lock..."
         sleep 5


### PR DESCRIPTION
`systemctl kill` fails if the service isn't running, which is the case with barebones devstack Ubuntu boxes.

Let's make sure `apt-daily.service` is running before trying to kill it.

/cc @nedbat @estute @feanil 

---

Make sure that the following steps are done before merging

  - [ ] @devops team member has commented with :+1: