### PR TITLE
Ignore logfiles that end in digits by default.

### DIFF
--- a/playbooks/roles/splunkforwarder/templates/opt/splunkforwarder/etc/system/local/inputs.conf.j2
+++ b/playbooks/roles/splunkforwarder/templates/opt/splunkforwarder/etc/system/local/inputs.conf.j2
@@ -2,7 +2,7 @@
 
 {% for loggable in SPLUNKFORWARDER_LOG_ITEMS%}
 [monitor://{{ loggable.source }}]
-blacklist = \.(gz)$
+blacklist = ((\.(gz))|\d)$
 {% if loggable.recursive | default(False) %}
 {# There's a bug in which "recursive" must be unset for logs to be forwarded #}
 {# See https://answers.splunk.com/answers/420901/splunk-not-matching-files-with-wildcard-in-monitor.html #}


### PR DESCRIPTION
Update splunkforwarder so that it doesn't read files that end with a digit.  Our log rotation scheme rotates the file but then zips at a later time.  This causes splunk to re-read the log files in some cases.  This should cause it to ignore all log files with a digit on the end.

This should ignore the logrotated edx.log files for all IDAs, and also ignore the rotated supervisor logs.

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] Have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?
