### PR TITLE
We need to be able to run on sandboxes/devstacks

### DIFF
--- a/playbooks/roles/rabbitmq/defaults/main.yml
+++ b/playbooks/roles/rabbitmq/defaults/main.yml
@@ -11,10 +11,6 @@
 # Defaults for role rabbitmq
 # 
 
-#Setting this to false means we will not check your rabbit version.
-#It is not safe to upgrade rabbit in place except for certain minor versions.
-CHECK_RABBIT_VERSION: true
-
 rabbitmq_app_dir: "{{ COMMON_APP_DIR }}/rabbitmq"
 rabbitmq_data_dir: "{{ COMMON_DATA_DIR }}/rabbitmq"
 rabbitmq_log_dir: "{{ COMMON_LOG_DIR }}/rabbitmq"

--- a/playbooks/roles/rabbitmq/tasks/main.yml
+++ b/playbooks/roles/rabbitmq/tasks/main.yml
@@ -44,9 +44,9 @@
     - "install"
     - "install:app-requirements"
 
-- name: Fail if wrong rabbit version is installed
-  fail: Expected rabbitmq version {{ RABBITMQ_VERSION }}, found {{ installed_version.stdout }}
-  when: CHECK_RABBIT_VERSION and installed_version.stdout is defined and installed_version.stdout not in [RABBITMQ_VERSION, 'not installed']
+- name: Warn if wrong rabbit version is installed
+  debug: msg="Expected rabbitmq version {{ RABBITMQ_VERSION }}, found {{ installed_version.stdout }} - will not upgrade in place"
+  when: installed_version.stdout is defined and installed_version.stdout not in [RABBITMQ_VERSION, 'not installed']
   tags:
     - "install"
     - "install:app-requirements"


### PR DESCRIPTION
We'll safely skip the install of rabbitmq if something is already
installed, so warning is sufficient for our purposes.

@edx/devops