### PR TITLE
Docker image name problem in compose file.

### DIFF
--- a/docker/compose/edx/docker-compose.yml
+++ b/docker/compose/edx/docker-compose.yml
@@ -93,7 +93,7 @@ forum:
   # Image built from the opencraft fork as it fixes
   # an auth bug.  Update when the change merges
   # upstream
-  image: edxops/forum:opencraft-v2
+  image: edxops/forums:opencraft-v2
   volumes:
     - ${DOCKER_EDX_ROOT}/cs_comments_service:/edx/app/forum/cs_comments_service
   ports:


### PR DESCRIPTION
edxops/forum not found: does not exist or no pull access

Configuration Pull Request
---

Make sure that the following steps are done before merging

  - [ ] A devops team member has commented with :+1:
  - [ ] are you adding any new default values that need to be overridden when this goes live?
    - [ ] Open a ticket (DEVOPS) to make sure that they have been added to secure vars.
    - [ ] Add an entry to the CHANGELOG.
