### PR TITLE
Make cookiecutter allow extra debian pkgs and update default dockerfile.

### DIFF
--- a/playbooks/roles/ansible-role-django-ida/templates/defaults/main.yml.j2
+++ b/playbooks/roles/ansible-role-django-ida/templates/defaults/main.yml.j2
@@ -98,6 +98,8 @@
 
 {{ role_name|upper }}_HOSTNAME: '~^((stage|prod)-)?{{ role_name|replace('_', '-') }}.*'
 
+{{ role_name|upper }}_DEBIAN_EXTRA_PKGS: []
+
 nginx_{{ role_name }}_gunicorn_hosts:
   - 127.0.0.1
 

--- a/playbooks/roles/ansible-role-django-ida/templates/docker/build/ROLE_NAME/Dockerfile.j2
+++ b/playbooks/roles/ansible-role-django-ida/templates/docker/build/ROLE_NAME/Dockerfile.j2
@@ -7,7 +7,7 @@
 # This allows the dockerfile to update /edx/app/edx_ansible/edx_ansible
 # with the currently checked-out configuration repo.
 
-FROM edxops/trusty-common:latest
+FROM edxops/xenial-common:latest
 MAINTAINER edxops
 
 ARG {{ role_name|upper }}_VERSION=master

--- a/playbooks/roles/ansible-role-django-ida/templates/meta/main.yml.j2
+++ b/playbooks/roles/ansible-role-django-ida/templates/meta/main.yml.j2
@@ -21,5 +21,5 @@ dependencies:
     edx_service_user: "{{ '{{' }} {{ role_name }}_user }}"
     edx_service_home: "{{ '{{' }} {{ role_name }}_home }}"
     edx_service_packages:
-      debian: "{{ '{{' }} {{ role_name }}_debian_pkgs }}"
+      debian: "{{ '{{' }} {{ role_name }}_debian_pkgs + {{ role_name|upper }}_DEBIAN_EXTRA_PKGS }}"
       redhat: "{{ '{{' }} {{ role_name }}_redhat_pkgs }}"


### PR DESCRIPTION
Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] Have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?
