### PR TITLE
Fix spelling of vagrant-hostsupdater

### DIFF
--- a/vagrant/release/fullstack/Vagrantfile
+++ b/vagrant/release/fullstack/Vagrantfile
@@ -1,6 +1,6 @@
 Vagrant.require_version ">= 1.8.7"
-unless Vagrant.has_plugin?("vagrant-hostupdater")
-  raise "Please install the vagrant-hostupdater plugin by running `vagrant plugin install vagrant-hostupdater`"
+unless Vagrant.has_plugin?("vagrant-hostsupdater")
+  raise "Please install the vagrant-hostsupdater plugin by running `vagrant plugin install vagrant-hostsupdater`"
 end
 
 VAGRANTFILE_API_VERSION = "2"


### PR DESCRIPTION
I added a check for the vagrant-hostsupdater plugin, except I spelled it non-plural so it broke this Vagrant file. This fixes it. 

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
