### PR TITLE
Add tag to jenkins_common to allow local dev

### DIFF
--- a/playbooks/roles/jenkins_common/tasks/main.yml
+++ b/playbooks/roles/jenkins_common/tasks/main.yml
@@ -50,6 +50,21 @@
     - install
     - install:system-requirements
 
+- name: Delete any existing jenkins-configuration folders to avoid unwanted configuration
+  file:
+    path: '{{ item }}'
+    owner: '{{ jenkins_common_user }}'
+    group: '{{ jenkins_common_group }}'
+    state: absent
+  with_items:
+    - '{{ jenkins_common_home }}/init.groovy.d'
+    - '{{ jenkins_common_config_path }}'
+  tags:
+    - install
+    - install:base
+    - install:jenkins-configuration
+    - jenkins:local-dev
+
 - name: Create necessary folders
   file:
     path: '{{ item }}'
@@ -68,6 +83,8 @@
   tags:
     - install
     - install:base
+    - install:jenkins-configuration
+    - jenkins:local-dev
 
 - name: Download Jenkins war file
   get_url:
@@ -118,6 +135,7 @@
     - install
     - install:base
     - install:jenkins-configuration
+    - jenkins:local-dev
 
 - name: Run gradle libs
   shell: './gradlew libs'
@@ -132,16 +150,27 @@
     - install
     - install:base
     - install:jenkins-configuration
+    - jenkins:local-dev
 
 - name: Copy init scripts into init.groovy.d
   command: 'cp {{ jenkins_common_git_home }}/jenkins-configuration/{{ jenkins_common_configuration_src_path }}/{{ item }} {{ jenkins_common_home }}/init.groovy.d/'
   with_items: '{{ jenkins_common_configuration_scripts }}'
   become: true
   become_user: '{{ jenkins_common_user }}'
+  register: init_scripts_copied
   tags:
     - install
     - install:base
     - install:jenkins-configuration
+
+- name: Copy all init scripts other than oauth for local dev
+  command: 'cp {{ jenkins_common_git_home }}/jenkins-configuration/{{ jenkins_common_configuration_src_path }}/{{ item }} {{ jenkins_common_home }}/init.groovy.d/'
+  with_items: '{{ jenkins_common_configuration_scripts }}'
+  become: true
+  become_user: '{{ jenkins_common_user }}'
+  when: 'item != "4configureGHOAuth.groovy" and init_scripts_copied is not defined'
+  tags:
+    - jenkins:local-dev
 
 - name: Create jenkins config sub folders
   file:
@@ -156,6 +185,8 @@
   tags:
      - install
      - install:base
+     - install:jenkins-configuration
+     - jenkins:local-dev
 
 - name: Copy non plugins template files
   template:
@@ -169,6 +200,17 @@
     - install
     - install:base
     - install:jenkins-configuration
+
+- name: For local dev, copy any config files other than oauth
+  template:
+    src: '{{ role_path }}/templates/config/{{ item }}.yml.j2'
+    dest: '{{ jenkins_common_config_path }}/{{ item }}.yml'
+    owner: '{{ jenkins_common_user }}'
+    group: '{{ jenkins_common_group }}'
+  with_items: '{{ jenkins_common_non_plugin_template_files }}'
+  when: 'item != "security" and templates_copied is not defined'
+  tags:
+    - jenkins:local-dev
 
 - name: Update Github OAUTH settings when promoting jenkins instance to production
   template:
@@ -191,6 +233,7 @@
     - install:base
     - install:plugins
     - install:jenkins-configuration
+    - jenkins:local-dev
 
 - name: Copy ec2 config files
   template:
@@ -204,6 +247,7 @@
     - install
     - install:base
     - install:jenkins-configuration
+    - jenkins:local-dev
 
 - name: Copy xml config files
   template:
@@ -217,6 +261,7 @@
     - install
     - install:base
     - install:jenkins-configuration
+    - jenkins:local-dev
 
 - name: Run plugins.gradle
   shell: './gradlew -b plugins.gradle plugins'
@@ -232,6 +277,7 @@
     - install:base
     - install:plugins
     - install:jenkins-configuration
+    - jenkins:local-dev
 
 - name: Copy secret file credentials
   copy:
@@ -243,6 +289,7 @@
     - install
     - install:base
     - install:jenkins-configuration
+    - jenkins:local-dev
 
 - name: Copy ssh key credentials
   copy:
@@ -256,6 +303,7 @@
     - install
     - install:base
     - install:jenkins-configuration
+    - jenkins:local-dev
 
 - name: Copy ec2 key
   copy:
@@ -268,6 +316,7 @@
     - install
     - install:base
     - install:jenkins-configuration
+    - jenkins:local-dev
 
 - name: Start Jenkins Service
   systemd:


### PR DESCRIPTION
Creates a tag that we can run for local dev (so we dont need to run all the services like nginx/ splunkforwarder/ etc). It also includes new stanzas for deleting existing files to avoid any unwanted configuration.

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
