### PR TITLE
jenkins_common: Add credential id for ssh template

### DIFF
--- a/playbooks/roles/jenkins_common/templates/config/credentials.yml.j2
+++ b/playbooks/roles/jenkins_common/templates/config/credentials.yml.j2
@@ -37,6 +37,7 @@
   isJenkinsMasterSsh: true
   passphrase: '{{ master_ssh.passphrase }}'
   description: '{{ master_ssh.description }}'
+  id: '{{ master_ssh.id }}'
 {% endfor %}
 {% for custom_ssh in JENKINS_CUSTOM_SSH_LIST %}
 - credentialType: 'ssh'
@@ -46,4 +47,5 @@
   path: 'credentials/{{ custom_ssh.name }}'
   passphrase: '{{ custom_ssh.passphrase }}'
   description: '{{ custom_ssh.description }}'
+  id: '{{ custom_ssh.id }}'
 {% endfor %}


### PR DESCRIPTION
Summary
---

The credentials.yml.j2 template currently does not allow ssh credentials to have an id.

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
