### PR TITLE
TNL-6278 Adds in xvfb and firefox to tools_jenkins for bok-choy tests

### DIFF
--- a/docker/build/tools_jenkins/Dockerfile
+++ b/docker/build/tools_jenkins/Dockerfile
@@ -1,4 +1,4 @@
-FROM edxops/precise-common:latest
+FROM edxops/trusty-common:latest
 MAINTAINER edxops
 
 USER root

--- a/playbooks/roles/browsers/defaults/main.yml
+++ b/playbooks/roles/browsers/defaults/main.yml
@@ -20,6 +20,12 @@ browser_s3_deb_pkgs:
   - name: google-chrome-stable_55.0.2883.87-1_amd64.deb
     url: https://s3.amazonaws.com/vagrant.testeng.edx.org/google-chrome-stable_55.0.2883.87-1_amd64.deb
 
+trusty_browser_s3_deb_pkgs:
+  - name: google-chrome-stable_30.0.1599.114-1_amd64.deb
+    url: https://s3.amazonaws.com/vagrant.testeng.edx.org/google-chrome-stable_30.0.1599.114-1_amd64.deb
+  - name: firefox-mozilla-build_42.0-0ubuntu1_amd64.deb
+    url: https://s3.amazonaws.com/vagrant.testeng.edx.org/firefox-mozilla-build_42.0-0ubuntu1_amd64.deb
+
 # ChromeDriver
 chromedriver_version: 2.27
 chromedriver_url: "http://chromedriver.storage.googleapis.com/{{ chromedriver_version }}/chromedriver_linux64.zip"

--- a/playbooks/roles/browsers/tasks/main.yml
+++ b/playbooks/roles/browsers/tasks/main.yml
@@ -21,20 +21,42 @@
     - install
     - install:system-requirements
 
-- name: download browser packages from S3
+- name: download trusty browser packages from S3
+  get_url:
+    dest: /tmp/{{ item.name }}
+    url: "{{ item.url }}"
+  register: download_deb
+  with_items: "{{ trusty_browser_s3_deb_pkgs }}"
+  when: ansible_distribution_release == 'trusty'
+  tags:
+    - install
+    - install:system-requirements
+
+- name: download xenial browser packages from S3
   get_url:
     dest: /tmp/{{ item.name }}
     url: "{{ item.url }}"
   register: download_deb
   with_items: "{{ browser_s3_deb_pkgs }}"
+  when: ansible_distribution_release == 'xenial'
   tags:
     - install
     - install:system-requirements
 
-- name: install browser packages
+- name: install trusty browser packages
+  shell: gdebi -nq /tmp/{{ item.name }}
+  when: download_deb.changed
+  with_items: "{{ trusty_browser_s3_deb_pkgs }}"
+  when: ansible_distribution_release == 'trusty'
+  tags:
+    - install
+    - install:system-requirements
+
+- name: install xenial browser packages
   shell: gdebi -nq /tmp/{{ item.name }}
   when: download_deb.changed
   with_items: "{{ browser_s3_deb_pkgs }}"
+  when: ansible_distribution_release == 'xenial'
   tags:
     - install
     - install:system-requirements
@@ -127,12 +149,29 @@
     - install
     - install:system-requirements
 
+# Systemd doesn't exist in 14.04, use upstart instead
+- name: create xvfb upstart script
+  template:
+    src: xvfb.conf.j2
+    dest: /etc/init/xvfb.conf
+    owner: root
+    group: root
+  when: ansible_distribution_release == 'trusty'
+
+- name: start xvfb
+  service:
+    name: xvfb
+    state: restarted
+  when: ansible_distribution_release == 'trusty'
+
+# Use systemd for xvfb in 16.04
 - name: create xvfb systemd service
   template:
     src: xvfb.service.j2
     dest: /etc/systemd/system/xvfb.service
     owner: root
     group: root
+  when: ansible_distribution_release == 'xenial'
   tags:
     - install
     - install:configuration
@@ -142,6 +181,7 @@
     name: xvfb
     enabled: yes
     state: started
+  when: ansible_distribution_release == 'xenial'
   tags:
     - install
     - install:configuration

--- a/playbooks/roles/browsers/templates/xvfb.conf.j2
+++ b/playbooks/roles/browsers/templates/xvfb.conf.j2
@@ -1,0 +1,6 @@
+description     "Xvfb X Server"
+start on (net-device-up and local-filesystems and runlevel [2345])
+stop on runlevel [016]
+exec /usr/bin/Xvfb {{ browser_xvfb_display }} -screen 0 1024x768x24
+respawn
+respawn limit 15 5

--- a/playbooks/roles/tools_jenkins/defaults/main.yml
+++ b/playbooks/roles/tools_jenkins/defaults/main.yml
@@ -1,4 +1,5 @@
 ---
+
 jenkins_tools_version: "1.651.3"
 
 jenkins_tools_plugins:
@@ -26,7 +27,7 @@ jenkins_tools_plugins:
   - { name: "tmpcleaner", version: "1.2" }
   - { name: "jobConfigHistory", version: "2.15" }
   - { name: "build-timeout", version: "1.17.1" }
-  - { name: "timestamper", version: "1.8.4" } 
+  - { name: "timestamper", version: "1.8.4" }
   - { name: "postbuild-task", version: "1.8" }
   - { name: "notification", version: "1.10" }
   - { name: "shiningpanda", version: "0.23" }

--- a/playbooks/roles/tools_jenkins/meta/main.yml
+++ b/playbooks/roles/tools_jenkins/meta/main.yml
@@ -2,6 +2,7 @@
 dependencies:
   - common
   - edxapp_common
+  - browsers
   - role: jenkins_master
     jenkins_plugins: "{{ jenkins_tools_plugins }}"
     jenkins_version: "{{ jenkins_tools_version }}"

--- a/playbooks/roles/tools_jenkins/tasks/main.yml
+++ b/playbooks/roles/tools_jenkins/tasks/main.yml
@@ -5,7 +5,7 @@
   ignore_errors: true
 
 - name: Set the permission on hpi files
-  file: 
+  file:
     path: "{{ item }}"
     owner: "{{ jenkins_user }}"
     group: "{{ jenkins_group }}"
@@ -21,7 +21,7 @@
   ignore_errors: true
 
 - name: Set the permission on jpi files
-  file: 
+  file:
     path: "{{ item }}"
     owner: "{{ jenkins_user }}"
     group: "{{ jenkins_group }}"


### PR DESCRIPTION
Adds the xvfb and firefox packages to tools_jenkins to support ora2 bok-choy testing.

Tested building with [precise](https://hub.docker.com/r/edxops/precise-common/) and [trusty](https://hub.docker.com/r/edxops/trusty-common/)

Should be merged alongside https://github.com/edx/jenkins-job-dsl-internal/pull/73 and https://github.com/edx/jenkins-job-dsl/pull/117

Configuration Pull Request
---

Make sure that the following steps are done before merging

  - [ ] A devops team member has commented with :+1:
  - [ ] are you adding any new default values that need to be overridden when this goes live?
    - [ ] Open a ticket (DEVOPS) to make sure that they have been added to secure vars.
    - [ ] Add an entry to the CHANGELOG.
