### PR TITLE
temporarily reduce build jenkins instance cap

### DIFF
--- a/playbooks/roles/jenkins_build/defaults/main.yml
+++ b/playbooks/roles/jenkins_build/defaults/main.yml
@@ -220,7 +220,7 @@ JENKINS_GITHUB_CONFIG: ''
 build_jenkins_hipchat_room: 'testeng'
 
 # ec2
-build_jenkins_instance_cap: '250'
+build_jenkins_instance_cap: '220'
 
 # seed
 build_jenkins_seed_name: 'manually_seed_one_job'


### PR DESCRIPTION
Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
---------------------------------------------------------------------------------------------------------------
Temporarily reduce the worker instance cap to 220 on build jenkins while we sort out our subnet issues