### PR TITLE
update credentials-binding plugin to version 1.10

### DIFF
--- a/playbooks/roles/tools_jenkins/defaults/main.yml
+++ b/playbooks/roles/tools_jenkins/defaults/main.yml
@@ -44,7 +44,7 @@ jenkins_tools_plugins:
   - { name: "plain-credentials", version: "1.2" }
   - { name: "github-oauth", version: "0.24" }
   - { name: "gradle", version: "1.25" }
-  - { name: "credentials-binding", version: "1.9" }
+  - { name: "credentials-binding", version: "1.10" }
   - { name: "envinject", version: "1.92.1" }
   - { name: "email-ext", version: "2.57.2" }
   - { name: "text-finder", version: "1.10"}


### PR DESCRIPTION
update the credentials-binding plugin of tools-edx-jenkins so that credentials are masked in the console