### PR TITLE
ENT-435: Enable third_party_auth flag by default

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -173,7 +173,7 @@ EDXAPP_CAS_ATTRIBUTE_PACKAGE: ""
 # Used for performance testing
 EDXAPP_ENABLE_AUTO_AUTH: false
 # Settings for enabling and configuring third party authorization
-EDXAPP_ENABLE_THIRD_PARTY_AUTH: false
+EDXAPP_ENABLE_THIRD_PARTY_AUTH: true
 EDXAPP_ENABLE_OAUTH2_PROVIDER: false
 
 EDXAPP_ENABLE_MOBILE_REST_API: false
@@ -490,11 +490,11 @@ EDXAPP_REGISTRATION_EXTRA_FIELDS:
   level_of_education: "optional"
   gender: "optional"
   year_of_birth: "optional"
-  mailing_address: "optional"
+  mailing_address: "hidden"
   goals: "optional"
   honor_code: "required"
   city: "hidden"
-  country: "hidden"
+  country: "required"
 
 EDXAPP_CELERY_WORKERS:
   - queue: low


### PR DESCRIPTION
Set ENABLE_THIRD_PARTY_AUTH flag to true by default
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] Have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?
