### PR TITLE
Ansible2 compatibility and jenkins plugin updates

### DIFF
--- a/playbooks/roles/jenkins_master/tasks/main.yml
+++ b/playbooks/roles/jenkins_master/tasks/main.yml
@@ -55,7 +55,7 @@
     backup: yes
     dest: /etc/default/jenkins
     regexp: '^JAVA_ARGS='
-    line: 'JAVA_ARGS=\"{{ jenkins_jvm_args }}\"'
+    line: 'JAVA_ARGS="{{ jenkins_jvm_args }}"'
   notify:
     - restart Jenkins
   tags:
@@ -67,7 +67,7 @@
     backup: yes
     dest: /etc/default/jenkins
     regexp: '^JENKINS_HOME='
-    line: 'JENKINS_HOME=\"{{ jenkins_home }}\"'
+    line: 'JENKINS_HOME="{{ jenkins_home }}"'
   notify:
     - restart Jenkins
   tags:

--- a/playbooks/roles/tools_jenkins/defaults/main.yml
+++ b/playbooks/roles/tools_jenkins/defaults/main.yml
@@ -37,7 +37,7 @@ jenkins_tools_plugins:
   - { name: "workflow-scm-step", version: "1.14.2" }
   - { name: "workflow-step-api", version: "1.14.2" }
   - { name: "ghprb", version: "1.35.0" }
-  - { name: "github-api", version: "1.77" }
+  - { name: "github-api", version: "1.82" }
   - { name: "git-client", version: "1.21.0"}
   - { name: "git", version: "2.5.3"}
   - { name: "github", version: "1.21.1" }


### PR DESCRIPTION
 github pr builder needed a newer github-api

linein was leaving \ in the generated files, which broke Jenkins

@edx/devops 

@jlajoie This was what was causing all the issues this afternoon, I'll rerun/retest your branch after we merge this and you rebase.