### PR TITLE
Added default values for the credentials-related edxapp settings

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -554,6 +554,8 @@ EDXAPP_ECOMMERCE_API_URL: "http://localhost:8002/api/v2"
 # TODO (CCB) Remove this after all references in edx/edx-platform have been removed.
 EDXAPP_ECOMMERCE_API_SIGNING_KEY: "{{ EDXAPP_JWT_SECRET_KEY }}"
 EDXAPP_COURSE_CATALOG_API_URL: "http://localhost:8008/api/v1"
+EDXAPP_CREDENTIALS_INTERNAL_SERVICE_URL: "http://localhost:8005"
+EDXAPP_CREDENTIALS_PUBLIC_SERVICE_URL: "http://localhost:8005"
 
 # which access.py permission name to check in order to determine if a course about page is
 # visible. We default this to the legacy permission 'see_exists'.
@@ -875,6 +877,8 @@ generic_cache_config: &default_generic_cache
   KEY_FUNCTION:  'util.memcache.safe_key'
 
 generic_env_config:  &edxapp_generic_env
+  CREDENTIALS_INTERNAL_SERVICE_URL: "{{ EDXAPP_CREDENTIALS_INTERNAL_SERVICE_URL }}"
+  CREDENTIALS_PUBLIC_SERVICE_URL: "{{ EDXAPP_CREDENTIALS_PUBLIC_SERVICE_URL }}"
   ECOMMERCE_PUBLIC_URL_ROOT: "{{ EDXAPP_ECOMMERCE_PUBLIC_URL_ROOT }}"
   ECOMMERCE_API_URL: "{{ EDXAPP_ECOMMERCE_API_URL }}"
   ENTERPRISE_API_URL: "{{ EDXAPP_ENTERPRISE_API_URL }}"


### PR DESCRIPTION
Local defaults are now in place for CREDENTIALS_INTERNAL_SERVICE_URL and CREDENTIALS_PUBLIC_SERVICE_URL.

LEARNER-1162