### PR TITLE
Update cache numbers 3.2.2

### DIFF
--- a/playbooks/roles/neo4j/defaults/main.yml
+++ b/playbooks/roles/neo4j/defaults/main.yml
@@ -28,6 +28,7 @@ neo4j_https_port: 7473  # default in package is 7473
 neo4j_http_port: 7474  # default in package is 7474
 neo4j_listen_address: "0.0.0.0"
 neo4j_heap_max_size: "3000m"
+neo4j_page_cache_size: "3000m"
 neo4j_log_dir: "/var/log/neo4j"
 
 # Properties file settings

--- a/playbooks/roles/neo4j/tasks/main.yml
+++ b/playbooks/roles/neo4j/tasks/main.yml
@@ -65,8 +65,11 @@
 - name: set neo4j heap size
   lineinfile:
     dest: "{{ neo4j_server_config_file }}"
-    regexp: "dbms.memory.heap.max_size="
-    line: "dbms.memory.heap.max_size={{ neo4j_heap_max_size }}"
+    regexp: "{{ item }}="
+    line: "{{ item }}={{ neo4j_heap_max_size }}"
+  with_items:
+    - "dbms.memory.heap.max_size"
+    - "dbms.memory.heap.initial_size"
   tags:
     - install
     - install:configuration

--- a/playbooks/roles/neo4j/tasks/main.yml
+++ b/playbooks/roles/neo4j/tasks/main.yml
@@ -62,6 +62,15 @@
     - install
     - install:configuration
 
+- name: set neo4j page cache size
+  lineinfile:
+    dest: "{{ neo4j_server_config_file }}"
+    regexp: "dbms.memory.pagecache.size="
+    line: "dbms.memory.pagecache.size={{ neo4j_page_cache_size }}"
+  tags:
+    - install
+    - install:configuration
+
 - name: set neo4j heap size
   lineinfile:
     dest: "{{ neo4j_server_config_file }}"


### PR DESCRIPTION
Configuration Pull Request
---

@fredsmith , this PR does two things:
* Sets the max and initial heap sizes to the same value, as [the docs suggest](https://neo4j.com/docs/operations-manual/current/performance/#heap-sizing)
* Sets the page cache value

The docs suggest a heap size of between [8 and 16 GB](https://neo4j.com/docs/operations-manual/current/performance/#heap-sizing), and a page cache value of [the size of your database](https://neo4j.com/docs/operations-manual/current/performance/#page-cache-sizing)

Furthermore, you should reserve [1GB + (size of graph.db/index) + (size of graph.db/schema)](https://neo4j.com/docs/operations-manual/current/performance/#os-memory-sizing) for the OS, which I'm assuming comes out to be around 2 GB. But I would love some confirmation on that, please.

Assuming a box with 8 GB of RAM, this PR allocates 3 GB to the heap and 3 to the page cache. Both of those numbers are far below what the documentation suggests. But let's start there and see if we need more RAM later.

By the way, I'm guessing one of the reasons why we have slow queries right now is that the page cache is so small.


Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] Have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?
