### PR TITLE
Deal with the case when CREATE_SERVICE_WORKER_USERS is false.

### DIFF
--- a/playbooks/roles/edxapp/tasks/deploy.yml
+++ b/playbooks/roles/edxapp/tasks/deploy.yml
@@ -418,28 +418,12 @@
   tags:
     - manage
 
-- name: build service worker users list
-  set_fact:
-    service_worker_users: "{{ [SERVICE_WORKER_USERS] }}"
-  when: CREATE_SERVICE_WORKER_USERS
-  tags:
-    - manage
-    - manage:db
-    
-- name: build service empty worker users list
-  set_fact:
-    service_worker_users: "{{ [] }}"
-  when: not CREATE_SERVICE_WORKER_USERS
-  tags:
-    - manage
-    - manage:db
-
 - name: create service worker users
   shell: "{{ edxapp_venv_bin }}/python ./manage.py lms --settings={{ edxapp_settings }} --service-variant lms manage_user {{ item.username}} {{ item.email }} --unusable-password {% if item.is_staff %} --staff{% endif %}"
   args:
     chdir: "{{ edxapp_code_dir }}"
   become_user: "{{ common_web_user }}"
-  with_items: "{{ service_worker_users }}"
+  with_items: "{{ SERVICE_WORKER_USERS }}"
   when: CREATE_SERVICE_WORKER_USERS
   tags:
     - manage

--- a/playbooks/roles/edxapp/tasks/deploy.yml
+++ b/playbooks/roles/edxapp/tasks/deploy.yml
@@ -425,6 +425,14 @@
   tags:
     - manage
     - manage:db
+    
+- name: build service empty worker users list
+  set_fact:
+    service_worker_users: "{{ [] }}"
+  when: not CREATE_SERVICE_WORKER_USERS
+  tags:
+    - manage
+    - manage:db
 
 - name: create service worker users
   shell: "{{ edxapp_venv_bin }}/python ./manage.py lms --settings={{ edxapp_settings }} --service-variant lms manage_user {{ item.username}} {{ item.email }} --unusable-password {% if item.is_staff %} --staff{% endif %}"


### PR DESCRIPTION
In this case, `service_worker_users` still needs to be defined because the when condition is applied for each item in the `{{ service_worker_users }}` list.  So that var always has to resolve.

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
