### PR TITLE
Mongo 3.2 expects xenial, which means bootstrapping

### DIFF
--- a/playbooks/edx-east/mongo_3_2.yml
+++ b/playbooks/edx-east/mongo_3_2.yml
@@ -10,6 +10,12 @@
 # ADDING A NEW CLUSTER MEMBER
 # If you are adding a member to a cluster, you must be sure that the new machine is not first in your inventory
 # ansible-playbook mongo_3_2.yml -i 203.0.113.11,203.0.113.12,new-machine-ip -e@/path/to/edx.yml -e@/path/to/ed.yml
+- name: Bootstrap instance(s)
+  hosts: all
+  gather_facts: no
+  become: True
+  roles:
+    - python
 - name: Deploy MongoDB
   hosts: all
   become: True


### PR DESCRIPTION
Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] Have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?