### PR TITLE
allow custom blacklist rules for splunk forwarder

### DIFF
--- a/playbooks/edx-east/jenkins_testeng_master.yml
+++ b/playbooks/edx-east/jenkins_testeng_master.yml
@@ -28,6 +28,7 @@
         sourcetype: build_result
         followSymlink: false
         crcSalt: '<SOURCE>'
+        blacklist: '(((\.(gz))|\d)$)|(.*seed.*)'
 
       - source: '/var/lib/jenkins/jobs/*/builds/*/log'
         index: 'testeng'

--- a/playbooks/edx-east/jenkins_testeng_master.yml
+++ b/playbooks/edx-east/jenkins_testeng_master.yml
@@ -35,6 +35,7 @@
         sourcetype: build_log
         followSymlink: false
         crcSalt: '<SOURCE>'
+        blacklist: '(((\.(gz))|\d)$)|(.*seed.*)'
 
       - source: '/var/lib/jenkins/jobs/*/builds/*/archive/test_root/log/timing.*.log'
         index: 'testeng'

--- a/playbooks/roles/splunkforwarder/templates/opt/splunkforwarder/etc/system/local/inputs.conf.j2
+++ b/playbooks/roles/splunkforwarder/templates/opt/splunkforwarder/etc/system/local/inputs.conf.j2
@@ -2,7 +2,11 @@
 
 {% for loggable in SPLUNKFORWARDER_LOG_ITEMS%}
 [monitor://{{ loggable.source }}]
+{% if loggable.blacklist is defined %}
+blacklist = {{ loggable.blacklist }}
+{% else %}
 blacklist = ((\.(gz))|\d)$
+{% endif %}
 {% if loggable.recursive | default(False) %}
 {# There's a bug in which "recursive" must be unset for logs to be forwarded #}
 {# See https://answers.splunk.com/answers/420901/splunk-not-matching-files-with-wildcard-in-monitor.html #}


### PR DESCRIPTION
We don't want to log the seed job logs. In the future, we will probably expand this, as other jobs are not important enough to index. I find it is more readable when the blacklist is complicated rather than the monitor field, but that's just me.