### PR TITLE
Add the throttle concurrents plugin to jenkins master.

### DIFF
--- a/playbooks/roles/jenkins_master/defaults/main.yml
+++ b/playbooks/roles/jenkins_master/defaults/main.yml
@@ -73,6 +73,7 @@ jenkins_plugins:
     - { name: "ssh-credentials", version: "1.11" }
     - { name: "ssh-slaves", version: "1.9" }
     - { name: "shiningpanda", version: "0.23" }
+    - { name: "throttle-concurrents", version: "1.9.0" }
     - { name: "tmpcleaner", version: "1.1" }
     - { name: "token-macro", version: "1.10" }
     - { name: "timestamper", version: "1.5.15" }


### PR DESCRIPTION
We need this on olivex jenkins because it is used by multiple jobs.

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] Have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?
