### PR TITLE
Updated edxapp Elasticsearch config 

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -97,7 +97,7 @@ EDXAPP_MYSQL_HOST: 'localhost'
 EDXAPP_MYSQL_PORT: '3306'
 
 EDXAPP_SEARCH_HOST: 'localhost'
-EDXAPP_SEARCH_PORT: '9200'
+EDXAPP_SEARCH_PORT: 9200
 
 # list of dictionaries of the format
 # { 'host': 'hostname', 'port': 'portnumber', 'otherconfigsuchas use_ssl': 'True' }


### PR DESCRIPTION
The urllib3 library (used by the Elasticsearch Python library) expects ports to be integers, not strings, when passed as kwargs. Thus, we set the port to be an integer in Ansible.