### PR TITLE
Added the option to split env_extras by app

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -315,6 +315,8 @@ EDXAPP_FOOTER_ORGANIZATION_IMAGE: "images/logo.png"
 
 EDXAPP_ENV_EXTRA: {}
 EDXAPP_AUTH_EXTRA: {}
+EDXAPP_LMS_ENV_EXTRA: "{{ EDXAPP_ENV_EXTRA }}"
+EDXAPP_CMS_ENV_EXTRA: "{{ EDXAPP_ENV_EXTRA }}"
 EDXAPP_LMS_AUTH_EXTRA: "{{ EDXAPP_AUTH_EXTRA }}"
 EDXAPP_CMS_AUTH_EXTRA: "{{ EDXAPP_AUTH_EXTRA }}"
 EDXAPP_ENABLE_MKTG_SITE: false
@@ -1093,6 +1095,7 @@ cms_auth_config:
                 fs_root:  "{{ edxapp_course_data_dir }}"
                 render_template: 'edxmako.shortcuts.render_to_string'
   PARSE_KEYS: "{{ EDXAPP_PARSE_KEYS }}"
+
 cms_env_config:
   <<: *edxapp_generic_env
   SITE_NAME:  "{{ EDXAPP_CMS_SITE_NAME }}"

--- a/playbooks/roles/edxapp/templates/cms.env.json.j2
+++ b/playbooks/roles/edxapp/templates/cms.env.json.j2
@@ -1,4 +1,4 @@
-{% do cms_env_config.update(EDXAPP_ENV_EXTRA) %}
+{% do cms_env_config.update(EDXAPP_CMS_ENV_EXTRA) %}
 {% for key, value in cms_env_config.iteritems() -%}
   {% if value == 'None' -%}
     {% do cms_env_config.update({key: None }) %}

--- a/playbooks/roles/edxapp/templates/lms.env.json.j2
+++ b/playbooks/roles/edxapp/templates/lms.env.json.j2
@@ -1,7 +1,7 @@
-{% do lms_env_config.update(EDXAPP_ENV_EXTRA) %}
+{% do lms_env_config.update(EDXAPP_LMS_ENV_EXTRA) %}
 {% for key, value in lms_env_config.iteritems() -%}
   {% if value == 'None' -%}
-    {% do lms_env_config.update({key: None }) %} 
+    {% do lms_env_config.update({key: None }) %}
   {%- endif %}
 {%- endfor %}
 {{ lms_env_config | to_nice_json }}


### PR DESCRIPTION
Added `EDXAPP_LMS_ENV_EXTRAS` and `EDXAPP_CMS_ENV_EXTRAS` to default vars in order to be able to have different values for the `env_extras` between LMS and CMS.

Configuration Pull Request
---

Make sure that the following steps are done before merging

  - [ ] A devops team member has commented with :+1:
  - [ ] are you adding any new default values that need to be overridden when this goes live?
    - [ ] Open a ticket (DEVOPS) to make sure that they have been added to secure vars.
    - [ ] Add an entry to the CHANGELOG.
