### PR TITLE
update c++ lib for android on xenial

### DIFF
--- a/playbooks/roles/android_sdk/defaults/main.yml
+++ b/playbooks/roles/android_sdk/defaults/main.yml
@@ -23,7 +23,7 @@ android_tools:
 #    - { package: 'sys-img-armeabi-v7a-android-23', android_test_path: 'system-images/android-23/default/armeabi-v7a/' }
 # libraries needed for avd(android virtual device) emulation
 android_apt_libraries:
-    - libstdc++6:i386
+    - lib32stdc++6
     - lib32z1
 android_sys_image_url: https://s3.amazonaws.com/edx-testeng-tools/android/android-sysimage-23.tar.gz
 android_sys_image_checksum: a111ad559000e91e1d8d9d76df83a6341cc8cbfc3608077380ab15f17b5d0033

--- a/playbooks/roles/jenkins_worker/meta/main.yml
+++ b/playbooks/roles/jenkins_worker/meta/main.yml
@@ -43,5 +43,5 @@ dependencies:
     #  - { package: 'sys-img-armeabi-v7a-android-23', android_test_path: 'system-images/android-23/default/armeabi-v7a/' }
     # libraries needed for avd(android virtual device) emulation
     android_apt_libraries:
-      - libstdc++6:i386
+      - lib32stdc++6
       - lib32z1


### PR DESCRIPTION
@jibsheet @MichaelRoytman 
The name of the library offered in the standard ubuntu apt repos changed from Precise to Xenial