### PR TITLE
Remove play made unnecessary by nodeenv 1.1.1

### DIFF
--- a/playbooks/roles/credentials/tasks/main.yml
+++ b/playbooks/roles/credentials/tasks/main.yml
@@ -42,17 +42,6 @@
     - install
     - install:app-requirements
 
-# See https://github.com/ekalinin/nodeenv/issues/182
-# This can be removed once https://github.com/ekalinin/nodeenv/pull/183 is merged
-- name: Remove nodeenv src
-  file:
-    path: "{{ credentials_nodeenv_dir }}/src"
-    state: absent
-  become_user: "{{ credentials_user }}"
-  tags:
-    - install
-    - install:system-requirements
-
 - name: create nodeenv
   shell: "{{ credentials_venv_dir }}/bin/nodeenv {{ credentials_nodeenv_dir }} --node={{ credentials_node_version }} --prebuilt --force"
   become_user: "{{ credentials_user }}"

--- a/playbooks/roles/discovery/tasks/main.yml
+++ b/playbooks/roles/discovery/tasks/main.yml
@@ -67,17 +67,6 @@
     - install
     - install:system-requirements
 
-# See https://github.com/ekalinin/nodeenv/issues/182
-# This can be removed once https://github.com/ekalinin/nodeenv/pull/183 is merged
-- name: remove nodeenv src
-  file:
-    path: "{{ discovery_nodeenv_dir }}/src"
-    state: absent
-  become_user: "{{ discovery_user }}"
-  tags:
-    - install
-    - install:system-requirements
-
 - name: create nodeenv
   shell: "{{ discovery_venv_dir }}/bin/nodeenv {{ discovery_nodeenv_dir }} --node={{ discovery_node_version }} --prebuilt --force"
   become_user: "{{ discovery_user }}"

--- a/playbooks/roles/discovery/tasks/main.yml
+++ b/playbooks/roles/discovery/tasks/main.yml
@@ -59,7 +59,7 @@
 - name: install nodenv
   pip:
     name: "nodeenv"
-    version: "1.1.0"
+    version: "1.1.1"
     # NOTE (CCB): Using the "virtualenv" option here doesn't seem to work.
     executable: "{{ discovery_venv_dir }}/bin/pip"
   become_user: "{{ discovery_user }}"

--- a/playbooks/roles/ecommerce/tasks/main.yml
+++ b/playbooks/roles/ecommerce/tasks/main.yml
@@ -40,17 +40,6 @@
     - install
     - install:app-requirements
 
-# See https://github.com/ekalinin/nodeenv/issues/182
-# This can be removed once https://github.com/ekalinin/nodeenv/pull/183 is merged
-- name: Remove nodeenv src
-  file:
-    path: "{{ ecommerce_nodeenv_dir }}/src"
-    state: absent
-  become_user: "{{ ecommerce_user }}"
-  tags:
-    - install
-    - install:system-requirements
-
 - name: Create nodeenv
   shell: "{{ ecommerce_venv_dir }}/bin/nodeenv {{ ecommerce_nodeenv_dir }} --node={{ ecommerce_node_version }} --prebuilt --force"
   become_user: "{{ ecommerce_user }}"

--- a/playbooks/roles/edxapp/tasks/deploy.yml
+++ b/playbooks/roles/edxapp/tasks/deploy.yml
@@ -210,16 +210,6 @@
     - install
     - install:app-requirements
 
-# See https://github.com/ekalinin/nodeenv/issues/182
-# This can be removed once https://github.com/ekalinin/nodeenv/pull/183 is merged
-- name: Remove nodeenv src
-  file:
-    path: "{{ edxapp_nodeenv_dir }}/src"
-    state: absent
-  tags:
-    - install
-    - install:system-requirements
-
 - name: create nodeenv
   shell: "{{ edxapp_venv_dir }}/bin/nodeenv {{ edxapp_nodeenv_dir }} --node={{ edxapp_node_version }} --prebuilt --force"
   tags:

--- a/playbooks/roles/insights/tasks/main.yml
+++ b/playbooks/roles/insights/tasks/main.yml
@@ -44,17 +44,6 @@
     - install
     - install:app-requirements
 
-# See https://github.com/ekalinin/nodeenv/issues/182
-# This can be removed once https://github.com/ekalinin/nodeenv/pull/183 is merged
-- name: Remove nodeenv src
-  file:
-    path: "{{ insights_nodeenv_dir }}/src"
-    state: absent
-  become_user: "{{ insights_user }}"
-  tags:
-    - install
-    - install:system-requirements
-
 - name: create nodeenv
   shell: "{{ insights_venv_dir }}/bin/nodeenv {{ insights_nodeenv_dir }}  --node={{ insights_node_version }} --prebuilt --force"
   become_user: "{{ insights_user }}"


### PR DESCRIPTION
These four PRs should merge first (and be incorporated into the ficus.master tag):

- [x] https://github.com/edx/credentials/pull/165
- [x] https://github.com/edx/edx-analytics-dashboard/pull/618
- [x]  https://github.com/edx/ecommerce/pull/1125
- [x] https://github.com/edx/edx-platform/pull/14454