### PR TITLE
Fixes for jenkins_common role

### DIFF
--- a/playbooks/edx-east/jenkins_test.yml
+++ b/playbooks/edx-east/jenkins_test.yml
@@ -13,7 +13,6 @@
   roles:
     - aws
     - role: jenkins_build
-      build_jenkins_server_name: test-jenkins.testeng.edx.org
       build_jenkins_configuration_scripts:
         - 1addJarsToClasspath.groovy
         - 2checkInstalledPlugins.groovy

--- a/playbooks/roles/jenkins_build/meta/main.yml
+++ b/playbooks/roles/jenkins_build/meta/main.yml
@@ -16,4 +16,4 @@ dependencies:
     jenkins_common_log_list: '{{ build_jenkins_log_list }}'
     jenkins_common_history_max_days: '{{ build_jenkins_history_max_days }}'
     jenkins_common_history_exclude_pattern: '{{ build_jenkins_history_exclude_pattern }}'
-    jenkins_common_server_name: '{{ build_jenkins_server_name }}'
+    jenkins_common_server_name: '{{ JENKINS_SERVER_NAME }}'

--- a/playbooks/roles/jenkins_common/defaults/main.yml
+++ b/playbooks/roles/jenkins_common/defaults/main.yml
@@ -7,7 +7,8 @@ jenkins_common_version: jenkins_1.651.3
 jenkins_common_war_source: https://s3.amazonaws.com/edx-testeng-tools/jenkins
 jenkins_common_nginx_port: 80
 jenkins_common_protocol_https: true
-jenkins_common_server_name: jenkins.example.org
+
+JENKINS_SERVER_NAME: jenkins.example.org
 
 jenkins_common_debian_pkgs:
   - nginx
@@ -107,7 +108,8 @@ JENKINS_SECRET_FILES_LIST: []
 JENKINS_USERNAME_PASSWORD_LIST: []
 JENKINS_SECRET_TEXT_LIST: []
 JENKINS_CERTIFICATES_LIST: []
-JENKINS_SSH_LIST: []
+JENKINS_MASTER_SSH_LIST: []
+JENKINS_CUSTOM_SSH_LIST: []
 
 # security
 jenkins_common_security_scopes: 'read:org,user:email'

--- a/playbooks/roles/jenkins_common/meta/main.yml
+++ b/playbooks/roles/jenkins_common/meta/main.yml
@@ -14,7 +14,7 @@ dependencies:
     nginx_template_dir: "etc/nginx/sites-available"
     nginx_sites: jenkins
     jenkins_nginx_port: "{{ jenkins_common_nginx_port }}"
-    jenkins_server_name: "{{ jenkins_common_server_name }}"
+    jenkins_server_name: "{{ JENKINS_SERVER_NAME }}"
     jenkins_port: "{{ jenkins_common_port }}"
     jenkins_protocol_https: "{{ jenkins_common_protocol_https }}"
   - role: oraclejdk

--- a/playbooks/roles/jenkins_common/tasks/main.yml
+++ b/playbooks/roles/jenkins_common/tasks/main.yml
@@ -164,11 +164,22 @@
     - install:plugins
     - install:jenkins-configuration
 
-- name: Copy credentials into files
+- name: Copy secret file credentials
   copy:
     content: "{{ item.content }}"
     dest: '{{ jenkins_common_config_path }}/credentials/{{ item.name }}'
   with_items: '{{ JENKINS_SECRET_FILES_LIST }}'
+  no_log: yes
+  tags:
+    - install
+    - install:base
+    - install:jenkins-configuration
+
+- name: Copy ssh key credentials
+  copy:
+    content: "{{ item.content }}"
+    dest: '{{ jenkins_common_config_path }}/credentials/{{ item.name }}'
+  with_items: '{{ JENKINS_CUSTOM_SSH_LIST }}'
   no_log: yes
   tags:
     - install

--- a/playbooks/roles/jenkins_common/templates/config/credentials.yml.j2
+++ b/playbooks/roles/jenkins_common/templates/config/credentials.yml.j2
@@ -12,7 +12,7 @@
   scope: '{{ userPass.scope }}'
   username: '{{ userPass.username }}'
   password: '{{ userPass.password }}'
-  description: '{{ userPass.password }}'
+  description: '{{ userPass.description }}'
   id: '{{ userPass.id }}'
 {% endfor %}
 {% for text in JENKINS_SECRET_TEXT_LIST %}
@@ -30,14 +30,20 @@
   description: '{{ cert.description }}'
   id: '{{ cert.id }}'
 {% endfor %}
-{% for ssh in JENKINS_SSH_LIST %}
+{% for master_ssh in JENKINS_MASTER_SSH_LIST %}
 - credentialType: 'ssh'
-  scope: '{{ ssh.scope }}'
-  username: '{{ ssh.username }}'
-  isJenkinsMasterSsh: '{{ ssh.isJenkinsMasterSsh}}'
-{% if not isJenkinsMasterSsh %}
-  path: '{{ ssh.path }}'
-{% endif %}
-  passphrase: '{{ ssh.passphrase }}'
-  description: '{{ ssh.description }}'
+  scope: '{{ master_ssh.scope }}'
+  username: '{{ master_ssh.username }}'
+  isJenkinsMasterSsh: true
+  passphrase: '{{ master_ssh.passphrase }}'
+  description: '{{ master_ssh.description }}'
+{% endfor %}
+{% for custom_ssh in JENKINS_CUSTOM_SSH_LIST %}
+- credentialType: 'ssh'
+  scope: '{{ custom_ssh.scope }}'
+  username: '{{ custom_ssh.username }}'
+  isJenkinsMasterSsh: false
+  path: 'credentials/{{ custom_ssh.name }}'
+  passphrase: '{{ custom_ssh.passphrase }}'
+  description: '{{ custom_ssh.description }}'
 {% endfor %}


### PR DESCRIPTION
Noticed a few things that needed to be tweaked in the jenkins_common role.
1- Got rid of edx specific server names.
2- Fixed credential support for ssh and usernamePassword credential types.

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
