### PR TITLE
Reverting ghprb versioning in template file

### DIFF
--- a/playbooks/edx-east/jenkins_build.yml
+++ b/playbooks/edx-east/jenkins_build.yml
@@ -16,6 +16,7 @@
       build_jenkins_configuration_scripts:
         - 1addJarsToClasspath.groovy
         - 2checkInstalledPlugins.groovy
+        - 3importCredentials.groovy
         - 3mainConfiguration.groovy
         - 3shutdownCLI.groovy
         - 4configureEc2Plugin.groovy
@@ -26,4 +27,3 @@
         - 4configureJobConfigHistory.groovy
         - 4configureMailerPlugin.groovy
         - 5createLoggers.groovy
-        - 6importCredentials.groovy

--- a/playbooks/roles/jenkins_build/defaults/main.yml
+++ b/playbooks/roles/jenkins_build/defaults/main.yml
@@ -2,6 +2,7 @@ build_jenkins_version: jenkins_1.651.3
 build_jenkins_configuration_scripts:
   - 1addJarsToClasspath.groovy
   - 2checkInstalledPlugins.groovy
+  - 3importCredentials.groovy
   - 3mainConfiguration.groovy
   - 3shutdownCLI.groovy
   - 4configureEc2Plugin.groovy
@@ -13,7 +14,6 @@ build_jenkins_configuration_scripts:
   - 4configureMailerPlugin.groovy
   - 5addSeedJob.groovy
   - 5createLoggers.groovy
-  - 6importCredentials.groovy
 
 # plugins
 build_jenkins_plugins_list:

--- a/playbooks/roles/jenkins_common/defaults/main.yml
+++ b/playbooks/roles/jenkins_common/defaults/main.yml
@@ -98,15 +98,6 @@ jenkins_common_ghprb_results:
   - STATUS: 'SUCCESS'
     MESSAGE: 'Test PASSed.'
 JENKINS_GHPRB_ADMIN_LIST: []
-
-# For versions >= 1.34.0
-JENKINS_GHPRB_BLACK_LIST: []
-JENKINS_GHPRB_WHITE_LIST: []
-
-# For versions < 1.23
-JENKINS_GHPRB_TOKEN: ''
-
-# For versions >= 1.23
 JENKINS_GHPRB_CREDENTIAL_ID: ''
 JENKINS_GHPRB_SHARED_SECRET: ''
 

--- a/playbooks/roles/jenkins_common/templates/config/ghprb_config.yml.j2
+++ b/playbooks/roles/jenkins_common/templates/config/ghprb_config.yml.j2
@@ -25,21 +25,5 @@ RESULT_MESSAGES:
     - STATUS: '{{ message.STATUS }}'
       MESSAGE: '{{ message.MESSAGE }}'
 {% endfor %}
-# The following fields will only be used by certain versions.
-
-# >= 1.34.0
-BLACK_LIST_LABELS:
-{% for blacklist in JENKINS_GHPRB_BLACK_LIST %}
-    - '{{ blacklist }}'
-{% endfor %}
-WHITE_LIST_LABELS:
-{% for whitelist in JENKINS_GHPRB_WHITE_LIST %}
-    - '{{ whitelist }}'
-{% endfor %}
-
-# < 1.23
-ACCESS_TOKEN: '{{ JENKINS_GHPRB_TOKEN }}'
-
-# >= 1.23
 CREDENTIALS_ID: '{{ JENKINS_GHPRB_CREDENTIAL_ID }}'
 SHARED_SECRET: '{{ JENKINS_GHPRB_SHARED_SECRET }}'


### PR DESCRIPTION
Summary
---
We quickly realized that supporting numerous versions of ghprb is not realistic, so reverting this additional templating.
Also accounting for the new import credentials groovy script file number.

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
