### PR TITLE
Rabbit will only use 40% of RAM, allow this to go up

### DIFF
--- a/playbooks/edx-east/rabbitmq.yml
+++ b/playbooks/edx-east/rabbitmq.yml
@@ -12,7 +12,7 @@
     elb_pre_post: true
     # Number of instances to operate on at a time
     serial_count: 1
-    CLUSTER_NAME: 'commoncluster'
+    CLUSTER_NAME: 'rabbitmq'
   serial: "{{ serial_count }}"
   pre_tasks:
     - action: ec2_facts

--- a/playbooks/roles/rabbitmq/defaults/main.yml
+++ b/playbooks/roles/rabbitmq/defaults/main.yml
@@ -25,6 +25,11 @@ RABBITMQ_VHOSTS:
   - '/'
 
 RABBITMQ_CLUSTERED_HOSTS: []
+# This is the default for rabbit, but allows overriding if
+# you run a dedicated rabbit cluster
+# https://www.rabbitmq.com/memory.html
+# https://www.rabbitmq.com/production-checklist.html
+RABBITMQ_VM_MEMORY_HIGH_WATERMARK: 0.4
 
 # Internal role variables below this line
 

--- a/playbooks/roles/rabbitmq/templates/etc/rabbitmq/rabbitmq.config.j2
+++ b/playbooks/roles/rabbitmq/templates/etc/rabbitmq/rabbitmq.config.j2
@@ -5,5 +5,6 @@
 {# 
    Note: That these names should include the node name prefix. eg. 'rabbit@hostname'
 #}
-  {cluster_nodes, {['{{ RABBITMQ_CLUSTERED_HOSTS|join("\',\'") }}'], disc}}
+  {cluster_nodes, {['{{ RABBITMQ_CLUSTERED_HOSTS|join("\',\'") }}'], disc}},
+  {vm_memory_high_watermark, {{ RABBITMQ_VM_MEMORY_HIGH_WATERMARK }} }
 ]}].


### PR DESCRIPTION
The linked documentation comes out ao .7 for a t2.large
We can also prevent rabbit from going to disk until more memory
is full, but that isn't needed right now.