### PR TITLE
Unpin Jenkins JDK 7 requirement.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+- Role: jenkins_master
+  - Update pinned use of JDK7 in Jenkins installs to default JDK version from role `oraclejdk`.
+
 - Role: notifier
   - Added `NOTIFIER_DATABASE_ENGINE`, `NOTIFIER_DATABASE_NAME`, `NOTIFIER_DATABASE_USER`, `NOTIFIER_DATABASE_PASSWORD`, `NOTIFIER_DATABASE_HOST`, and `NOTIFIER_DATABASE_PORT` to be able to configure the `notifier` service to use a database engine other than sqlite. Defaults to local sqlite.
   - Deprecated: `NOTIFIER_DB_DIR`: Please use `NOTIFIER_DATABASE_NAME` instead.

--- a/playbooks/roles/jenkins_master/meta/main.yml
+++ b/playbooks/roles/jenkins_master/meta/main.yml
@@ -3,7 +3,3 @@ dependencies:
   - common
   - role: oraclejdk
     tags: java
-    oraclejdk_version: "7u51"
-    oraclejdk_base: "jdk1.7.0_51"
-    oraclejdk_build: "b13"
-    oraclejdk_link: "/usr/lib/jvm/java-7-oracle"


### PR DESCRIPTION
JDK7 is no longer available through the oracle site.

While running the `analytics-jenkins` playbook, I ran into an error while trying to untar the JDK file:

```bash
TASK [oraclejdk : Install debian needed pkgs] **********************************
ok: [34.227.166.123] => (item=[u'curl'])

TASK [oraclejdk : Download Oracle Java] ****************************************
ok: [34.227.166.123]

TASK [oraclejdk : Create jvm dir] **********************************************
ok: [34.227.166.123]

TASK [oraclejdk : Untar Oracle Java] *******************************************
fatal: [34.227.166.123]: FAILED! => {"changed": true, "cmd": "tar -C /usr/lib/jvm -zxvf /var/tmp/jdk-7u51-linux-x64.tar.gz", "delta": "0:00:00.003579", "end": "2017-06-15 14:31:23.550613", "failed": true, "rc": 2, "start": "2017-06-15 14:31:23.547034", "stderr": "\ngzip: stdin: not in gzip format\ntar: Child returned status 1\ntar: Error is not recoverable: exiting now", "stdout": "", "stdout_lines": [], "warnings": ["Consider using unarchive module rather than running tar"]}
	to retry, use: --limit @/home/ubuntu/configuration/playbooks/analytics-jenkins.retry

PLAY RECAP *********************************************************************
34.227.166.123             : ok=28   changed=4    unreachable=0    failed=1   
```

After taking a look at the contents inside the `.tar.gz` file that ansible downloaded, it turned out to be a 404 page. That's because JDK7 isn't downloadable from the oracle site anymore.

Not sure if it's okay to just ignore the "pin" to JDK7 and let it default to whatever JDK8 version is written in the `oraclejdk` role. If it is, then this should do the trick, if not, then one can still get JDK7 from ppa repos. That'd require some more changes...

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] Have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?
