### PR TITLE
Upgrade to latest ansible.

### DIFF
--- a/playbooks/edx-east/create_rds_secondary.yml
+++ b/playbooks/edx-east/create_rds_secondary.yml
@@ -16,7 +16,7 @@
     - name: Validate arguments
       fail:
         msg: "One or more arguments were not set correctly: {{ item }}"
-      when: not {{ item }}
+      when: not item
       with_items:
         - from_db
         - rds_name

--- a/playbooks/edx-east/promote_rds_secondary.yml
+++ b/playbooks/edx-east/promote_rds_secondary.yml
@@ -21,7 +21,7 @@
     - name: Validate arguments
       fail:
         msg: "One or more arguments were not set correctly: {{ item }}"
-      when: not {{ item }}
+      when: not item
       with_items:
         - rds_name
         - admin_password
@@ -52,7 +52,7 @@
     - name: Modify edxapp history RDS
       shell: >
         aws rds modify-db-instance
-        --db-instance-identifier {{ rds_name }}        
+        --db-instance-identifier {{ rds_name }}
         --apply-immediately
         --multi-az
         --master-user-password {{ admin_password }}

--- a/playbooks/roles/automated/tasks/main.yml
+++ b/playbooks/roles/automated/tasks/main.yml
@@ -61,7 +61,6 @@
     group: "root"
     mode: "0440"
     validate: 'visudo -cf %s'
-  when: automated_sudoers_template
   with_dict: "{{ AUTOMATED_USERS }}"
   
 - name: Create .ssh directory

--- a/playbooks/roles/common/tasks/main.yml
+++ b/playbooks/roles/common/tasks/main.yml
@@ -2,7 +2,7 @@
 - name: Check Configuration Sources
   fail:
     msg: "Configuration Sources Checking (COMMON_EXTRA_CONFIGURATION_SOURCES_CHECKING) is enabled, you must define {{ item }}"
-  when: COMMON_EXTRA_CONFIGURATION_SOURCES_CHECKING and ({{ item }} is not defined or {{ item }} != True)
+  when: COMMON_EXTRA_CONFIGURATION_SOURCES_CHECKING and (item is not defined or item != True)
   with_items: "{{ COMMON_EXTRA_CONFIGURATION_SOURCES }}"
   tags:
     - "install"

--- a/playbooks/roles/common/tasks/main.yml
+++ b/playbooks/roles/common/tasks/main.yml
@@ -2,7 +2,7 @@
 - name: Check Configuration Sources
   fail:
     msg: "Configuration Sources Checking (COMMON_EXTRA_CONFIGURATION_SOURCES_CHECKING) is enabled, you must define {{ item }}"
-  when: COMMON_EXTRA_CONFIGURATION_SOURCES_CHECKING and (item is not defined or item != True)
+  when: COMMON_EXTRA_CONFIGURATION_SOURCES_CHECKING and ({{ item }} is not defined or {{ item }} != True)
   with_items: "{{ COMMON_EXTRA_CONFIGURATION_SOURCES }}"
   tags:
     - "install"

--- a/playbooks/roles/ecommerce/meta/main.yml
+++ b/playbooks/roles/ecommerce/meta/main.yml
@@ -9,7 +9,7 @@
 #
 ##
 # Role includes for role ecommerce
-# 
+#
 dependencies:
   - common
   - supervisor
@@ -25,6 +25,6 @@ dependencies:
   - role: edx_themes
     theme_users:
       - "{{ ecommerce_user }}"
-    when: "{{ ECOMMERCE_ENABLE_COMPREHENSIVE_THEMING }}"
+    when: ECOMMERCE_ENABLE_COMPREHENSIVE_THEMING
 
   - oraclejdk

--- a/playbooks/roles/edxapp/meta/main.yml
+++ b/playbooks/roles/edxapp/meta/main.yml
@@ -7,4 +7,4 @@ dependencies:
   - role: edx_themes
     theme_users:
       - "{{ edxapp_user }}"
-    when: "{{ EDXAPP_ENABLE_COMPREHENSIVE_THEMING }}"
+    when: EDXAPP_ENABLE_COMPREHENSIVE_THEMING

--- a/playbooks/roles/mount_ebs/tasks/main.yml
+++ b/playbooks/roles/mount_ebs/tasks/main.yml
@@ -23,7 +23,7 @@
     src: "{{ (ansible_mounts | selectattr('device', 'equalto', item.device) | first | default({'device': None})).device }}"
     fstype: "{{ (ansible_mounts | selectattr('device', 'equalto', item.device) | first | default({'fstype': None})).fstype }}"
     state: unmounted
-  when: "{{ UNMOUNT_DISKS and (ansible_mounts | selectattr('device', 'equalto', item.device) | first | default({'fstype': None})).fstype != item.fstype }}"
+  when: UNMOUNT_DISKS and (ansible_mounts | selectattr('device', 'equalto', item.device) | first | default({'fstype': None})).fstype != item.fstype
   with_items: "{{ volumes }}"
 
 # Noop & reports "ok" if fstype is correct

--- a/playbooks/roles/mount_ebs/tasks/main.yml
+++ b/playbooks/roles/mount_ebs/tasks/main.yml
@@ -23,7 +23,7 @@
     src: "{{ (ansible_mounts | selectattr('device', 'equalto', item.device) | first | default({'device': None})).device }}"
     fstype: "{{ (ansible_mounts | selectattr('device', 'equalto', item.device) | first | default({'fstype': None})).fstype }}"
     state: unmounted
-  when: UNMOUNT_DISKS and (ansible_mounts | selectattr('device', 'equalto', item.device) | first | default({'fstype': None})).fstype != item.fstype
+  when: "UNMOUNT_DISKS and (ansible_mounts | selectattr('device', 'equalto', item.device) | first | default({'fstype': None})).fstype != item.fstype"
   with_items: "{{ volumes }}"
 
 # Noop & reports "ok" if fstype is correct

--- a/playbooks/roles/notifier/tasks/deploy.yml
+++ b/playbooks/roles/notifier/tasks/deploy.yml
@@ -103,7 +103,7 @@
     chdir: "{{ NOTIFIER_CODE_DIR }}"
   become: true
   become_user: "{{ notifier_user }}"
-  environment: notifier_env_vars
+  environment: "{{ notifier_env_vars }}"
   when: migrate_db is defined and migrate_db|lower == "yes"
   tags:
     - "install"

--- a/playbooks/roles/splunk-server/tasks/main.yml
+++ b/playbooks/roles/splunk-server/tasks/main.yml
@@ -10,13 +10,13 @@
 #
 #
 # Tasks for role splunk-server
-# 
+#
 # Overview:
-# 
+#
 #
 # Dependencies:
 #
-# 
+#
 # Example play:
 #
 #
@@ -44,7 +44,7 @@
     owner: splunk
     group: splunk
     mode: "0400"
-  when: "{{ SPLUNK_SSL_CERT is defined and SPLUNK_SSL_CERT | length > 0 }}"
+  when: SPLUNK_SSL_CERT is defined and SPLUNK_SSL_CERT | length > 0
   with_together:
     - [forwarder.pem, cacert.pem]
     - ["{{ SPLUNK_SSL_CERT }}", "{{ SPLUNK_SSL_ROOT_CA }}"]
@@ -150,9 +150,9 @@
     - install:configuration
 
 - name: restart splunk
-  service: 
+  service:
     name: splunk
-    state: restarted 
+    state: restarted
   tags:
     - "install"
     - "install:configuration"

--- a/playbooks/roles/splunkforwarder/tasks/main.yml
+++ b/playbooks/roles/splunkforwarder/tasks/main.yml
@@ -115,7 +115,7 @@
     owner: splunk
     group: splunk
     mode: "0400"
-  when: "{{ item.ssl_cert is defined }}"
+  when: item.ssl_cert is defined
   with_items: "{{ SPLUNKFORWARDER_SERVERS }}"
 
 - name: Write root CA to disk
@@ -125,7 +125,7 @@
     owner: splunk
     group: splunk
     mode: "0400"
-  when: "{{ item.ssl_cert is defined }}"
+  when: item.ssl_cert is defined
   with_items: "{{ SPLUNKFORWARDER_SERVERS }}"
 
 - name: Create inputs and outputs configuration

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-ansible==2.2.0.0
+ansible==2.3.1.0
 PyYAML==3.12
 Jinja2==2.8
 MarkupSafe==0.23


### PR DESCRIPTION
Changelog - https://github.com/ansible/ansible/blob/devel/CHANGELOG.md

@edx/devops 

The relevant bits are below:
## 2.3 "Ramble On" - 2017-04-12

### Major Changes
* Documented and renamed the previously released 'single var vaulting' feature, allowing user to use vault encryption for single variables in a normal YAML vars file.
* Allow module_utils for custom modules to be placed in site-specific directories and shipped in roles
* On platforms that support it, use more modern system polling API instead of select in the ssh connection plugin.
  This removes one limitation on how many parallel forks are feasible on these systems.
* Windows/WinRM supports (experimental) become method "runas" to run modules and scripts as a different user, and to transparently access network resources.
* The WinRM connection plugin now uses pipelining when executing modules, resulting in significantly faster execution for small tasks.
* The WinRM connection plugin can now manage Kerberos tickets automatically when `ansible_winrm_transport=kerberos` and `ansible_user`/`ansible_password` are specified.
* Refactored/standardized most Windows modules, adding check-mode and diff support where possible.
* Extended Windows module API with parameter-type support, helper functions. (i.e. Expand-Environment, Add-Warning, Add-DeprecatationWarning)
* restructured how async works to allow it to apply to action plugins that choose to support it.

### Minor Changes
* The version and release facts for OpenBSD hosts were reversed.
  This has been changed so that version has the numeric portion and release has the name of the release.
* removed 'package' from default squash actions as not all package managers support it and it creates errors when using loops,
  any user can add back via config options if they don't use those package managers or otherwise avoid the errors.
* Blocks can now have a `name` field, to aid in playbook readability.
* default strategy is now configurable via ansible.cfg or environment variable.
* Added 'ansible_playbook_python' which contains 'current python executable', it can be blank in some cases in which Ansible is not invoked via the standard CLI (sys.executable limitation).
* Added 'metadata' to modules to enable classification
* ansible-doc now displays path to module and existing 'metadata'
* added optional 'piped' transfer method to ssh plugin for when scp and sftp are missing, ssh plugin is also now 'smarter' when using these options
* default controlpersist path is now a custom hash of host-port-user to avoid the socket path length errors for long hostnames
* Various fixes for Python3 compatibility
* Fixed issues with inventory formats not handling 'all' and 'ungrouped' in an uniform way.
* 'service' tasks can now use async again, we had lost this capability when changed into an action plugin.
* made any_errors_fatal inheritable from play to task and all other objects in between.
* many small performance improvements in inventory and variable handling and in task execution.

### Deprecations
* Specifying --tags (or --skip-tags) multiple times on the command line
  currently leads to the last one overriding all the previous ones. This behaviour is deprecated.
  In the future, if you specify --tags multiple times the tags will be merged together.
  From now on, using --tags multiple times on one command line will emit a deprecation warning.
  Setting the merge_multiple_cli_tags option to True in the ansible.cfg file will enable the new behaviour.
  In 2.4, the default will be to merge and you can enable the old overwriting behaviour via the config option.
  In 2.5, multiple --tags options will be merged with no way to go back to the old behaviour.

* Modules (scheduled for removal in 2.5)
  * ec2_vpc
  * cl_bond
  * cl_bridge
  * cl_img_install
  * cl_interface
  * cl_interface_policy
  * cl_license
  * cl_ports
  * nxos_mtu, use nxos_system instead

#### New: Callbacks

- dense: minimal stdout output with fallback to default when verbose

#### New: lookups

- keyring: allows getting password from the 'controller' system's keyrings

#### New: cache

- pickle (uses python's own serializer)
- yaml

#### New: inventory scripts
- oVirt/RHV

#### New: filters
- combinations
- permutations
- zip
- zip_longest


### Module Notes
- AWS lambda: previously ignored changes that only affected one parameter. Existing deployments may have outstanding changes that this bugfix will apply.
- oVirt/RHV: Added support for 4.1 features and the following:
  * data centers, clusters, hosts, storage domains and networks management.
  * hosts and virtual machines affinity groups and labels.
  * users, groups and permissions management.
  * Improved virtual machines and disks management.
- Mount: Some fixes so bind mounts are not mounted each time the playbook runs.

### New Modules
Truncated, there are a lot.


## 2.2.1 "The Battle of Evermore" - 2017-01-16

### Major Changes:

* Security fix for CVE-2016-9587 - An attacker with control over a client system being managed by Ansible and the ability to send facts back to the Ansible server could use this flaw to execute arbitrary code on the Ansible server as the user and group Ansible is running as.

### Minor Changes:

* Fixes a bug where undefined variables in with_* loops would cause a task failure even if the when condition would cause the task to be skipped.
* Fixed a bug related to roles where in certain situations a role may be run more than once despite not allowing duplicates.
* Fixed some additional bugs related to atomic_move for modules.
* Fixes multiple bugs related to field/attribute inheritance in nested blocks and includes, as well as task iteration logic during failures.
* **Fixed pip installing packages into virtualenvs using the system pip instead of the virtualenv pip.**
* Fixed dnf on systems with dnf-2.0.x (some changes in the API).
* Fixed traceback with dnf install of groups.
* Fixes a bug in which include_vars was not working with failed_when.
* Fix for include_vars only loading files with .yml, .yaml, and .json extensions.  This was only supposed to apply to loading a directory of vars files.
* Fixes several bugs related to properly incrementing the failed count in the host statistics.
* Fixes a bug with listening handlers which did not specify a `name` field.
* Fixes a bug with the `play_hosts` internal variable, so that it properly reflects the current list of hosts.
* Fixes a bug related to the v2_playbook_on_start callback method and legacy (v1) plugins.
* Fixes an openssh related process exit race condition, related to the fact that connections using ControlPersist do not close stderr.
* Improvements and fixes to OpenBSD fact gathering.
* Updated `make deb` to use pbuilder. Use `make local_deb` for the previous non-pbuilder build.
* Fixed Windows async to avoid blocking due to handle inheritance.
* Fixed bugs in the mount module on older Linux kernels and *BSDs
* Various minor fixes for Python 3
* Inserted some checks for jinja2-2.9, which can cause some issues with Ansible currently.
