### PR TITLE
Fix blacklist for jenkins build logs  TE-2275

### DIFF
--- a/playbooks/edx-east/jenkins_build.yml
+++ b/playbooks/edx-east/jenkins_build.yml
@@ -22,6 +22,7 @@
         index: 'testeng'
         sourcetype: junit
         followSymlink: false
+        blacklist: '\.gz$'
         crcSalt: '<SOURCE>'
 
       - source: '/var/lib/jenkins/jobs/*/builds/*/build.xml'
@@ -30,7 +31,7 @@
         sourcetype: build_result
         followSymlink: false
         crcSalt: '<SOURCE>'
-        blacklist: '(((\.(gz))|\d)$)|(.*seed.*)'
+        blacklist: '\.gz$'
 
       - source: '/var/lib/jenkins/jobs/*/builds/*/log'
         index: 'testeng'
@@ -38,17 +39,19 @@
         sourcetype: build_log
         followSymlink: false
         crcSalt: '<SOURCE>'
-        blacklist: '(((\.(gz))|\d)$)|(.*seed.*)'
+        blacklist: 'seed|\.gz$'
 
       - source: '/var/lib/jenkins/jobs/*/builds/*/archive/test_root/log/timing.*.log'
         index: 'testeng'
         sourcetype: 'json_timing_log'
         followSymlink: false
+        blacklist: '\.gz$'
 
       - source: '/var/log/jenkins/jenkins.log'
         index: 'testeng'
         recursive: false
         followSymlink: false
+        blacklist: '\.gz$'
 
   roles:
     - aws


### PR DESCRIPTION
This is needed to override blacklist defaults defined in #4033.

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
