### PR TITLE
ubuntu-restricted-extras requires multiverse

### DIFF
--- a/playbooks/roles/browsers/defaults/main.yml
+++ b/playbooks/roles/browsers/defaults/main.yml
@@ -1,3 +1,13 @@
+# We install at least one package from the multiverse (ubuntu-restricted-extras)
+# Ensure that we have it enabled for machines that run the browser role.
+multiverse_urls:
+    - 'deb http://archive.ubuntu.com/ubuntu {{ansible_distribution_release}} multiverse'
+    - 'deb-src http://archive.ubuntu.com/ubuntu {{ansible_distribution_release}} multiverse'
+    - 'deb http://archive.ubuntu.com/ubuntu {{ansible_distribution_release}}-updates multiverse'
+    - 'deb-src http://archive.ubuntu.com/ubuntu {{ansible_distribution_release}}-updates multiverse'
+    - 'deb http://archive.ubuntu.com/ubuntu {{ansible_distribution_release}}-security multiverse'
+    - 'deb-src http://archive.ubuntu.com/ubuntu {{ansible_distribution_release}}-security multiverse'
+
 browser_deb_pkgs:
     - dbus-x11
     - gdebi

--- a/playbooks/roles/browsers/tasks/main.yml
+++ b/playbooks/roles/browsers/tasks/main.yml
@@ -12,6 +12,25 @@
     - install
     - install:system-requirements
 
+- name: Add multiverse repos
+  apt_repository:
+    repo: "{{item}}"
+    update_cache: false  # only update when adding new repos
+  register: multiverse_installed
+  when: ansible_distribution == 'Ubuntu'
+  with_items: "{{ multiverse_urls }}"
+  tags:
+    - install
+    - install:system-requirements
+
+- name: Update cache when adding multiverse repos
+  apt:
+    update_cache: true
+  when: multiverse_installed | changed
+  tags:
+    - install
+    - install:system-requirements
+
 - name: install system packages
   apt:
     name: "{{ item }}"


### PR DESCRIPTION
This is not enabled by default, enable it for machines using the
browsers role.

Without this I cannot build docker containers for tools-jenkins.
Going to test the build-packer job

@edx/devops please review
FYI @benpatterson