### PR TITLE
Add option to fail/halt Ansible when github user is missing ssh keys

### DIFF
--- a/playbooks/roles/user/defaults/main.yml
+++ b/playbooks/roles/user/defaults/main.yml
@@ -47,4 +47,4 @@ user_debian_pkgs:
 # users. In the default false state this playbook will only print a warning
 # message, but not halt.
 #
-user_fail_missing_keys: false
+USER_FAIL_MISSING_KEYS: false

--- a/playbooks/roles/user/defaults/main.yml
+++ b/playbooks/roles/user/defaults/main.yml
@@ -38,3 +38,13 @@ user_info: []
 user_debian_pkgs:
   # This is needed for the uri module to work correctly.
   - python-httplib2
+
+# Boolean variable that will cause the user module to stop Ansible with a
+# failure if a user that has been configured to have their keys pulled from
+# GitHub does not have any ssh keys configured on GitHub. This is set to
+# false by default as we normally do not wish to interrupt Ansible, but
+# we wish to selectively enable it for a particular Jenkins job that adds
+# users. In the default false state this playbook will only print a warning
+# message, but not halt.
+#
+user_fail_missing_keys: false

--- a/playbooks/roles/user/tasks/main.yml
+++ b/playbooks/roles/user/tasks/main.yml
@@ -140,7 +140,7 @@
     msg: "User {{ item.item.name }} doesn't have an SSH key associated with their github account"
   with_items: "{{ github_users_return.results | default([]) }}"
   # We skip users in the previous task, and they end up with no content_length
-  when: (user_fail_missing_keys and 'content' in item and item.content == "")
+  when: (USER_FAIL_MISSING_KEYS and 'content' in item and item.content == "")
 
 - name: Get github key(s) and update the authorized_keys file
   authorized_key:

--- a/playbooks/roles/user/tasks/main.yml
+++ b/playbooks/roles/user/tasks/main.yml
@@ -130,13 +130,15 @@
   with_items: "{{ user_info }}"
   register: github_users_return
 
-- debug:
+- name: Print warning if github user(s) missing ssh key
+  debug:
     msg: "User {{ item.item.name }} doesn't have an SSH key associated with their github account"
   with_items: "{{ github_users_return.results | default([]) }}"
   # We skip users in the previous task, and they end up with no content_length
   when: ('content' in item and item.content == "")
 
-- fail:
+- name: Halt if USER_FAIL_MISSING_KEYS is true and github user(s) missing ssh key
+  fail:
     msg: "User {{ item.item.name }} doesn't have an SSH key associated with their github account"
   with_items: "{{ github_users_return.results | default([]) }}"
   # We skip users in the previous task, and they end up with no content_length

--- a/playbooks/roles/user/tasks/main.yml
+++ b/playbooks/roles/user/tasks/main.yml
@@ -124,16 +124,23 @@
 - name: Check the ssh key(s) for user(s) over github
   uri:
     url: "https://github.com/{{ item.name }}.keys"
+    return_content: true
   # We don't care if absent users lack ssh keys
   when: item.get('state', 'present') == 'present'
   with_items: "{{ user_info }}"
   register: github_users_return
 
 - debug:
-    msg: "User {{ item.item.name }} doesn't have an SSH key associated with their account"
+    msg: "User {{ item.item.name }} doesn't have an SSH key associated with their github account"
   with_items: "{{ github_users_return.results | default([]) }}"
   # We skip users in the previous task, and they end up with no content_length
-  when: item.get('content_length') and item.content_length == "0"
+  when: ('content' in item and item.content == "")
+
+- fail:
+    msg: "User {{ item.item.name }} doesn't have an SSH key associated with their github account"
+  with_items: "{{ github_users_return.results | default([]) }}"
+  # We skip users in the previous task, and they end up with no content_length
+  when: (user_fail_missing_keys and 'content' in item and item.content == "")
 
 - name: Get github key(s) and update the authorized_keys file
   authorized_key:


### PR DESCRIPTION
Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] Have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?
