### PR TITLE
Fix broken edxapp Docker test

### DIFF
--- a/docker/build/edxapp/Dockerfile
+++ b/docker/build/edxapp/Dockerfile
@@ -1,3 +1,12 @@
+# To build this Dockerfile:
+#
+# From the root of configuration:
+#
+# docker build -f docker/build/edxapp/Dockerfile .
+#
+# This allows the dockerfile to update /edx/app/edx_ansible/edx_ansible
+# with the currently checked-out configuration repo.
+
 FROM edxops/precise-common:latest
 MAINTAINER edxops
 
@@ -8,7 +17,11 @@ ADD . /edx/app/edx_ansible/edx_ansible
 COPY docker/build/edxapp/ansible_overrides.yml /
 WORKDIR /edx/app/edx_ansible/edx_ansible/docker/plays
 COPY docker/build/edxapp/ansible_overrides.yml /
-RUN /edx/app/edx_ansible/venvs/edx_ansible/bin/ansible-playbook edxapp.yml -i '127.0.0.1,' -c local -e "EDXAPP_PYTHON_SANDBOX=false" -t "install:base,install:configuration,install:app-requirements,install:code" -e@/ansible_overrides.yml
+RUN /edx/app/edx_ansible/venvs/edx_ansible/bin/ansible-playbook \
+    edxapp.yml -i '127.0.0.1,' -c local \
+    -e "EDXAPP_PYTHON_SANDBOX=false" \
+    -e@/ansible_overrides.yml \
+    -t "install:base,install:configuration,install:system-requirements,install:app-requirements,install:code"
 WORKDIR /edx/app
 CMD ["/edx/app/supervisor/venvs/supervisor/bin/supervisord", "-n", "--configuration", "/edx/app/supervisor/supervisord.conf"]
 EXPOSE 8000 8010


### PR DESCRIPTION
Add `install:system-requirements` build tag

---

Make sure that the following steps are done before merging

  - [ ] @devops team member has commented with :+1: