### PR TITLE
[ENT-290] Update default value of the audit modes setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+- Role: edxapp
+  - Updated default value of the EDXAPP_ENTERPRISE_COURSE_ENROLLMENT_AUDIT_MODES setting to ["audit", "honor"]
+
 - Role: edx_notes_api
   - Removed EDX_NOTES_API_ELASTICSEARCH_HOST.
   - Removed EDX_NOTES_API_ELASTICSEARCH_PORT.

--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -684,6 +684,7 @@ EDXAPP_ENTERPRISE_SERVICE_WORKER_USERNAME: "enterprise_worker"
 
 EDXAPP_ENTERPRISE_COURSE_ENROLLMENT_AUDIT_MODES:
   - audit
+  - honor
 
 # The assigned ICP license number for display in the platform footer
 EDXAPP_ICP_LICENSE: !!null


### PR DESCRIPTION
This PR updates the default value of the ENTERPRISE_COURSE_ENROLLMENT_AUDIT_MODES to also include "honor".

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] Have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?
