### PR TITLE
Apply changes from the previous task.

### DIFF
--- a/playbooks/roles/vhost/tasks/main.yml
+++ b/playbooks/roles/vhost/tasks/main.yml
@@ -46,6 +46,10 @@
     dest: /etc/dhcp/dhclient.conf
   when: COMMON_CUSTOM_DHCLIENT_CONFIG
 
+- name: Rerun dhclient to apply template
+  shell: dhclient -n
+  when: COMMON_CUSTOM_DHCLIENT_CONFIG
+
 - name: Copy the MOTD template in place
   template:
     src: etc/motd.tail.j2


### PR DESCRIPTION
Without this, resolv.conf won't be updated in our environment until the
lease expires and dhclient reruns.  The -n should prevent it from
*actually* changing interfaces, and instead just updates the conf files.

@edx/devops 
 