### PR TITLE
Remove outdated `SUPPORT_URL` setting in `INSIGHTS_CONFIG`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -271,3 +271,6 @@
 
 - Role: insights
   - Removed `INSIGHTS_FEEDBACK_EMAIL` which is no longer used, as it was deemed redundant with `INSIGHTS_SUPPORT_EMAIL`.
+
+- Role: insights
+  - Removed `SUPPORT_EMAIL` setting from `INSIGHTS_CONFIG`, as it is was replaced by `SUPPORT_URL`.

--- a/playbooks/roles/insights/defaults/main.yml
+++ b/playbooks/roles/insights/defaults/main.yml
@@ -19,8 +19,6 @@ INSIGHTS_MKTG_BASE: 'http://example.com'
 INSIGHTS_LOGOUT_URL: '{{ INSIGHTS_MKTG_BASE }}/accounts/logout/'
 INSIGHTS_PRIVACY_POLICY_URL: '{{ INSIGHTS_MKTG_BASE }}/privacy-policy'
 INSIGHTS_TERMS_OF_SERVICE_URL: '{{ INSIGHTS_MKTG_BASE }}/terms-service'
-# Delete the 'INSIGHTS_SUPPORT_URL' once the release will out for 'INSIGHTS_SUPPORT_EMAIL'
-INSIGHTS_SUPPORT_URL: ''
 INSIGHTS_SUPPORT_EMAIL: ''
 INSIGHTS_CMS_COURSE_SHORTCUT_BASE_URL: '{{ INSIGHTS_LMS_BASE }}/course'
 INSIGHTS_OAUTH2_SECRET: 'secret'
@@ -85,8 +83,6 @@ INSIGHTS_SESSION_EXPIRE_AT_BROWSER_CLOSE: false
 # This block of config is dropped into /edx/etc/insights.yml
 # and is read in by analytics_dashboard/settings/production.py
 INSIGHTS_CONFIG:
-  # Delete the 'SUPPORT_URL' once the release will out for 'SUPPORT_EMAIL'
-  SUPPORT_URL: '{{ INSIGHTS_SUPPORT_URL }}'
   SUPPORT_EMAIL: '{{ INSIGHTS_SUPPORT_EMAIL }}'
   DOCUMENTATION_LOAD_ERROR_URL: '{{ INSIGHTS_DOC_BASE }}/Reference.html#error-conditions'
   SEGMENT_IO_KEY: '{{ INSIGHTS_SEGMENT_IO_KEY }}'


### PR DESCRIPTION
See https://openedx.atlassian.net/servicedesk/customer/portal/3/DEVOPS-6004.

---

Make sure that the following steps are done before merging:

  - [x] A DevOps team member has approved the PR.
  - [x] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [x] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [x] Add an entry to the CHANGELOG.
  - [ ] Have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?
    - Probably not necessary for this (@jibsheet?)
      - Confirmed it's not necessary
