### PR TITLE
ENT-367: Add BASE_COOKIE_DOMAIN settings for edxapp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -319,3 +319,6 @@
 
 - Role: edxapp
   - Added `EDXAPP_VIDEO_IMAGE_SETTINGS` to configure S3-backed video images.
+
+- Role: edxapp
+  - Added `EDXAPP_BASE_COOKIE_DOMAIN` for sharing cookies across edx domains.

--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -706,6 +706,9 @@ EDXAPP_ENTERPRISE_COURSE_ENROLLMENT_AUDIT_MODES:
 # The assigned ICP license number for display in the platform footer
 EDXAPP_ICP_LICENSE: !!null
 
+# Base Cookie Domain to share cookie across edx domains
+EDXAPP_BASE_COOKIE_DOMAIN: "{{ EDXAPP_LMS_SITE_NAME }}"
+
 #-------- Everything below this line is internal to the role ------------
 
 #Use YAML references (& and *) and hash merge <<: to factor out shared settings
@@ -1083,6 +1086,8 @@ generic_env_config:  &edxapp_generic_env
   HELP_TOKENS_BOOKS: "{{ EDXAPP_HELP_TOKENS_BOOKS }}"
   # License for serving content in China
   ICP_LICENSE: "{{ EDXAPP_ICP_LICENSE }}"
+  # Base Cookie Domain to share cookie across edx domains
+  BASE_COOKIE_DOMAIN: "{{ EDXAPP_BASE_COOKIE_DOMAIN }}"
 
   POLICY_CHANGE_GRADES_ROUTING_KEY: "{{ EDXAPP_POLICY_CHANGE_GRADES_ROUTING_KEY }}"
 


### PR DESCRIPTION
Hi @douglashall , @fredsmith 

Please take a look at this, This PR adds `BASE_COOKIE_DOMAIN` to lms.env.json. Setting was introduced in https://github.com/edx/edx-platform/pull/15383.

---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [x] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [x] ~~If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.~~ N/A
    - [x] Add an entry to the CHANGELOG.
  - [x] Have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?
