### PR TITLE
download specific branches of jenkins configuration

### DIFF
--- a/playbooks/roles/jenkins_common/defaults/main.yml
+++ b/playbooks/roles/jenkins_common/defaults/main.yml
@@ -19,6 +19,7 @@ jenkins_common_debian_pkgs:
   - psmisc
 
 jenkins_common_configuration_git_url: https://github.com/edx/jenkins-configuration.git
+jenkins_common_jenkins_configuration_branch: master
 jenkins_common_configuration_src_path: src/main/groovy
 jenkins_common_git_home: /git
 

--- a/playbooks/roles/jenkins_common/tasks/main.yml
+++ b/playbooks/roles/jenkins_common/tasks/main.yml
@@ -75,6 +75,7 @@
   git:
       repo: '{{ jenkins_common_configuration_git_url }}'
       dest: '{{ jenkins_common_git_home }}/jenkins-configuration'
+      version: '{{ jenkins_common_jenkins_configuration_branch }}'
   tags:
     - install
     - install:base


### PR DESCRIPTION
In order to test the jenkins 2.0 rollout, it is helpful to be able to specify the branch of the jenkins-configuration repo to use.