### PR TITLE
set no-cache on 404s on static files

### DIFF
--- a/playbooks/roles/nginx/tasks/main.yml
+++ b/playbooks/roles/nginx/tasks/main.yml
@@ -111,6 +111,7 @@
   with_items:
     - { src: 'etc/nginx/nginx.conf.j2', dest: '/etc/nginx/nginx.conf', group: '{{ common_web_user }}', mode: "0644" }
     - { src: 'edx/app/nginx/sites-available/edx-release.j2', dest: '{{ nginx_sites_available_dir }}/edx-release', group: 'root', mode: "0600" }
+    - { src: 'edx/app/nginx/sites-available/maps.j2', dest: '{{ nginx_sites_available_dir }}/maps', group: 'root', mode: "0600" }
   notify: restart nginx
   tags:
     - install
@@ -131,12 +132,15 @@
 
 - name: Creating link for common nginx configuration
   file:
-    src: "{{ nginx_sites_available_dir }}/edx-release"
-    dest: "{{ nginx_sites_enabled_dir }}/edx-release"
+    src: "{{ nginx_sites_available_dir }}/{{ item }}"
+    dest: "{{ nginx_sites_enabled_dir }}/{{ item }}"
     state: link
     owner: root
     group: root
   notify: reload nginx
+  with_items:
+    - "edx-release"
+    - "maps"
   tags:
     - install
     - install:configuration

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/maps.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/maps.j2
@@ -1,0 +1,12 @@
+# nginx maps are defined at the top level and are global
+
+# cache header for static files
+map $status $cache_header_long_lived {
+  default   "max-age=315360000";
+  404       "no-cache";
+}
+
+map $status $cache_header_short_lived {
+  default   "max-age=300";
+  404       "no-cache";
+}

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/static-files.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/static-files.j2
@@ -16,14 +16,14 @@
 
     # http://www.red-team-design.com/firefox-doesnt-allow-cross-domain-fonts-by-default
     location ~ "/static/(?P<collected>.*\.[0-9a-f]{12}\.(eot|otf|ttf|woff|woff2)$)" {
-        expires max;
+        add_header "Cache-Control" $cache_header_long_lived always;
         add_header Access-Control-Allow-Origin *;
         try_files /staticfiles/$collected /course_static/$collected =404;
     }
 
     # Set django-pipelined files to maximum cache time
     location ~ "/static/(?P<collected>.*\.[0-9a-f]{12}\..*)" {
-        expires max;
+        add_header "Cache-Control" $cache_header_long_lived always;
         # Without this try_files, files that have been run through
         # django-pipeline return 404s
         try_files /staticfiles/$collected /course_static/$collected =404;
@@ -31,7 +31,7 @@
 
     # Set django-pipelined files for studio to maximum cache time
     location ~ "/static/(?P<collected>[0-9a-f]{7}/.*)" {
-        expires max;
+        add_header "Cache-Control" $cache_header_long_lived always;
 
         # Without this try_files, files that have been run through
         # django-pipeline return 404s
@@ -40,8 +40,8 @@
 
     {% include "static-files-extra.j2" ignore missing %}
 
-    # Expire other static files immediately (there should be very few / none of these)
-    expires 300;
+    # Non-hashed files (there should be very few / none of these)
+    add_header "Cache-Control" $cache_header_short_lived always;
   }
 
 


### PR DESCRIPTION
Cloudflare caches 404 responses for 5 minutes if no cache-control header is set, but they say that they will expire 404's immediately if they are given a cache-control: no-cache header.  This will hopefully set that value properly.