### PR TITLE
Make edx_service stricter about edx_service_config

### DIFF
--- a/playbooks/roles/edx_service/defaults/main.yml
+++ b/playbooks/roles/edx_service/defaults/main.yml
@@ -17,6 +17,12 @@
 edx_service_name: edx_service
 
 edx_service_repos: []
+
+# A few roles meta this role but don't need a config file written
+# this allows them to not pass a config and the tasks will skip
+# and not write out a config at all.
+edx_service_config: {}
+
 #
 # OS packages
 #

--- a/playbooks/roles/edx_service/tasks/main.yml
+++ b/playbooks/roles/edx_service/tasks/main.yml
@@ -95,7 +95,7 @@
     src: "config.yml.j2"
     dest: "{{ COMMON_CFG_DIR  }}/{{ edx_service_name }}.yml"
     mode: "0644"
-  when: edx_service_config is defined
+  when: edx_service_config
   tags:
     - install
     - install:configuration


### PR DESCRIPTION

With the defined check, it's possible to have config syntax errors and Ansible will then skip the task and not write a config file.  I contend that we want ansible to bail out if the dict it gets in edx_service_config is invalid.  It appears to be the checking of the variable that evaluates the various interpolations.

Noticed this when manually testing config changes and saw missing files rather than syntax errors.  In particular, this will make our config checking code much better.