### PR TITLE
Always autorestart edxapp workers

### DIFF
--- a/playbooks/roles/edxapp/templates/workers.conf.j2
+++ b/playbooks/roles/edxapp/templates/workers.conf.j2
@@ -10,6 +10,11 @@ stderr_logfile={{ supervisor_log_dir }}/%(program_name)s-stderr.log
 command={{ edxapp_venv_dir + '/bin/newrelic-admin run-program ' if w.monitor and COMMON_ENABLE_NEWRELIC_APP else ''}}{{ edxapp_venv_bin }}/python {{ edxapp_code_dir }}/manage.py {{ w.service_variant }} --settings={{ worker_django_settings_module }} celery worker --loglevel=info --queues=edx.{{ w.service_variant }}.core.{{ w.queue }} --hostname=edx.{{ w.service_variant }}.core.{{ w.queue }}.%%h --concurrency={{ w.concurrency }} {{ '--maxtasksperchild ' + w.max_tasks_per_child|string if w.max_tasks_per_child is defined else '' }}
 killasgroup=true
 stopwaitsecs={{ w.stopwaitsecs | default(EDXAPP_WORKER_DEFAULT_STOPWAITSECS) }}
+; Set autorestart to `true`. The default value for autorestart is `unexpected`, but celery < 4.x will exit
+; with an exit code of zero for certain types of unrecoverable errors, so we must make sure that the workers
+; are auto restarted even when exiting with code 0.
+; The Celery bug was reported in https://github.com/celery/celery/issues/2024, and is fixed in Celery 4.0.0.
+autorestart=true
 
 {% endfor %}
 


### PR DESCRIPTION
By default supervisor will only automatically restart services when they exit code is not `0` or `2`.
Edxapp workers sometimes exit with a code of `0` on certain network failures, so make sure they are restarted even if exit code is `0`.

JIRA ticket: [OSPR-1713](https://openedx.atlassian.net/browse/OSPR-1713)

Configuration Pull Request
---

Make sure that the following steps are done before merging

  - [x] @devops team member has commented with :+1:
  - [ ] ~~are you adding any new default values that need to be overridden when this goes live?~~ nope
    - ~~[ ] Open a ticket (DEVOPS) to make sure that they have been added to secure vars.~~
    - ~~[ ] Add an entry to the CHANGELOG.~~
