### PR TITLE
Updated PhantomJs version

### DIFF
--- a/playbooks/roles/browsers/defaults/main.yml
+++ b/playbooks/roles/browsers/defaults/main.yml
@@ -42,7 +42,7 @@ chromedriver_version: 2.27
 chromedriver_url: "http://chromedriver.storage.googleapis.com/{{ chromedriver_version }}/chromedriver_linux64.zip"
 
 # PhantomJS
-phantomjs_version: "phantomjs-1.9.8-linux-x86_64"
+phantomjs_version: "phantomjs-2.1.1-linux-x86_64"
 phantomjs_tarfile: "{{ phantomjs_version }}.tar.bz2"
 phantomjs_url: "https://bitbucket.org/ariya/phantomjs/downloads/{{ phantomjs_tarfile }}"
 


### PR DESCRIPTION
Configuration Pull Request
Update PhantomJs version as the version (1.9.8) uses an old version of JavaScriptCore. That causes some tests to fail on PhantomJs. The issue is now resolved in the version (2.1.1).

----------------------------------------------------------------------------------------------------

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] Have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?
