### PR TITLE
Ginkgo: Add optional task to rebuild the forum elasticsearch index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+- Role: forum
+  - Added `FORUM_REBUILD_INDEX` to rebuild the ElasticSearch index from the database, when enabled.  Default: `False`.
+
 - Role: edxapp
   - Let `confirm_email` in `EDXAPP_REGISTRATION_EXTRA_FIELDS` default to `"hidden"`.
   - Let `terms_of_service` in `EDXAPP_REGISTRATION_EXTRA_FIELDS` default to `"hidden"`.

--- a/playbooks/roles/forum/defaults/main.yml
+++ b/playbooks/roles/forum/defaults/main.yml
@@ -45,6 +45,9 @@ FORUM_USE_TCP: false
 # wait this long before attempting to restart it
 FORUM_RESTART_DELAY: 60
 
+# Set to rebuild the forum ElasticSearch index from the database.
+FORUM_REBUILD_INDEX: false
+
 forum_environment:
   RBENV_ROOT: "{{ forum_rbenv_root }}"
   GEM_HOME: "{{ forum_gem_root }}"

--- a/playbooks/roles/forum/tasks/deploy.yml
+++ b/playbooks/roles/forum/tasks/deploy.yml
@@ -71,6 +71,17 @@
     - migrate
     - migrate:db
 
+- name: rebuild elasticsearch indexes
+  command: "{{ forum_code_dir }}/bin/rake search:rebuild_index"
+  args:
+    chdir: "{{ forum_code_dir }}"
+  become_user: "{{ forum_user }}"
+  environment: "{{ forum_environment }}"
+  when: migrate_db is defined and migrate_db|lower == "yes" and FORUM_REBUILD_INDEX|bool
+  tags:
+    - migrate
+    - migrate:db
+
   # call supervisorctl update. this reloads
   # the supervisorctl config and restarts
   # the services if any of the configurations


### PR DESCRIPTION
set FORUM_REBUILD_INDEX to run the rebuild_index rake task.

(cherry picked from commit d07e6fca7cdb4222ed1f40dd649b310866ad611f)

Applies https://github.com/edx/configuration/pull/3988 to `open-release/ginkgo.master`.

CC @gsong @nedbat 

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [x] Add an entry to the CHANGELOG.
  - [ ] Have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?
