### PR TITLE
Remove ecommerce from nginx_sites in edx_sandbox.yml.

### DIFF
--- a/playbooks/edx_sandbox.yml
+++ b/playbooks/edx_sandbox.yml
@@ -33,7 +33,6 @@
       - lms
       - forum
       - xqueue
-      - ecommerce
       nginx_default_sites:
       - lms
     - role: edxlocal


### PR DESCRIPTION
Since #3941  is merged, the nginx configuration of ecommerce is handled by the ecommerce role itself (via the edx_django_service role).

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
