### PR TITLE
change test specifiers for move to pytest

### DIFF
--- a/playbooks/roles/test_build_server/files/test-development-environment.sh
+++ b/playbooks/roles/test_build_server/files/test-development-environment.sh
@@ -44,9 +44,9 @@ case "$1" in
     "bokchoy")
 
         # Run some of the bok-choy tests
-        paver test_bokchoy -t discussion/test_discussion.py:DiscussionTabSingleThreadTest
-        paver test_bokchoy -t studio/test_studio_outline.py:WarningMessagesTest.test_unreleased_published_locked --fasttest
-        paver test_bokchoy -t lms/test_lms_matlab_problem.py:MatlabProblemTest --fasttest
+        paver test_bokchoy -t discussion/test_discussion.py::DiscussionTabSingleThreadTest
+        paver test_bokchoy -t studio/test_studio_outline.py::WarningMessagesTest::test_unreleased_published_locked --fasttest
+        paver test_bokchoy -t lms/test_lms_matlab_problem.py::MatlabProblemTest --fasttest
         ;;
 
     "lettuce")


### PR DESCRIPTION
Packer builds were failing since the platform switched from nose to pytest for bokchoy tests. This fixes the problem

CC @edx/devops 