### PR TITLE
Add flag EDXAPP_REINDEX_ALL_COURSES (reindex courses on deploy)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 - Role: edxapp
+  - Added `EDXAPP_REINDEX_ALL_COURSES` to rebuild the course index on deploy. Disabled by default.
+
+- Role: edxapp
   - Added `ENTERPRISE_SUPPORT_URL` variable used by the LMS.
 
 - Role: edxapp

--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -455,6 +455,9 @@ EDXAPP_COURSES_WITH_UNSAFE_CODE: []
 EDXAPP_SESSION_COOKIE_DOMAIN: ""
 EDXAPP_SESSION_COOKIE_NAME: "sessionid"
 
+# Whether to run reindex_course on deploy
+EDXAPP_REINDEX_ALL_COURSES: false
+
 # XML Course related flags
 EDXAPP_XML_FROM_GIT: false
 EDXAPP_XML_S3_BUCKET: !!null

--- a/playbooks/roles/edxapp/tasks/deploy.yml
+++ b/playbooks/roles/edxapp/tasks/deploy.yml
@@ -436,3 +436,13 @@
   tags:
     - manage
     - manage:db
+
+- name: reindex all courses
+  shell: "{{ edxapp_venv_bin }}/python ./manage.py cms reindex_course --all --settings={{ edxapp_settings }}"
+  args:
+    chdir: "{{ edxapp_code_dir }}"
+  become_user: "{{ common_web_user }}"
+  when: EDXAPP_REINDEX_ALL_COURSES
+  tags:
+    - migrate
+    - migrate:db

--- a/playbooks/roles/edxapp/tasks/deploy.yml
+++ b/playbooks/roles/edxapp/tasks/deploy.yml
@@ -438,13 +438,9 @@
     - manage:db
 
 - name: reindex all courses
-  expect:
-    command: "{{ edxapp_venv_bin }}/python ./manage.py cms reindex_course --all --settings={{ edxapp_settings }}"
-    responses:
-      Re-indexing all courses might be a time consuming operation. Do you want to continue: "y"
+  shell: "{{ edxapp_venv_bin }}/python ./manage.py cms reindex_course --setup --settings={{ edxapp_settings }}"
+  args:
     chdir: "{{ edxapp_code_dir }}"
-    timeout: 60
-    echo: true
   become_user: "{{ common_web_user }}"
   when: EDXAPP_REINDEX_ALL_COURSES
   tags:

--- a/playbooks/roles/edxapp/tasks/deploy.yml
+++ b/playbooks/roles/edxapp/tasks/deploy.yml
@@ -444,5 +444,5 @@
   become_user: "{{ common_web_user }}"
   when: EDXAPP_REINDEX_ALL_COURSES
   tags:
-    - migrate
-    - migrate:db
+    - install
+    - install:base

--- a/playbooks/roles/edxapp/tasks/deploy.yml
+++ b/playbooks/roles/edxapp/tasks/deploy.yml
@@ -438,9 +438,13 @@
     - manage:db
 
 - name: reindex all courses
-  shell: "{{ edxapp_venv_bin }}/python ./manage.py cms reindex_course --all --settings={{ edxapp_settings }}"
-  args:
+  expect:
+    command: "{{ edxapp_venv_bin }}/python ./manage.py cms reindex_course --all --settings={{ edxapp_settings }}"
+    responses:
+      Re-indexing all courses might be a time consuming operation. Do you want to continue: "y"
     chdir: "{{ edxapp_code_dir }}"
+    timeout: 60
+    echo: true
   become_user: "{{ common_web_user }}"
   when: EDXAPP_REINDEX_ALL_COURSES
   tags:


### PR DESCRIPTION
This adds a task to call reindex_course on deploy. Toggle-able through a flag `EDXAPP_REINDEX_ALL_COURSES` (disabled by default).
 
**JIRA tickets**: [OSPR-1888](https://openedx.atlassian.net/browse/OSPR-1888)

**Discussions**: N/A

**Dependencies**: None

**Screenshots**:

**Sandbox URL**: TBD - sandbox is being provisioned.

**Merge deadline**: None

**Testing instructions**:

1. Do a deploy with this variable set to False. Nothing should change
2. Temporarily add a tag to the new task („reindex all courses“) in deploy.yml: `testing-clemente-reindex-courses`. This will be used in the ansible-playbook invocation.
2. Test in local in an already deployed devstack with some course, with:
    ```bash
    cd /edx/app/edx_ansible
    source venvs/edx_ansible/bin/activate
    cd edx_ansible/playbooks/
    ansible-playbook -e "{role: 'edxapp'}" -i "localhost," -c local --tags testing-clemente-reindex-courses  run_role.yml -e EDXAPP_REINDEX_ALL_COURSES=true -e edxapp_settings=devstack -vvv
    ```
7. Verify (in the verbose info) that some courses are processed and reindexed

**Author notes and concerns**:

- This is supposed to be a one-time operation, on deploy, for the cases when an instance is using a local ElasticSearch.
- The command doesn't depend on any particular ModuleStore

**Reviewers**
- [x] @pomegranited 
- [ ] edX reviewer[s] TBD - @edx/devops 

**Settings**
```yaml
EDXAPP_REINDEX_ALL_COURSES: true
```

---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [X] Add an entry to the CHANGELOG.
  - [ ] Have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?
