### PR TITLE
Use the ubuntu keyserver to retrieve the edX PPA key.

### DIFF
--- a/util/install/ansible-bootstrap.sh
+++ b/util/install/ansible-bootstrap.sh
@@ -48,7 +48,7 @@ PYTHON_BIN="${VIRTUAL_ENV}/bin"
 ANSIBLE_DIR="/tmp/ansible"
 CONFIGURATION_DIR="/tmp/configuration"
 EDX_PPA="deb http://ppa.edx.org precise main"
-EDX_PPA_KEY_SERVER="hkp://pgp.mit.edu:80"
+EDX_PPA_KEY_SERVER="keyserver.ubuntu.com"
 EDX_PPA_KEY_ID="B41E5E3969464050"
 
 cat << EOF

--- a/util/vpc-tools/abbey.py
+++ b/util/vpc-tools/abbey.py
@@ -331,7 +331,7 @@ VIRTUAL_ENV_VERSION="15.0.2"
 PIP_VERSION="8.1.2"
 SETUPTOOLS_VERSION="24.0.3"
 EDX_PPA="deb http://ppa.edx.org precise main"
-EDX_PPA_KEY_SERVER="hkp://pgp.mit.edu:80"
+EDX_PPA_KEY_SERVER="keyserver.ubuntu.com"
 EDX_PPA_KEY_ID="B41E5E3969464050"
 
 cat << EOF


### PR DESCRIPTION
We already do this in the common role but not in bootstrap or abbey roles.

Review: @nedbat @edx/devops 

The key must have already been on the ubuntu keyserver.  When I thought I was uploading it for the first time I updated it so that it's no longer expired.  The mit keyserver has been flaky in the past, we should try to consistently use the ubuntu keyserver if we can.