### PR TITLE
The great ansible2 upgrade grep missed this because of the \n

### DIFF
--- a/playbooks/roles/mongo_mms/tasks/main.yml
+++ b/playbooks/roles/mongo_mms/tasks/main.yml
@@ -22,8 +22,7 @@
     deb: "/tmp/{{ item.agent }}-{{ item.version }}.deb"
   when: download_mms_deb.changed
   notify: restart mms
-  with_items:
-    agents
+  with_items: "{{ agents }}"
 
 - name: add key to monitoring-agent.config
   lineinfile:


### PR DESCRIPTION
Found as part of DEVOPS-5415