### PR TITLE
This is missing on the newest docker images

### DIFF
--- a/playbooks/roles/tools_jenkins/defaults/main.yml
+++ b/playbooks/roles/tools_jenkins/defaults/main.yml
@@ -46,6 +46,7 @@ jenkins_tools_plugins:
   - { name: "github-oauth", version: "0.24" }
   - { name: "gradle", version: "1.25" }
   - { name: "credentials-binding", version: "1.9" }
+  - { name: "envinject", version: "1.92.1" }
 
 # ec2 + dependencies, used by the android build workers + any additional workers we build
   - { name: "ec2", version: "1.36" }


### PR DESCRIPTION
From resurrecting old docker images, it appears that we got it for
"free" as part of the jenkins container, but don't have it now that
we're starting from a clean install.

@edx/devops