### PR TITLE
Pass these in because the defaults in docker.mk are lost

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,8 @@ install:
   - "pip install --allow-all-external demjson"
 
 env:
-  - MAKE_TARGET=test.syntax
-  - MAKE_TARGET=test.edx_east_roles
+  - MAKE_TARGET=test.syntax SHARD=0 SHARDS=1
+  - MAKE_TARGET=test.edx_east_roles SHARD=0 SHARDS=1
   - MAKE_TARGET=docker.test.shard SHARD=0 SHARDS=3
   - MAKE_TARGET=docker.test.shard SHARD=1 SHARDS=3
   - MAKE_TARGET=docker.test.shard SHARD=2 SHARDS=3


### PR DESCRIPTION
Travis otherwise runs SHARD= SHARDS=
causing this line
docker.test.shard: $(foreach image,$(shell echo $(images) | python util/balancecontainers.py $(SHARDS) | awk 'NR%$(SHARDS)==$(SHARD)'),$(docker_test)$(image))

to error with

```
awk: cmd. line:1: NR%==
awk: cmd. line:1:     ^ syntax error
usage: balancecontainers.py [-h] num_shards
balancecontainers.py: error: too few arguments
awk: cmd. line:1: NR%==
awk: cmd. line:1:     ^ syntax error
usage: balancecontainers.py [-h] num_shards
```

@edx/devops

Super confused by this error, it was distracting while trying to figure out why balancecontainers wasn't sharding tools_jenkins, and appears to have been around a while?