### PR TITLE
Switch from git_add_course to standard import

### DIFF
--- a/playbooks/roles/testcourses/tasks/deploy.yml
+++ b/playbooks/roles/testcourses/tasks/deploy.yml
@@ -1,9 +1,9 @@
 ---
-- name: import the test courses from github
-  shell: "{{ demo_edxapp_venv_bin }}/python /edx/bin/manage.edxapp lms git_add_course --settings={{ demo_edxapp_settings }} \"{{ item.github_url }}\""
-  become_user: "{{ common_web_user }}"
-  when: item.install == True
+- include: import_course.yml
+  when: course.install == True
   with_items: "{{ TESTCOURSES_EXPORTS }}"
+  loop_control:
+    loop_var: course
 
 - name: enroll test users in the testcourses
   shell: "{{ demo_edxapp_venv_bin }}/python ./manage.py lms --settings={{ demo_edxapp_settings }} --service-variant lms enroll_user_in_course -e {{ item[0].email }} -c {{ item[1].course_id }}"

--- a/playbooks/roles/testcourses/tasks/import_course.yml
+++ b/playbooks/roles/testcourses/tasks/import_course.yml
@@ -1,0 +1,14 @@
+- name: check out testcourses
+  git:
+    dest: "{{ demo_app_dir }}/{{ course.course_id }}"
+    repo: "{{ course.github_url }}"
+    accept_hostkey: yes
+  become_user: "{{ demo_edxapp_user }}"
+  register: testcourse_checkout
+
+- name: import testcourse
+  shell: "{{ demo_edxapp_venv_bin }}/python ./manage.py cms --settings={{ demo_edxapp_settings }} import {{ demo_app_dir }} {{ course.course_id }}"
+  args:
+    chdir: "{{ demo_edxapp_code_dir }}"
+  when: testcourse_checkout.changed
+  become_user: "{{ common_web_user }}"


### PR DESCRIPTION
git_add_course uses the platform's sysadmin dashboard which assumes it
can create an xlog mongo database and write into it without auth
configured.  This is not something we want to spend more time enabling,
so switch to our 'standard' import technique.

This relies on the demo role more than I would like, but we have a
backlog task to clean that role up, and can touch this at the same time
(this role has always imported a bunch of vars from demo, so I'm not
 adding any new deps).

Test build https://tools-edx-jenkins.edx.org/job/Sandboxes/job/CreateSandbox/73/console

https://openedx.atlassian.net/browse/DEVOPS-5587

@edx/devops