### PR TITLE
chmod and chown the edx_ansible_venv_dir to make vagrant provision more reliable

### DIFF
--- a/playbooks/roles/edx_ansible/tasks/deploy.yml
+++ b/playbooks/roles/edx_ansible/tasks/deploy.yml
@@ -10,6 +10,16 @@
     - install
     - install:code
 
+- name: Ensure directory permissions for Install edx_ansible venv requirements
+  command: chmod -R 755 "{{ edx_ansible_venv_dir }}"
+  become: yes
+  become_user: root
+
+- name: Ensure directory owner for Install edx_ansible venv requirements
+  command: chown -R "{{ edx_ansible_user }}" "{{ edx_ansible_venv_dir }}"
+  become: yes
+  become_user: root
+
 - name: Install edx_ansible venv requirements
   pip:
     requirements: "{{ edx_ansible_requirements_file }}"


### PR DESCRIPTION

Make sure that the following steps are done before merging

  - [ ] A devops team member has commented with :+1:
  - [ ] are you adding any new default values that need to be overridden when this goes live?
    - [ ] Open a ticket (DEVOPS) to make sure that they have been added to secure vars.
    - [ ] Add an entry to the CHANGELOG.
