### PR TITLE
Remove the specific version AMI version tagging in favor of using the version_tags variable

### DIFF
--- a/playbooks/continuous_delivery/create_ami.yml
+++ b/playbooks/continuous_delivery/create_ami.yml
@@ -9,10 +9,6 @@
 #   - app_repo                        - the url of the github repo for this app
 #   - app_version                     - git hash of the app (play, service, IDA) being deployed
 #   - play                            - the play that was run
-#   - configuration_repo              - The github url for the configuration repo
-#   - configuration_version           - The version (git hash) of configuration
-#   - configuration_secure_repo       - the github url for the configuration secure repository
-#   - configuration_secure_version    - the version (git hash) of configuration secure
 #   - cache_id                        - the cache_id version
 #
 # Other variables
@@ -21,8 +17,6 @@
 #   - ami_wait                        - (yes/no) should ansible pause while
 #   - no_reboot                       - (yes/no) should the instance not be rebooted during AMI creation
 #   - artifact_path                   - the path to where this ansible run stores the artifacts for the pipeline
-#   - edxapp_theme_source_repo        - the edx_app_theme repository
-#   - edxapp_theme_version            - the edx_app_theme repository version (git hash)
 #   - hipchat_token                   - API token to send messages to hipchat
 #   - hipchat_room                    - ID or name of the room to send the notification
 #   - hipchat_url                     - URL of the hipchat API  (defaults to v1 of the api)
@@ -38,9 +32,7 @@
 #       -e deployment=edx \
 #       -e edx_environment=sandbox \
 #       -e app_version=12345 \
-#       -e configuration_version=12345
-#       -e configuration_secure_version=12345
-#       -e cache_id=12345
+#       -e cache_id=12345 \
 #       create_ami.yml
 #
 
@@ -77,8 +69,6 @@
       # used a JSON object here as there is a string interpolation in the keys.
       tags: "{
                 'version:{{ play }}':'{{ app_repo }} {{ app_version }}',
-                'version:configuration':'{{ configuration_repo }} {{ configuration_version }}',
-                'version:configuration_secure':'{{ configuration_secure_repo }} {{ configuration_secure_version }}',
                 'play':'{{ play }}',
                 'cache_id':'{{ cache_id }}',
                 'environment':'{{ edx_environment }}',
@@ -101,14 +91,6 @@
           'version:{{ name }}': '{{ repo }} {{ version }}',
           {% endfor %}
       }"
-
-  - name: add optional edx-theme tag
-    ec2_tag:
-      region: "{{ ec2_region }}"
-      resource: "{{ ami_register.image_id }}"
-      tags:
-        version:edxapp_theme: "{{ edxapp_theme_source_repo }} {{ edxapp_theme_version }}"
-    when: edxapp_theme_version is defined and edxapp_theme_source_repo is defined
 
   - name: Fetch tags on the AMI
     ec2_tag:


### PR DESCRIPTION
This shouldn't merge until https://github.com/edx/edx-gomatic/pull/280 merges.

Configuration Pull Request
---

Make sure that the following steps are done before merging

  - [ ] A devops team member has commented with :+1:
