### PR TITLE
Add Dockerfile for Selenium Firefox w/mp4 video support

### DIFF
--- a/docker/build/chrome/Dockerfile
+++ b/docker/build/chrome/Dockerfile
@@ -1,0 +1,19 @@
+FROM selenium/standalone-chrome-debug:3.4.0-einsteinium
+MAINTAINER edxops
+
+USER root
+
+# Install a password generator
+RUN apt-get update -qqy \
+  && apt-get -qqy install \
+  pwgen \
+  && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+
+USER seluser
+
+CMD export VNC_PASSWORD=$(pwgen -s -1 $(shuf -i 10-20 -n 1)) \
+  && x11vnc -storepasswd $VNC_PASSWORD /home/seluser/.vnc/passwd \
+  && echo "Chrome VNC password: $VNC_PASSWORD" \
+  && /opt/bin/entry_point.sh
+
+EXPOSE 4444 5900

--- a/docker/build/firefox/Dockerfile
+++ b/docker/build/firefox/Dockerfile
@@ -1,0 +1,20 @@
+FROM selenium/standalone-firefox-debug:3.4.0-einsteinium
+MAINTAINER edxops
+
+USER root
+
+# Install a password generator and the codecs needed to support mp4 video in Firefox
+RUN apt-get update -qqy \
+  && apt-get -qqy install \
+  gstreamer1.0-libav \
+  pwgen \
+  && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+
+USER seluser
+
+CMD export VNC_PASSWORD=$(pwgen -s -1 $(shuf -i 10-20 -n 1)) \
+  && x11vnc -storepasswd $VNC_PASSWORD /home/seluser/.vnc/passwd \
+  && echo "Firefox VNC password: $VNC_PASSWORD" \
+  && /opt/bin/entry_point.sh
+
+EXPOSE 4444 5900


### PR DESCRIPTION
The [official Selenium docker containers](https://github.com/SeleniumHQ/docker-selenium) don't include the multimedia libraries required to support [mp4 playback on Firefox](https://github.com/SeleniumHQ/docker-selenium/pull/217) (partially because they add non-trivially to the container's size).  Quite a few of our JavaScript and acceptance tests count on this working, so this Dockerfile builds an image (derived from one of the official Selenium images) which we can use to run our tests in the latest Firefox with that particular obstacle resolved.

We'll probably want to rebuild and upload this automatically whenever the Dockerfile changes (like when we want to upgrade to a newer known-working version of the upstream image), but I didn't see anything in this repo to enable that.

I've also added support for generating a random, random-length password for VNC connections each time the container starts (and added a Dockerfile for a Chrome Selenium image which does this as well).  Once this is merged and we upload the images, I'll create a PR for the devstack repo which uses these images and adds a "vnc-passwords" make target which retrieves the current passwords from the container logs.

---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
