### PR TITLE
infrastructure for building an AMI for a loadtest driver jenkins worker

### DIFF
--- a/playbooks/edx-east/jenkins_worker_loadtest_driver.yml
+++ b/playbooks/edx-east/jenkins_worker_loadtest_driver.yml
@@ -1,0 +1,12 @@
+# Configure a Jenkins worker instance
+# This has all the requirements to run load tests.
+
+- name: Configure instance(s)
+  hosts: jenkins_worker
+  become: True
+  gather_facts: True
+  vars:
+    loadtest_driver_worker: True
+  roles:
+    - aws
+    - jenkins_worker

--- a/playbooks/roles/jenkins_worker/meta/main.yml
+++ b/playbooks/roles/jenkins_worker/meta/main.yml
@@ -45,3 +45,7 @@ dependencies:
     android_apt_libraries:
       - lib32stdc++6
       - lib32z1
+
+  # dependencies for loadtest driver worker
+  - role: loadtest_driver
+    when: loadtest_driver_worker is defined

--- a/playbooks/roles/loadtest_driver/defaults/main.yml
+++ b/playbooks/roles/loadtest_driver/defaults/main.yml
@@ -1,0 +1,14 @@
+---
+
+# ulimit variables
+ulimit_config:
+  - domain: '*'
+    type: soft
+    item: nofile
+    value: 4096
+  - domain: '*'
+    type: hard
+    item: nofile
+    value: 4096
+
+ulimit_conf_file: "/etc/security/limits.conf"

--- a/playbooks/roles/loadtest_driver/meta/main.yml
+++ b/playbooks/roles/loadtest_driver/meta/main.yml
@@ -1,0 +1,15 @@
+---
+#
+# edX Configuration
+#
+# github:     https://github.com/edx/configuration
+# wiki:       https://openedx.atlassian.net/wiki/display/OpenOPS
+# code style: https://openedx.atlassian.net/wiki/display/OpenOPS/Ansible+Code+Conventions
+# license:    https://github.com/edx/configuration/blob/master/LICENSE.TXT
+#
+##
+# Role includes for role loadtest_driver
+#
+
+dependencies:
+  - common

--- a/playbooks/roles/loadtest_driver/tasks/main.yml
+++ b/playbooks/roles/loadtest_driver/tasks/main.yml
@@ -1,0 +1,11 @@
+---
+# configure a machine for driving loadtests.
+
+# Specifically, we want to allow as many open connections as possible, to
+# simulate more locust clients.
+- name: Increase file descriptor limit of the system
+  lineinfile:
+    dest: "{{ ulimit_conf_file }}"
+    line: "{{ item.domain }}  {{ item.type }}  {{ item.item }}  {{ item.value }}"
+  with_items: "{{ ulimit_config }}"
+

--- a/playbooks/roles/locust/meta/main.yml
+++ b/playbooks/roles/locust/meta/main.yml
@@ -12,6 +12,7 @@
 # 
 dependencies:
   - common
+  - loadtest_driver
   - role: edx_service
     edx_service_name: "{{ locust_service_name }}"
     edx_service_config: "{{ LOCUST_SERVICE_CONFIG }}"

--- a/playbooks/roles/locust/tasks/main.yml
+++ b/playbooks/roles/locust/tasks/main.yml
@@ -19,6 +19,7 @@
 #
 # Dependencies:
 #  - edx-service role
+#  - loadtest_driver role
 #  - load tests repo with locust tests in it.
 #
 # Example play:
@@ -37,14 +38,6 @@
     virtualenv: "{{ locust_home }}/venvs/{{ locust_service_name }}"
     state: present
   become_user: "{{ locust_user }}"
-
-# Specifically, we are concerned about allowing as many open connections as
-# possible, to simulate more locust clients.
-- name: Increase file descriptor limit of the system (Session Logout and Login would be required)
-  lineinfile:
-    dest: "{{ ulimit_conf_file }}"
-    line: "{{ item.domain }}  {{ item.type }}  {{ item.item }}  {{ item.value }}"
-  with_items: "{{ ulimit_config }}"
 
 - name: Configure locust user with an interactive shell
   user:

--- a/util/packer/jenkins_worker_loadtest.json
+++ b/util/packer/jenkins_worker_loadtest.json
@@ -1,0 +1,53 @@
+{
+  "variables": {
+    "aws_access_key": "{{env `AWS_ACCESS_KEY_ID`}}",
+    "aws_secret_key": "{{env `AWS_SECRET_ACCESS_KEY`}}",
+    "playbook_remote_dir": "/tmp/packer-edx-playbooks",
+    "venv_dir": "/edx/app/edx_ansible/venvs/edx_ansible",
+    "ami": "{{env `JENKINS_WORKER_AMI`}}",
+    "delete_or_keep": "{{env `DELETE_OR_KEEP_AMI`}}",
+    "remote_branch": "{{env `REMOTE_BRANCH`}}"
+  },
+  "builders": [{
+    "type": "amazon-ebs",
+    "access_key": "{{user `aws_access_key`}}",
+    "secret_key": "{{user `aws_secret_key`}}",
+    "ami_name": "jenkins_worker_loadtest_driver-{{isotime | clean_ami_name}}",
+    "instance_type": "m3.medium",
+    "region": "us-east-1",
+    "source_ami": "{{user `ami`}}",
+    "ssh_username": "ubuntu",
+    "ami_description": "jenkins worker loadtest driver",
+    "iam_instance_profile": "jenkins-worker",
+    "security_group_id": "sg-75af5e18",
+    "tags": {
+      "delete_or_keep": "{{user `delete_or_keep`}}"
+    }
+  }],
+  "provisioners": [{
+    "type": "shell",
+    "inline": ["rm -rf {{user `playbook_remote_dir`}}",
+      "mkdir {{user `playbook_remote_dir`}}"]
+  }, {
+    "type": "file",
+    "source": "stop-automatic-updates.sh",
+    "destination": "{{user `playbook_remote_dir`}}/stop-automatic-updates.sh"
+  }, {
+    "type": "file",
+    "source": "../../util/install/ansible-bootstrap.sh",
+    "destination": "{{user `playbook_remote_dir`}}/ansible-bootstrap.sh"
+  }, {
+    "type": "shell",
+    "inline": ["cd {{user `playbook_remote_dir`}}",
+      "export CONFIGURATION_VERSION='{{user `remote_branch`}}'",
+      "sudo bash ./stop-automatic-updates.sh",
+      "sudo bash ./ansible-bootstrap.sh" ]
+  }, {
+    "type": "ansible-local",
+    "playbook_file": "../../playbooks/edx-east/jenkins_worker_loadtest_driver.yml",
+    "playbook_dir": "../../playbooks",
+    "command": ". {{user `venv_dir`}}/bin/activate && ansible-playbook",
+    "inventory_groups": "jenkins_worker",
+    "extra_arguments": [ "-vvv" ]
+  }]
+}


### PR DESCRIPTION
* Add a new ansible role "loadtest_driver" for setting up any instance
  for running load tests.
* Make the existing "locust" role depend on loadtest_driver and pull out
  the redundant tasks.  The "locust" role is outside of the AMI-building
  code path, but we do use it for something else and want to keep common
  tasks shared.
* Make the "jenkins_worker" role depend on the new "loadtest_driver"
  role.
* Create a new ansible playbook for setting up loadtest drivers.
* create a new packer script to build an AMI for loadtest drivers.

Configuration Pull Request
---

Make sure that the following steps are done before merging

  - [ ] A devops team member has commented with :+1:
  - [ ] are you adding any new default values that need to be overridden when this goes live?
    - [ ] Open a ticket (DEVOPS) to make sure that they have been added to secure vars.
    - [ ] Add an entry to the CHANGELOG.
