### PR TITLE
Update to the latest awscli.

### DIFF
--- a/docker/build/go-agent/Dockerfile
+++ b/docker/build/go-agent/Dockerfile
@@ -58,7 +58,7 @@ RUN \
 
 
 # Install AWS command-line interface - for AWS operations in a go-agent task.
-RUN pip install awscli
+RUN pip install awscli>=1.11.58
 
 # !!!!NOTICE!!!! ---- Runner of this pipeline take heed!! You must replace go_github_key.pem with the REAL key material
 # that can checkout private github repositories used as pipeline materials. The key material here is faked and is only

--- a/docker/build/go-agent/Dockerfile
+++ b/docker/build/go-agent/Dockerfile
@@ -58,7 +58,7 @@ RUN \
 
 
 # Install AWS command-line interface - for AWS operations in a go-agent task.
-RUN pip install awscli>=1.11.58
+RUN pip install 'awscli>=1.11.58'
 
 # !!!!NOTICE!!!! ---- Runner of this pipeline take heed!! You must replace go_github_key.pem with the REAL key material
 # that can checkout private github repositories used as pipeline materials. The key material here is faked and is only

--- a/playbooks/roles/aws/defaults/main.yml
+++ b/playbooks/roles/aws/defaults/main.yml
@@ -44,7 +44,7 @@ aws_debian_pkgs:
 
 aws_pip_pkgs:
   - https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz
-  - awscli==1.10.28
+  - awscli==1.11.58
   - boto=="{{ common_boto_version }}"
   - s3cmd==1.6.1
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ python-simple-hipchat==0.2
 prettytable==0.7.2
 # Don't forget to update the version of this installed in
 # the aws role as well.
-awscli==1.10.28
+awscli==1.11.58
 requests==2.9.1
 datadog==0.8.0
 networkx==1.11


### PR DESCRIPTION
Prompted because the awscli on go-agents needs to be above 1.10.47 to be
able to take advantage of IAM roles for tasks automatically.
http://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html

Changelog: https://github.com/aws/aws-cli/blob/develop/CHANGELOG.rst

@edx/devops @edx/pipeline-team 

We'll need to build a new agent and deploy it once this lands.

Configuration Pull Request
---

Make sure that the following steps are done before merging

  - [ ] A devops team member has commented with :+1:
  - [ ] are you adding any new default values that need to be overridden when this goes live?
    - [ ] Open a ticket (DEVOPS) to make sure that they have been added to secure vars.
    - [ ] Add an entry to the CHANGELOG.
