### PR TITLE
Switch to gp2 disks

### DIFF
--- a/playbooks/roles/launch_ec2/tasks/main.yml
+++ b/playbooks/roles/launch_ec2/tasks/main.yml
@@ -50,6 +50,7 @@
       - device_name: /dev/sda1
         volume_size: "{{ root_ebs_size }}"
         delete_on_termination: true
+        volume_type: "gp2"
     zone: "{{ zone }}"
     instance_profile_name: "{{ instance_profile_name }}"
     user_data: "{{ user_data }}"


### PR DESCRIPTION
They cost twice as much, but in our usage scenario this means $5/month instead of $2.50/month and they shave several minutes off of sandbox builds (and will probably aid other builds).
    
The continuous_delivery launch_instance playbook is already using gp2

@edx/devops 