### PR TITLE
Fullstack is now a native install, in Vagrant

### DIFF
--- a/util/install/install_stack.sh
+++ b/util/install/install_stack.sh
@@ -123,11 +123,6 @@ if [[ ! $release ]]; then
     exit 1
 fi
 
-if [[ $release == *ficus* && $stack == "fullstack" ]]; then
-    echo -e "${ERROR}Fullstack is not yet supported for Ficus. Soon..."
-    exit 1
-fi
-
 # If there are positional arguments left, something is wrong.
 if [[ $1 ]]; then
     echo "Don't understand extra arguments: $*"

--- a/vagrant/base/fullstack/Vagrantfile
+++ b/vagrant/base/fullstack/Vagrantfile
@@ -1,9 +1,14 @@
-Vagrant.require_version ">= 1.5.3"
+Vagrant.require_version ">= 1.8.7"
 
 VAGRANTFILE_API_VERSION = "2"
 
 MEMORY = 4096
 CPU_COUNT = 2
+
+vm_guest_ip = "192.168.33.10"
+if ENV["VAGRANT_GUEST_IP"]
+  vm_guest_ip = ENV["VAGRANT_GUEST_IP"]
+end
 
 # These are versioning variables in the roles. Each can be overridden, first
 # with OPENEDX_RELEASE, and then with a specific environment variable of the
@@ -15,19 +20,24 @@ VERSION_VARS = [
     'forum_version',
     'xqueue_version',
     'demo_version',
+    'NOTIFIER_VERSION',
+    'ECOMMERCE_VERSION',
+    'ECOMMERCE_WORKER_VERSION',
+    'PROGRAMS_VERSION',
 ]
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  config.vm.box     = "precise64"
-  config.vm.box_url = "http://files.vagrantup.com/precise64.box"
+
+  # Creates a machine from a base Ubuntu 16.04 image for virtualbox
+  config.vm.box = "boxcutter/ubuntu1604"
+
+  config.vm.network :private_network, ip: vm_guest_ip, nic_type: "virtio"
+
   config.ssh.insert_key = true
-  config.vm.synced_folder  ".", "/vagrant", disabled: true
-  config.vm.network :private_network, ip: "192.168.33.10"
+  config.vm.synced_folder ".", "/vagrant", disabled: true
 
   config.vm.provider :virtualbox do |vb|
     vb.customize ["modifyvm", :id, "--memory", MEMORY.to_s]
-
-    # You can adjust this to the amount of CPUs your system has available
     vb.customize ["modifyvm", :id, "--cpus", CPU_COUNT.to_s]
 
     # Allow DNS to work for Ubuntu 12.10 host
@@ -41,8 +51,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   config.vm.provision :ansible do |ansible|
     # point Vagrant at the location of your playbook you want to run
-    ansible.playbook = "../../../playbooks/vagrant-fullstack.yml"
-    ansible.verbose = "vvv"
+    ansible.playbook = "../../../playbooks/edx_sandbox.yml"
+    ansible.verbose = "vv"
 
     # Set extra-vars here instead of in the vagrant play so that
     # they are written out to /edx/etc/server-vars.yml which can

--- a/vagrant/release/fullstack/Vagrantfile
+++ b/vagrant/release/fullstack/Vagrantfile
@@ -1,4 +1,4 @@
-Vagrant.require_version ">= 1.5.3"
+Vagrant.require_version ">= 1.8.7"
 
 VAGRANTFILE_API_VERSION = "2"
 
@@ -41,15 +41,21 @@ openedx_releases = {
 openedx_releases.default = "eucalyptus-fullstack-2016-09-01"
 
 openedx_release = ENV['OPENEDX_RELEASE']
+boxname = ENV['OPENEDX_BOXNAME']
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
-  reldata = openedx_releases[openedx_release]
-  if Hash == reldata.class
-    boxname = openedx_releases[openedx_release][:name]
-    boxfile = openedx_releases[openedx_release].fetch(:file, "#{boxname}.box")
-  else
-    boxname = reldata
+  boxfile = ""
+  if not boxname
+    reldata = openedx_releases[openedx_release]
+    if Hash == reldata.class
+      boxname = openedx_releases[openedx_release][:name]
+      boxfile = openedx_releases[openedx_release].fetch(:file, "")
+    else
+      boxname = reldata
+    end
+  end
+  if boxfile == ""
     boxfile = "#{boxname}.box"
   end
 
@@ -58,10 +64,10 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box_url = "http://files.edx.org/vagrant-images/#{boxfile}"
   config.vm.box_check_update = false
 
+  config.vm.network :private_network, ip: "192.168.33.10"
   config.vm.synced_folder  ".", "/vagrant", disabled: true
   config.ssh.insert_key = true
 
-  config.vm.network :private_network, ip: "192.168.33.10"
   config.hostsupdater.aliases = ["preview.localhost"]
 
   config.vm.provider :virtualbox do |vb|
@@ -71,5 +77,11 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     # Allow DNS to work for Ubuntu 12.10 host
     # http://askubuntu.com/questions/238040/how-do-i-fix-name-service-for-vagrant-client
     vb.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
+
+    # Virtio is faster, but the box needs to have support for it.  We didn't
+    # have support in the boxes before Ficus.
+    if !(boxname.include?("dogwood") || boxname.include?("eucalyptus"))
+      vb.customize ['modifyvm', :id, '--nictype1', 'virtio']
+    end
   end
 end


### PR DESCRIPTION
Make "fullstack" be the same installation as "native" (edx_sandbox.yml), but in a Vagrantfile.

Make sure that the following steps are done before merging

  - [ ] @devops team member has commented with :+1:
  - [ ] @gsong review?
  - [ ] are you adding any new default values that need to be overridden when this goes live?  
    - [ ] Open a ticket (DEVOPS) to make sure that they have been added to secure vars.
    - [ ] Add an entry to the CHANGELOG.
