### PR TITLE
Include the Environment-Deployment when announcing an AMI build

### DIFF
--- a/playbooks/continuous_delivery/create_ami.yml
+++ b/playbooks/continuous_delivery/create_ami.yml
@@ -116,7 +116,7 @@
       api: "{{ hipchat_url }}"
       token: "{{ hipchat_token }}"
       room: "{{ hipchat_room }}"
-      msg: "Finished baking AMI for: {{ play }} \n
+      msg: "Finished baking AMI for: {{ edx_environment }}-{{ deployment }}-{{ play }} \n
             AMI-ID: {{ ami_register.image_id }} \n
            "
     ignore_errors: yes


### PR DESCRIPTION
Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] Have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?

Otherwise, we see 3 edxapp AMI builds per gocd pipeline, but have
no idea which one is which.  Similar issue for IDAs where you get at
least 2 AMIs.