### PR TITLE
Add splunk to neo4j

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+- Role: neo4j
+  - Enabled splunk forwarding for neo4j logs.
+  - Increased maximum amount of open files to 40000, as suggested by neo4j.
+  - Updated the java build that neo4j uses to run.
+
 - Role: edxapp
   - Set the default value for EDXAPP_BULK_EMAIL_ROUTING_KEY_SMALL_JOBS to
  'edx.lms.core.low'.

--- a/playbooks/edx-east/neo4j.yml
+++ b/playbooks/edx-east/neo4j.yml
@@ -13,3 +13,5 @@
         - coursegraph
 #    - aws
     - neo4j
+    - role: splunkforwarder
+      when: COMMON_ENABLE_SPLUNKFORWARDER

--- a/playbooks/roles/neo4j/defaults/main.yml
+++ b/playbooks/roles/neo4j/defaults/main.yml
@@ -21,6 +21,7 @@ NEO4J_SERVER_NAME: "localhost"
 neo4j_gpg_key_url: https://debian.neo4j.org/neotechnology.gpg.key
 neo4j_apt_repository: "deb http://debian.neo4j.org/repo stable/"
 neo4j_version: "3.0.3"
+neo4j_defaults_file: "/etc/default/neo4j"
 neo4j_server_config_file: "/etc/neo4j/neo4j.conf"
 neo4j_wrapper_config_file: "/etc/neo4j/neo4j-wrapper.conf"
 neo4j_https_port: 7473  # default in package is 7473

--- a/playbooks/roles/neo4j/defaults/main.yml
+++ b/playbooks/roles/neo4j/defaults/main.yml
@@ -27,6 +27,7 @@ neo4j_https_port: 7473  # default in package is 7473
 neo4j_http_port: 7474  # default in package is 7474
 neo4j_listen_address: "0.0.0.0"
 neo4j_heap_max_size: "3000"
+neo4j_log_dir: "/var/log/neo4j"
 
 # Properties file settings
 neo4j_https_settings_key: "dbms.connector.https.address"

--- a/playbooks/roles/neo4j/meta/main.yml
+++ b/playbooks/roles/neo4j/meta/main.yml
@@ -2,7 +2,7 @@
 dependencies:
   - common
   - role: oraclejdk
-    oraclejdk_version: "8u60"
-    oraclejdk_base: "jdk1.8.0_60"
-    oraclejdk_build: "b27"
+    oraclejdk_version: "8u131"
+    oraclejdk_base: "jdk1.8.0_131"
+    oraclejdk_build: "b11"
     oraclejdk_link: "/usr/lib/jvm/java-8-oracle"

--- a/playbooks/roles/neo4j/tasks/main.yml
+++ b/playbooks/roles/neo4j/tasks/main.yml
@@ -92,6 +92,25 @@
     - install
     - install:base
 
+- name: Create neo4j default file
+  file:
+    path: "{{ neo4j_defaults_file }}"
+    state: touch
+    owner: neo4j
+    mode: "0755"
+  tags:
+    - install
+    - install:base
+
+- name: set max open files to 40000
+  lineinfile:
+    dest: "{{ neo4j_defaults_file }}"
+    regexp: "#NEO4J_ULIMIT_NOFILE=40000"
+    line: "NEO4J_ULIMIT_NOFILE=40000"
+  tags:
+    - install
+    - install:base
+
 - name: restart neo4j
   service:
     name: neo4j

--- a/playbooks/roles/neo4j/tasks/main.yml
+++ b/playbooks/roles/neo4j/tasks/main.yml
@@ -72,9 +72,29 @@
     - install
     - install:configuration
 
+- name: set log dir for neo4j
+  lineinfile:
+    create: yes
+    dest: "{{ neo4j_server_config_file }}"
+    regexp: "dbms.directories.logs="
+    line: "dbms.directories.logs={{ neo4j_log_dir }}"
+  tags:
+    - install
+    - install:configuration
+
+- name: Create neo4j logging dir
+  file:
+    path: "{{ neo4j_log_dir }}"
+    state: directory
+    owner: neo4j
+    mode: "0755"
+  tags:
+    - install
+    - install:base
+
 - name: restart neo4j
-  service: 
-    name: neo4j 
+  service:
+    name: neo4j
     state: restarted
   tags:
     - manage

--- a/playbooks/roles/splunkforwarder/defaults/main.yml
+++ b/playbooks/roles/splunkforwarder/defaults/main.yml
@@ -76,6 +76,10 @@ SPLUNKFORWARDER_LOG_ITEMS:
     recursive: true
     index: '{{ COMMON_ENVIRONMENT }}-{{ COMMON_DEPLOYMENT }}'
     sourcetype: 'rabbitmq'
+  - source: '/var/log/neo4j'
+    recursive: true
+    index: '{{ COMMON_ENVIRONMENT }}-{{ COMMON_DEPLOYMENT }}'
+    sourcetype: 'neo4j'
 
 #
 # OS packages


### PR DESCRIPTION
Configuration Pull Request
---

I'm closing https://github.com/edx/configuration/pull/3943 in favor of this PR. It does the same things, but also:

1. Increases the maximum amount of open files to 40000, as suggested by [neo4j](https://neo4j.com/developer/kb/how-do-i-set-max-open-files-for-debian-installs/)
2. Updates the version of java that neo4j uses to run

I've run this play against a sandbox to verify that it completes and that the logs are getting outputted where I expect them to be outputted. However, I don't know how to verify that, once splunk forwarding is enabled, they will get forwarded to splunk.

@feanil , could you please take a look at this PR too? Thanks!

Make sure that the following steps are done before merging:

  - [x] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [x] Add an entry to the CHANGELOG.
  - [x] Have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?
