### PR TITLE
find-exec won't expand wildcards

### DIFF
--- a/playbooks/roles/edx_ansible/templates/pre-box.j2
+++ b/playbooks/roles/edx_ansible/templates/pre-box.j2
@@ -8,10 +8,10 @@ set -x
 
 # Discard packages we don't need.
 apt-get clean -y
-apt-get autoclean -y 
+apt-get autoclean -y
 
 # Clean out pip caches.
-find / -type d -path '*/.cache/pip' -print -exec rm -rf '{}/*' \;
+find / -type d -path '*/.cache/pip' -print -exec rm -rf '{}' \;
 
 # We used to remove all .pyc files. This caused problems in sandboxes,
 # where code couldn't write .pyc files, and everything took too long.


### PR DESCRIPTION
This wasn't clearing the pip caches at all, because there was no file named "*" to remove. D'oh.