### PR TITLE
This cleans up a warning about wait being defined twice in this task

### DIFF
--- a/playbooks/continuous_delivery/launch_instance.yml
+++ b/playbooks/continuous_delivery/launch_instance.yml
@@ -70,7 +70,6 @@
       key_name: "{{ automation_prefix }} {{ unique_key_name.stdout }}"
       instance_type: "{{ ec2_instance_type }}"
       image: "{{ launch_ami_id }}"
-      wait: yes
       group_id: "{{ ec2_security_group_id }}"
       count: 1
       vpc_subnet_id: "{{ ec2_vpc_subnet_id }}"


### PR DESCRIPTION
[WARNING]: While constructing a mapping from /var/lib/go-agent/pipelines
  /loadtest-
  credentials/configuration/playbooks/continuous_delivery/launch_instance.yml,
  line 68, column 7, found a duplicate dict key (wait). Using last defined value
  only.