### PR TITLE
Provide broker host var to ecomworker role

### DIFF
--- a/playbooks/edx_sandbox.yml
+++ b/playbooks/edx_sandbox.yml
@@ -55,6 +55,7 @@
     - role: ecommerce
       when: SANDBOX_ENABLE_ECOMMERCE
     - role: ecomworker
+      ECOMMERCE_WORKER_BROKER_HOST: 127.0.0.1
       when: SANDBOX_ENABLE_ECOMMERCE
     - programs
     - analytics_api

--- a/playbooks/edx_sandbox.yml
+++ b/playbooks/edx_sandbox.yml
@@ -26,7 +26,8 @@
     SANDBOX_ENABLE_ECOMMERCE: False
     COMMON_ENABLE_SPLUNKFORWARDER: False
   roles:
-    - { role: swapfile, SWAPFILE_SIZE: "2GB" }
+    - role: swapfile
+      SWAPFILE_SIZE: 2GB
     - role: nginx
       nginx_sites:
       - certs
@@ -46,8 +47,10 @@
       when: "'localhost' in ' '.join(EDXAPP_MEMCACHE)"
     - role: mongo
       when: "'localhost' in EDXAPP_MONGO_HOSTS"
-    - { role: 'rabbitmq', rabbitmq_ip: '127.0.0.1' }
-    - { role: 'edxapp', celery_worker: True }
+    - role: rabbitmq
+      rabbitmq_ip: 127.0.0.1
+    - role: edxapp
+      celery_worker: True
     - edxapp
     - role: ecommerce
       when: SANDBOX_ENABLE_ECOMMERCE
@@ -63,8 +66,10 @@
     - role: elasticsearch
       when: "'localhost' in EDXAPP_ELASTIC_SEARCH_CONFIG|map(attribute='host')"
     - forum
-    - { role: notifier, NOTIFIER_DIGEST_TASK_INTERVAL: "5" }
-    - { role: "xqueue", update_users: True }
+    - role: notifier
+      NOTIFIER_DIGEST_TASK_INTERVAL: 5
+    - role: xqueue
+      update_users: True
     - certs
     - edx_ansible
     - role: datadog

--- a/playbooks/vagrant-devstack.yml
+++ b/playbooks/vagrant-devstack.yml
@@ -26,7 +26,8 @@
     - edxlocal
     - memcache
     - mongo
-    - { role: 'rabbitmq', rabbitmq_ip: '127.0.0.1' }
+    - role: rabbitmq
+      rabbitmq_ip: 127.0.0.1
     - edxapp
     - oraclejdk
     - elasticsearch

--- a/playbooks/vagrant-devstack.yml
+++ b/playbooks/vagrant-devstack.yml
@@ -33,7 +33,8 @@
     - elasticsearch
     - forum
     - ecommerce
-    - ecomworker
+    - role: ecomworker
+      ECOMMERCE_WORKER_BROKER_HOST: 127.0.0.1
     - programs
     - role: notifier
       NOTIFIER_DIGEST_TASK_INTERVAL: "5"


### PR DESCRIPTION
Fix #3611, which is a **blocker for Ficus release**.

Set the default broker host for ecomworker to be 127.0.0.1 in alignment with how we set up rabbitmq.

/cc @nedbat 

---

Make sure that the following steps are done before merging

  - [ ] @devops team member has commented with :+1: