### PR TITLE
Upgrade neo4j to 3.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 - Role: neo4j
   - Updated neo4j to 3.2.2
+  - Removed authentication requirement for neo4j
 
 - Role: forum
   - Added `FORUM_REBUILD_INDEX` to rebuild the ElasticSearch index from the database, when enabled.  Default: `False`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+- Role: neo4j
+  - Updated neo4j to 3.2.2
+
 - Role: forum
   - Added `FORUM_REBUILD_INDEX` to rebuild the ElasticSearch index from the database, when enabled.  Default: `False`.
 

--- a/playbooks/roles/neo4j/defaults/main.yml
+++ b/playbooks/roles/neo4j/defaults/main.yml
@@ -28,6 +28,7 @@ neo4j_https_port: 7473  # default in package is 7473
 neo4j_http_port: 7474  # default in package is 7474
 neo4j_listen_address: "0.0.0.0"
 neo4j_heap_max_size: "3000m"
+neo4j_page_cache_size: "3000m"
 neo4j_log_dir: "/var/log/neo4j"
 
 # Properties file settings

--- a/playbooks/roles/neo4j/defaults/main.yml
+++ b/playbooks/roles/neo4j/defaults/main.yml
@@ -20,16 +20,20 @@ NEO4J_SERVER_NAME: "localhost"
 
 neo4j_gpg_key_url: https://debian.neo4j.org/neotechnology.gpg.key
 neo4j_apt_repository: "deb http://debian.neo4j.org/repo stable/"
-neo4j_version: "3.0.3"
 neo4j_defaults_file: "/etc/default/neo4j"
+neo4j_version: "3.2.2"
 neo4j_server_config_file: "/etc/neo4j/neo4j.conf"
-neo4j_wrapper_config_file: "/etc/neo4j/neo4j-wrapper.conf"
 neo4j_https_port: 7473  # default in package is 7473
 neo4j_http_port: 7474  # default in package is 7474
 neo4j_listen_address: "0.0.0.0"
-neo4j_heap_max_size: "3000"
+neo4j_heap_max_size: "3000m"
 neo4j_log_dir: "/var/log/neo4j"
 
 # Properties file settings
-neo4j_https_settings_key: "dbms.connector.https.address"
-neo4j_http_settings_key: "dbms.connector.http.address"
+neo4j_https_settings_key: "dbms.connector.https.listen_address"
+neo4j_http_settings_key: "dbms.connector.http.listen_address"
+
+# Deprecated files to delete
+deprecated_neo4j_wrapper_config_file: "/etc/neo4j/neo4j-wrapper.conf"
+deprecated_neo4j_https_settings_key: "dbms.connector.https.address"
+deprecated_neo4j_http_settings_key: "dbms.connector.http.address"

--- a/playbooks/roles/neo4j/defaults/main.yml
+++ b/playbooks/roles/neo4j/defaults/main.yml
@@ -17,6 +17,7 @@
 # vars are namespaced with the module name.
 #
 NEO4J_SERVER_NAME: "localhost"
+NEO4J_AUTH_ENABLED: "true"
 
 neo4j_gpg_key_url: https://debian.neo4j.org/neotechnology.gpg.key
 neo4j_apt_repository: "deb http://debian.neo4j.org/repo stable/"

--- a/playbooks/roles/neo4j/tasks/main.yml
+++ b/playbooks/roles/neo4j/tasks/main.yml
@@ -53,6 +53,15 @@
     - install
     - install:base
 
+- name: turn off authentication (we're accessing neo4j from behind a private vpn)
+  lineinfile:
+    dest: "{{ neo4j_server_config_file }}"
+    regexp: "dbms.security.auth_enabled="
+    line: "dbms.security.auth_enabled=false"
+  tags:
+    - install
+    - install:configuration
+
 - name: set neo4j heap size
   lineinfile:
     dest: "{{ neo4j_server_config_file }}"

--- a/playbooks/roles/neo4j/tasks/main.yml
+++ b/playbooks/roles/neo4j/tasks/main.yml
@@ -65,8 +65,11 @@
 - name: set neo4j heap size
   lineinfile:
     dest: "{{ neo4j_server_config_file }}"
-    regexp: "dbms.memory.heap.max_size="
-    line: "dbms.memory.heap.max_size={{ neo4j_heap_max_size }}"
+    regexp: "{{ item }}="
+    line: "{{ item }}={{ neo4j_heap_max_size }}"
+  with_items:
+    - "dbms.memory.heap.max_size"
+    - "dbms.memory.heap.initial_size"
   tags:
     - install
     - install:configuration

--- a/playbooks/roles/neo4j/tasks/main.yml
+++ b/playbooks/roles/neo4j/tasks/main.yml
@@ -37,6 +37,14 @@
     - install
     - install:system-requirements
 
+- name: remove deprecated config file
+  file:
+    state: absent
+    path: "{{ deprecated_neo4j_wrapper_config_file }}"
+  tags:
+    - install
+    - install:base
+
 - name: install neo4j
   apt:
     name: "neo4j={{neo4j_version}}"
@@ -47,15 +55,25 @@
 
 - name: set neo4j heap size
   lineinfile:
-    dest: "{{ neo4j_wrapper_config_file }}"
+    dest: "{{ neo4j_server_config_file }}"
     regexp: "dbms.memory.heap.max_size="
     line: "dbms.memory.heap.max_size={{ neo4j_heap_max_size }}"
   tags:
     - install
     - install:configuration
 
+- name: allow format migration (when updating neo4j versions)
+  lineinfile:
+    dest: "{{ neo4j_server_config_file }}"
+    regexp: "dbms.allow_format_migration="
+    line: "dbms.allow_format_migration=true"
+  tags:
+    - install
+    - install:configuration
+
 - name: set to listen on specific port for https
   lineinfile:
+    create: yes
     dest: "{{ neo4j_server_config_file }}"
     regexp: "{{ neo4j_https_settings_key }}="
     line: "{{ neo4j_https_settings_key }}={{ neo4j_listen_address }}:{{ neo4j_https_port }}"
@@ -65,6 +83,7 @@
 
 - name: set to listen on specific port for http
   lineinfile:
+    create: yes
     dest: "{{ neo4j_server_config_file }}"
     regexp: "{{ neo4j_http_settings_key }}="
     line: "{{ neo4j_http_settings_key }}={{ neo4j_listen_address }}:{{ neo4j_http_port }}"
@@ -72,12 +91,14 @@
     - install
     - install:configuration
 
-- name: set log dir for neo4j
+- name: remove deprecated listen address lines
   lineinfile:
-    create: yes
+    state: absent
     dest: "{{ neo4j_server_config_file }}"
-    regexp: "dbms.directories.logs="
-    line: "dbms.directories.logs={{ neo4j_log_dir }}"
+    regexp: "{{ item }}"
+  with_items:
+    - "{{ deprecated_neo4j_https_settings_key }}"
+    - "{{ deprecated_neo4j_http_settings_key }}"
   tags:
     - install
     - install:configuration

--- a/playbooks/roles/neo4j/tasks/main.yml
+++ b/playbooks/roles/neo4j/tasks/main.yml
@@ -53,11 +53,11 @@
     - install
     - install:base
 
-- name: turn off authentication (we're accessing neo4j from behind a private vpn)
+- name: enable or disable authentication
   lineinfile:
     dest: "{{ neo4j_server_config_file }}"
     regexp: "dbms.security.auth_enabled="
-    line: "dbms.security.auth_enabled=false"
+    line: "dbms.security.auth_enabled={{ NEO4J_AUTH_ENABLED }}"
   tags:
     - install
     - install:configuration

--- a/playbooks/roles/neo4j/tasks/main.yml
+++ b/playbooks/roles/neo4j/tasks/main.yml
@@ -62,6 +62,15 @@
     - install
     - install:configuration
 
+- name: set neo4j page cache size
+  lineinfile:
+    dest: "{{ neo4j_server_config_file }}"
+    regexp: "dbms.memory.pagecache.size="
+    line: "dbms.memory.pagecache.size={{ neo4j_page_cache_size }}"
+  tags:
+    - install
+    - install:configuration
+
 - name: set neo4j heap size
   lineinfile:
     dest: "{{ neo4j_server_config_file }}"


### PR DESCRIPTION
Configuration Pull Request
---

@fredsmith here's a PR to upgrade neo4j from 3.0.3—its current version—to 3.2.2, the most recent. As part of the upgrade, there are few things that I think will be prudent to do:

* As part of the [upgrade](https://neo4j.com/guides/upgrade/), neo4 changes the way it stores data. In order to mitigate the risk of the the updated data storage format, it makes a backup of the data before it does anything. As a result, we need to make sure we have 2x the storage that neo4j is currently taking up.
* It probably doesn't hurt to download a backup of the database before we run the update anyway
* We need to bring down neo4j while we do the update

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] ~Update the appropriate internal repo (be sure to update for all our environments)~
    - [ ] ~If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.~
    - [x] Add an entry to the CHANGELOG.
  - [x] Have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?
