### PR TITLE
increase neo4j heap size

### DIFF
--- a/playbooks/roles/neo4j/defaults/main.yml
+++ b/playbooks/roles/neo4j/defaults/main.yml
@@ -26,7 +26,8 @@ neo4j_wrapper_config_file: "/etc/neo4j/neo4j-wrapper.conf"
 neo4j_https_port: 7473  # default in package is 7473
 neo4j_http_port: 7474  # default in package is 7474
 neo4j_listen_address: "0.0.0.0"
-neo4j_heap_max_size: "3000"
+neo4j_heap_max_size: "8000"
+neo4j_heap_initial_size: "8000"
 
 # Properties file settings
 neo4j_https_settings_key: "dbms.connector.https.address"

--- a/playbooks/roles/neo4j/tasks/main.yml
+++ b/playbooks/roles/neo4j/tasks/main.yml
@@ -45,11 +45,20 @@
     - install
     - install:base
 
-- name: set neo4j heap size
+- name: set neo4j max heap size
   lineinfile:
     dest: "{{ neo4j_wrapper_config_file }}"
     regexp: "dbms.memory.heap.max_size="
     line: "dbms.memory.heap.max_size={{ neo4j_heap_max_size }}"
+  tags:
+    - install
+    - install:configuration
+
+- name: set neo4j initial heap size
+  lineinfile:
+    dest: "{{ neo4j_wrapper_config_file }}"
+    regexp: "dbms.memory.heap.initial_size="
+    line: "dbms.memory.heap.initial_size={{ neo4j_heap_initial_size }}"
   tags:
     - install
     - install:configuration
@@ -73,8 +82,8 @@
     - install:configuration
 
 - name: restart neo4j
-  service: 
-    name: neo4j 
+  service:
+    name: neo4j
     state: restarted
   tags:
     - manage


### PR DESCRIPTION
Configuration Pull Request
---
@MichaelRoytman  and @fredsmith — I'm making this PR to increase the heap size available to neo4j. First, I think we need a larger heap to accommodate more entities being written per transaction, and second, now that we're soon to be making asynchronous writes to neo4j, it needs more memory to handle concurrent writes.

The question I have is: how much memory does the neo4j box have available to it?

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] Have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?
