### PR TITLE
PLAT-1590 New container for edx-e2e-tests

### DIFF
--- a/docker/build/e2e/Dockerfile
+++ b/docker/build/e2e/Dockerfile
@@ -1,0 +1,47 @@
+# To build this Dockerfile:
+#
+# From the root of configuration:
+#
+# docker build -f docker/build/e2e/Dockerfile . -t edxops/e2e:latest
+
+
+FROM edxops/python:2.7
+MAINTAINER edxops
+USER root
+CMD bash -c 'while true; do sleep 60; done'
+
+ENV ACCESS_TOKEN="" \
+    BASIC_AUTH_USER="" \
+    BASIC_AUTH_PASSWORD="" \
+    CONFIG_ROOT="/edx/app/e2e" \
+    USER_LOGIN_EMAIL="staff@example.com" \
+    USER_LOGIN_PASSWORD="edx" \
+    COURSE_ORG="edX" \
+    COURSE_NUMBER="E2E-101" \
+    COURSE_RUN="course" \
+    COURSE_DISPLAY_NAME="Manual Smoke Test Course 1 - Auto" \
+    EDXAPP_CMS_DOC_LINK_BASE_URL="http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course" \
+    GLOBAL_PASSWORD="" \
+    LMS_BASE_URL="edx.devstack.lms:18000" \
+    LMS_PROTOCOL="http" \
+    SELENIUM_BROWSER="chrome" \
+    SELENIUM_HOST="edx.devstack.chrome" \
+    SELENIUM_PORT="4444" \
+    STAFF_USER_EMAIL="" \
+    STUDIO_BASE_URL="edx.devstack.studio:18010" \
+    STUDIO_PROTOCOL="http" \
+    VIRTUAL_ENV="/edx/app/e2e/venvs/e2e"
+
+COPY docker/build/e2e/devstack.sh /edx/app/e2e/
+
+RUN apt-get update -qqy \
+    && apt-get -qqy install \
+    libxml2-dev \
+    libxslt1-dev \
+    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+    && git clone https://github.com/edx/edx-e2e-tests.git ${CONFIG_ROOT}/edx-e2e-tests \
+    && cd ${CONFIG_ROOT}/edx-e2e-tests \
+    && pip install -r requirements/base.txt \
+    && paver install_pages \
+    && rm -rf /edx/app/e2e/edx-e2e-tests/ \
+    && chmod u+x /edx/app/e2e/devstack.sh

--- a/docker/build/e2e/Dockerfile
+++ b/docker/build/e2e/Dockerfile
@@ -1,47 +1,26 @@
 # To build this Dockerfile:
 #
-# From the root of configuration:
+# From the root of the edx-e2e-tests repository:
 #
-# docker build -f docker/build/e2e/Dockerfile . -t edxops/e2e:latest
-
+# docker build -f Dockerfile . -t edxops/e2e:latest
 
 FROM edxops/python:2.7
 MAINTAINER edxops
-USER root
-CMD bash -c 'while true; do sleep 60; done'
 
-ENV ACCESS_TOKEN="" \
-    BASIC_AUTH_USER="" \
-    BASIC_AUTH_PASSWORD="" \
-    CONFIG_ROOT="/edx/app/e2e" \
-    USER_LOGIN_EMAIL="staff@example.com" \
-    USER_LOGIN_PASSWORD="edx" \
-    COURSE_ORG="edX" \
-    COURSE_NUMBER="E2E-101" \
-    COURSE_RUN="course" \
-    COURSE_DISPLAY_NAME="Manual Smoke Test Course 1 - Auto" \
-    EDXAPP_CMS_DOC_LINK_BASE_URL="http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course" \
-    GLOBAL_PASSWORD="" \
-    LMS_BASE_URL="edx.devstack.lms:18000" \
-    LMS_PROTOCOL="http" \
-    SELENIUM_BROWSER="chrome" \
-    SELENIUM_HOST="edx.devstack.chrome" \
-    SELENIUM_PORT="4444" \
-    STAFF_USER_EMAIL="" \
-    STUDIO_BASE_URL="edx.devstack.studio:18010" \
-    STUDIO_PROTOCOL="http" \
-    VIRTUAL_ENV="/edx/app/e2e/venvs/e2e"
-
-COPY docker/build/e2e/devstack.sh /edx/app/e2e/
-
+# Install system libraries needed for lxml
 RUN apt-get update -qqy \
     && apt-get -qqy install \
     libxml2-dev \
     libxslt1-dev \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-    && git clone https://github.com/edx/edx-e2e-tests.git ${CONFIG_ROOT}/edx-e2e-tests \
-    && cd ${CONFIG_ROOT}/edx-e2e-tests \
-    && pip install -r requirements/base.txt \
+    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+
+ADD . /edx-e2e-tests
+WORKDIR /edx-e2e-tests
+
+# Set up the virtualenv
+# Deletes the edx-platform checkout afterwards, it will be mapped in from the host
+RUN pip install -r requirements/base.txt \
     && paver install_pages \
-    && rm -rf /edx/app/e2e/edx-e2e-tests/ \
-    && chmod u+x /edx/app/e2e/devstack.sh
+    && rm -rf /edx-e2e-tests/lib
+
+CMD ["paver", "e2e_test", "--exclude=whitelabel"]

--- a/docker/build/e2e/devstack.sh
+++ b/docker/build/e2e/devstack.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-
-cd /edx/app/e2e/edx-e2e-tests
-
-/bin/bash

--- a/docker/build/e2e/devstack.sh
+++ b/docker/build/e2e/devstack.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+cd /edx/app/e2e/edx-e2e-tests
+
+/bin/bash


### PR DESCRIPTION
We want to be able to run the edx-platform e2e tests in Docker Devstack; this will help making development of those tests easier, sanity check major code changes locally, and let us run smoke tests against our built container images.  This test repo does browser automation and assumes a local checkout of edx-platform; in Docker Devstack, we can just reuse the existing Selenium containers and edx-platform containers and git checkout.  So all we really need is a new container with a pre-configured virtualenv, with the test repo content being mapped in from the host at runtime as with the edxapp and IDA containers.

I've already merged a PR with some minor fixes that were needed for edx-platform settings, and have an open [edx-e2e-tests PR](https://github.com/edx/edx-e2e-tests/pull/204) with the changes needed for the tests to run and pass reliably under Docker.

---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.