### PR TITLE
Restricting Credentials CORS access

### DIFF
--- a/playbooks/roles/credentials/templates/edx/app/nginx/sites-available/credentials.j2
+++ b/playbooks/roles/credentials/templates/edx/app/nginx/sites-available/credentials.j2
@@ -15,6 +15,19 @@ upstream credentials_app_server {
 {% endfor %}
 }
 
+# The Origin request header indicates where a fetch originates from. It doesn't include any path information,
+# but only the server name (e.g. https://www.example.com).
+# See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Origin for details.
+#
+# Here we set the value that is included in the Access-Control-Allow-Origin response header. If the origin is one
+# of our known hosts--served via HTTP or HTTPS--we allow for CORS. Otherwise, we set the "null" value, disallowing CORS.
+map $http_origin $cors_origin {
+  default "null";
+{% for host in CREDENTIALS_CORS_ORIGIN_WHITELIST %}
+  "~*^https?:\/\/{{ host|replace('.', '\.') }}$" $http_origin;
+{% endfor %}
+}
+
 server {
   server_name {{ CREDENTIALS_HOSTNAME }};
 
@@ -40,32 +53,7 @@ server {
   location ~ ^{{ CREDENTIALS_STATIC_URL }}(?P<file>.*) {
     root {{ CREDENTIALS_STATIC_ROOT }};
     add_header Cache-Control "max-age=31536000";
-
-    # NOTE (CCB): We have invested *numerous* man-hours in attempting to provide a properly-secured CORS implementation.
-    # Unfortunately, our efforts have only resulted in a lot of frustration, failure, and new knowledge. For now,
-    # given the low risk of exposing these files, we will move forward with the insecure option.
-    #
-    # References for future explorers:
-    # * https://www.nginx.com/resources/wiki/start/topics/depth/ifisevil/
-    # * https://enable-cors.org/server_nginx.html
-    # * http://stackoverflow.com/questions/27955233/nginx-config-for-cors-add-header-directive-is-not-allowed/41467679
-    #
-    add_header 'Access-Control-Allow-Origin' '*';
-    add_header 'Access-Control-Allow-Methods' 'GET, OPTIONS';
-    add_header 'Access-Control-Allow-Headers' 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Content-Range,Range';
-
-    if ($request_method = 'OPTIONS') {
-      add_header 'Access-Control-Allow-Origin' '*';
-      add_header 'Access-Control-Allow-Methods' 'GET, OPTIONS';
-      add_header 'Access-Control-Allow-Headers' 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Content-Range,Range';
-
-      # Tell client that this pre-flight info is valid for 20 days
-      add_header 'Access-Control-Max-Age' 1728000;
-      add_header 'Content-Type' 'text/plain charset=UTF-8';
-      add_header 'Content-Length' 0;
-      return 204;
-    }
-
+    add_header 'Access-Control-Allow-Origin' $cors_origin;
     try_files /$file =404;
   }
 


### PR DESCRIPTION
After reading more on CORS (and sleeping!) I have finally corrected CORS
for static files, restricting access to our knwon hosts. Our initial
implementation was almost correct. It simply lacked the protocol—HTTP,
HTTPS—on the regex.

In my late-night push to just be done with this, I failed to go back to
"first principles" and actually understand CORS, choosing to rely on
various online "solutions". This lead to the unnecessary headers seen in
previous commits. Since we only care about GET requests for fonts, we
only need the single header. There is no need to handle preflight
OPTIONS requests because we aren't making such requests.

LEARNER-568