### PR TITLE
Quiet an ansible deprecation warnings

### DIFF
--- a/docker/plays/analytics_api.yml
+++ b/docker/plays/analytics_api.yml
@@ -1,6 +1,6 @@
 - name: Deploy Analytics API
   hosts: all
-  sudo: True
+  become: True
   gather_facts: True
   vars:
     serial_count: 1

--- a/docker/plays/automated.yml
+++ b/docker/plays/automated.yml
@@ -1,6 +1,6 @@
 - name: Deploy autom
   hosts: all
-  sudo: True
+  become: True
   gather_facts: True
   roles:
     - common_vars

--- a/docker/plays/credentials.yml
+++ b/docker/plays/credentials.yml
@@ -1,6 +1,6 @@
 - name: Deploy Credentials
   hosts: all
-  sudo: True
+  become: True
   gather_facts: True
   vars:
     serial_count: 1

--- a/docker/plays/discovery.yml
+++ b/docker/plays/discovery.yml
@@ -1,6 +1,6 @@
 - name: Deploy Discovery
   hosts: all
-  sudo: True
+  become: True
   gather_facts: True
   vars:
     serial_count: 1

--- a/docker/plays/docker-tools.yml
+++ b/docker/plays/docker-tools.yml
@@ -1,6 +1,6 @@
 - name: build a VM with docker-tools
   hosts: all
-  sudo: True
+  become: True
   gather_facts: True
   roles:
     - docker

--- a/docker/plays/ecommerce.yml
+++ b/docker/plays/ecommerce.yml
@@ -1,6 +1,6 @@
 - name: Deploy ecommerce
   hosts: all
-  sudo: True
+  become: True
   gather_facts: True
   vars:
     serial_count: 1

--- a/docker/plays/ecomworker.yml
+++ b/docker/plays/ecomworker.yml
@@ -1,6 +1,6 @@
 - name: Deploy ecommerce worker
   hosts: all
-  sudo: True
+  become: True
   gather_facts: True
   vars:
     serial_count: 1

--- a/docker/plays/edxapp.yml
+++ b/docker/plays/edxapp.yml
@@ -1,6 +1,6 @@
 - name: Deploy edxapp
   hosts: all
-  sudo: True
+  become: True
   gather_facts: True
   vars:
     serial_count: 1

--- a/docker/plays/forum.yml
+++ b/docker/plays/forum.yml
@@ -1,6 +1,6 @@
 - name: Deploy forum
   hosts: all
-  sudo: True
+  become: True
   gather_facts: True
   vars:
     serial_count: 1

--- a/docker/plays/harstorage.yml
+++ b/docker/plays/harstorage.yml
@@ -1,6 +1,6 @@
 - name: Deploy Harstorage
   hosts: all
-  sudo: True
+  become: True
   gather_facts: True
   roles:
     - docker

--- a/docker/plays/insights.yml
+++ b/docker/plays/insights.yml
@@ -1,6 +1,6 @@
 - name: Deploy Insights
   hosts: all
-  sudo: True
+  become: True
   gather_facts: True
   vars:
     serial_count: 1

--- a/docker/plays/jenkins_analytics.yml
+++ b/docker/plays/jenkins_analytics.yml
@@ -1,6 +1,6 @@
 - name: Deploy the analytics jenkins
   hosts: all
-  sudo: True
+  become: True
   gather_facts: True
   vars:
     serial_count: 1

--- a/docker/plays/jenkins_tools.yml
+++ b/docker/plays/jenkins_tools.yml
@@ -1,6 +1,6 @@
 - name: Deploy the tools jenkins
   hosts: all
-  sudo: True
+  become: True
   gather_facts: True
   vars:
     serial_count: 1

--- a/docker/plays/mysql.yml
+++ b/docker/plays/mysql.yml
@@ -1,6 +1,6 @@
 - name: Deploy MySQL 5.6
   hosts: all
-  sudo: True
+  become: True
   gather_facts: True
   roles:
     - common_vars

--- a/docker/plays/nginx.yml
+++ b/docker/plays/nginx.yml
@@ -1,6 +1,6 @@
 - name: Deploy nginx
   hosts: all
-  sudo: True
+  become: True
   gather_facts: True
   vars:
     serial_count: 1

--- a/docker/plays/notes.yml
+++ b/docker/plays/notes.yml
@@ -1,6 +1,6 @@
 - name: Deploy Notes
   hosts: all
-  sudo: True
+  become: True
   gather_facts: True
   vars:
     serial_count: 1

--- a/docker/plays/rabbitmq.yml
+++ b/docker/plays/rabbitmq.yml
@@ -1,6 +1,6 @@
 - name: Deploy rabbitmq
   hosts: all
-  sudo: True
+  become: True
   gather_facts: True
   vars:
     serial_count: 1

--- a/docker/plays/xqueue.yml
+++ b/docker/plays/xqueue.yml
@@ -1,6 +1,6 @@
 - name: Deploy xqueue
   hosts: all
-  sudo: True
+  become: True
   gather_facts: True
   roles:
     - common_vars

--- a/docker/plays/xqwatcher.yml
+++ b/docker/plays/xqwatcher.yml
@@ -1,6 +1,6 @@
 - name: Deploy xqwatcher
   hosts: all
-  sudo: True
+  become: True
   gather_facts: True
   roles:
     - docker


### PR DESCRIPTION
[DEPRECATION WARNING]: Instead of sudo/sudo_user, use become/become_user and
make sure become_method is 'sudo' (default).
This feature will be removed in a
future release. Deprecation warnings can be disabled by setting
deprecation_warnings=False in ansible.cfg.

@edx/devops Please review - ansible has gotten noisier about this.