### PR TITLE
Always reboot when taking an AMI

### DIFF
--- a/util/vpc-tools/abbey.py
+++ b/util/vpc-tools/abbey.py
@@ -701,7 +701,7 @@ def create_ami(instance_id, name, description):
     params = {'instance_id': instance_id,
               'name': name,
               'description': description,
-              'no_reboot': True}
+              'no_reboot': False}
 
     AWS_API_WAIT_TIME = 1
     image_id = ec2.create_image(**params)


### PR DESCRIPTION
Not doing this means we can't guarantee filesystem integrity
and we've seen this bear out recently when several 16.04 instances had 0
length minos installs (the last task to run before the AMI is cut)