### PR TITLE
Disable app preload in gunicorn for LMS & Studio.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Role: edxapp
+  - Set preload_app to False in gunicorn config for LMS and Studio.
 - Role: analytics_api
   - Added `ANALYTICS_API_AGGREGATE_PAGE_SIZE`, default value 10.  Adjust this parameter to increase the number of
     aggregate search results returned by the Analytics API, i.e. in course_metadata: enrollment_modes, cohorts, and

--- a/playbooks/roles/edxapp/templates/cms_gunicorn.py.j2
+++ b/playbooks/roles/edxapp/templates/cms_gunicorn.py.j2
@@ -5,7 +5,7 @@ gunicorn configuration file: http://docs.gunicorn.org/en/develop/configure.html
 """
 import multiprocessing
 
-preload_app = True
+preload_app = False
 timeout = 300
 bind = "{{ edxapp_cms_gunicorn_host }}:{{ edxapp_cms_gunicorn_port }}"
 pythonpath = "{{ edxapp_code_dir }}"

--- a/playbooks/roles/edxapp/templates/lms_gunicorn.py.j2
+++ b/playbooks/roles/edxapp/templates/lms_gunicorn.py.j2
@@ -5,7 +5,7 @@ gunicorn configuration file: http://docs.gunicorn.org/en/develop/configure.html
 """
 import multiprocessing
 
-preload_app = True
+preload_app = False
 timeout = 300
 bind = "{{ edxapp_lms_gunicorn_host }}:{{ edxapp_lms_gunicorn_port }}"
 pythonpath = "{{ edxapp_code_dir }}"


### PR DESCRIPTION
Since the earliest days of edX, we've run gunicorn with preload_app as
True. This was primarily because the first handful of courses were using
the XMLModuleStore, which was extremely slow to initialize because it
had to read entire courses from disk and load them into memory at
startup.

XMLModuleStore courses stopped being created with the introduction of
Studio, and we've long since removed them from edx.org. Note: This
should not be confused with importing courses that are authored in XML.
XMLModuleStore courses are courses who use the disk instead of Mongo
for content persistence, and require a server restart for content edits
to show.

This commit sets things back to how Django is more commonly deployed
with gunicorn. It will make server startup time somewhat more expensive
because each worker process does init work, but it should make it
easier to safely enable features like database connection pooling
without having to worry about shared resources.

[PERF-305]

Configuration Pull Request
---

Make sure that the following steps are done before merging

  - [ ] A devops team member has commented with :+1:
  - [ ] are you adding any new default values that need to be overridden when this goes live?
    - [ ] Open a ticket (DEVOPS) to make sure that they have been added to secure vars.
    - [ ] Add an entry to the CHANGELOG.
