### PR TITLE
Add playbook for installing oauth2_proxy.

### DIFF
--- a/playbooks/edx-auth-proxy.yml
+++ b/playbooks/edx-auth-proxy.yml
@@ -1,0 +1,17 @@
+---
+- name: Bootstrap instance(s)
+  hosts: all
+  gather_facts: no
+  become: True
+  roles:
+    - role: python
+      tags:
+        - install
+        - install:system-requirements
+
+- name: Configure instance(s)
+  hosts: all
+  become: True
+  gather_facts: True
+  roles:
+    - oauth2_proxy

--- a/playbooks/roles/oauth2_proxy/defaults/main.yml
+++ b/playbooks/roles/oauth2_proxy/defaults/main.yml
@@ -1,0 +1,60 @@
+---
+oauth2_proxy_app_dir: "{{ COMMON_APP_DIR }}/oauth2_proxy"
+oauth2_proxy_conf_dir: "{{ COMMON_CFG_DIR }}/oauth2_proxy"
+
+oauth2_proxy_user: "oauth2_proxy"
+
+# We define this tuple here separately because we need to know it for downloading the right tarball.  Given that they
+# bake in both the version number -- which doesn't always match the actual Git tag they release off -- and the Go version,
+# it's nearly impossible to use only `oauth2_proxy_version` to build a valid URL.
+oauth2_proxy_version: "2.2.0"
+oauth2_proxy_version_tuple: "2.2.0.linux-amd64.go1.8.1"
+oauth2_proxy_pkg_name: "oauth2_proxy-{{ oauth2_proxy_version_tuple }}"
+oauth2_proxy_release_url: "https://github.com/bitly/oauth2_proxy/releases/download/v2.2/{{ oauth2_proxy_pkg_name }}.tar.gz"
+oauth2_proxy_release_sha256: "1c16698ed0c85aa47aeb80e608f723835d9d1a8b98bd9ae36a514826b3acce56"
+
+oauth2_proxy_listen_port: 4180
+oauth2_proxy_listen_addr: "0.0.0.0"
+oauth2_proxy_upstreams: ["localhost:80"] # List of address:port values acting as upstreams/backends.
+oauth2_proxy_request_logging: true
+oauth2_proxy_pass_basic_auth: true # Pass Basic Authorization header to upstream(s).
+oauth2_proxy_pass_user_headers: true # Passes X-Forwarded-User and X-Forwarded-Email to upstream(s).
+oauth2_proxy_pass_host_header: true # Pass original Host header to upstream(s).  If false, Host header will come from upstream address.
+oauth2_proxy_pass_access_token: true # Pass OAuth access token via X-Forwarded-Access-Token header to upstream(s).
+oauth2_proxy_email_domains: ["example.com"] # Which e-mail domains, if any, to validate for.  Needed for things like validating a specific G Suite apps domain, etc.
+oauth2_proxy_provider: "google" # OAuth provider type.
+oauth2_proxy_client_id: "CHANGEME-OAUTH2-CLIENT-ID" # OAuth client ID.
+oauth2_proxy_client_secret: "CHANGEME-OAUTH2-CLIENT-SECRET" # OAuth client secret.
+oauth2_proxy_custom_templates_dir: "" # Directory having template overrides for the login/error pages.
+oauth2_proxy_cookie_name: "_oauth2_proxy" # Client-side browser cookie name.
+oauth2_proxy_cookie_secret: "CHANGEME-COOKIE-SECRET" # Cookie encryption secret.
+oauth2_proxy_cookie_domain: "example.com" # Domain pattern for this cookie.
+oauth2_proxy_cookie_expire: "168h" # How long before the cookie expires. (168h = 7 days)
+oauth2_proxy_cookie_refresh: "4h" # How long since cookie issuance (and since last refresh) to validate existing OAuth token.
+oauth2_proxy_cookie_secure: true # Whether or not cookie is HTTPS only.
+oauth2_proxy_cookie_httponly: true # Whether or not cookie is browser-only (i.e. Javascript can't access it)
+
+oauth2_proxy_services:
+  - { service: "oauth2_proxy", host: "localhost", port: "{{ oauth2_proxy_listen_port }}" }
+
+oauth2_proxy_config:
+  http_address: "{{ oauth2_proxy_listen_addr }}:{{ oauth2_proxy_listen_port }}"
+  upstreams: "{{ oauth2_proxy_upstreams }}"
+  request_logging: "{{ oauth2_proxy_request_logging }}"
+  pass_basic_auth: "{{ oauth2_proxy_pass_basic_auth }}"
+  pass_user_headers: "{{ oauth2_proxy_pass_user_headers }}"
+  pass_host_header: "{{ oauth2_proxy_pass_host_header }}"
+  pass_access_token: "{{ oauth2_proxy_pass_access_token }}"
+  email_domains: "{{ oauth2_proxy_email_domains }}"
+  provider: "{{ oauth2_proxy_provider }}"
+  client_id: "{{ oauth2_proxy_client_id }}"
+  client_secret: "{{ oauth2_proxy_client_secret }}"
+  custom_templates_dir: "{{ oauth2_proxy_custom_templates_dir }}"
+  cookie_name: "{{ oauth2_proxy_cookie_name }}"
+  cookie_secret: "{{ oauth2_proxy_cookie_secret }}"
+  cookie_domain: "{{ oauth2_proxy_cookie_domain }}"
+  cookie_expire: "{{ oauth2_proxy_cookie_expire }}"
+  cookie_refresh: "{{ oauth2_proxy_cookie_refresh }}"
+  cookie_secure: "{{ oauth2_proxy_cookie_secure }}"
+  cookie_httponly: "{{ oauth2_proxy_cookie_httponly }}"
+

--- a/playbooks/roles/oauth2_proxy/meta/main.yml
+++ b/playbooks/roles/oauth2_proxy/meta/main.yml
@@ -1,0 +1,7 @@
+---
+dependencies:
+  - role: common
+    tags:
+      - always # We want to make sure the role always runs, otherwise the system isn't in a state to install Python/Supervisord.
+  - config-encoders
+  - supervisor

--- a/playbooks/roles/oauth2_proxy/tasks/deploy.yml
+++ b/playbooks/roles/oauth2_proxy/tasks/deploy.yml
@@ -1,0 +1,95 @@
+---
+- name: create the supervisor config
+  template:
+    src: oauth2_proxy_supervisor.conf.j2
+    dest: "{{ supervisor_available_dir }}/oauth2_proxy.conf"
+    owner: "{{ supervisor_user }}"
+    group: "{{ supervisor_user }}"
+    mode: 0644
+  become_user: "{{ supervisor_user }}"
+  register: oauth2_proxy_supervisor
+  tags:
+    - install
+    - install:configuration
+
+- name: enable the supervisor config
+  file:
+    src: "{{ supervisor_available_dir }}/oauth2_proxy.conf"
+    dest: "{{ supervisor_cfg_dir }}/oauth2_proxy.conf"
+    owner: "{{ supervisor_user }}"
+    state: link
+    force: yes
+    mode: 0644
+  become_user: "{{ supervisor_user }}"
+  register: oauth2_proxy_supervisor
+  tags:
+    - install
+    - install:configuration
+
+- name: download oauth2_proxy release
+  get_url:
+    url: "{{ oauth2_proxy_release_url }}"
+    dest: "/tmp/oauth2_proxy.tar.gz"
+    force: yes
+    sha256sum: "{{ oauth2_proxy_release_sha256 }}"
+  tags:
+    - install
+    - install:configuration
+
+- name: extract the oauth2_proxy release
+  unarchive:
+    src: "/tmp/oauth2_proxy.tar.gz"
+    dest: "/tmp"
+    remote_src: True
+  tags:
+    - install
+    - install:configuration
+
+- name: move the oauth2_proxy binary into place
+  command: "mv /tmp/{{ oauth2_proxy_pkg_name }}/oauth2_proxy {{ oauth2_proxy_app_dir }}/"
+  tags:
+    - install
+    - install:configuration
+
+- name: update oauth2_proxy configuration
+  template:
+    src: oauth2_proxy.cfg.j2
+    dest: "{{ oauth2_proxy_conf_dir }}/oauth2_proxy.cfg"
+    owner: "{{ oauth2_proxy_user }}"
+    group: "{{ common_web_group }}"
+    mode: 0644
+  tags:
+    - install
+    - install:configuration
+
+- name: update supervisor configuration
+  shell:  "{{ supervisor_ctl }} -c {{ supervisor_cfg }} update"
+  register: supervisor_update
+  changed_when: supervisor_update.stdout is defined and supervisor_update.stdout != ""
+  when: not disable_edx_services
+  tags:
+    - manage
+    - manage:start
+    - manage:update
+
+- name: ensure oauth2_proxy is started
+  supervisorctl:
+    name: oauth2_proxy
+    supervisorctl_path: "{{ supervisor_ctl }}"
+    config: "{{ supervisor_cfg }}"
+    state: started
+  tags:
+    - manage
+    - manage:start
+
+- include: test.yml
+  tags:
+    - deploy
+
+- include: tag_ec2.yml
+  when: COMMON_TAG_EC2_INSTANCE
+  tags:
+    - deploy
+
+- set_fact:
+    oauth2_proxy_installed: true

--- a/playbooks/roles/oauth2_proxy/tasks/main.yml
+++ b/playbooks/roles/oauth2_proxy/tasks/main.yml
@@ -1,0 +1,41 @@
+---
+# oauth2_proxy
+#
+# Dependencies:
+#
+#   * common
+
+- name: create application user
+  user:
+    name: "{{ oauth2_proxy_user }}"
+    home: "{{ oauth2_proxy_app_dir }}"
+    createhome: yes
+    shell: /bin/false
+    generate_ssh_key: yes
+  tags:
+    - install
+    - install:base
+
+- name: set oauth2_proxy app dir permissions
+  file:
+    path: "{{ oauth2_proxy_app_dir }}"
+    state: directory
+    owner: "{{ oauth2_proxy_user }}"
+    group: "{{ common_web_group }}"
+  tags:
+    - install
+    - install:base
+
+- name: set oauth2_proxy conf dir permissions
+  file:
+    path: "{{ oauth2_proxy_conf_dir }}"
+    state: directory
+    owner: "{{ oauth2_proxy_user }}"
+    group: "{{ common_web_group }}"
+  tags:
+    - install
+    - install:base
+
+- include: deploy.yml
+  tags:
+    - deploy

--- a/playbooks/roles/oauth2_proxy/tasks/tag_ec2.yml
+++ b/playbooks/roles/oauth2_proxy/tasks/tag_ec2.yml
@@ -1,0 +1,10 @@
+---
+- name: get instance information
+  action: ec2_facts
+
+- name: tag instance
+  ec2_tag:
+    resource: "{{ ansible_ec2_instance_id }}"
+    region: "{{ ansible_ec2_placement_region }}"
+    tags:
+      "version:oauth2_proxy" : "{{ oauth2_proxy_version }} {{ oauth2_proxy_release_sha256 }}"

--- a/playbooks/roles/oauth2_proxy/tasks/test.yml
+++ b/playbooks/roles/oauth2_proxy/tasks/test.yml
@@ -1,0 +1,7 @@
+---
+- name: test that the required service are listening
+  wait_for:
+    port: "{{ item.port }}"
+    host: "{{ item.host }}"
+    timeout: 30
+  with_items: "{{ oauth2_proxy_services }}"

--- a/playbooks/roles/oauth2_proxy/templates/oauth2_proxy.cfg.j2
+++ b/playbooks/roles/oauth2_proxy/templates/oauth2_proxy.cfg.j2
@@ -1,0 +1,1 @@
+{{ oauth2_proxy_config | encode_toml }}

--- a/playbooks/roles/oauth2_proxy/templates/oauth2_proxy_supervisor.conf.j2
+++ b/playbooks/roles/oauth2_proxy/templates/oauth2_proxy_supervisor.conf.j2
@@ -1,0 +1,7 @@
+[program:oauth2_proxy]
+command={{ oauth2_proxy_app_dir }}/oauth2_proxy -config {{ oauth2_proxy_conf_dir }}/oauth2_proxy.cfg
+priority=999
+user={{ oauth2_proxy_user }}
+stdout_logfile={{ supervisor_log_dir }}/%(program_name)s-stdout.log
+stderr_logfile={{ supervisor_log_dir }}/%(program_name)s-stderr.log
+stopsignal=QUIT


### PR DESCRIPTION
This is a weaponized version of bit.ly's oauth2_proxy, which provides a reverse proxy implementation that allows you to add authn/authz in front of a web application(s).  I've been using this in Data Engineering for our metrics front-end, but will be extending the usage to other DE-maintained applications and want to start legitimizing the set-up.

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] Have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?
