### PR TITLE
PLAT-1228 Support bok-choy in edxapp Docker devstack

### DIFF
--- a/docker/build/edxapp/ansible_overrides.yml
+++ b/docker/build/edxapp/ansible_overrides.yml
@@ -26,3 +26,12 @@ EDXAPP_INSTALL_PRIVATE_REQUIREMENTS: true
 EDXAPP_SEARCH_HOST: 'edx.devstack.elasticsearch'
 
 EDXAPP_PYTHON_SANDBOX: false
+
+edxapp_debian_pkgs_extra:
+  - mongodb-clients
+  - mysql-client
+
+edxapp_environment_extra:
+  SELENIUM_BROWSER: 'firefox'
+  SELENIUM_HOST: 'edx.devstack.firefox'
+  SELENIUM_PORT: '4444'

--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -747,7 +747,7 @@ edxapp_helper_scripts:
     - edxapp-update-assets
     - edxapp-shell
 
-edxapp_environment:
+edxapp_environment_default:
   LANG: "{{ EDXAPP_LANG }}"
   NO_PREREQ_INSTALL: "{{ EDXAPP_NO_PREREQ_INSTALL }}"
   SKIP_WS_MIGRATIONS: 1
@@ -760,6 +760,10 @@ edxapp_environment:
   # be updated to /edx/etc/edxapp when the switch to
   # yaml based configs is complete
   CONFIG_ROOT: "{{ edxapp_app_dir }}"
+
+edxapp_environment_extra: {}
+
+edxapp_environment: "{{ edxapp_environment_default | combine(edxapp_environment_extra) }}"
 
 edxapp_generic_doc_store_config: &edxapp_generic_default_docstore
   db: "{{ EDXAPP_MONGO_DB_NAME }}"
@@ -1253,7 +1257,7 @@ edxapp_requirements_with_github_urls:
 
 edxapp_chrislea_ppa: "ppa:chris-lea/node.js"
 
-edxapp_debian_pkgs:
+edxapp_debian_pkgs_default:
   # for compiling the virtualenv
   # (only needed if wheel files aren't available)
   - s3cmd
@@ -1275,6 +1279,8 @@ edxapp_debian_pkgs:
   - libffi-dev
   - python-dev
   - libsqlite3-dev
+
+edxapp_debian_pkgs_extra: []
 
 # Deploy Specific Vars
 edxapp_lms_variant: lms

--- a/playbooks/roles/edxapp/tasks/main.yml
+++ b/playbooks/roles/edxapp/tasks/main.yml
@@ -124,7 +124,9 @@
     name: "{{ item }}"
     state: present
     update_cache: yes
-  with_items: "{{ edxapp_debian_pkgs }}"
+  with_flattened:
+    - "{{ edxapp_debian_pkgs_default }}"
+    - "{{ edxapp_debian_pkgs_extra }}"
   tags:
     - install
     - install:base


### PR DESCRIPTION
Making the following changes to enable running bok-choy tests in devstack Docker images:

* Install the mongo and mysql clients required for test setup (*only* for devstack Docker images)
* Set some environment variables to point selenium at the correct separate container running a selenium standalone server with Firefox
* Refactor the Debian package list and environment variable settings to be cleanly overridden in order to accomplish the goals above

In the long term, we probably want to refactor the test setup in order to avoid needing the database clients in the base edx-platform container (they add almost 250 MB to its size).  But the immediate goal is to just get it working.

---

Make sure that the following steps are done before merging:

  - [x] A DevOps team member has approved the PR.
  - [x] Are you adding any new default values that need to be overridden when this change goes live? - No
  - [x] Have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?
