### PR TITLE
Revert to Firefox 42 for Trusty servers

### DIFF
--- a/playbooks/roles/browsers/defaults/main.yml
+++ b/playbooks/roles/browsers/defaults/main.yml
@@ -32,8 +32,8 @@ browser_s3_deb_pkgs:
     url: https://s3.amazonaws.com/vagrant.testeng.edx.org/google-chrome-stable_55.0.2883.87-1_amd64.deb
 
 trusty_browser_s3_deb_pkgs:
-  - name: firefox_45.0.2+build1-0ubuntu1_amd64
-    url: https://s3.amazonaws.com/vagrant.testeng.edx.org/firefox_45.0.2%2Bbuild1-0ubuntu1_amd64.deb
+  - name: firefox-mozilla-build_42.0-0ubuntu1_amd64.deb
+    url: https://s3.amazonaws.com/vagrant.testeng.edx.org/firefox-mozilla-build_42.0-0ubuntu1_amd64.deb
   - name: google-chrome-stable_59.0.3071.115-1_amd64.deb
     url: https://s3.amazonaws.com/vagrant.testeng.edx.org/google-chrome-stable_59.0.3071.115-1_amd64.deb
 


### PR DESCRIPTION
The Firefox 45 package is not installable on Trusty due to a missing dependency. Since we are fine with Chrome for ecommerce tests, we will stick with the older version.

LEARNER-509