### PR TITLE
Fix devstack issues DEVSTACK-28 and DEVSTACK-29

### DIFF
--- a/playbooks/roles/ecommerce/tasks/main.yml
+++ b/playbooks/roles/ecommerce/tasks/main.yml
@@ -68,6 +68,24 @@
     - install
     - install:app-requirements
 
+# This is a hacked fix for the fact that the table `thumbnail_kvstore` exists in
+# some environments, which won't need the 3rd party newly introduced migration
+# to create this table, so we fake the migration.
+# This is required for the Ginkgo release.
+# TODO: Delete this task for the Hawthorn release.
+- name: fake thumbnails
+  shell: >
+    table_exists=`mysql -uroot -ss -e "SELECT EXISTS(SELECT * FROM information_schema.tables WHERE table_schema = '{{ ECOMMERCE_DEFAULT_DB_NAME }}' AND table_name = 'thumbnail_kvstore')"`;
+    if [ "$table_exists" -eq "1" ]; then {{ ecommerce_venv_dir }}/bin/python ./manage.py migrate thumbnail 0001 --fake; fi;
+  args:
+    chdir: "{{ ecommerce_code_dir }}"
+  become_user: "{{ ecommerce_user }}"
+  environment: "{{ ecommerce_environment }}"
+  when: migrate_db is defined and migrate_db|lower == "yes"
+  tags:
+    - migrate
+    - migrate:db
+
 - name: Migrate
   shell: >
     DB_MIGRATION_USER='{{ COMMON_MYSQL_MIGRATE_USER }}'

--- a/playbooks/vagrant-devstack.yml
+++ b/playbooks/vagrant-devstack.yml
@@ -16,6 +16,7 @@
     # When provisioning your devstack, we apply security updates
     COMMON_SECURITY_UPDATES: true
     SECURITY_UPGRADE_ON_ANSIBLE: true
+    MONGO_AUTH: false
   vars_files:
     - roles/edxapp/vars/devstack.yml
   roles:


### PR DESCRIPTION
Configuration Pull Request
---

Fixes issues DEVSTACK-28 and DEVSTACK-29:
- Adding ecommerce fake thumnail migration when needed.
- Turning off MONGO_AUTH for devstacks.

Make sure that the following steps are done before merging

  - [x] A devops team member has commented with :+1:
  - [ ] are you adding any new default values that need to be overridden when this goes live?
    - [ ] Open a ticket (DEVOPS) to make sure that they have been added to secure vars.
    - [ ] Add an entry to the CHANGELOG.
