### PR TITLE
increase heap and page cache sizes for neo4j

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 - Role: neo4j
+  - Increase heap and page caches sizes for neo4j
+
+- Role: neo4j
   - Updated neo4j to 3.2.2
   - Removed authentication requirement for neo4j
 

--- a/playbooks/roles/neo4j/defaults/main.yml
+++ b/playbooks/roles/neo4j/defaults/main.yml
@@ -27,8 +27,8 @@ neo4j_server_config_file: "/etc/neo4j/neo4j.conf"
 neo4j_https_port: 7473  # default in package is 7473
 neo4j_http_port: 7474  # default in package is 7474
 neo4j_listen_address: "0.0.0.0"
-neo4j_heap_max_size: "3000m"
-neo4j_page_cache_size: "3000m"
+neo4j_heap_max_size: "6000m"
+neo4j_page_cache_size: "6000m"
 neo4j_log_dir: "/var/log/neo4j"
 
 # Properties file settings


### PR DESCRIPTION
Configuration Pull Request
---
Now that neo4j is on a box with 16 GB of memory, this PR increases the amount of memory available to the heap and to the page cache.

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] Have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?
