### PR TITLE
remove ES cluster members var override for analyticstack

### DIFF
--- a/vagrant/release/analyticstack/Vagrantfile
+++ b/vagrant/release/analyticstack/Vagrantfile
@@ -84,7 +84,7 @@ EXTRA_VARS="#{extra_vars_lines}"
 CONFIG_VER="#{ENV['CONFIGURATION_VERSION'] || openedx_release || 'master'}"
 
 ansible-playbook -i localhost, -c local run_role.yml -e role=edx_ansible -e configuration_version=$CONFIG_VER $EXTRA_VARS
-ansible-playbook -i localhost, -c local vagrant-analytics.yml -e configuration_version=$CONFIG_VER $EXTRA_VARS -e ELASTICSEARCH_CLUSTER_MEMBERS=[]
+ansible-playbook -i localhost, -c local vagrant-analytics.yml -e configuration_version=$CONFIG_VER $EXTRA_VARS
 
 SCRIPT
 


### PR DESCRIPTION
@edx/devops

This was causing analyticstack builds to fail by writing this incorrect setting to the elasticsearch.yml file (clearly problematic).

```yaml
discovery.zen.ping.unicast.hosts: ['[',']']
```

FYI - @azafty468 @brianhw @HassanJaveed84 @iloveagent57
