### PR TITLE
Remove compile translations step in insights role

### DIFF
--- a/playbooks/roles/insights/tasks/main.yml
+++ b/playbooks/roles/insights/tasks/main.yml
@@ -106,15 +106,6 @@
     - assets
     - assets:gather
 
-- name: compile translations
-  shell: ". {{ insights_venv_dir }}/bin/activate && i18n_tool generate -v"
-  args:
-    chdir: "{{ insights_code_dir }}/analytics_dashboard"
-  become_user: "{{ insights_user }}"
-  tags:
-    - assets
-    - assets:gather
-
 - name: write out the supervisior wrapper
   template:
     src: "edx/app/insights/insights.sh.j2"


### PR DESCRIPTION
We keep the [compiled translation files in git](https://github.com/edx/edx-analytics-dashboard/tree/master/analytics_dashboard/conf/locale) already and have [an automated job](https://github.com/edx/edx-analytics-dashboard/pulls?q=is%3Apr+author%3Aedx-transifex-bot) that compiles them regularly, so there's no need to keep this step.

I thought this might fix stage-edx-insights from failing when trying to build AMIs, but it looks like it still failed when I tried to build an AMI with Alton using this branch. Regardless, I think this still makes sense to merge.

Configuration Pull Request
---

Make sure that the following steps are done before merging

  - [x] A devops team member has commented with :+1:
