### PR TITLE
Set a cluster name on new rabbit clusters

### DIFF
--- a/playbooks/roles/rabbitmq/defaults/main.yml
+++ b/playbooks/roles/rabbitmq/defaults/main.yml
@@ -43,6 +43,8 @@ RABBITMQ_VM_MEMORY_HIGH_WATERMARK: 0.4
 
 RABBITMQ_VERSION: 3.6.9-1
 
+RABBITMQ_CLUSTER_NAME: "{{ COMMON_ENVIRONMENT }}-{{ COMMON_DEPLOYMENT }}-rabbit"
+
 # Internal role variables below this line
 
 # option to force deletion of the mnesia dir

--- a/playbooks/roles/rabbitmq/tasks/main.yml
+++ b/playbooks/roles/rabbitmq/tasks/main.yml
@@ -316,3 +316,9 @@
   tags:
     - "install"
     - "install:app-configuration"
+
+- name: Set cluster name
+  command: "/usr/sbin/rabbitmqctl set_cluster_name  {{ RABBITMQ_CLUSTER_NAME }}"
+  tags:
+    - "install"
+    - "install:app-configuration"


### PR DESCRIPTION
This is also click-changeable in the UI, and seems to not impact running clusters from some testing. This gives you a better name than i-asdfasdfasdfasdf.rabbit.lol which is what you get by default on AWS. This is mostly seen in logs and rabbitmqctl output.

@edx/devops