### PR TITLE
Explicitly allow read access to gocd log directory.

### DIFF
--- a/playbooks/roles/go-server/tasks/main.yml
+++ b/playbooks/roles/go-server/tasks/main.yml
@@ -83,6 +83,17 @@
     group: "{{ GO_SERVER_GROUP }}"
     force: no
 
+- name: ensure everyone can read go-server log files
+  file:
+    path: "/var/log/go-server"
+    state: directory
+    mode: "0755"
+    owner: "{{ GO_SERVER_USER }}"
+    group: "{{ GO_SERVER_GROUP }}"
+  tags:
+    - install
+    - install:base
+
 - include: download_backup.yml
   when: GO_SERVER_BACKUP_S3_BUCKET and GO_SERVER_BACKUP_S3_OBJECT and GO_SERVER_RESTORE_BACKUP
 


### PR DESCRIPTION
Configuration Pull Request
---

Make sure that the following steps are done before merging

  - [ ] A devops team member has commented with :+1:
  - [ ] are you adding any new default values that need to be overridden when this goes live?
    - [ ] Open a ticket (DEVOPS) to make sure that they have been added to secure vars.
    - [ ] Add an entry to the CHANGELOG.


@edx/pipeline-team the re-install made this directory only readable by the go user even though the files in it are readable by everyone. So splunk was unable to list the directory to figure out the names of the files.