### PR TITLE
Added yarn to IDAs

### DIFF
--- a/playbooks/roles/credentials/meta/main.yml
+++ b/playbooks/roles/credentials/meta/main.yml
@@ -9,12 +9,12 @@
 #
 ##
 # Role includes for role credentials
-# 
+#
 # Example:
 #
 # dependencies:
 #   - {
-#   role: my_role 
+#   role: my_role
 #   my_role_var0: "foo"
 #   my_role_var1: "bar"
 # }
@@ -30,3 +30,4 @@ dependencies:
     edx_service_packages:
       debian: "{{ credentials_debian_pkgs }}"
       redhat: "{{ credentials_redhat_pkgs }}"
+  - yarn

--- a/playbooks/roles/discovery/meta/main.yml
+++ b/playbooks/roles/discovery/meta/main.yml
@@ -9,12 +9,12 @@
 #
 ##
 # Role includes for role discovery
-# 
+#
 # Example:
 #
 # dependencies:
 #   - {
-#   role: my_role 
+#   role: my_role
 #   my_role_var0: "foo"
 #   my_role_var1: "bar"
 # }
@@ -30,3 +30,4 @@ dependencies:
     edx_service_packages:
       debian: "{{ discovery_debian_pkgs }}"
       redhat: "{{ discovery_redhat_pkgs }}"
+  - yarn

--- a/playbooks/roles/ecommerce/meta/main.yml
+++ b/playbooks/roles/ecommerce/meta/main.yml
@@ -9,7 +9,7 @@
 #
 ##
 # Role includes for role ecommerce
-# 
+#
 dependencies:
   - common
   - supervisor
@@ -28,3 +28,4 @@ dependencies:
     when: "{{ ECOMMERCE_ENABLE_COMPREHENSIVE_THEMING }}"
 
   - oraclejdk
+  - yarn

--- a/playbooks/roles/edx_django_service/meta/main.yml
+++ b/playbooks/roles/edx_django_service/meta/main.yml
@@ -11,3 +11,4 @@ dependencies:
     edx_service_packages:
       debian: "{{ edx_django_service_debian_pkgs }}"
       redhat: []
+  - yarn

--- a/playbooks/roles/yarn/defaults/main.yml
+++ b/playbooks/roles/yarn/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+# This file is intentionally empty.

--- a/playbooks/roles/yarn/tasks/main.yml
+++ b/playbooks/roles/yarn/tasks/main.yml
@@ -1,0 +1,41 @@
+---
+# Configures Yarn package sources, and installs the package.
+# Adapted from https://github.com/fubarhouse/ansible-role-yarn.
+
+- name: "Yarn | GPG"
+  become: yes
+  become_user: root
+  apt_key:
+    url: https://dl.yarnpkg.com/debian/pubkey.gpg
+    state: present
+
+- name: "Yarn | Ensure Debian sources list file exists"
+  become: yes
+  become_user: root
+  file:
+    path: /etc/apt/sources.list.d/yarn.list
+    owner: root
+    mode: 0644
+    state: touch
+
+- name: "Yarn | Ensure Debian package is in sources list"
+  become: yes
+  become_user: root
+  lineinfile:
+    dest: /etc/apt/sources.list.d/yarn.list
+    regexp: 'deb http://dl.yarnpkg.com/debian/ stable main'
+    line: 'deb http://dl.yarnpkg.com/debian/ stable main'
+    state: present
+
+- name: "Yarn | Update APT cache"
+  become: yes
+  become_user: root
+  apt:
+    update_cache: yes
+
+- name: "Yarn | Install"
+  become: yes
+  become_user: root
+  package:
+    name: yarn
+    state: latest


### PR DESCRIPTION
The credentials, discovery, ecommerce, and edx_django_service roles now include yarn as a replacement for npm.