### PR TITLE
Add git GC defaults for go-server

### DIFF
--- a/playbooks/roles/go-server/tasks/main.yml
+++ b/playbooks/roles/go-server/tasks/main.yml
@@ -158,6 +158,15 @@
   tags:
     - git_identity
 
+# Setup environment variables to cleanup the git config repository
+- name: Set go-server environment variables
+  lineinfile:
+    destfile: /etc/default/go-server
+    regexp: "^export GO_SERVER_SYSTEM_PROPERTIES=*"
+    line: "export GO_SERVER_SYSTEM_PROPERTIES=\"-Dgo.config.repo.gc.cron=\"0 0 2 ? * SAT\" go.config.repo.gc.periodic=\"Y\"\""
+  tags:
+    - environment_variables
+
 - name: restart go-server
   service:
     name: "{{ GO_SERVER_SERVICE_NAME }}"


### PR DESCRIPTION
TE-1951:
@edx/pipeline-team PTAL. This will cause the go-server to run configuration git repo GC every saturday at 1 am.

more info: https://docs.gocd.io/current/advanced_usage/other_config_options.html#environment-variables

I am planning on manually running this overnight them running and merging this change.