### PR TITLE
Don't enrol the staff user in the demo course if the staff user wasn't created.

### DIFF
--- a/playbooks/roles/demo/defaults/main.yml
+++ b/playbooks/roles/demo/defaults/main.yml
@@ -22,17 +22,21 @@ demo_hashed_password: 'pbkdf2_sha256$20000$TjE34FJjc3vv$0B7GUmH8RwrOc/BvMoxjb5j8
 demo_test_users:
   - email: 'honor@example.com'
     username: honor
-    mode: honor
     hashed_password: "{{ demo_hashed_password }}"
+    is_staff: false
   - email: 'audit@example.com'
     username: audit
-    mode: audit
     hashed_password: "{{ demo_hashed_password }}"
+    is_staff: false
   - email: 'verified@example.com'
     username: verified
-    mode: verified
     hashed_password: "{{ demo_hashed_password }}"
-
+    is_staff: false
+demo_staff_user:
+  email: 'staff@example.com'
+  username: staff
+  hashed_password: "{{ demo_hashed_password }}"
+  is_staff: true
 demo_edxapp_user: 'edxapp'
 demo_edxapp_settings: '{{ COMMON_EDXAPP_SETTINGS }}'
 demo_edxapp_venv_bin: '{{ COMMON_APP_DIR }}/{{ demo_edxapp_user }}/venvs/{{demo_edxapp_user}}/bin'

--- a/playbooks/roles/demo/tasks/deploy.yml
+++ b/playbooks/roles/demo/tasks/deploy.yml
@@ -16,22 +16,23 @@
   become_user: "{{ common_web_user }}"
   when: demo_checkout.changed
 
-- name: create some test users
-  shell: "{{ demo_edxapp_venv_bin }}/python ./manage.py lms --settings={{ demo_edxapp_settings }} --service-variant lms manage_user {{ item.username}} {{ item.email }} --initial-password-hash {{ item.hashed_password | quote }}"
-  args:
-    chdir: "{{ demo_edxapp_code_dir }}"
-  become_user: "{{ common_web_user }}"
-  with_items: "{{ demo_test_users }}"
-  when: demo_checkout.changed
+- name: build staff and test user list
+  set_fact:
+    demo_test_and_staff_users: "{{ demo_test_users + [demo_staff_user] }}"
+  when: DEMO_CREATE_STAFF_USER
 
-- name: create staff user
-  shell: "{{ demo_edxapp_venv_bin }}/python ./manage.py lms --settings={{ demo_edxapp_settings }} --service-variant lms manage_user staff staff@example.com --initial-password-hash {{ demo_hashed_password | quote }} --staff"
+- name: build staff and test user list
+  set_fact:
+    demo_test_and_staff_users: "{{ demo_test_users }}"
+  when: not DEMO_CREATE_STAFF_USER
+
+- name: create some test users
+  shell: "{{ demo_edxapp_venv_bin }}/python ./manage.py lms --settings={{ demo_edxapp_settings }} --service-variant lms manage_user {{ item.username}} {{ item.email }} --initial-password-hash {{ item.hashed_password | quote }}{% if item.is_staff %} --staff{% endif %}"
   args:
     chdir: "{{ demo_edxapp_code_dir }}"
   become_user: "{{ common_web_user }}"
-  when:
-    - demo_checkout.changed
-    - DEMO_CREATE_STAFF_USER
+  with_items: "{{ demo_test_and_staff_users }}"
+  when: demo_checkout.changed
 
 - name: enroll test users in the demo course
   shell: "{{ demo_edxapp_venv_bin }}/python ./manage.py lms --settings={{ demo_edxapp_settings }} --service-variant lms enroll_user_in_course -e {{ item.email }} -c {{ demo_course_id }}"
@@ -39,10 +40,8 @@
     chdir: "{{ demo_edxapp_code_dir }}"
   become_user: "{{ common_web_user }}"
   with_items:
-      - "{{ demo_test_users }}"
-      - { email: 'staff@example.com' }
+      - "{{ demo_test_and_staff_users }}"
   when: demo_checkout.changed
-
 
 - name: add test users to the certificate whitelist
   shell: "{{ demo_edxapp_venv_bin }}/python ./manage.py lms --settings={{ demo_edxapp_settings }} --service-variant lms cert_whitelist -a {{ item.email }} -c {{ demo_course_id }}"


### PR DESCRIPTION
When `DEMO_CREATE_STAFF_USER` is set to false, the user won't be created, but the demo role will try to enrol the user anyway, resulting in an error.  This fix makes sure the staff user is only enroled if it was created.

This fix should also be cherry-picked on the Ficus release branch.

Configuration Pull Request
---

Make sure that the following steps are done before merging

  - [ ] @devops team member has commented with :+1:
  - [ ] are you adding any new default values that need to be overridden when this goes live?  
    - [ ] Open a ticket (DEVOPS) to make sure that they have been added to secure vars.
    - [ ] Add an entry to the CHANGELOG.
