### PR TITLE
New base AMI

### DIFF
--- a/util/jenkins/ansible-provision.sh
+++ b/util/jenkins/ansible-provision.sh
@@ -127,9 +127,9 @@ fi
 
 if [[ -z $ami ]]; then
   if [[ $server_type == "full_edx_installation" ]]; then
-    ami="ami-cf244ad9"
+    ami="ami-134c1305"
   elif [[ $server_type == "ubuntu_16.04" || $server_type == "full_edx_installation_from_scratch" ]]; then
-    ami="ami-9dcfdb8a"
+    ami="ami-20631a36"
   fi
 fi
 


### PR DESCRIPTION
DEVOPS-6012 which drops the django celery tables
Newer clean 16.04 AMI so that it'll get newer kernel modules.

FYI @efischer19 

@edx/devops  please review