### PR TITLE
enable rpc service for devstacks

### DIFF
--- a/playbooks/roles/local_dev/tasks/main.yml
+++ b/playbooks/roles/local_dev/tasks/main.yml
@@ -132,3 +132,10 @@
     line: "127.0.0.1 localhost preview.localhost"
     state: present
   become: yes
+
+# Enable the rpc-stat service to handle NFS locks correctly
+- name: enable and start rpc-stat service
+  systemd:
+    name: rpc-statd
+    enabled: yes
+    state: started


### PR DESCRIPTION
Starting with Ficus (first devstack to run Xenial and therefore defaulting to use systemd for init), I have run into multiple FS locks when running tests (while locally running a host system running systemd). 

@edx/devops I would like your opinion: Should this be something contained within the play, or instructions for Linux users?
CC @benpatterson 