### PR TITLE
We've run this against two hosts by manually hacking run_role.yml

### DIFF
--- a/playbooks/edx-east/bootstrap_python.yml
+++ b/playbooks/edx-east/bootstrap_python.yml
@@ -1,0 +1,14 @@
+---
+# Runs the python bootstratpping role against an ubuntu machine
+# This is not as complete as ansible_bootstrap.sh (intentionally so)
+# This lets you get pythong2.7 installed on a machine so you can followup
+# with your actual playbook or role.  The key is gather_facts: False.
+#
+# Usage:
+#   ansible-playbook ./bootstrap_python.yml -i "hostname,"
+#
+- hosts: all
+  become: True
+  gather_facts: False
+  roles:
+    - python


### PR DESCRIPTION
This helps make it simpler until we write the ansible to support
playbooks that don't gather facts, bootstrap, gather facts, run the
other role.

@edx/devops
@michaelroytman next time you have a 16.04 box make sure we set you up with the ubuntu user's key and you can run this yourself.