### PR TITLE
nginx: Make it possible to add custom settings to site configuration for Studio and LMS.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+- Role: nginx
+  - Added `NGINX_EDXAPP_CMS_APP_EXTRA`, which makes it possible to add custom settings to the site configuration for Studio.
+  - Added `NGINX_EDXAPP_LMS_APP_EXTRA`, which makes it possible to add custom settings to the site configuration for the LMS.
+
 - Role: edxapp
   - DOC_LINK_BASE settings have been removed, replaced by HELP_TOKENS_BOOKS
 

--- a/playbooks/roles/nginx/defaults/main.yml
+++ b/playbooks/roles/nginx/defaults/main.yml
@@ -153,3 +153,8 @@ NGINX_CREATE_HTPASSWD_FILE: >
     XQUEUE_ENABLE_BASIC_AUTH|bool or
     XSERVER_ENABLE_BASIC_AUTH|bool
   }}
+
+# Extra settings to add to site configuration for Studio
+NGINX_EDXAPP_CMS_APP_EXTRA: ""
+# Extra settings to add to site configuration for LMS
+NGINX_EDXAPP_LMS_APP_EXTRA: ""

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/cms.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/cms.j2
@@ -104,6 +104,8 @@ error_page {{ k }} {{ v }};
 
     proxy_redirect off;
     proxy_pass http://cms-backend;
+
+    {{ NGINX_EDXAPP_CMS_APP_EXTRA }}
   }
 
   location / {

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
@@ -149,6 +149,8 @@ error_page {{ k }} {{ v }};
 
     proxy_redirect off;
     proxy_pass http://lms-backend;
+
+    {{ NGINX_EDXAPP_LMS_APP_EXTRA }}
   }
 
   location / {


### PR DESCRIPTION
Part of the scope of [OC-2506](https://tasks.opencraft.com/browse/OC-2506).

At OpenCraft, we ran into a situation where we needed to be able to override the default value of `proxy_read_timeout` for `cms` and `lms` sites. The changes in this PR are generic, though, and make it possible to add custom settings of any kind to the configuration of these sites.

**Test instructions**

1. SSH into the newest app server for the Cloudera instance (see internal ticket for details).
2. Verify that `/edx/app/nginx/sites-available/{cms,lms}` contain custom value for `proxy_read_timeout` setting.

**Reviewers**

- [x] @bdero 
- [ ] edX: TBD

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [x] ~~Are you adding any new default values that need to be overridden when this change goes live?~~ **No** If so: ... 
  - [x] ~~Have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?~~ No (minor change that does not affect existing deployments)
