### PR TITLE
Allow configurable activation email support link.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 - Role: edxapp
+  - Added the EDXAPP_ACTIVATION_EMAIL_SUPPORT_LINK URL with default value [https://support.edx.org/hc/en-us/articles/227340127-Why-haven-t-I-received-my-activation-email-].
+
+- Role: edxapp
   - Added the EDXAPP_SHOW_HEADER_LANGUAGE_SELECTOR feature flag with default value [false]
   - Added the EDXAPP_SHOW_FOOTER_LANGUAGE_SELECTOR feature flag with default value [false]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 - Role: edxapp
-  - Added the EDXAPP_ACTIVATION_EMAIL_SUPPORT_LINK URL with default value [https://support.edx.org/hc/en-us/articles/227340127-Why-haven-t-I-received-my-activation-email-].
+  - Added the EDXAPP_ACTIVATION_EMAIL_SUPPORT_LINK URL with default value `''`.
 
 - Role: edxapp
   - Added the EDXAPP_SHOW_HEADER_LANGUAGE_SELECTOR feature flag with default value [false]

--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -342,6 +342,7 @@ EDXAPP_ENABLE_MKTG_SITE: false
 EDXAPP_MKTG_URL_LINK_MAP: {}
 EDXAPP_MKTG_URLS: {}
 EDXAPP_SUPPORT_SITE_LINK: ''
+EDXAPP_ACTIVATION_EMAIL_SUPPORT_LINK: 'https://support.edx.org/hc/en-us/articles/227340127-Why-haven-t-I-received-my-activation-email-'
 EDXAPP_EDXMKTG_USER_INFO_COOKIE_NAME: "edx-user-info"
 # Set this sets the url for static files
 # Override this var to use a CDN
@@ -960,6 +961,7 @@ generic_env_config:  &edxapp_generic_env
   MKTG_URL_LINK_MAP: "{{ EDXAPP_MKTG_URL_LINK_MAP }}"
   MKTG_URLS: "{{ EDXAPP_MKTG_URLS }}"
   SUPPORT_SITE_LINK: "{{ EDXAPP_SUPPORT_SITE_LINK }}"
+  ACTIVATION_EMAIL_SUPPORT_LINK: "{{ EDXAPP_ACTIVATION_EMAIL_SUPPORT_LINK }}"
   CDN_VIDEO_URLS: "{{ CDN_VIDEO_URLS }}"
   PERFORMANCE_GRAPHITE_URL: "{{ PERFORMANCE_GRAPHITE_URL }}"
 

--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -342,7 +342,7 @@ EDXAPP_ENABLE_MKTG_SITE: false
 EDXAPP_MKTG_URL_LINK_MAP: {}
 EDXAPP_MKTG_URLS: {}
 EDXAPP_SUPPORT_SITE_LINK: ''
-EDXAPP_ACTIVATION_EMAIL_SUPPORT_LINK: 'https://support.edx.org/hc/en-us/articles/227340127-Why-haven-t-I-received-my-activation-email-'
+EDXAPP_ACTIVATION_EMAIL_SUPPORT_LINK: ''
 EDXAPP_EDXMKTG_USER_INFO_COOKIE_NAME: "edx-user-info"
 # Set this sets the url for static files
 # Override this var to use a CDN


### PR DESCRIPTION
Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [x] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [x] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [x] Add an entry to the CHANGELOG.
  - [ ] Have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)? -- (This link does not work for me; "Page not found")

---

This is a child PR of [#15161 from edx/edx-platform](https://github.com/edx/edx-platform/pull/15161), where we allow the activation email support link to be configurable.