### PR TITLE
PLAT-1659 Remove git checkout from edxapp

### DIFF
--- a/docker/build/edxapp/Dockerfile
+++ b/docker/build/edxapp/Dockerfile
@@ -29,6 +29,7 @@ RUN sudo /edx/app/edx_ansible/venvs/edx_ansible/bin/ansible-playbook edxapp.yml 
     --extra-vars=edx_platform_version=${OPENEDX_RELEASE} \
     --extra-vars="@/ansible_overrides.yml" \
     --extra-vars="@/devstack.yml" \
-    --extra-vars="@/devstack/ansible_overrides.yml"
+    --extra-vars="@/devstack/ansible_overrides.yml" \
+    && rm -rf /edx/app/edxapp/edx-platform
 
 EXPOSE 18000 18010


### PR DESCRIPTION
The edxapp container currently includes the /edx/app/edxapp/edx-platform directory which gets completely overridden in devstack by a volume representing the host's local edx-platform git checkout.  A local build indicates that removing this unused directory reduces the image size by about 1.35 GB (the compressed download size difference will be somewhat less).  Given that we download new versions of this image all the time, this seems like a pretty substantial win.

Can anybody think of good reasons why we shouldn't do this?  It would make it impossible to use the image without a local edx-platform checkout, but all of our current tooling assumes that you have that.  If we want to support Docker in production, we'll definitely need an image that has this directory, but we'd want to make enough other changes for that use case that it should be a separate image anyway.

---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
