### PR TITLE
Silently fail on missing requirements

### DIFF
--- a/util/balancecontainers.py
+++ b/util/balancecontainers.py
@@ -1,11 +1,20 @@
-import yaml
-import os
-import pathlib2
-import itertools
-import sys
 import argparse
 import logging
+import os
+import sys
+
+try:
+    # This script is used by docker.mk at parse-time, which means when you run
+    # "make requirements" to install the required Python packages, this script
+    # runs before its requirements are installed. That means this import will
+    # fail.  To prevent a successful installation from having irrelevant error
+    # messages, we catch the failure and exit silently.
+    import pathlib2
+except ImportError:
+    sys.exit(1)
+
 import docker_images
+
 
 TRAVIS_BUILD_DIR = os.environ.get("TRAVIS_BUILD_DIR", "")
 CONFIG_FILE_PATH = pathlib2.Path(TRAVIS_BUILD_DIR, "util", "parsefiles_config.yml")
@@ -22,7 +31,7 @@ def pack_shards(used_images, num_shards):
     """
 
     # sorts used containers in descending order on the weight
-    sorted_images = sorted(used_images, key = lambda x: x[1], reverse=True) 
+    sorted_images = sorted(used_images, key = lambda x: x[1], reverse=True)
 
     shards = []
 


### PR DESCRIPTION
The way this was before, in a new virtualenv, you would get this:
```
$ make requirements
Traceback (most recent call last):
  File "util/balancecontainers.py", line 1, in <module>
    import yaml
ImportError: No module named yaml
Traceback (most recent call last):
  File "util/balancecontainers.py", line 1, in <module>
    import yaml
ImportError: No module named yaml
pip install -qr pre-requirements.txt --exists-action w
pip install -qr requirements.txt --exists-action w
```
This would alarm cautious installers.  Now you get:
```
$ make requirements
pip install -qr pre-requirements.txt --exists-action w
pip install -qr requirements.txt --exists-action w
```


Make sure that the following steps are done before merging

  - [ ] A devops team member has commented with :+1:
  - [ ] are you adding any new default values that need to be overridden when this goes live?
    - [ ] Open a ticket (DEVOPS) to make sure that they have been added to secure vars.
    - [ ] Add an entry to the CHANGELOG.
