### PR TITLE
Template out version possibilities for ghprb config file

### DIFF
--- a/playbooks/roles/jenkins_build/defaults/main.yml
+++ b/playbooks/roles/jenkins_build/defaults/main.yml
@@ -123,7 +123,7 @@ build_jenkins_plugins_list:
     version: '0.15.2'
     group: 'org.jenkins-ci.plugins'
   - name: 'ghprb'
-    version: '1.22.4'
+    version: '1.30.1'
     group: 'org.jenkins-ci.plugins'
   - name: 'github'
     version: '1.14.0'
@@ -202,6 +202,7 @@ build_jenkins_plugins_list:
     group: 'org.jenkins-ci.plugins'
 
 # ghprb
+build_jenkins_ghprb_white_list_phrase: '.*[Aa]dd\W+to\W+whitelist.*'
 build_jenkins_ghprb_ok_phrase: '.*ok\W+to\W+test.*'
 build_jenkins_ghprb_retest_phrase: '.*jenkins\W+run\W+all.*'
 build_jenkins_ghprb_skip_phrase: '.*\[[Ss]kip\W+ci\].*'

--- a/playbooks/roles/jenkins_build/meta/main.yml
+++ b/playbooks/roles/jenkins_build/meta/main.yml
@@ -6,6 +6,7 @@ dependencies:
     jenkins_common_configuration_scripts: '{{ build_jenkins_configuration_scripts }}'
     jenkins_common_template_files: '{{ build_jenkins_template_files }}'
     jenkins_common_plugins_list: '{{ build_jenkins_plugins_list }}'
+    jenkins_common_ghprb_white_list_phrase: '{{ build_jenkins_ghprb_white_list_phrase }}'
     jenkins_common_ghprb_ok_phrase: '{{ build_jenkins_ghprb_ok_phrase }}'
     jenkins_common_ghprb_retest_phrase: '{{ build_jenkins_ghprb_retest_phrase }}'
     jenkins_common_ghprb_skip_phrase: '{{ build_jenkins_ghprb_skip_phrase }}'

--- a/playbooks/roles/jenkins_common/defaults/main.yml
+++ b/playbooks/roles/jenkins_common/defaults/main.yml
@@ -97,11 +97,18 @@ jenkins_common_ghprb_results:
     MESSAGE: 'Test FAILed.'
   - STATUS: 'SUCCESS'
     MESSAGE: 'Test PASSed.'
-
-JENKINS_GHPRB_TOKEN: ''
 JENKINS_GHPRB_ADMIN_LIST: []
+
+# For versions >= 1.34.0
 JENKINS_GHPRB_BLACK_LIST: []
 JENKINS_GHPRB_WHITE_LIST: []
+
+# For versions < 1.23
+JENKINS_GHPRB_TOKEN: ''
+
+# For versions >= 1.23
+JENKINS_GHPRB_CREDENTIAL_ID: ''
+JENKINS_GHPRB_SHARED_SECRET: ''
 
 # credentials
 JENKINS_SECRET_FILES_LIST: []

--- a/playbooks/roles/jenkins_common/templates/config/ghprb_config.yml.j2
+++ b/playbooks/roles/jenkins_common/templates/config/ghprb_config.yml.j2
@@ -1,6 +1,5 @@
 ---
 SERVER_API_URL: '{{ jenkins_common_ghprb_server }}'
-ACCESS_TOKEN: '{{ JENKINS_GHPRB_TOKEN }}'
 ADMIN_LIST:
 {% for admin in JENKINS_GHPRB_ADMIN_LIST %}
     - '{{ admin }}'
@@ -17,14 +16,6 @@ MANAGE_WEBHOOKS:  {{ jenkins_common_ghprb_manage_webhooks }}
 UNSTABLE_AS: '{{ jenkins_common_ghprb_failure_as }}'
 AUTO_CLOSE_FAILED_PRS: {{ jenkins_common_ghprb_auto_close_fails }}
 DISPLAY_ERRORS_DOWNSTREAM: {{ jenkins_commmon_ghprb_display_errors }}
-BLACK_LIST_LABELS:
-{% for blacklist in JENKINS_GHPRB_BLACK_LIST %}
-    - '{{ blacklist }}'
-{% endfor %}
-WHITE_LIST_LABELS:
-{% for whitelist in JENKINS_GHPRB_WHITE_LIST %}
-    - '{{ whitelist }}'
-{% endfor %}
 GITHUB_AUTH: '{{ jenkins_common_ghprb_github_auth }}'
 SIMPLE_STATUS: '{{ jenkins_common_ghprb_simple_status }}'
 PUBLISH_JENKINS_URL: '{{ jenkins_common_ghprb_publish_jenkins_url }}'
@@ -34,3 +25,21 @@ RESULT_MESSAGES:
     - STATUS: '{{ message.STATUS }}'
       MESSAGE: '{{ message.MESSAGE }}'
 {% endfor %}
+# The following fields will only be used by certain versions.
+
+# >= 1.34.0
+BLACK_LIST_LABELS:
+{% for blacklist in JENKINS_GHPRB_BLACK_LIST %}
+    - '{{ blacklist }}'
+{% endfor %}
+WHITE_LIST_LABELS:
+{% for whitelist in JENKINS_GHPRB_WHITE_LIST %}
+    - '{{ whitelist }}'
+{% endfor %}
+
+# < 1.23
+ACCESS_TOKEN: '{{ JENKINS_GHPRB_TOKEN }}'
+
+# >= 1.23
+CREDENTIALS_ID: '{{ JENKINS_GHPRB_CREDENTIAL_ID }}'
+SHARED_SECRET: '{{ JENKINS_GHPRB_SHARED_SECRET }}'


### PR DESCRIPTION
Summary
---

This PR, in addition to changes in the jenkins-config repo (https://github.com/edx/jenkins-configuration/pull/50), will allow the support of multiple ghprb versions. This is necessary as some of the configuration relies on different fields being set, and we want to make this as robust as possible. The reason for starting with ghprb is becuase we have recently upgraded our version number and the script is no longer functioning properly.

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
