### PR TITLE
Who supervises the supervisor?

### DIFF
--- a/playbooks/roles/supervisor/templates/etc/init/supervisor-systemd.service.j2
+++ b/playbooks/roles/supervisor/templates/etc/init/supervisor-systemd.service.j2
@@ -28,12 +28,17 @@ PermissionsStartOnly=true
 User={{ supervisor_service_user }}
 
 Type=forking
-TimeoutStartSec=432000
+TimeoutSec=432000
 
 ExecStart={{ supervisor_venv_dir }}/bin/supervisord --configuration {{ supervisor_cfg }}
 ExecReload={{ supervisor_venv_dir }}/bin/supervisorctl reload
 ExecStop={{ supervisor_venv_dir }}/bin/supervisorctl shutdown
 
+# Trust supervisor to kill all its children
+# Otherwise systemd will see that ExecStop ^ comes back synchronously and say "Oh, I can kill everyone in this cgroup"
+# https://www.freedesktop.org/software/systemd/man/systemd.service.html#ExecStop=
+# https://www.freedesktop.org/software/systemd/man/systemd.kill.html
+KillMode=none
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
InstructorTasks (celery tasks) are dying before they finish. From what I can determine, what's happening is:

- systemd tells supervisor to stop (SIGTERM)
- supervisor helpfully relays that through to the processes it supervises, which are the python processes executing our celery tasks.
  - at this point, no further tasks will be started, but supervisor will allow running tasks to finish
  - long running tasks (grade reports, bulk email) continue to execute, preventing their process from going down
- after a period of time (~90 seconds?), systemd decides that supervisor has had more than enough time and terminates forcefully via SIGKILL
  - this signal is then forwarded through to supervisor's children (the python processes), and they die too.

[Here's a splunk search showing the above sequence playing out](https://splunk.edx.org/en-US/app/search/search?sid=1498156537.1897804)


The fix is to set `TimeoutStopSec` to the same 5 day period we've defined for `TimeoutStartSec`, which can both be defined via `TimeoutSec`

```
TimeoutStartSec=
Configures the time to wait for start-up. If a daemon service does not signal start-up completion within the configured time, the service will be considered failed and will be shut down again. Takes a unit-less value in seconds, or a time span value such as "5min 20s". Pass "infinity" to disable the timeout logic. Defaults to DefaultTimeoutStartSec= from the manager configuration file, except when Type=oneshot is used, in which case the timeout is disabled by default (see systemd-system.conf(5)).

TimeoutStopSec=
Configures the time to wait for stop. If a service is asked to stop, but does not terminate in the specified time, it will be terminated forcibly via SIGTERM, and after another timeout of equal duration with SIGKILL (see KillMode= in systemd.kill(5)). Takes a unit-less value in seconds, or a time span value such as "5min 20s". Pass "infinity" to disable the timeout logic. Defaults to DefaultTimeoutStopSec= from the manager configuration file (see systemd-system.conf(5)).

TimeoutSec=
A shorthand for configuring both TimeoutStartSec= and TimeoutStopSec= to the specified value.
```
https://www.freedesktop.org/software/systemd/man/systemd.service.html

---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
