### PR TITLE
Allow `./shovel.py`, not just `python shovel.py`

### DIFF
--- a/util/rabbitmq/shovel.py
+++ b/util/rabbitmq/shovel.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 import argparse
 import subprocess
 import requests


### PR DESCRIPTION
@edx/devops