### PR TITLE
jenkins_common: Allow v2enabled config in Hipchat

### DIFF
--- a/playbooks/roles/jenkins_common/defaults/main.yml
+++ b/playbooks/roles/jenkins_common/defaults/main.yml
@@ -139,6 +139,7 @@ jenkins_common_github_configs:
 
 # hipchat
 jenkins_common_hipchat_room: ''
+jenkins_common_hipchat_v2_enabled: true
 JENKINS_HIPCHAT_API_TOKEN: ''
 
 # seed

--- a/playbooks/roles/jenkins_common/templates/config/hipchat_config.yml.j2
+++ b/playbooks/roles/jenkins_common/templates/config/hipchat_config.yml.j2
@@ -1,3 +1,4 @@
 ---
 API_TOKEN: '{{ JENKINS_HIPCHAT_API_TOKEN }}'
 ROOM: '{{ jenkins_common_hipchat_room }}'
+V2_ENABLED: {{ jenkins_common_hipchat_v2_enabled }}


### PR DESCRIPTION
This will fix the issue we're seeing with hipchat config

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
