### PR TITLE
Optimize the blacklist for jenkins timing logs

### DIFF
--- a/playbooks/edx-east/jenkins_build.yml
+++ b/playbooks/edx-east/jenkins_build.yml
@@ -33,19 +33,13 @@
         crcSalt: '<SOURCE>'
         blacklist: '\.gz$'
 
-      - source: '/var/lib/jenkins/jobs/*/builds/*/log'
+      - source: '/var/lib/jenkins/jobs/edx-platform-*/builds/*/archive/test_root/log/timing.*.log'
         index: 'testeng'
         recursive: true
-        sourcetype: build_log
-        followSymlink: false
-        crcSalt: '<SOURCE>'
-        blacklist: 'seed|\.gz$'
-
-      - source: '/var/lib/jenkins/jobs/*/builds/*/archive/test_root/log/timing.*.log'
-        index: 'testeng'
         sourcetype: 'json_timing_log'
         followSymlink: false
-        blacklist: '\.gz$'
+        crcSalt: '<SOURCE>'
+        blacklist: coverage|private|subset|specific|custom|special|\.gz$
 
       - source: '/var/log/jenkins/jenkins.log'
         index: 'testeng'


### PR DESCRIPTION
For reviewers:
* removing indexing the console log of builds
* narrowing the directories in which we search for timing logs 


Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
