### PR TITLE
Add new relic config for jenkins_build play

### DIFF
--- a/playbooks/edx-east/jenkins_build.yml
+++ b/playbooks/edx-east/jenkins_build.yml
@@ -13,6 +13,7 @@
   vars:
     COMMON_ENABLE_DATADOG: True
     COMMON_ENABLE_SPLUNKFORWARDER: True
+    COMMON_ENABLE_NEWRELIC: True
     COMMON_SECURITY_UPDATES: yes
     SECURITY_UPGRADE_ON_ANSIBLE: true
 
@@ -62,3 +63,8 @@
         - splunkonly
         - jenkins:promote-to-production
       become: True
+
+    - role: newrelic
+      when: COMMON_ENABLE_NEWRELIC
+      tags:
+        - newreliconly


### PR DESCRIPTION
The Jenkins build play should automatically install the New Relic service so we can receive alerts out of the box. The tag should allow us to run this right away without interrupting anything related to the Jenkins service on our current instance.

Note: We will have to switch away from New Relic to datadog shortly, but this will leave us covered in the meantime. I've added a ticket in the backlog representing this.

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
