### PR TITLE
Added an Elasticsearch Dockerfile for devstack

### DIFF
--- a/docker/build/elasticsearch-devstack/Dockerfile
+++ b/docker/build/elasticsearch-devstack/Dockerfile
@@ -1,0 +1,7 @@
+# docker build -f docker/build/elasticsearch-devstack/Dockerfile . -t edxops/elasticsearch:devstack
+
+FROM elasticsearch:1.5.2
+MAINTAINER edxops
+
+# Install the elastcisearch-head plugin (https://mobz.github.io/elasticsearch-head/)
+RUN /usr/share/elasticsearch/bin/plugin -install mobz/elasticsearch-head


### PR DESCRIPTION
This Dockerfile is based on the official image (rather than built from scratch by us) and includes the elasticsearch-head plugin.