### PR TITLE
Allows the Forum Hostname to be overridden

### DIFF
--- a/playbooks/roles/forum/defaults/main.yml
+++ b/playbooks/roles/forum/defaults/main.yml
@@ -23,6 +23,7 @@ FORUM_MONGO_USE_SSL: false
 FORUM_MONGO_URL: "mongodb://{{ FORUM_MONGO_USER }}:{{ FORUM_MONGO_PASSWORD }}@{%- for host in FORUM_MONGO_HOSTS -%}{{ host }}:{{ FORUM_MONGO_PORT }}{%- if not loop.last -%},{%- endif -%}{%- endfor -%}/{{ FORUM_MONGO_DATABASE }}{%- if FORUM_MONGO_TAGS -%}?tags={{ FORUM_MONGO_TAGS }}{%- endif -%}"
 FORUM_SINATRA_ENV: "development"
 FORUM_RACK_ENV: "development"
+FORUM_NGINX_HOSTNAME: "forum.*"
 FORUM_NGINX_PORT: "18080"
 # FORUM_API_KEY must match EDXAPP_COMMENTS_SERVICE_KEY
 FORUM_API_KEY: "password"

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/forum.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/forum.j2
@@ -31,7 +31,7 @@ upstream forum_app_server {
 
 server {
 
-  server_name forum.*;
+  server_name {{ FORUM_NGINX_HOSTNAME }};
   listen {{ FORUM_NGINX_PORT }} {{ default_site }};
   client_max_body_size 1M;
   keepalive_timeout 5;


### PR DESCRIPTION
As the name suggests, this allows a different DNS name to be used. This should be backwards compatible. 

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
