### PR TITLE
Add check to see if hive metastore is initialized.

### DIFF
--- a/playbooks/roles/analytics_pipeline/tasks/main.yml
+++ b/playbooks/roles/analytics_pipeline/tasks/main.yml
@@ -230,9 +230,18 @@
     - install
     - install:configuration
 
+- name: Test if Hive metadata store schema exists
+  shell: ". {{ HADOOP_COMMON_CONF_DIR }}/hadoop-env.sh && {{ HIVE_HOME }}/bin/hive | tr '\n' ' '"
+  become_user: "{{ hadoop_common_user }}"
+  register: hive_metastore_info
+  tags:
+    - install
+    - install:configuration
+
 - name: Initialize Hive metadata store schema
   shell: ". {{ HADOOP_COMMON_CONF_DIR }}/hadoop-env.sh && {{ HIVE_HOME }}/bin/schematool -dbType mysql -initSchema"
   become_user: "{{ hadoop_common_user }}"
+  when: "'Version information not found in metastore' in hive_metastore_info.stderr"
   tags:
     - install
-    - install:base
+    - install:configuration


### PR DESCRIPTION
As part of a recent Hive upgrade, an additional task was added to analytics_pipeline role to initialize the Hive schema using a call to schematool. However, this was not idempotent – it failed when it had already been run. 

This PR addresses that, by checking first whether Hive finds version information in its metastore.  See DE-109.

Make sure that the following steps are done before merging

  - [ ] A devops team member has commented with :+1:
