### PR TITLE
Insights: Pass THEME_SCSS as an env var to webpack task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -331,3 +331,6 @@
   - Removed `bower install` task
   - Replaced r.js build task with webpack build task
   - Removed `./maange.py compress` task
+
+- Role: insights
+  - Moved `THEME_SCSS` from `INSIGHTS_CONFIG` to `insights_environment`

--- a/playbooks/roles/insights/defaults/main.yml
+++ b/playbooks/roles/insights/defaults/main.yml
@@ -128,7 +128,6 @@ INSIGHTS_CONFIG:
   # static file config
   STATICFILES_DIRS: ["{{ insights_static_path }}"]
   STATIC_ROOT: "{{ COMMON_DATA_DIR }}/{{ insights_service_name }}/staticfiles"
-  THEME_SCSS: '{{ INSIGHTS_THEME_SCSS }}'
   RESEARCH_URL: '{{ INSIGHTS_RESEARCH_URL }}'
   OPEN_SOURCE_URL: '{{ INSIGHTS_OPEN_SOURCE_URL }}'
   # db config
@@ -177,6 +176,7 @@ insights_environment:
   DJANGO_SETTINGS_MODULE: "analytics_dashboard.settings.production"
   ANALYTICS_DASHBOARD_CFG: "{{ COMMON_CFG_DIR  }}/{{ insights_service_name }}.yml"
   PATH: "{{ insights_nodeenv_bin }}:{{ insights_venv_dir }}/bin:{{ ansible_env.PATH }}"
+  THEME_SCSS: '{{ INSIGHTS_THEME_SCSS }}'
 
 
 insights_service_name: insights

--- a/playbooks/roles/insights/tasks/main.yml
+++ b/playbooks/roles/insights/tasks/main.yml
@@ -58,10 +58,10 @@
     production: yes
     state: latest
   become_user: "{{ insights_user }}"
+  environment: "{{ insights_environment }}"
   tags:
     - install
     - install:app-requirements
-  environment: "{{ insights_environment }}"
 
 - name: migrate
   shell: "DB_MIGRATION_USER='{{ COMMON_MYSQL_MIGRATE_USER }}' DB_MIGRATION_PASS='{{ COMMON_MYSQL_MIGRATE_PASS }}' {{ insights_venv_dir }}/bin/python {{ insights_manage }} migrate --noinput"
@@ -79,10 +79,10 @@
   args:
     chdir: "{{ insights_code_dir }}"
   become_user: "{{ insights_user }}"
+  environment: "{{ insights_environment }}"
   tags:
     - assets
     - assets:gather
-  environment: "{{ insights_environment }}"
 
 - name: run collectstatic
   shell: "{{ insights_venv_dir }}/bin/python {{ insights_manage }} {{ item }}"

--- a/playbooks/roles/insights/tasks/main.yml
+++ b/playbooks/roles/insights/tasks/main.yml
@@ -82,6 +82,7 @@
   tags:
     - assets
     - assets:gather
+  environment: "{{ insights_environment }}"
 
 - name: run collectstatic
   shell: "{{ insights_venv_dir }}/bin/python {{ insights_manage }} {{ item }}"


### PR DESCRIPTION
After merging the Insights webpack work we realized we broke theming and Insights was always loading the open-edx theme. This change will pass the INSIGHTS_THEME_SCSS variable to the webpack task (via environmental variables) which an upcoming Insights PR will read to find the theme to use when building the static assets. Django no longer handles theming, so I removed it from the INSIGHTS_CONFIG django settings.

I tested this out on https://loadtest-edx-insights.edx.org/ and verified that the edx theme (not open-edx) is loaded.

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [X] Are you adding any new default values that need to be overridden when this change goes live? No, I am changing an existing variable. If so:
    - [X] Update the appropriate internal repo (be sure to update for all our environments)
    - [X] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [X] Add an entry to the CHANGELOG.
  - [X] Have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)? On loadtest, yes.
