### PR TITLE
Add missing dependency on cryptography

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,7 @@ requests==2.9.1
 datadog==0.8.0
 networkx==1.11
 pathlib2==2.1.0
+cryptography==1.7.1
 
 # Needed for the mongo_* modules (playbooks/library/mongo_*)
 pymongo==3.1


### PR DESCRIPTION
It is required by paramiko, otherwise ansible does not work (at least) on Ubuntu 14.04.

Configuration Pull Request
---

Make sure that the following steps are done before merging

  - [ ] @devops team member has commented with :+1:
  - [ ] are you adding any new default values that need to be overridden when this goes live?  
    - [ ] Open a ticket (DEVOPS) to make sure that they have been added to secure vars.
    - [ ] Add an entry to the CHANGELOG.
