### PR TITLE
The sed -E still doesn't work on OS-X

### DIFF
--- a/docker.mk
+++ b/docker.mk
@@ -70,10 +70,12 @@ $(docker_push)%: $(docker_pkg)%
 
 .build/%/Dockerfile.test: docker/build/%/Dockerfile Makefile
 	@mkdir -p .build/$*
-	@sed -E "s#FROM edxops/([^:]+)(:\S*)?#FROM \1:test#" $< > $@
+# perl p (print the line) n (loop over every line) e (exec the regex), like sed but cross platform
+	@perl -pne "s#FROM edxops/([^:]+)(:\S*)?#FROM \1:test#" $< > $@
 
 .build/%/Dockerfile.pkg: docker/build/%/Dockerfile Makefile
 	@mkdir -p .build/$*
-	@sed -E "s#FROM edxops/([^:]+)(:\S*)?#FROM \1:test#" $< > $@
+# perl p (print the line) n (loop over every line) e (exec the regex), like sed but cross platform
+	@perl -pne "s#FROM edxops/([^:]+)(:\S*)?#FROM \1:test#" $< > $@
 
 -include $(foreach image,$(images),.build/$(image)/Dockerfile.d)


### PR DESCRIPTION
Noticed when something that worked for Feanil didn't work for Michael

In 7cd04db1 this was updated to rely less on gnu sed, but it still didn't work properly on the sed shipped with OS-X Sierra.  gsed does, but I don't want people to need to install that.

Error was that (:\S*)? was only matching : not :tagname, so the generated Docker file was foo:testbar rather than foo:test

Feel free to push alternate sed solutions, I gave up after a few minutes and went with the bandaid I know and understand.

@edx/devops 

@clintonb @cpennington 

@MichaelRoytman this is what was breaking make docker.push.tools-jenkins for you