### PR TITLE
Parameterize Dockerfiles for Open edX releases

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -37,6 +37,35 @@ make docker.pkg.<service>    # Package <service> for publishing to Dockerhub. Th
 make docker.push.<service>   # Push <service> to Dockerhub as latest.
 ```
 
+
+## Image naming
+
+Images built from master branches are named `edxops/<service>`, for example,
+`edxops/edxapp`.  Images built from Open edX release branches include the
+short release name: `edxops/ficus/edxapp`.  Both images will have a `:latest`
+version.
+
+
+## Build arguments
+
+Dockerfiles make use of these build arguments:
+
+* `OPENEDX_RELEASE` is the release branch to use.  It defaults to "master".
+  To use an Open edX release, provide the full branch name:
+
+  ```
+  --build-arg OPENEDX_RELEASE=open-release/ficus.master
+  ```
+
+* `IMAGE_PREFIX` is the release branch component to add to images.  It defaults
+  to an empty string for master builds.  For Open edX release, use the short
+  name of the release, with a trailing slash:
+
+  ```
+  --build-arg IMAGE_PREFIX=ficus/
+  ```
+
+
 ## Conventions
 
 In order to facilitate development, Dockerfiles should be based on

--- a/docker/build/edxapp/Dockerfile
+++ b/docker/build/edxapp/Dockerfile
@@ -8,7 +8,8 @@
 # with the currently checked-out configuration repo.
 
 
-FROM edxops/xenial-common:latest
+ARG IMAGE_PREFIX
+FROM edxops/${IMAGE_PREFIX}xenial-common:latest
 MAINTAINER edxops
 USER root
 CMD ["/edx/app/supervisor/venvs/supervisor/bin/supervisord", "-n", "--configuration", "/edx/app/supervisor/supervisord.conf"]
@@ -18,9 +19,12 @@ WORKDIR /edx/app/edx_ansible/edx_ansible/docker/plays
 
 COPY docker/build/edxapp/ansible_overrides.yml /
 
+ARG OPENEDX_RELEASE=master
+ENV OPENEDX_RELEASE=${OPENEDX_RELEASE}
 RUN sudo /edx/app/edx_ansible/venvs/edx_ansible/bin/ansible-playbook edxapp.yml \
     -c local -i '127.0.0.1,' \
     -t 'install,assets,devstack' \
+    --extra-vars=edx_platform_version=${OPENEDX_RELEASE} \
     --extra-vars="@/ansible_overrides.yml"
 
 EXPOSE 18000 18010

--- a/docker/build/edxapp/ansible_overrides.yml
+++ b/docker/build/edxapp/ansible_overrides.yml
@@ -8,7 +8,6 @@ EDXAPP_MONGO_HOSTS:
 devstack: true
 migrate_db: false
 mongo_enable_journal: false
-edx_platform_version: 'master'
 edxapp_npm_production: "no"
 
 EDXAPP_LMS_GUNICORN_EXTRA_CONF: 'reload = True'

--- a/docker/build/xenial-common/Dockerfile
+++ b/docker/build/xenial-common/Dockerfile
@@ -1,5 +1,5 @@
 FROM ubuntu:xenial
-MAINTAINER edxops 
+MAINTAINER edxops
 
 # Set locale to UTF-8 which is not the default for docker.
 # See the links for details:
@@ -10,7 +10,8 @@ ENV LANG C.UTF-8
 
 ENV ANSIBLE_REPO="https://github.com/edx/ansible"
 ENV CONFIGURATION_REPO="https://github.com/edx/configuration.git"
-ENV CONFIGURATION_VERSION="master"
+ARG OPENEDX_RELEASE=master
+ENV CONFIGURATION_VERSION="${OPENEDX_RELEASE}"
 
 ADD util/install/ansible-bootstrap.sh /tmp/ansible-bootstrap.sh
 RUN chmod +x /tmp/ansible-bootstrap.sh


### PR DESCRIPTION
Configuration Pull Request
---

Add some parameterization to the Dockerfiles so we can make images for Open edX releases. (Much more is needed to complete that work, this is a start).

This provides for choosing a different branch other than master ($OPENEDX_RELEASE), and for adding a component to the image names ($IMAGE_PREFIX).

The IMAGE_PREFIX would be empty for master builds, so the images will be named as they are today: "edxops/edxapp:latest".  For Ficus, IMAGE_PREFIX would be "ficus/", so the image would be "edxops/ficus/edxapp:latest".

These files use a feature newly available in Docker 17.05: the use of ARGS in the FROM line.

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] Have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?
