### PR TITLE
Use INSIGHTS_DATABASE variables in edxlocal role

### DIFF
--- a/playbooks/roles/edxlocal/defaults/main.yml
+++ b/playbooks/roles/edxlocal/defaults/main.yml
@@ -24,8 +24,8 @@ edxlocal_database_users:
     }
   - {
       db: "{{ INSIGHTS_DATABASE_NAME | default(None) }}",
-      user: "{{ INSIGHTS_MYSQL_USER | default(None) }}",
-      pass: "{{ INSIGHTS_MYSQL_USER | default(None) }}"
+      user: "{{ INSIGHTS_DATABASE_USER | default(None) }}",
+      pass: "{{ INSIGHTS_DATABASE_PASSWORD | default(None) }}"
     }
   - {
       db: "{{ XQUEUE_MYSQL_DB_NAME | default(None) }}",


### PR DESCRIPTION
The INSIGHTS_MYSQL_USER variable is not defined, so the Insights database user was not being created.

This commit was made by @thallada and merged in subsequent releases like Ginkgo. However, it is not applied to Ficus.4 release, so it might cause problem for people like me who follow [this document](http://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/latest/platform_releases/ginkgo.html#upgrading-from-the-ficus-release) to install Ficus.4 before upgrading to Ginkgo.