### PR TITLE
There were two whens in these tasks

### DIFF
--- a/playbooks/roles/browsers/tasks/main.yml
+++ b/playbooks/roles/browsers/tasks/main.yml
@@ -45,18 +45,18 @@
 
 - name: install trusty browser packages
   shell: gdebi -nq /tmp/{{ item.name }}
-  when: download_deb.changed
   with_items: "{{ trusty_browser_s3_deb_pkgs }}"
-  when: ansible_distribution_release == 'trusty'
+  when: download_deb.changed and
+        ansible_distribution_release == 'trusty'
   tags:
     - install
     - install:system-requirements
 
 - name: install xenial browser packages
   shell: gdebi -nq /tmp/{{ item.name }}
-  when: download_deb.changed
   with_items: "{{ browser_s3_deb_pkgs }}"
-  when: ansible_distribution_release == 'xenial'
+  when: download_deb.changed and
+        ansible_distribution_release == 'xenial'
   tags:
     - install
     - install:system-requirements


### PR DESCRIPTION
Ansible warned at the top, rather than complaining louder.

Impact was that we always reinstalled the browsers, not just on update.

FYI @jlajoie 

@edx/devops please review