### PR TITLE
matrix-auth was being overridden by Jenkins (down to 1.1)

### DIFF
--- a/playbooks/roles/tools_jenkins/defaults/main.yml
+++ b/playbooks/roles/tools_jenkins/defaults/main.yml
@@ -5,7 +5,7 @@ jenkins_tools_version: "1.651.3"
 jenkins_tools_plugins:
   - { name: "cloudbees-folder", version: "5.12" }
   - { name: "structs", version: "1.2" }
-  - { name: "job-dsl", version: "1.50" }
+  - { name: "job-dsl", version: "1.52" }
   - { name: "greenballs", version: "1.15" }
   - { name: "rebuild", version: "1.25" }
   - { name: "build-user-vars-plugin", version: "1.5" }

--- a/playbooks/roles/tools_jenkins/defaults/main.yml
+++ b/playbooks/roles/tools_jenkins/defaults/main.yml
@@ -9,7 +9,6 @@ jenkins_tools_plugins:
   - { name: "greenballs", version: "1.15" }
   - { name: "rebuild", version: "1.25" }
   - { name: "build-user-vars-plugin", version: "1.5" }
-  - { name: "matrix-auth", version: "1.4" }
   - { name: "mailer", version: "1.17" }
   - { name: "credentials", version: "2.1.4" }
   - { name: "ssh-credentials", version: "1.12" }
@@ -48,9 +47,22 @@ jenkins_tools_plugins:
   - { name: "credentials-binding", version: "1.9" }
   - { name: "envinject", version: "1.92.1" }
 
+# matrix-auth is now pinned to avoid Jenkins overriding
+# 1.3 and later requires icon-shim
+  - { name: "matrix-auth", version: "1.4" }
+  - { name: "icon-shim", version: "2.0.3" }
+
 # ec2 + dependencies, used by the android build workers + any additional workers we build
   - { name: "ec2", version: "1.36" }
   - { name: "node-iterator-api", version: "1.5" }
   - { name: "aws-java-sdk", version: "1.11.37" }
   - { name: "jackson2-api", version: "2.5.4" }
   - { name: "aws-credentials", version: "1.11" }
+
+jenkins_tools_bundled_plugins:
+  - 'matrix-auth'
+  - "credentials"
+  - "git"
+  - "pam-auth"
+  - "ssh-credentials"
+  - "ssh-slaves"

--- a/playbooks/roles/tools_jenkins/meta/main.yml
+++ b/playbooks/roles/tools_jenkins/meta/main.yml
@@ -8,3 +8,4 @@ dependencies:
     jenkins_version: "{{ jenkins_tools_version }}"
     jenkins_deb_url: "http://pkg.jenkins-ci.org/debian-stable/binary/jenkins_{{ jenkins_version }}_all.deb"
     jenkins_custom_plugins: []
+    jenkins_bundled_plugins: "{{ jenkins_tools_bundled_plugins }}"


### PR DESCRIPTION
This appears to be because it wasn't pinned and the shipped version
of the plugin won.  We have pinning code in jenkins_master that we
can use, but we have to copy down that list to add ours (ansible
doesn't allow "recursive references" of a variable passed back to
itself.

Also upgrade DSL plugin to get better error handling.
https://github.com/jenkinsci/job-dsl-plugin/wiki#release-notes
https://github.com/jenkinsci/job-dsl-plugin/wiki/Migration#migrating-to-152


Continue process of trying to group plugins and their deps.