### PR TITLE
Added Vary header to credentials /static/ path

### DIFF
--- a/playbooks/roles/credentials/templates/edx/app/nginx/sites-available/credentials.j2
+++ b/playbooks/roles/credentials/templates/edx/app/nginx/sites-available/credentials.j2
@@ -54,6 +54,10 @@ server {
     root {{ CREDENTIALS_STATIC_ROOT }};
     add_header Cache-Control "max-age=31536000";
     add_header 'Access-Control-Allow-Origin' $cors_origin;
+
+    # Inform downstream caches to take certain headers into account when reading/writing to cache.
+    add_header 'Vary' 'Accept-Encoding,Origin';
+
     try_files /$file =404;
   }
 


### PR DESCRIPTION
This header will provide more information to downstream caches so they know which headers to consider when determining a match. This is especially important to ensure browsers do not cache incorrect CORS headers when switching between sites/tenants.

DEVOPS-5807