### PR TITLE
Make edx_notes_api endpoint HTTPS aware

### DIFF
--- a/playbooks/roles/edx_notes_api/defaults/main.yml
+++ b/playbooks/roles/edx_notes_api/defaults/main.yml
@@ -103,6 +103,7 @@ edx_notes_api_gunicorn_port: 8120
 edx_notes_api_gunicorn_timeout: 300
 edx_notes_api_wsgi: notesserver.wsgi:application
 edx_notes_api_nginx_port: 18120
+edx_notes_api_ssl_nginx_port: 443
 edx_notes_api_manage: "{{ edx_notes_api_code_dir }}/manage.py" 
 edx_notes_api_requirements_base: "{{ edx_notes_api_code_dir }}/requirements"
 # Application python requirements

--- a/playbooks/roles/edx_notes_api/defaults/main.yml
+++ b/playbooks/roles/edx_notes_api/defaults/main.yml
@@ -103,7 +103,7 @@ edx_notes_api_gunicorn_port: 8120
 edx_notes_api_gunicorn_timeout: 300
 edx_notes_api_wsgi: notesserver.wsgi:application
 edx_notes_api_nginx_port: 18120
-edx_notes_api_ssl_nginx_port: 443
+edx_notes_api_ssl_nginx_port: 48120
 edx_notes_api_manage: "{{ edx_notes_api_code_dir }}/manage.py" 
 edx_notes_api_requirements_base: "{{ edx_notes_api_code_dir }}/requirements"
 # Application python requirements

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/edx_notes_api.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/edx_notes_api.j2
@@ -7,6 +7,16 @@ upstream {{ edx_notes_api_service_name }}_app_server {
 server {
   listen {{ edx_notes_api_nginx_port }} default_server;
 
+  {% if NGINX_ENABLE_SSL %}
+
+  listen {{ edx_notes_api_ssl_nginx_port }} ssl;
+
+  ssl_certificate /etc/ssl/certs/{{ NGINX_SSL_CERTIFICATE|basename }};
+  ssl_certificate_key /etc/ssl/private/{{ NGINX_SSL_KEY|basename }};
+  # request the browser to use SSL for all connections
+  add_header Strict-Transport-Security "max-age=31536000; includeSubDomains";
+  {% endif %}
+
   {% include "common-settings.j2" %}
 
   # Prevent invalid display courseware in IE 10+ with high privacy settings


### PR DESCRIPTION
The edx-notes API endpoint isn't HTTPS aware by default, but setting:

```
NGINX_REDIRECT_TO_HTTPS: true
```

does force HTTP requests to HTTPS:

https://github.com/edx/configuration/blob/0271c34899f7d8b6208787c0def1ea66b58e7ae6/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/edx_notes_api.j2#L17

The resulting HTTPS request connects to whatever Nginx service is defined as `default` (in most cases, the LMS).

This PR enables HTTPS when:

```
NGINX_ENABLE_SSL: true
```

One thing I'm unsure of is whether or not to set a different default port number for the newly created variable `edx_notes_api_ssl_nginx_port`. Other services have seemingly random port numbers assigned. e.g.:

- [EDXAPP_LMS_SSL_NGINX_PORT: 48000](https://github.com/edx/configuration/blob/a3b27e91e2f46ac3a12f22b5421331e587e33559/playbooks/roles/edxapp/defaults/main.yml#L275)
- [EDXAPP_CMS_SSL_NGINX_PORT: 48010](https://github.com/edx/configuration/blob/a3b27e91e2f46ac3a12f22b5421331e587e33559/playbooks/roles/edxapp/defaults/main.yml#L278)
- [ECOMMERCE_SSL_NGINX_PORT: 48130](https://github.com/edx/configuration/blob/2656eb9f36bcdd9283fe34a0ec95fc0de263caee/playbooks/roles/ecommerce/defaults/main.yml#L21)
- [INSIGHTS_NGINX_SSL_PORT: "18113"](https://github.com/edx/configuration/blob/2656eb9f36bcdd9283fe34a0ec95fc0de263caee/playbooks/roles/insights/defaults/main.yml#L149)

Also, the newly created variable doesn't follow the convention of using all uppercase letters for variables that are often changed. But in the edx_notes_api role, neither does `edx_notes_api_nginx_port` (among others). 

---

Make sure that the following steps are done before merging

  - [ ] A devops team member has commented with :+1:
  - [ ] are you adding any new default values that need to be overridden when this goes live?
    - [ ] Open a ticket (DEVOPS) to make sure that they have been added to secure vars.
    - [ ] Add an entry to the CHANGELOG.
