### PR TITLE
PLAT-1614 Make Docker containers use en_US.UTF-8

### DIFF
--- a/docker/build/precise-common/Dockerfile
+++ b/docker/build/precise-common/Dockerfile
@@ -6,7 +6,12 @@ MAINTAINER edxops
 # http://jaredmarkell.com/docker-and-locales/
 # https://github.com/docker-library/python/issues/13
 # https://github.com/docker-library/python/pull/14/files
-ENV LANG C.UTF-8
+RUN apt-get update &&\
+    apt-get install -y locales &&\
+    locale-gen en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
 
 ENV ANSIBLE_REPO="https://github.com/edx/ansible"
 ENV CONFIGURATION_REPO="https://github.com/edx/configuration.git"

--- a/docker/build/xenial-common/Dockerfile
+++ b/docker/build/xenial-common/Dockerfile
@@ -6,7 +6,12 @@ MAINTAINER edxops
 # http://jaredmarkell.com/docker-and-locales/
 # https://github.com/docker-library/python/issues/13
 # https://github.com/docker-library/python/pull/14/files
-ENV LANG C.UTF-8
+RUN apt-get update &&\
+    apt-get install -y locales &&\
+    locale-gen en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
 
 ENV ANSIBLE_REPO="https://github.com/edx/ansible"
 ENV CONFIGURATION_REPO="https://github.com/edx/configuration.git"


### PR DESCRIPTION
While running edx-platform tests in Docker devstack, I noticed that some involving unicode filenames were failing because ASCII was being used as the filesystem encoding.  `LANG` had been set to `C.UTF-8`, but `LC_ALL` was unset; and this was still inconsistent with production and Vagrant devstack, which both use `en_US.UTF-8`.  This latter locale is not present by default on the official Ubuntu Docker containers, so we need to install the `locales` package and then run its `locale-gen` command to create it.  I also set the `LANGUAGE` environment variable for good measure, to specify the language of system messages.

This seems like it should be common to all our containers to avoid unexpected bugs down the road, so I've added it to our common base images.  Both built successfully for me locally, and I verified that the specified environment variables are correctly set inside the containers.