### PR TITLE
Use ec2_remote_facts module instead of custom module

### DIFF
--- a/playbooks/roles/launch_ec2/tasks/main.yml
+++ b/playbooks/roles/launch_ec2/tasks/main.yml
@@ -5,10 +5,11 @@
 
 - name: lookup tags for terminating existing instance
   local_action:
-    module: ec2_lookup
+    module: ec2_remote_facts
     region: "{{ region }}"
-    tags:
-      Name: "{{ name_tag }}"
+    filters:
+      instance-state-name: running
+      "tag:Name": "{{ name_tag }}"
   register: tag_lookup
   when: terminate_instance == true
 
@@ -21,14 +22,14 @@
     module: ec2_2_1_1_0
     state: 'absent'
     region: "{{ region }}"
-    instance_ids: "{{tag_lookup.instance_ids}}"
+    instance_ids: "{{ tag_lookup.instances[0].id }}"
   when: terminate_instance == true and tag_lookup.instance_ids|length == 1
 
 - name: deregister instance from an an elb if it was in one
   local_action:
     module: ec2_elb
     region: "{{ region }}"
-    instance_id: "{{ tag_lookup.instance_ids[0] }}"
+    instance_id: "{{ tag_lookup.instances[0].id }}"
     ec2_elbs:
       - "{{ elb }}"
     state: absent


### PR DESCRIPTION
@edx/devops, Ansible 2.x includes the `ec2_remote_facts` module, can use that instead of custom `ec2_lookup` module. Thanks

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [x] Have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?
