### PR TITLE
Stop killing instructor tasks prematurely

### DIFF
--- a/playbooks/roles/stop_all_edx_services/handlers/main.yml
+++ b/playbooks/roles/stop_all_edx_services/handlers/main.yml
@@ -56,7 +56,7 @@
 
 # Celery and Supervisord should not be killed because they may have long running tasks that need to finish
 - name: kill processes by user
-  shell: pgrep -u {{ item }} -lf | grep -v celery | grep -v supervisord | grep -v gunicorn |  awk '{ print $1}' | xargs -I {} kill {} || true
+  shell: pgrep -u {{ item }} -laf | grep -v celery | grep -v supervisord | grep -v gunicorn |  awk '{ print $1}' | xargs -I {} kill {} || true
   with_items:
     - www-data
     - rabbitmq


### PR DESCRIPTION
# [EDU-416](https://openedx.atlassian.net/browse/EDUCATOR-416)

We've realized that celery workers report their process name differently
on 16.04, so we need to add this additional -a flag to ensure workers
are not killed prematurely.

FYI @adampalay @noraiz-anwar @jibsheet

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?
