### PR TITLE
Remove jenkins_build play script override

### DIFF
--- a/playbooks/edx-east/jenkins_build.yml
+++ b/playbooks/edx-east/jenkins_build.yml
@@ -61,21 +61,7 @@
     - role: datadog
       when: COMMON_ENABLE_DATADOG
 
-    - role: jenkins_build
-      build_jenkins_configuration_scripts:
-        - 1addJarsToClasspath.groovy
-        - 2checkInstalledPlugins.groovy
-        - 3importCredentials.groovy
-        - 3mainConfiguration.groovy
-        - 3shutdownCLI.groovy
-        - 4configureEc2Plugin.groovy
-        - 4configureGHOAuth.groovy
-        - 4configureGHPRB.groovy
-        - 4configureGit.groovy
-        - 4configureHipChat.groovy
-        - 4configureJobConfigHistory.groovy
-        - 4configureMailerPlugin.groovy
-        - 5createLoggers.groovy
+    - jenkins_build
 
     # run just the splunkforwarder role by using '--tags "splunkonly"'
     # e.g. ansible-playbook jenkins_testeng_master.yml -i inventory.ini --tags "splunkonly" -vvvv

--- a/playbooks/roles/jenkins_build/defaults/main.yml
+++ b/playbooks/roles/jenkins_build/defaults/main.yml
@@ -15,7 +15,6 @@ build_jenkins_configuration_scripts:
   - 4configureJobConfigHistory.groovy
   - 4configureMailerPlugin.groovy
   - 4configureMaskPasswords.groovy
-  - 5addSeedJob.groovy
   - 5createLoggers.groovy
 
 # plugins


### PR DESCRIPTION
Summary
---
This process made more sense when we had both a build and test jenkins play using the build jenkins role. But that is no longer the case

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
