### PR TITLE
Remove alternate firefox version from jenkins workers  TE-1293

### DIFF
--- a/playbooks/roles/jenkins_worker/defaults/main.yml
+++ b/playbooks/roles/jenkins_worker/defaults/main.yml
@@ -14,7 +14,3 @@ jenkins_debian_pkgs:
 
 # packer direct download URL
 packer_url: "https://releases.hashicorp.com/packer/0.8.6/packer_0.8.6_linux_amd64.zip"
-
-# custom firefox
-custom_firefox_version: 42.0
-custom_firefox_url: "https://ftp.mozilla.org/pub/firefox/releases/{{ custom_firefox_version }}/linux-x86_64/en-US/firefox-{{ custom_firefox_version }}.tar.bz2"

--- a/playbooks/roles/jenkins_worker/tasks/python_platform_worker.yml
+++ b/playbooks/roles/jenkins_worker/tasks/python_platform_worker.yml
@@ -61,19 +61,3 @@
 # done with it
 - name: Remove shallow-clone
   file: path={{ jenkins_home }}/shallow-clone state=absent
-
-# Although firefox is installed through the browsers role, install
-# a newer copy under the jenkins home directory. This will allow
-# platform pull requests to use a custom firefox path to a different
-# version
-- name: Install custom firefox to jenkins home
-  get_url:
-    url: "{{ custom_firefox_url }}"
-    dest: "{{ jenkins_home }}/firefox-{{ custom_firefox_version }}.tar.bz2"
-
-- name: unpack custom firefox version
-  unarchive:
-    src: "{{ jenkins_home }}/firefox-{{ custom_firefox_version }}.tar.bz2"
-    dest: "{{ jenkins_home }}"
-    creates: "{{ jenkins_home }}/firefox"
-    copy: no


### PR DESCRIPTION
Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] Have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?
