### PR TITLE
Remove seed job groovy script for testeng plays

### DIFF
--- a/playbooks/edx-east/jenkins_build.yml
+++ b/playbooks/edx-east/jenkins_build.yml
@@ -12,4 +12,18 @@
   gather_facts: True
   roles:
     - aws
-    - jenkins_build
+    - role: jenkins_build
+      build_jenkins_configuration_scripts:
+        - 1addJarsToClasspath.groovy
+        - 2checkInstalledPlugins.groovy
+        - 3mainConfiguration.groovy
+        - 3shutdownCLI.groovy
+        - 4configureEc2Plugin.groovy
+        - 4configureGHOAuth.groovy
+        - 4configureGHPRB.groovy
+        - 4configureGit.groovy
+        - 4configureHipChat.groovy
+        - 4configureJobConfigHistory.groovy
+        - 4configureMailerPlugin.groovy
+        - 5createLoggers.groovy
+        - 6importCredentials.groovy

--- a/playbooks/edx-east/jenkins_test.yml
+++ b/playbooks/edx-east/jenkins_test.yml
@@ -24,6 +24,5 @@
         - 4configureGit.groovy
         - 4configureHipChat.groovy
         - 4configureJobConfigHistory.groovy
-        - 5addSeedJob.groovy
         - 5createLoggers.groovy
         - 6importCredentials.groovy


### PR DESCRIPTION
Since our plan for setting up test/build jenkins involves attaching an existing volume containing all of our job information, we don't need to have the seed job groovy script creating a seed job for us on every boot.

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
