### PR TITLE
remove systemctl calls to release dpkg lock

### DIFF
--- a/util/install/ansible-bootstrap.sh
+++ b/util/install/ansible-bootstrap.sh
@@ -92,17 +92,6 @@ fi
 
 EDX_PPA="deb http://ppa.edx.org ${SHORT_DIST} main"
 
-# Temporarily turn off the automatic updates for Xenial (16.04) to avoid 
-# conflicts with this script
-if [ $SHORT_DIST == "xenial" ]; then
-    systemctl stop apt-daily.service
-    systemctl kill --kill-who=all apt-daily.service
-    while lsof |grep -q /var/lib/dpkg/lock; do
-        echo "Waiting for apt to release the dpkg lock..."
-        sleep 5
-    done
-fi
-
 # Upgrade the OS
 apt-get update -y
 apt-key update -y


### PR DESCRIPTION
This was caused by the fact that we were using an AMI that had been manually booted once before (and thus triggered the apt services)
@edx/devops will move this into the tools scripts for the short term, and use the appropriate plays when I get a chance.
CC @gsong @clintonb 