### PR TITLE
Travis updated the trusty images, docker renamed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ addons:
 
 before_install:
   - sudo apt-get -y update
-  - sudo apt-get -y install -o Dpkg::Options::="--force-confold" docker-engine
+  - sudo apt-get -y install -o Dpkg::Options::="--force-confold" docker-ce
 
 install:
   - "pip install --allow-all-external -r requirements.txt"


### PR DESCRIPTION
https://blog.travis-ci.com/2017-06-21-trusty-updates-2017-Q2-launch
https://github.com/travis-ci/build-environment-updates/blob/master/2017Q2/gce/garnet-trusty/dpkg-manifest.diff