### PR TITLE
Determine default network interface name instead of hardcoding to eth0.

### DIFF
--- a/playbooks/roles/aws/tasks/main.yml
+++ b/playbooks/roles/aws/tasks/main.yml
@@ -31,7 +31,7 @@
     - deploy
 
 - name: Get name of default network interface
-  shell: "ip route show 0/0 | awk '{print $NF}'"
+  shell: "ip route show 0/0 | grep -oP '(?<=dev )[[:alnum:]]+'"
   register: get_interface_name
   when: ansible_distribution in common_debian_variants
 

--- a/playbooks/roles/aws/tasks/main.yml
+++ b/playbooks/roles/aws/tasks/main.yml
@@ -30,13 +30,8 @@
   tags:
     - deploy
 
-- name: Get name of default network interface
-  shell: "ip route show 0/0 | grep -oP '(?<=dev )[[:alnum:]]+'"
-  register: get_interface_name
-  when: ansible_distribution in common_debian_variants
-
 - name: Set the MTU to 1500 temporarily
-  shell: "/sbin/ifconfig {{ get_interface_name.stdout }} mtu 1500 up"
+  shell: "/sbin/ifconfig {{ ansible_default_ipv4.interface }} mtu 1500 up"
   when: ansible_distribution in common_debian_variants
 
 - name: Set the MTU to 1500 permanently

--- a/playbooks/roles/aws/tasks/main.yml
+++ b/playbooks/roles/aws/tasks/main.yml
@@ -30,24 +30,23 @@
   tags:
     - deploy
 
+- name: Get name of default network interface
+  shell: "ip route show 0/0 | awk '{print $NF}'"
+  register: get_interface_name
+  when: ansible_distribution in common_debian_variants
+
 - name: Set the MTU to 1500 temporarily
-  shell: /sbin/ifconfig eth0 mtu 1500 up
+  shell: "/sbin/ifconfig {{ get_interface_name.stdout }} mtu 1500 up"
   when: ansible_distribution in common_debian_variants
 
-- name: Check for eth0.cfg
-  stat:
-    path: /etc/network/interfaces.d/eth0.cfg
-  register: eth0_cfg
+- name: Set the MTU to 1500 permanently
+  template:
+    dest: /etc/network/if-up.d/mtu
+    src: mtu.j2
+    mode: 0755
+    owner: root
+    group: root
   when: ansible_distribution in common_debian_variants
-
-- name: Set the MTU to 1500 inside eth0.cfg file
-  lineinfile:
-    dest: /etc/network/interfaces.d/eth0.cfg
-    regexp: "^post-up /sbin/ifconfig eth0 mtu 1500"
-    line: "post-up /sbin/ifconfig eth0 mtu 1500"
-    insertafter: "^iface"
-  when: ansible_distribution in common_debian_variants and eth0_cfg.stat.exists
-
 #
 # End dealing with Jumbo frames issue in mixed MTU deployements in AWS
 #

--- a/playbooks/roles/aws/templates/mtu.j2
+++ b/playbooks/roles/aws/templates/mtu.j2
@@ -1,2 +1,2 @@
 #!/bin/sh
-ifconfig {{ get_interface_name.stdout }} mtu 1500
+ifconfig {{ ansible_default_ipv4.interface }} mtu 1500

--- a/playbooks/roles/aws/templates/mtu.j2
+++ b/playbooks/roles/aws/templates/mtu.j2
@@ -1,0 +1,2 @@
+#!/bin/sh
+ifconfig {{ get_interface_name.stdout }} mtu 1500

--- a/playbooks/roles/vhost/templates/etc/dhcp/dhclient.conf.j2
+++ b/playbooks/roles/vhost/templates/etc/dhcp/dhclient.conf.j2
@@ -56,7 +56,7 @@ request subnet-mask, broadcast-address, time-offset, routers,
 #  expire 2 2000/1/12 00:00:01;
 #}
 
-interface "eth0" {
+interface "{{ ansible_default_ipv4.interface }}" {
     prepend domain-search {% for search in COMMON_DHCLIENT_DNS_SEARCH -%}"{{ search }}"{%- if not loop.last -%},{%- endif -%}
 {%- endfor -%};
 }


### PR DESCRIPTION
Depending on the hardware configuration, the default network interface is not always named `eth0` in Ubuntu 16.04. On some EC2 VM types, the interface is named `ens3`, for example.

This patch adds a task to determine the interface name using `ip route` command instead of     hardcoding to `eth0`.
    
Also, since `/etc/network/interfaces.d/<interface-name>.cfg` files no longer exist in Ubuntu 16.04, this patch adds a script to `/etc/network/if-up.d` to adjust the MTU value at network startup instead.

**JIRA Ticket**: [OSPR-1746](https://openedx.atlassian.net/browse/OSPR-1746)

**Merge deadline**: None

**Partner information**: 3rd party-hosted open edX instance

---

Make sure that the following steps are done before merging

  - [ ] A devops team member has commented with :+1:
  - [ ] are you adding any new default values that need to be overridden when this goes live?
    - [ ] Open a ticket (DEVOPS) to make sure that they have been added to secure vars.
    - [ ] Add an entry to the CHANGELOG.
