### PR TITLE
jenkins_common github template fix

### DIFF
--- a/playbooks/roles/jenkins_common/templates/config/github_config.yml.j2
+++ b/playbooks/roles/jenkins_common/templates/config/github_config.yml.j2
@@ -4,5 +4,5 @@
   MANAGE_HOOKS: '{{ config.MANAGE_HOOKS }}'
   USE_CUSTOM_API_URL: '{{ config.USE_CUSTOM_API_URL }}'
   API_URL: '{{ config.API_URL }}'
-  CACHE_SIZE: '{{ config.CACHE_SIZE}}'
+  CACHE_SIZE: {{ config.CACHE_SIZE}}
 {% endfor %}


### PR DESCRIPTION
Summary
---
This fixes the issue we saw this morning:

```
Failed to run script file:/var/lib/jenkins/init.groovy.d/4configureGithub.groovy
java.lang.ClassCastException: java.lang.Integer cannot be cast to java.lang.String
	at java.lang.String.compareTo(String.java:111)
	at org.codehaus.groovy.runtime.typehandling.DefaultTypeTransformation.compareToWithEqualityCheck(DefaultTypeTransformation.java:599)
	at org.codehaus.groovy.runtime.typehandling.DefaultTypeTransformation.compareTo(DefaultTypeTransformation.java:554)
	at org.codehaus.groovy.runtime.ScriptBytecodeAdapter.compareTo(ScriptBytecodeAdapter.java:688)
	at org.codehaus.groovy.runtime.ScriptBytecodeAdapter.compareGreaterThan(ScriptBytecodeAdapter.java:705)
	at 4configureGithub$_run_closure1.doCall(4configureGithub.groovy:36)
```

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
