### PR TITLE
`retries` don't work without `until`

### DIFF
--- a/playbooks/roles/launch_ec2/tasks/main.yml
+++ b/playbooks/roles/launch_ec2/tasks/main.yml
@@ -66,6 +66,10 @@
     ttl: 300
     record: "{{ dns_name }}.{{ dns_zone }}"
     value: "{{ item.public_dns_name }}"
+  register: task_result
+  until: task_result|succeeded
+  retries: 5
+  delay: 30
   with_items: "{{ ec2.instances }}"
 
 - name: Add DNS names for services
@@ -78,6 +82,10 @@
     ttl: 300
     record: "{{ item[1] }}-{{ dns_name }}.{{ dns_zone }}"
     value: "{{ item[0].public_dns_name }}"
+  register: task_result
+  until: task_result|succeeded
+  retries: 5
+  delay: 30
   with_nested:
     - "{{ ec2.instances }}"
     - ['studio', 'ecommerce', 'preview', 'discovery', 'credentials']

--- a/playbooks/roles/splunkforwarder/tasks/main.yml
+++ b/playbooks/roles/splunkforwarder/tasks/main.yml
@@ -37,6 +37,7 @@
     dest: "/tmp/{{ SPLUNKFORWARDER_DEB }}"
     url: "{{ SPLUNKFORWARDER_PACKAGE_URL }}"
   register: download_deb
+  until: download_deb|succeeded
   retries: 5
 
 - name: Install splunk forwarder

--- a/playbooks/roles/user/tasks/main.yml
+++ b/playbooks/roles/user/tasks/main.yml
@@ -128,8 +128,9 @@
   # We don't care if absent users lack ssh keys
   when: item.get('state', 'present') == 'present' and item.github is defined
   with_items: "{{ user_info }}"
-  retries: 5
   register: github_users_return
+  until: github_users_return|succeeded
+  retries: 5
 
 - name: Print warning if github user(s) missing ssh key
   debug:
@@ -151,6 +152,8 @@
     exclusive: yes
     key: "https://github.com/{{ item.name }}.keys"
   when: item.github is defined and item.get('state', 'present') == 'present'
+  register: task_result
+  until: task_result|succeeded
   retries: 5
   with_items: "{{ user_info }}"
 


### PR DESCRIPTION
The `retries` statement is just ignored unless an `until` clause
is provided.

https://github.com/ansible/ansible/issues/20802

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] Have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?
