### PR TITLE
There's actually 3 layers of quoting here so using some single quotes.

### DIFF
--- a/playbooks/roles/go-server/tasks/main.yml
+++ b/playbooks/roles/go-server/tasks/main.yml
@@ -162,7 +162,7 @@
   lineinfile:
     destfile: /etc/default/go-server
     regexp: "^export GO_SERVER_SYSTEM_PROPERTIES=*"
-    line: "export GO_SERVER_SYSTEM_PROPERTIES=\"-Dgo.config.repo.gc.cron=\"0 0 2 ? * SAT\" go.config.repo.gc.periodic=\"Y\"\""
+    line: "export GO_SERVER_SYSTEM_PROPERTIES='-Dgo.config.repo.gc.cron=\"0 0 2 ? * SAT\" -Dgo.config.repo.gc.periodic=\"Y\"'"
   tags:
     - environment_variables
 


### PR DESCRIPTION
The end result in the file was previously
`export GO_SERVER_SYSTEM_PROPERTIES="-Dgo.config.repo.gc.cron="0 0 2 ? * SAT" go.config.repo.gc.periodic="Y""`

Note how the open quote after the equal gets closed by the quote after `cron=`.  This is not what we want.
The new output looks like this:
`export GO_SERVER_SYSTEM_PROPERTIES='-Dgo.config.repo.gc.cron="0 0 2 ? * SAT" -Dgo.config.repo.gc.periodic="Y"'`

Single quoting all the double quotes on that line.

@edx/pipeline-team 
