### PR TITLE
Install jenkins nginx config to nginx_sites_available_dir

### DIFF
--- a/playbooks/analytics-jenkins.yml
+++ b/playbooks/analytics-jenkins.yml
@@ -5,3 +5,4 @@
   become: True
   roles:
   - jenkins_analytics
+  - nginx

--- a/playbooks/roles/jenkins_master/tasks/main.yml
+++ b/playbooks/roles/jenkins_master/tasks/main.yml
@@ -249,18 +249,18 @@
     - install:base
     - install:plugins
 
-- name: Setup nginix vhost
+- name: Setup nginx vhost
   template:
     src: "etc/nginx/sites-available/jenkins.j2"
-    dest: "/etc/nginx/sites-available/jenkins"
+    dest: "{{ nginx_sites_available_dir }}/jenkins"
   tags:
     - install
     - install:vhosts
 
 - name: Enable jenkins vhost
   file:
-    src: "/etc/nginx/sites-available/jenkins"
-    dest: "/etc/nginx/sites-enabled/jenkins"
+    src: "{{ nginx_sites_available_dir }}/jenkins"
+    dest: "{{ nginx_sites_enabled_dir }}/jenkins"
     state: link
   tags:
     - install


### PR DESCRIPTION
Configuration Pull Request
---

On our Insights instances, the majority of edx applications install their nginx configuration under `/edx/app/nginx/sites-available`, but the [`jenkins_master` role installs to `/etc/nginx/sites-available`](https://github.com/edx/configuration/blob/master/playbooks/roles/jenkins_master/tasks/main.yml#L255), which doesn't seem to be created anymore.

This change updates `jenkins_master` to install its nginx configuration in the standard locations, defined by `nginx_sites_available_dir` and `nginx_sites_enabled_dir`.  In order for these variables to be available when running `analytics-jenkins.yml`, this change also adds the `nginx` role to that playbook.

#
**JIRA tickets**: [OSPR-1740](https://openedx.atlassian.net/browse/OSPR-1740)

**Partner information**: 3rd party openedx instance

**Merge deadline**: None

**Reviewers**
- [x] @mtyaka 
- [ ] edX reviewer[s] TBD

Make sure that the following steps are done before merging

  - [ ] A devops team member has commented with :+1:
  - [ ] are you adding any new default values that need to be overridden when this goes live?
    - [ ] Open a ticket (DEVOPS) to make sure that they have been added to secure vars.
    - [ ] Add an entry to the CHANGELOG.