### PR TITLE
Pin nodeenv's node version to 6.9.4 LTS for Platform, Ecommerce, Insights and Credentials

### DIFF
--- a/playbooks/roles/common_vars/defaults/main.yml
+++ b/playbooks/roles/common_vars/defaults/main.yml
@@ -45,7 +45,7 @@ common_directories:
   - path: "/etc/logrotate.d/hourly"
   - path: "/etc/rsyslog.d/50-default.conf"
     state: absent
-    
+
 COMMON_ENVIRONMENT: 'default_env'
 COMMON_DEPLOYMENT: 'default_deployment'
 COMMON_PIP_VERBOSITY: ''
@@ -98,6 +98,7 @@ COMMON_ENABLE_NEWRELIC_APP: False
 COMMON_ENABLE_MINOS: False
 COMMON_TAG_EC2_INSTANCE: False
 common_boto_version: '2.34.0'
+common_node_version: '6.9.4'
 common_redhat_pkgs:
   - ntp
   - lynx

--- a/playbooks/roles/credentials/defaults/main.yml
+++ b/playbooks/roles/credentials/defaults/main.yml
@@ -9,7 +9,7 @@
 #
 ##
 # Defaults for role credentials
-# 
+#
 CREDENTIALS_GIT_IDENTITY: !!null
 
 # depends upon Newrelic being enabled via COMMON_ENABLE_NEWRELIC
@@ -219,6 +219,7 @@ credentials_nodeenv_dir: "{{ credentials_home }}/nodeenvs/{{ credentials_service
 credentials_nodeenv_bin: "{{ credentials_nodeenv_dir }}/bin"
 credentials_node_modules_dir: "{{ credentials_code_dir }}/node_modules"
 credentials_node_bin: "{{ credentials_node_modules_dir }}/.bin"
+credentials_node_version: "6.9.4"
 
 credentials_environment:
   DJANGO_SETTINGS_MODULE: "{{ CREDENTIALS_DJANGO_SETTINGS_MODULE }}"

--- a/playbooks/roles/credentials/defaults/main.yml
+++ b/playbooks/roles/credentials/defaults/main.yml
@@ -219,7 +219,7 @@ credentials_nodeenv_dir: "{{ credentials_home }}/nodeenvs/{{ credentials_service
 credentials_nodeenv_bin: "{{ credentials_nodeenv_dir }}/bin"
 credentials_node_modules_dir: "{{ credentials_code_dir }}/node_modules"
 credentials_node_bin: "{{ credentials_node_modules_dir }}/.bin"
-credentials_node_version: "6.9.4"
+credentials_node_version: "{{ common_node_version }}"
 
 credentials_environment:
   DJANGO_SETTINGS_MODULE: "{{ CREDENTIALS_DJANGO_SETTINGS_MODULE }}"

--- a/playbooks/roles/credentials/tasks/main.yml
+++ b/playbooks/roles/credentials/tasks/main.yml
@@ -43,9 +43,7 @@
     - install:app-requirements
 
 - name: create nodeenv
-  shell: "{{ credentials_venv_dir }}/bin/nodeenv {{ credentials_nodeenv_dir }} --prebuilt"
-  args:
-    creates: "{{ credentials_nodeenv_dir }}"
+  shell: "{{ credentials_venv_dir }}/bin/nodeenv {{ credentials_nodeenv_dir }} --node={{ credentials_node_version }} --prebuilt --force"
   become_user: "{{ credentials_user }}"
   tags:
     - install

--- a/playbooks/roles/credentials/tasks/main.yml
+++ b/playbooks/roles/credentials/tasks/main.yml
@@ -42,6 +42,17 @@
     - install
     - install:app-requirements
 
+# See https://github.com/ekalinin/nodeenv/issues/182
+# This can be removed once https://github.com/ekalinin/nodeenv/pull/183 is merged
+- name: Remove nodeenv src
+  file:
+    path: "{{ credentials_nodeenv_dir }}/src"
+    state: absent
+  become_user: "{{ credentials_user }}"
+  tags:
+    - install
+    - install:app-requirements
+
 - name: create nodeenv
   shell: "{{ credentials_venv_dir }}/bin/nodeenv {{ credentials_nodeenv_dir }} --node={{ credentials_node_version }} --prebuilt --force"
   become_user: "{{ credentials_user }}"

--- a/playbooks/roles/discovery/defaults/main.yml
+++ b/playbooks/roles/discovery/defaults/main.yml
@@ -99,7 +99,7 @@ DISCOVERY_MEDIA_STORAGE_BACKEND:
   DEFAULT_FILE_STORAGE: 'django.core.files.storage.FileSystemStorage'
   MEDIA_ROOT: '{{ DISCOVERY_MEDIA_ROOT }}'
   MEDIA_URL: '{{ DISCOVERY_MEDIA_URL }}'
-  
+
 DISCOVERY_STATICFILES_STORAGE: 'django.contrib.staticfiles.storage.StaticFilesStorage'
 
 # You can set different email backends with django:
@@ -241,7 +241,7 @@ discovery_nodeenv_dir: "{{ discovery_home }}/nodeenvs/{{ discovery_service_name 
 discovery_nodeenv_bin: "{{ discovery_nodeenv_dir }}/bin"
 discovery_node_modules_dir: "{{ discovery_code_dir }}/node_modules"
 discovery_node_bin: "{{ discovery_node_modules_dir }}/.bin"
-discovery_node_version: "6.9.4"
+discovery_node_version: "{{ common_node_version }}"
 
 discovery_gunicorn_host: "127.0.0.1"
 discovery_gunicorn_port: 8381

--- a/playbooks/roles/discovery/tasks/main.yml
+++ b/playbooks/roles/discovery/tasks/main.yml
@@ -77,9 +77,7 @@
     - devstack:install
 
 - name: create nodeenv
-  shell: "{{ discovery_venv_dir }}/bin/nodeenv {{ discovery_nodeenv_dir }} --node={{ discovery_node_version }} --prebuilt"
-  args:
-    creates: "{{ discovery_nodeenv_dir }}"
+  shell: "{{ discovery_venv_dir }}/bin/nodeenv {{ discovery_nodeenv_dir }} --node={{ discovery_node_version }} --prebuilt --force"
   become_user: "{{ discovery_user }}"
   tags:
     - install

--- a/playbooks/roles/discovery/tasks/main.yml
+++ b/playbooks/roles/discovery/tasks/main.yml
@@ -84,7 +84,11 @@
     - install:app-requirements
 
 - name: install node dependencies
-  npm: executable={{ discovery_nodeenv_bin }}/npm path={{ discovery_code_dir }} production=yes
+  npm:
+    executable: "{{ discovery_nodeenv_bin }}/npm"
+    path: "{{ discovery_code_dir }}"
+    production: yes
+    state: latest
   become_user: "{{ discovery_user }}"
   environment: "{{ discovery_environment }}"
   tags:

--- a/playbooks/roles/discovery/tasks/main.yml
+++ b/playbooks/roles/discovery/tasks/main.yml
@@ -76,6 +76,17 @@
     - devstack
     - devstack:install
 
+# See https://github.com/ekalinin/nodeenv/issues/182
+# This can be removed once https://github.com/ekalinin/nodeenv/pull/183 is merged
+- name: Remove nodeenv src
+  file:
+    path: "{{ discovery_nodeenv_dir }}/src"
+    state: absent
+  become_user: "{{ discovery_user }}"
+  tags:
+    - install
+    - install:app-requirements
+
 - name: create nodeenv
   shell: "{{ discovery_venv_dir }}/bin/nodeenv {{ discovery_nodeenv_dir }} --node={{ discovery_node_version }} --prebuilt --force"
   become_user: "{{ discovery_user }}"

--- a/playbooks/roles/ecommerce/defaults/main.yml
+++ b/playbooks/roles/ecommerce/defaults/main.yml
@@ -214,6 +214,7 @@ ecommerce_nodeenv_dir: "{{ ecommerce_home }}/nodeenvs/{{ ecommerce_service_name 
 ecommerce_nodeenv_bin: "{{ ecommerce_nodeenv_dir }}/bin"
 ecommerce_node_modules_dir: "{{ ecommerce_code_dir }}/node_modules"
 ecommerce_node_bin: "{{ ecommerce_node_modules_dir }}/.bin"
+ecommerce_node_version: "6.9.4"
 
 ecommerce_gunicorn_host: "127.0.0.1"
 ecommerce_gunicorn_port: "8130"

--- a/playbooks/roles/ecommerce/defaults/main.yml
+++ b/playbooks/roles/ecommerce/defaults/main.yml
@@ -214,7 +214,7 @@ ecommerce_nodeenv_dir: "{{ ecommerce_home }}/nodeenvs/{{ ecommerce_service_name 
 ecommerce_nodeenv_bin: "{{ ecommerce_nodeenv_dir }}/bin"
 ecommerce_node_modules_dir: "{{ ecommerce_code_dir }}/node_modules"
 ecommerce_node_bin: "{{ ecommerce_node_modules_dir }}/.bin"
-ecommerce_node_version: "6.9.4"
+ecommerce_node_version: "{{ common_node_version }}"
 
 ecommerce_gunicorn_host: "127.0.0.1"
 ecommerce_gunicorn_port: "8130"

--- a/playbooks/roles/ecommerce/tasks/main.yml
+++ b/playbooks/roles/ecommerce/tasks/main.yml
@@ -41,9 +41,7 @@
     - install:app-requirements
 
 - name: Create nodeenv
-  shell: "{{ ecommerce_venv_dir }}/bin/nodeenv {{ ecommerce_nodeenv_dir }} --prebuilt"
-  args:
-    creates: "{{ ecommerce_nodeenv_dir }}"
+  shell: "{{ ecommerce_venv_dir }}/bin/nodeenv {{ ecommerce_nodeenv_dir }} --node={{ ecommerce_node_version }} --prebuilt --force"
   become_user: "{{ ecommerce_user }}"
   tags:
     - install

--- a/playbooks/roles/ecommerce/tasks/main.yml
+++ b/playbooks/roles/ecommerce/tasks/main.yml
@@ -40,6 +40,17 @@
     - install
     - install:app-requirements
 
+# See https://github.com/ekalinin/nodeenv/issues/182
+# This can be removed once https://github.com/ekalinin/nodeenv/pull/183 is merged
+- name: Remove nodeenv src
+  file:
+    path: "{{ ecommerce_nodeenv_dir }}/src"
+    state: absent
+  become_user: "{{ ecommerce_user }}"
+  tags:
+    - install
+    - install:app-requirements
+
 - name: Create nodeenv
   shell: "{{ ecommerce_venv_dir }}/bin/nodeenv {{ ecommerce_nodeenv_dir }} --node={{ ecommerce_node_version }} --prebuilt --force"
   become_user: "{{ ecommerce_user }}"

--- a/playbooks/roles/ecommerce/tasks/main.yml
+++ b/playbooks/roles/ecommerce/tasks/main.yml
@@ -52,6 +52,7 @@
     executable: "{{ ecommerce_nodeenv_bin }}/npm"
     path: "{{ ecommerce_code_dir }}"
     production: yes
+    state: latest
   become_user: "{{ ecommerce_user }}"
   environment: "{{ ecommerce_environment }}"
   tags:

--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -642,7 +642,7 @@ edxapp_venv_bin: "{{ edxapp_venv_dir }}/bin"
 edxapp_nodeenv_dir: "{{ edxapp_app_dir }}/nodeenvs/edxapp"
 edxapp_nodeenv_bin: "{{ edxapp_nodeenv_dir }}/bin"
 edxapp_settings: '{{ EDXAPP_SETTINGS }}'
-edxapp_node_version: "6.9.2"
+edxapp_node_version: "{{ common_node_version }}"
 # This is where node installs modules, not node itself
 edxapp_node_bin: "{{ edxapp_code_dir }}/node_modules/.bin"
 edxapp_user: edxapp

--- a/playbooks/roles/edxapp/tasks/deploy.yml
+++ b/playbooks/roles/edxapp/tasks/deploy.yml
@@ -243,6 +243,7 @@
     executable: "{{ edxapp_nodeenv_bin }}/npm"
     path: "{{ edxapp_code_dir }}"
     production: yes
+    state: latest
   environment: "{{ edxapp_environment }}"
   become_user: "{{ edxapp_user }}"
   tags:

--- a/playbooks/roles/edxapp/tasks/deploy.yml
+++ b/playbooks/roles/edxapp/tasks/deploy.yml
@@ -210,6 +210,16 @@
     - install
     - install:app-requirements
 
+# See https://github.com/ekalinin/nodeenv/issues/182
+# This can be removed once https://github.com/ekalinin/nodeenv/pull/183 is merged
+- name: Remove nodeenv src
+  file:
+    path: "{{ edxapp_nodeenv_dir }}/src"
+    state: absent
+  tags:
+    - install
+    - install:app-requirements
+
 - name: create nodeenv
   shell: "{{ edxapp_venv_dir }}/bin/nodeenv {{ edxapp_nodeenv_dir }} --node={{ edxapp_node_version }} --prebuilt --force"
   tags:

--- a/playbooks/roles/edxapp/tasks/deploy.yml
+++ b/playbooks/roles/edxapp/tasks/deploy.yml
@@ -1,7 +1,7 @@
 ---
 - name: create edxapp configuration dir
   file:
-    path: "{{ EDXAPP_CFG_DIR }}" 
+    path: "{{ EDXAPP_CFG_DIR }}"
     state: directory
     owner: "{{ edxapp_user }}"
     group: "{{ common_web_group }}"
@@ -13,7 +13,7 @@
   template:
     src: "{{ item.src }}"
     dest: "{{ item.dest }}"
-    owner: "{{ item.owner }}"  
+    owner: "{{ item.owner }}"
     group: "{{ item.group }}"
     mode: "{{ item.mode }}"
   with_items:
@@ -211,9 +211,7 @@
     - install:app-requirements
 
 - name: create nodeenv
-  shell: "{{ edxapp_venv_dir }}/bin/nodeenv {{ edxapp_nodeenv_dir }} --node={{ edxapp_node_version }} --prebuilt"
-  args:
-    creates: "{{ edxapp_nodeenv_dir }}"
+  shell: "{{ edxapp_venv_dir }}/bin/nodeenv {{ edxapp_nodeenv_dir }} --node={{ edxapp_node_version }} --prebuilt --force"
   tags:
     - install
     - install:app-requirements

--- a/playbooks/roles/insights/defaults/main.yml
+++ b/playbooks/roles/insights/defaults/main.yml
@@ -185,7 +185,7 @@ insights_nodeenv_dir: "{{ insights_home }}/nodeenvs/{{ insights_service_name }}"
 insights_nodeenv_bin: "{{ insights_nodeenv_dir }}/bin"
 insights_node_modules_dir: "{{ insights_code_dir }}/node_modules"
 insights_node_bin: "{{ insights_node_modules_dir }}/.bin"
-insights_node_version: "6.9.4"
+insights_node_version: "{{ common_node_version }}"
 
 insights_gunicorn_host: "127.0.0.1"
 insights_gunicorn_port: "8110"

--- a/playbooks/roles/insights/defaults/main.yml
+++ b/playbooks/roles/insights/defaults/main.yml
@@ -9,7 +9,7 @@
 #
 #
 # Defaults for role insights
-# 
+#
 
 INSIGHTS_LMS_BASE: 'http://127.0.0.1:8000'
 INSIGHTS_CMS_BASE: 'http://127.0.0.1:8010'
@@ -169,7 +169,7 @@ insights_environment:
   ANALYTICS_DASHBOARD_CFG: "{{ COMMON_CFG_DIR  }}/{{ insights_service_name }}.yml"
   PATH: "{{ insights_nodeenv_bin }}:{{ insights_venv_dir }}/bin:{{ ansible_env.PATH }}"
 
-  
+
 insights_service_name: insights
 insights_venv_dir: "{{ insights_home }}/venvs/{{ insights_service_name }}"
 insights_user: "{{ insights_service_name }}"
@@ -185,6 +185,7 @@ insights_nodeenv_dir: "{{ insights_home }}/nodeenvs/{{ insights_service_name }}"
 insights_nodeenv_bin: "{{ insights_nodeenv_dir }}/bin"
 insights_node_modules_dir: "{{ insights_code_dir }}/node_modules"
 insights_node_bin: "{{ insights_node_modules_dir }}/.bin"
+insights_node_version: "6.9.4"
 
 insights_gunicorn_host: "127.0.0.1"
 insights_gunicorn_port: "8110"

--- a/playbooks/roles/insights/tasks/main.yml
+++ b/playbooks/roles/insights/tasks/main.yml
@@ -44,6 +44,17 @@
     - install
     - install:app-requirements
 
+# See https://github.com/ekalinin/nodeenv/issues/182
+# This can be removed once https://github.com/ekalinin/nodeenv/pull/183 is merged
+- name: Remove nodeenv src
+  file:
+    path: "{{ insights_nodeenv_dir }}/src"
+    state: absent
+  become_user: "{{ insights_user }}"
+  tags:
+    - install
+    - install:app-requirements
+
 - name: create nodeenv
   shell: "{{ insights_venv_dir }}/bin/nodeenv {{ insights_nodeenv_dir }}  --node={{ insights_node_version }} --prebuilt --force"
   become_user: "{{ insights_user }}"

--- a/playbooks/roles/insights/tasks/main.yml
+++ b/playbooks/roles/insights/tasks/main.yml
@@ -45,9 +45,7 @@
     - install:app-requirements
 
 - name: create nodeenv
-  shell: "{{ insights_venv_dir }}/bin/nodeenv {{ insights_nodeenv_dir }}  --prebuilt"
-  args:
-    creates: "{{ insights_nodeenv_dir }}"
+  shell: "{{ insights_venv_dir }}/bin/nodeenv {{ insights_nodeenv_dir }}  --node={{ insights_node_version }} --prebuilt --force"
   become_user: "{{ insights_user }}"
   tags:
     - install

--- a/playbooks/roles/insights/tasks/main.yml
+++ b/playbooks/roles/insights/tasks/main.yml
@@ -52,7 +52,11 @@
     - install:base
 
 - name: install node dependencies
-  npm: executable={{ insights_nodeenv_bin }}/npm path={{ insights_code_dir }} production=yes
+  npm:
+    executable: "{{ insights_nodeenv_bin }}/npm"
+    path: "{{ insights_code_dir }}"
+    production: yes
+    state: latest
   become_user: "{{ insights_user }}"
   tags:
     - install


### PR DESCRIPTION
Fixes [FEDX-299](https://openedx.atlassian.net/browse/FEDX-299).

Currently, new devstacks are unable to be built from the `open-release/ficus.master` tag. Devstack provisioning repeatedly fails on the following step:

```
TASK [ecommerce : Install bower dependencies] **********************************
==> default: fatal: [localhost]: FAILED! => {"changed": true, "cmd": ". /edx/app/ecommerce/nodeenvs/ecommerce/bin/activate && /edx/app/ecommerce/ecommerce/node_modules/.bin/bower install --production --config.interactive=false", "delta": "0:00:02.984544", "end": "2017-01-30 16:12:40.111830", "failed": true, "rc": 1, "start": "2017-01-30 16:12:37.127286", "stderr": "module.js:472\n    throw err;\n    ^\n\nError: Cannot find module 'internal/fs'\n    at Function.Module._resolveFilename (module.js:470:15)\n    at Function.Module._load (module.js:418:25)\n    at Module.require (module.js:498:17)\n    at require (internal/module.js:20:19)\n    at evalmachine.<anonymous>:18:20\n    at Object.<anonymous> (/edx/app/ecommerce/ecommerce/node_modules/bower/lib/node_modules/graceful-fs/fs.js:11:1)\n    at Module._compile (module.js:571:32)\n    at Object.Module._extensions..js (module.js:580:10)\n    at Module.load (module.js:488:32)\n    at tryModuleLoad (module.js:447:12)", "stdout": "", "stdout_lines": [], "warnings": []}
```

This is due to:

**Bug 1**: the Ecom nodeenv is not passing a specific Node version to `nodeenv`. The behavior of this for `nodeenv` results in installing the latest node with a prebuilt binary for that system, which for Ubuntu 16.04 is Node 7.4.0.

[The error above is a known issue with Bower and Node 7](https://github.com/bower/bower/issues/2393), and in general we haven't tested any edX applications with Node 7 yet, so we want to pin to Node 6.9.4 (most recent in the LTS branch) for now. I have made this change to all edX apps that do not specify a node version and are using nodeenv - Insights and Credentials are also affected.

**Bug 2**: the `ficus-devstack-2017-01-11` Vagrant box appears to ship with a Node 7.4.0 nodeenv inside `/edx/app/ecommerce/nodeenvs/ecommerce` - that is, there is a nodeenv in this folder before the ecom role runs during provisioning. This causes the play "Create nodeenv" in `ecommerce/tasks/main.yml` to fail silently on every installation with `ficus-devstack-2017-01-11` as a base, because the nodeenv cannot be created in a non-empty directory. Thus, Node 7.4.0 is still the Node version in the ecom nodeenv post-provisioning, even if you manually specify 6.9.4 in the nodeenv creation command in the playbook. To fix this, I've ~~added a step to the Ecom playbook that deletes the nodeenv if it exists before it creates a new nodeenv using the pinned version~~ made nodeenv run with `--force` every time.

You can test this locally with:

```
$> export OPENEDX_RELEASE=open-release/ficus.master
$> curl -OL https://raw.github.com/edx/configuration/$OPENEDX_RELEASE/vagrant/release/devstack/Vagrantfile
$> CONFIGURATION_VERSION=bjacobel/ecom-node-version vagrant up
```

Tagging @clintonb and @rlucioni as reviewers on this as they made similar changes to Discovery last week. I don't think review from Analytics should be needed as they have never pinned a specific version of Node before.

Also tagging @nedbat and @gsong because of the issues with the Vagrant box, ~~which we may want to fix rather than adding the deletion step to the playbook, although I don't know if that is possible now that that specific named box has shipped~~. @nedbat, I believe this is a release blocker for Ficus.

Also tagging @jibsheet because ✨ devops ✨.

FYI: @andy-armstrong @dsjen @thallada
