### PR TITLE
Use INSIGHTS_DATABASE variables in edxlocal role

### DIFF
--- a/playbooks/roles/edxlocal/defaults/main.yml
+++ b/playbooks/roles/edxlocal/defaults/main.yml
@@ -23,8 +23,8 @@ edxlocal_database_users:
     }
   - {
       db: "{{ INSIGHTS_DATABASE_NAME | default(None) }}",
-      user: "{{ INSIGHTS_MYSQL_USER | default(None) }}",
-      pass: "{{ INSIGHTS_MYSQL_USER | default(None) }}"
+      user: "{{ INSIGHTS_DATABASE_USER | default(None) }}",
+      pass: "{{ INSIGHTS_DATABASE_PASSWORD | default(None) }}"
     }
   - {
       db: "{{ XQUEUE_MYSQL_DB_NAME | default(None) }}",


### PR DESCRIPTION
The INSIGHTS_MYSQL_USER variable is not defined in this repo (don't know about the secure config repo, though), so the Insights database user was not being created. I changed the config to point to [these variables in the insights role](https://github.com/edx/configuration/blob/master/playbooks/roles/insights/defaults/main.yml#L64) instead.

This was causing a permission error the first time someone tries to run an insights command in the analyticstack.

I'm not totally sure how to test this change or how to tell if this file has access to variables in the insights role... Any guidance with that would be helpful!

FYI: @dsjen @iloveagent57 @brianhw 

Configuration Pull Request
---

Make sure that the following steps are done before merging

  - [x] A devops team member has commented with :+1:
  - [ ] are you adding any new default values that need to be overridden when this goes live? Kind of, Can someone in @edx/devops search the secure config repo for these variables to see if there are overrides for them?
    - [x] Open a ticket (DEVOPS) to make sure that they have been added to secure vars.
    - [ ] Add an entry to the CHANGELOG.
