### PR TITLE
Upgrade default vagrant file to one that runs elasticsearch 1.5

### DIFF
--- a/vagrant/release/devstack/Vagrantfile
+++ b/vagrant/release/devstack/Vagrantfile
@@ -63,7 +63,7 @@ openedx_releases = {
   # Cypress is deprecated and unsupported
   # Birch is deprecated and unsupported
 }
-openedx_releases.default = "ficus-devstack-2017-02-07"
+openedx_releases.default = "devstack-periodic-2017-06-12"
 
 openedx_release = ENV['OPENEDX_RELEASE']
 boxname = ENV['OPENEDX_BOXNAME']


### PR DESCRIPTION
Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] Have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?
