### PR TITLE
remove docker-proxy-user and add jenkins user to docker group instead

### DIFF
--- a/playbooks/roles/tools_jenkins/defaults/main.yml
+++ b/playbooks/roles/tools_jenkins/defaults/main.yml
@@ -77,5 +77,3 @@ jenkins_tools_debian_pkgs:
     - python-pycurl
     - psmisc
     - mysql-client-core-5.6
-
-JENKINS_TOOLS_DOCKER_USER: 'jenkins-docker-proxy'

--- a/playbooks/roles/tools_jenkins/meta/main.yml
+++ b/playbooks/roles/tools_jenkins/meta/main.yml
@@ -12,9 +12,6 @@ dependencies:
     jenkins_debian_pkgs: "{{ jenkins_tools_debian_pkgs }}"
 
   # Needed to be able to build docker images. Used by Docker Image Builder Jobs.
-  - role: user
-    user_info:
-        - name: '{{ JENKINS_TOOLS_DOCKER_USER }}'
   - role: docker-tools
     docker_users:
-        - '{{ JENKINS_TOOLS_DOCKER_USER }}'
+        - '{{ jenkins_user }}'

--- a/playbooks/roles/tools_jenkins/tasks/main.yml
+++ b/playbooks/roles/tools_jenkins/tasks/main.yml
@@ -19,15 +19,3 @@
   tags:
     - install
     - install:system-requirements
-
-- name: Create sudoers file from template
-  template:
-    dest: "/etc/sudoers.d/99-tools_jenkins"
-    src: "99-tools-jenkins.j2"
-    owner: "root"
-    group: "root"
-    mode: "0440"
-    validate: 'visudo -cf %s'
-  tags:
-    - install
-    - install:configuration

--- a/playbooks/roles/tools_jenkins/templates/99-tools-jenkins.j2
+++ b/playbooks/roles/tools_jenkins/templates/99-tools-jenkins.j2
@@ -1,1 +1,0 @@
-{{ jenkins_user }} ALL=({{ JENKINS_TOOLS_DOCKER_USER }}) SETENV:NOPASSWD:/usr/bin/docker


### PR DESCRIPTION
Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] Have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?
