### PR TITLE
Make it possible to run the newrelic play on a box without ec2 access

### DIFF
--- a/playbooks/edx-east/newrelic.yml
+++ b/playbooks/edx-east/newrelic.yml
@@ -1,5 +1,7 @@
 # Run newrelic against a set of machines by tag.
 # ansible-playbook -i ec2.py --limit "tag_cluster_mongo" newrelic.yml -e NEWRELIC_LICENSE_KEY='SET_ME' -v
+# You can also pass in -e COMMON_ENVIRONMENT=foo -e COMMON_DEPLOYMENT=bar -e CLUSTER_NAME=baz if you want
+# to skip looking at ec2 tags.
 - name: Deploy Newrelic Server Monitoring
   hosts: all
   become: True
@@ -16,10 +18,12 @@
         region: "{{ ec2_region }}"
         state: "list"
       register: instance_tags
+      when: not COMMON_ENVIRONMENT and not COMMON_DEPLOYMENT
     - name: Set labels from EDC
       set_fact:
         COMMON_ENVIRONMENT: "{{ instance_tags.tags.environment }}"
         COMMON_DEPLOYMENT: "{{ instance_tags.tags.deployment }}"
         CLUSTER_NAME: "{{ instance_tags.tags.cluster }}"
+      when: not COMMON_ENVIRONMENT and not COMMON_DEPLOYMENT
   roles:
     - role: newrelic


### PR DESCRIPTION
Many of our machines aren't granted DescribeInstances because there's no
real need.  This let's you -e in those vars instead.

@edx/devops