### PR TITLE
Downgrade to 2.2.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-ansible==2.3.1.0
+ansible==2.2.0.0
 PyYAML==3.12
 Jinja2==2.8
 MarkupSafe==0.23


### PR DESCRIPTION
abbey.py is throwing errors on copying with 2.3.1

This reverts https://github.com/edx/configuration/pull/3704/files
More details are in
https://openedx.atlassian.net/browse/OPS-2296 although I suspect
our fix is going to be to remove our use of abbey.py

