### PR TITLE
Add Consent API to basic auth whitelist

### DIFF
--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
@@ -199,6 +199,11 @@ error_page {{ k }} {{ v }};
     try_files $uri @proxy_to_lms_app;
   }
 
+  # Consent API
+  location /consent/api {
+    try_files $uri @proxy_to_lms_app;
+  }
+
   # Need a separate location for the image uploads endpoint to limit upload sizes
   location ~ ^/api/profile_images/[^/]*/[^/]*/upload$ {
     try_files $uri @proxy_to_lms_app;


### PR DESCRIPTION
This pull request adds the Consent service API (`/consent/api`) to the list of subpaths that may be accessed on the LMS without providing basic auth information. This is required in order to access the relevant endpoints with an OAuth client.

Testing:

Do the following:

```
curl -v "https://courses.stage.edx.org/consent/api/v1/data_sharing_consent"
```

This sandbox has not had this change deployed to its nginx configuration. Observe that the response requesting authentication comes from nginx directly and is in the form of an HTML page.

Do the following:

```
curl -v "https://business.sandbox.edx.org/consent/api/v1/data_sharing_consent"
```

This sandbox has had this change deployed to its nginx configuration. Observe that the response requesting authentication comes from edx-platform in the form of a JSON API response.

There are no new variables, roles, or actions in this PR; this is a template change only.

---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] Have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?
