### PR TITLE
Don't truncate version shas when tagging AWS resources.

### DIFF
--- a/playbooks/continuous_delivery/create_ami.yml
+++ b/playbooks/continuous_delivery/create_ami.yml
@@ -73,9 +73,9 @@
       description: "AMI built via edX continuous delivery pipeline - Ansible version: {{ ansible_version }}"
       # used a JSON object here as there is a string interpolation in the keys.
       tags: "{
-                'version:{{ play }}':'{{ app_repo }} {{ app_version[:7] }}',
-                'version:configuration':'{{ configuration_repo }} {{ configuration_version[:7] }}',
-                'version:configuration_secure':'{{ configuration_secure_repo }} {{ configuration_secure_version[:7] }}',
+                'version:{{ play }}':'{{ app_repo }} {{ app_version }}',
+                'version:configuration':'{{ configuration_repo }} {{ configuration_version }}',
+                'version:configuration_secure':'{{ configuration_secure_repo }} {{ configuration_secure_version }}',
                 'play':'{{ play }}',
                 'cache_id':'{{ cache_id }}',
                 'environment':'{{ edx_environment }}',
@@ -94,7 +94,7 @@
       region: "{{ ec2_region }}"
       resource: "{{ ami_register.image_id }}"
       tags:
-        version:edxapp_theme: "{{ edxapp_theme_source_repo }} {{ edxapp_theme_version[:7] }}"
+        version:edxapp_theme: "{{ edxapp_theme_source_repo }} {{ edxapp_theme_version }}"
     when: edxapp_theme_version is defined and edxapp_theme_source_repo is defined
 
   - name: Fetch tags on the AMI

--- a/playbooks/roles/alton/tasks/tag_ec2.yml
+++ b/playbooks/roles/alton/tasks/tag_ec2.yml
@@ -10,7 +10,7 @@
     resource: "{{ ansible_ec2_instance_id }}"
     region: "{{ ansible_ec2_placement_region }}"
     tags:
-      "version:alton" : "{{ alton_source_repo }} {{ alton_checkout.after |truncate(7,True,'')}}"
+      "version:alton" : "{{ alton_source_repo }} {{ alton_checkout.after }}"
   when: alton_checkout.after is defined
   tags:
   - deploy

--- a/playbooks/roles/certs/tasks/tag_ec2.yml
+++ b/playbooks/roles/certs/tasks/tag_ec2.yml
@@ -8,5 +8,5 @@
     resource: "{{ ansible_ec2_instance_id }}"
     region: "{{ ansible_ec2_placement_region }}"
     tags:
-      "version:certs" : "{{ CERT_REPO }} {{ certs_checkout.after|truncate(7,True,'') }}"
+      "version:certs" : "{{ CERT_REPO }} {{ certs_checkout.after }}"
   when: certs_checkout.after is defined

--- a/playbooks/roles/edxapp/tasks/tag_ec2.yml
+++ b/playbooks/roles/edxapp/tasks/tag_ec2.yml
@@ -7,7 +7,7 @@
     resource: "{{ ansible_ec2_instance_id }}"
     region: "{{ ansible_ec2_placement_region }}"
     tags:
-      "version:edx_platform" : "{{ edx_platform_repo }} {{ edxapp_platform_checkout.after|truncate(7,True,'') }}"
+      "version:edx_platform" : "{{ edx_platform_repo }} {{ edxapp_platform_checkout.after }}"
   when: edxapp_platform_checkout.after is defined
 
 - name: tag instance with edxapp theme version
@@ -15,5 +15,5 @@
     resource: "{{ ansible_ec2_instance_id }}"
     region: "{{ ansible_ec2_placement_region }}"
     tags:
-      "version:edxapp_theme" : "{{ edxapp_theme_source_repo }} {{ edxapp_theme_checkout.after|truncate(7,True,'') }}"
+      "version:edxapp_theme" : "{{ edxapp_theme_source_repo }} {{ edxapp_theme_checkout.after }}"
   when: edxapp_theme_checkout.after is defined

--- a/playbooks/roles/forum/tasks/tag_ec2.yml
+++ b/playbooks/roles/forum/tasks/tag_ec2.yml
@@ -7,5 +7,5 @@
     resource: "{{ ansible_ec2_instance_id }}"
     region: "{{ ansible_ec2_placement_region }}"
     tags:
-      "version:forum" : "{{ forum_source_repo }} {{ forum_checkout.after|truncate(7,True,'') }}"
+      "version:forum" : "{{ forum_source_repo }} {{ forum_checkout.after }}"
   when: forum_checkout.after is defined

--- a/playbooks/roles/xserver/tasks/ec2.yml
+++ b/playbooks/roles/xserver/tasks/ec2.yml
@@ -7,7 +7,7 @@
     resource: "{{ ansible_ec2_instance_id }}"
     region: "{{ ansible_ec2_placement_region }}"
     tags:
-      "version:xserver" : "{{ xserver_source_repo }} {{ xserver_checkout.after|truncate(7,True,'') }}"
+      "version:xserver" : "{{ xserver_source_repo }} {{ xserver_checkout.after }}"
   when: xserver_checkout.after is defined
 
 - name: Tag instance for xserver grader
@@ -15,5 +15,5 @@
     resource: "{{ ansible_ec2_instance_id }}"
     region: "{{ ansible_ec2_placement_region }}"
     tags:
-      "version:xserver_grader" : "{{ XSERVER_GRADER_SOURCE }} {{ xserver_grader_checkout.after|truncate(7,True,'') }}"
+      "version:xserver_grader" : "{{ XSERVER_GRADER_SOURCE }} {{ xserver_grader_checkout.after }}"
   when: xserver_grader_checkout.after is defined

--- a/playbooks/roles/xsy/tasks/tag_ec2.yml
+++ b/playbooks/roles/xsy/tasks/tag_ec2.yml
@@ -10,7 +10,7 @@
     resource: "{{ ansible_ec2_instance_id }}"
     region: "{{ ansible_ec2_placement_region }}"
     tags:
-      "version:xsy" : "{{ xsy_source_repo }} {{ xsy_checkout.after |truncate(7,True,'')}}"
+      "version:xsy" : "{{ xsy_source_repo }} {{ xsy_checkout.after }}"
   when: xsy_checkout.after is defined
   tags:
     - deploy


### PR DESCRIPTION
It's hard to know when a repo will get big enough that any given truncation won't be long enough. (This is already a problem on edx-platform (compare https://github.com/edx/edx-platform/compare/ae1853b...e50d45d and https://github.com/edx/edx-platform/compare/ae1853bc300d56971b44cd0fe0b3617b1704baab...e50d45dbb56c7cde03ee56cb24c85c07c3c2f0d3).

Configuration Pull Request
---

Make sure that the following steps are done before merging

  - [ ] A devops team member has commented with :+1:
