### PR TITLE
Copy pattern for delegating auth to the api, skipping basic auth

### DIFF
--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/cms.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/cms.j2
@@ -125,6 +125,13 @@ error_page {{ k }} {{ v }};
     try_files $uri @proxy_to_cms_app;
   }
 
+  # The api is accessed using OAUTH2 which
+  # uses the authorization header so we can't have
+  # basic auth on it as well.
+  location /api {
+    try_files $uri @proxy_to_cms_app;
+  }
+
   {% include "robots.j2" %}
   {% include "static-files.j2" %}
 


### PR DESCRIPTION
Copy pattern for delegating auth to the api, skipping basic auth from the LMS to CMS

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [x] A DevOps team member has approved the PR.
  - [x] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [x] Have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?
