### PR TITLE
Better overridability of Graphite/Carbon configuration.

### DIFF
--- a/playbooks/roles/config-encoders/filter_plugins/config_encoders.py
+++ b/playbooks/roles/config-encoders/filter_plugins/config_encoders.py
@@ -370,12 +370,6 @@ def encode_ini(
             vals = [val]
 
         for item in vals:
-            if (
-                    len(quote) == 0 and
-                    isinstance(item, basestring) and
-                    len(item) == 0):
-                item = '""'
-
             if item is not None:
                 rv += "%s%s%s%s%s\n" % (
                     prop, delimiter, quote, _escape(item, quote), quote)

--- a/playbooks/roles/graphite/defaults/main.yml
+++ b/playbooks/roles/graphite/defaults/main.yml
@@ -54,33 +54,54 @@ graphite_group: "graphite"
 GRAPHITE_NGINX_PORT: 6000
 GRAPHITE_GUNICORN_WORKERS: 3
 
-CARBON_LISTEN_ADDR: 0.0.0.0
+carbon_listen_addr: 0.0.0.0
+
+carbon_storage_dir: "{{ graphite_storage_root }}"
+carbon_cache_write_strategy: max
+carbon_max_cache_size: inf
+carbon_use_flow_control: True
+carbon_whisper_fallocate_create: True
+carbon_max_creates_per_minute: 100
+carbon_max_updates_per_second: 1000
+carbon_line_receiver_interface: "{{ carbon_listen_addr }}"
+carbon_pickle_receiver_interface: "{{ carbon_listen_addr }}"
+carbon_cache_query_interface: "{{ carbon_listen_addr }}"
+carbon_use_insecure_unpickler: False
+carbon_log_cache_hits: False
+carbon_log_cache_queue_sorts: True
+carbon_log_listener_connections: True
+carbon_log_updates: False
+carbon_enable_log_rotation: True
+carbon_whisper_autoflush: False
+carbon_default_line_receiver_port: 2003
+carbon_default_pickle_receiver_port: 2004
+carbon_default_cache_query_port: 7002
 
 CARBON_CONF:
   cache:
     USER: "{{ carbon_user }}"
     STORAGE_DIR: "{{ graphite_storage_root }}"
-    CACHE_WRITE_STRATEGY: max
-    MAX_CACHE_SIZE: inf
-    USE_FLOW_CONTROL:  True
-    WHISPER_FALLOCATE_CREATE: True
-    MAX_CREATES_PER_MINUTE: 100
-    MAX_UPDATES_PER_SECOND: 1000
-    LINE_RECEIVER_INTERFACE: "{{ CARBON_LISTEN_ADDR }}"
-    PICKLE_RECEIVER_INTERFACE: "{{ CARBON_LISTEN_ADDR }}"
-    USE_INSECURE_UNPICKLER: False
-    CACHE_QUERY_INTERFACE: "{{ CARBON_LISTEN_ADDR }}"
-    LOG_CACHE_HITS: False
-    LOG_CACHE_QUEUE_SORTS: True
-    LOG_LISTENER_CONNECTIONS: True
-    LOG_UPDATES: False
-    ENABLE_LOGROTATION: True
-    WHISPER_AUTOFLUSH: False
+    CACHE_WRITE_STRATEGY: "{{ carbon_cache_write_strategy }}"
+    MAX_CACHE_SIZE: "{{ carbon_max_cache_size }}"
+    USE_FLOW_CONTROL: "{{ carbon_use_flow_control }}"
+    WHISPER_FALLOCATE_CREATE: "{{ carbon_whisper_fallocate_create }}"
+    MAX_CREATES_PER_MINUTE: "{{ carbon_max_creates_per_minute }}"
+    MAX_UPDATES_PER_SECOND: "{{ carbon_max_updates_per_second }}"
+    LINE_RECEIVER_INTERFACE: "{{ carbon_listen_addr }}"
+    PICKLE_RECEIVER_INTERFACE: "{{ carbon_listen_addr }}"
+    USE_INSECURE_UNPICKLER: "{{ carbon_use_insecure_unpickler }}"
+    CACHE_QUERY_INTERFACE: "{{ carbon_listen_addr }}"
+    LOG_CACHE_HITS: "{{ carbon_log_cache_hits }}"
+    LOG_CACHE_QUEUE_SORTS: "{{ carbon_log_cache_queue_sorts }}"
+    LOG_LISTENER_CONNECTIONS: "{{ carbon_log_listener_connections }}"
+    LOG_UPDATES: "{{ carbon_log_updates }}"
+    ENABLE_LOGROTATION: "{{ carbon_enable_log_rotation }}"
+    WHISPER_AUTOFLUSH: "{{ carbon_whisper_autoflush }}"
 
   "cache:1":
-    LINE_RECEIVER_PORT: 2003
-    PICKLE_RECEIVER_PORT: 2004
-    CACHE_QUERY_PORT: 7002
+    LINE_RECEIVER_PORT: "{{ carbon_default_line_receiver_port }}"
+    PICKLE_RECEIVER_PORT: "{{ carbon_default_line_receiver_port }}"
+    CACHE_QUERY_PORT: "{{ carbon_default_cache_query_port }}"
 
 CARBON_STORAGE_SCHEMAS:
   carbon:
@@ -113,4 +134,4 @@ GRAPHITE_API_CONF:
   search_index: "{{ graphite_root }}/api/index"
   whisper:
     directories:
-      - "{{ graphite_storage_root }}"
+      - "{{ graphite_storage_root }}/whisper"

--- a/playbooks/roles/graphite/templates/carbon/conf/storage-aggregation.conf.j2
+++ b/playbooks/roles/graphite/templates/carbon/conf/storage-aggregation.conf.j2
@@ -11,4 +11,4 @@
 #  xFilesFactor: Ratio of valid data points required for aggregation to the next retention to occur
 #  aggregationMethod: function to apply to data points for aggregation
 
-{{ CARBON_STORAGE_AGGREGATIONS | encode_ini }}
+{{ CARBON_STORAGE_AGGREGATIONS_OVERRIDE | default(CARBON_STORAGE_AGGREGATIONS) | encode_ini }}

--- a/playbooks/roles/graphite/templates/carbon/conf/storage-schemas.conf.j2
+++ b/playbooks/roles/graphite/templates/carbon/conf/storage-schemas.conf.j2
@@ -1,4 +1,4 @@
 # Schema definitions for Whisper files. Entries are scanned in order,
 # and first match wins. This file is scanned for changes every 60 seconds.
 
-{{ CARBON_STORAGE_SCHEMAS | encode_ini }}
+{{ CARBON_STORAGE_SCHEMAS_OVERRIDE | default(CARBON_STORAGE_SCHEMAS) | encode_ini }}


### PR DESCRIPTION
The current setup requires overriding the entire configuration, and this makes it granular.

I also fixed a bug with bad INI encoding.
---

Make sure that the following steps are done before merging

  - [ ] A devops team member has commented with :+1:
  - [ ] are you adding any new default values that need to be overridden when this goes live?
    - [ ] Open a ticket (DEVOPS) to make sure that they have been added to secure vars.
    - [ ] Add an entry to the CHANGELOG.
