### PR TITLE
Adds mongo read preferences for use when a replica set is provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,14 +9,21 @@
     your configuration to set `EDXAPP_CELERY_BROKER_TRANSPORT` explicitly.
 
 - Role: edxapp
-  - Added `EDXAPP_LMS_SPLIT_DOC_STORE_READ_PREFERENCE` with a default value of
-    SECONDARY_PREFERED to distribute read workload across the replica set.
-  - Changed `EDXAPP_MONGO_HOSTS` to be a comma seperated string, which is
-    required by pymongo.MongoReplicaSetClient for multiple hosts instead of an
-    array.
   - Added `EDXAPP_MONGO_REPLICA_SET`, which is required to use
-    pymongo.MongoReplicaSetClient in PyMongo 2.9.1, whis is required to use the
-    read_preference setting. This should be set to the name of your replica set.
+    pymongo.MongoReplicaSetClient in PyMongo 2.9.1.  This should be set to the
+    name of your replica set.
+    This setting causes the `EDXAPP_*_READ_PREFERENCE` settings below to be used.
+  - Added `EDXAPP_MONGO_CMS_READ_PREFERENCE` with a default value of `PRIMARY`.
+  - Added `EDXAPP_MONGO_LMS_READ_PREFERENCE` with a default value of
+    `SECONDARY_PREFERED` to distribute the read workload across the replica set
+    for replicated docstores and contentstores.
+  - Added `EDXAPP_LMS_SPLIT_DOC_STORE_READ_PREFERENCE` with a default value of
+    `EDXAPP_MONGO_LMS_READ_PREFERENCE`.
+  - Added `EDXAPP_LMS_DRAFT_DOC_STORE_CONFIG` with a default value of
+    `EDXAPP_MONGO_CMS_READ_PREFERENCE`, to enforce consistency between
+    Studio and the LMS Preview modes.
+  - Removed `EDXAPP_CONTENTSTORE_ADDITIONAL_OPTS`, since there is no notion of
+    common options to the content store anymore.
 
 - Role: nginx
   - Modified `lms.j2` , `cms.j2` , `credentials.j2` , `edx_notes_api.j2` and `insights.j2` to enable HTTP Strict Transport Security

--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -65,8 +65,7 @@ EDXAPP_XQUEUE_DJANGO_AUTH:
   password: 'password'
 EDXAPP_XQUEUE_URL: 'http://localhost:18040'
 
-# EDXAPP_MONGO_HOSTS must be a comma seperated list of hosts/ips for
-# compatibility with pymongo.MongoReplicaSetClient in PyMongo 2.9.1
+# Comma-separated list of hosts/ips
 EDXAPP_MONGO_HOSTS: 'localhost'
 EDXAPP_MONGO_PASSWORD: 'password'
 EDXAPP_MONGO_PORT: 27017
@@ -74,7 +73,14 @@ EDXAPP_MONGO_USER: 'edxapp'
 EDXAPP_MONGO_DB_NAME: 'edxapp'
 EDXAPP_MONGO_USE_SSL: False
 EDXAPP_MONGO_REPLICA_SET: ''
-EDXAPP_LMS_SPLIT_DOC_STORE_READ_PREFERENCE: 'SECONDARY_PREFERRED'
+# Used only if EDXAPP_MONGO_REPLICA_SET is provided.
+EDXAPP_MONGO_CMS_READ_PREFERENCE: 'PRIMARY'
+EDXAPP_MONGO_LMS_READ_PREFERENCE: 'SECONDARY_PREFERRED'
+# We use the CMS read_preference here because the draft docstore's view of
+# the modulestore should mirror Studio's, so that instructors can check their
+# changes in Preview mode.
+EDXAPP_LMS_DRAFT_DOC_STORE_READ_PREFERENCE: '{{ EDXAPP_MONGO_CMS_READ_PREFERENCE }}'
+EDXAPP_LMS_SPLIT_DOC_STORE_READ_PREFERENCE: '{{ EDXAPP_MONGO_LMS_READ_PREFERENCE }}'
 
 EDXAPP_MYSQL_DB_NAME: 'edxapp'
 EDXAPP_MYSQL_USER: 'edxapp001'
@@ -851,9 +857,24 @@ edxapp_environment_extra: {}
 
 edxapp_environment: "{{ edxapp_environment_default | combine(edxapp_environment_extra) }}"
 
+edxapp_generic_contentstore_config: &edxapp_generic_default_contentstore
+  ENGINE:  'xmodule.contentstore.mongo.MongoContentStore'
+  #
+  # connection strings are duplicated temporarily for
+  # backward compatibility
+  #
+  OPTIONS:
+    db: "{{ EDXAPP_MONGO_DB_NAME }}"
+    host: "{{ EDXAPP_MONGO_HOSTS }}"
+    password: "{{ EDXAPP_MONGO_PASSWORD }}"
+    port: "{{ EDXAPP_MONGO_PORT }}"
+    user: "{{ EDXAPP_MONGO_USER }}"
+    ssl: "{{ EDXAPP_MONGO_USE_SSL }}"
+
 edxapp_generic_doc_store_config: &edxapp_generic_default_docstore
   db: "{{ EDXAPP_MONGO_DB_NAME }}"
   host: "{{ EDXAPP_MONGO_HOSTS }}"
+  replicaSet: "{{ EDXAPP_MONGO_REPLICA_SET }}"
   password: "{{ EDXAPP_MONGO_PASSWORD }}"
   port: "{{ EDXAPP_MONGO_PORT }}"
   user: "{{ EDXAPP_MONGO_USER }}"
@@ -864,17 +885,17 @@ edxapp_generic_doc_store_config: &edxapp_generic_default_docstore
   connectTimeoutMS: 2000 # default is 20000, I believe raises pymongo.errors.ConnectionFailure
   # Not setting waitQueueTimeoutMS and waitQueueMultiple since pymongo defaults to nobody being allowed to wait
 
-
 EDXAPP_LMS_DRAFT_DOC_STORE_CONFIG:
   <<: *edxapp_generic_default_docstore
+  read_preference: "{{ EDXAPP_LMS_DRAFT_DOC_STORE_READ_PREFERENCE }}"
 
 EDXAPP_LMS_SPLIT_DOC_STORE_CONFIG:
   <<: *edxapp_generic_default_docstore
-  replicaSet: "{{ EDXAPP_MONGO_REPLICA_SET }}"
   read_preference: "{{ EDXAPP_LMS_SPLIT_DOC_STORE_READ_PREFERENCE }}"
 
 EDXAPP_CMS_DOC_STORE_CONFIG:
   <<: *edxapp_generic_default_docstore
+  read_preference: "{{ EDXAPP_MONGO_CMS_READ_PREFERENCE }}"
 
 edxapp_databases:
 # edxapp's edxapp-migrate scripts and the edxapp_migrate play
@@ -929,26 +950,10 @@ edxapp_generic_auth_config:  &edxapp_generic_auth
   SWIFT_TEMP_URL_KEY: "{{ EDXAPP_SWIFT_TEMP_URL_KEY }}"
   SWIFT_TEMP_URL_DURATION: "{{ EDXAPP_SWIFT_TEMP_URL_DURATION }}"
   SECRET_KEY:  "{{ EDXAPP_EDXAPP_SECRET_KEY }}"
-  DOC_STORE_CONFIG: "{{ edxapp_generic_doc_store_config }}"
   XQUEUE_INTERFACE:
     basic_auth: "{{ EDXAPP_XQUEUE_BASIC_AUTH }}"
     django_auth: "{{ EDXAPP_XQUEUE_DJANGO_AUTH }}"
     url: "{{ EDXAPP_XQUEUE_URL }}"
-  CONTENTSTORE:
-    ENGINE:  'xmodule.contentstore.mongo.MongoContentStore'
-    #
-    # connection strings are duplicated temporarily for
-    # backward compatibility
-    #
-    OPTIONS:
-      db: "{{ EDXAPP_MONGO_DB_NAME }}"
-      host: "{{ EDXAPP_MONGO_HOSTS }}"
-      password: "{{ EDXAPP_MONGO_PASSWORD }}"
-      port: "{{ EDXAPP_MONGO_PORT }}"
-      user: "{{ EDXAPP_MONGO_USER }}"
-      ssl: "{{ EDXAPP_MONGO_USE_SSL }}"
-    ADDITIONAL_OPTIONS: "{{ EDXAPP_CONTENTSTORE_ADDITIONAL_OPTS }}"
-    DOC_STORE_CONFIG: *edxapp_generic_default_docstore
   DATABASES: "{{ edxapp_databases }}"
   EMAIL_HOST_USER: "{{ EDXAPP_EMAIL_HOST_USER }}"
   EMAIL_HOST_PASSWORD: "{{ EDXAPP_EMAIL_HOST_PASSWORD }}"
@@ -1166,6 +1171,11 @@ generic_env_config:  &edxapp_generic_env
 
 lms_auth_config:
   <<: *edxapp_generic_auth
+  CONTENTSTORE:
+    <<: *edxapp_generic_default_contentstore
+    ADDITIONAL_OPTIONS: "{{ EDXAPP_CONTENTSTORE_ADDITIONAL_OPTS }}"
+    DOC_STORE_CONFIG: "{{ EDXAPP_LMS_SPLIT_DOC_STORE_CONFIG }}"
+  DOC_STORE_CONFIG: "{{ EDXAPP_LMS_SPLIT_DOC_STORE_CONFIG }}"
   SEGMENT_KEY: "{{ EDXAPP_LMS_SEGMENT_KEY }}"
   OPTIMIZELY_PROJECT_ID: "{{ EDXAPP_OPTIMIZELY_PROJECT_ID }}"
   EDX_API_KEY: "{{ EDXAPP_EDX_API_KEY }}"
@@ -1256,7 +1266,11 @@ lms_env_config:
 
 cms_auth_config:
   <<: *edxapp_generic_auth
-  SEGMENT_KEY: "{{ EDXAPP_CMS_SEGMENT_KEY }}"
+  CONTENTSTORE:
+    <<: *edxapp_generic_default_contentstore
+    ADDITIONAL_OPTIONS: "{{ EDXAPP_CONTENTSTORE_ADDITIONAL_OPTS }}"
+    DOC_STORE_CONFIG: "{{ EDXAPP_CMS_DOC_STORE_CONFIG }}"
+  DOC_STORE_CONFIG: "{{ EDXAPP_CMS_DOC_STORE_CONFIG }}"
   MODULESTORE:
     default:
         ENGINE: 'xmodule.modulestore.mixed.MixedModuleStore'
@@ -1277,6 +1291,7 @@ cms_auth_config:
                 default_class: 'xmodule.hidden_module.HiddenDescriptor'
                 fs_root:  "{{ edxapp_course_data_dir }}"
                 render_template: 'edxmako.shortcuts.render_to_string'
+  SEGMENT_KEY: "{{ EDXAPP_CMS_SEGMENT_KEY }}"
   PARSE_KEYS: "{{ EDXAPP_PARSE_KEYS }}"
 
 cms_env_config:


### PR DESCRIPTION
Allows for different mongo `read_preference` settings to be used for the LMS, Preview, and Studio, and ensures that the mongo replicaset setting is included in all modulestore and contentstore configuration blocks.

The default value of `EDXAPP_MONGO_REPLICA_SET: ''` means no replicaset will be used.

If `EDXAPP_MONGO_REPLICA_SET` is set, then the replica set will be used for modulestore and contentstore connections for the LMS and Studio.

When a replica set is configured, the `read_preference` setting has a different default for each system:
* CMS: `PRIMARY`
  Shared by CMS content, module, and doc stores.
  Can be changed using `EDXAPP_MONGO_CMS_READ_PREFERENCE`
* LMS draft docstore: `PRIMARY`
  Can be changed using `EDXAPP_MONGO_CMS_READ_PREFERENCE`, or independently from the CMS using `EDXAPP_LMS_SPLIT_DOC_STORE_READ_PREFERENCE`.
  This provides instructors with consistent content between Preview and Studio views.
* LMS: `SECONDARY_PREFERRED`.
  Shared by LMS content, module, and doc stores (except for the draft doc store, noted above).
  Can be changed using `EDXAPP_MONGO_LMS_READ_PREFERENCE`.

**JIRA tickets**: [OSPR-1989](https://openedx.atlassian.net/browse/OSPR-1989), OC-3200, OC-2840

**Sandbox URL**:

Configured using the default, no replica set:
* LMS: https://oc3200-2.sandbox.stage.opencraft.hosting/
* Studio: https://studio-oc3200-2.sandbox.stage.opencraft.hosting/

Configured using a replica set:
* LMS: https://oc3200.sandbox.opencraft.hosting/
* Studio: https://studio-oc3200.sandbox.opencraft.hosting/

**Merge deadline**: None

**Testing instructions**:

To verify the default, no replica setup
1. Provision a new appserver without setting `EDXAPP_MONGO_REPLICA_SET`  (e.g. [oc3200-2.sandbox.stage.opencraft.hosting](https://oc3200-2.sandbox.stage.opencraft.hosting/)).
1. Verify that you can create and edit courses as usual.
1. From the LMS shell, run these commands to verify the replica set is not enabled:
   ```python
   >>> from xmodule.modulestore.django import modulestore
   >>> modulestore().default_modulestore.db_connection.database.client._rs_client
   False
   >>> modulestore().contentstore.fs_files.database.client._rs_client
   False
   ```

To verify that using this new variable configures the replica set:
1. Provision a new appserver and set `EDXAPP_MONGO_REPLICA_SET`, e.g. [oc3200.sandbox.opencraft.hosting]( https://oc3200.sandbox.opencraft.hosting/):
   ```yaml
   # Note that the MONGO_HOSTS must be in a comma-delimited string, not a list
   EDXAPP_MONGO_HOSTS: "ds231255-a0.mlab.com,ds231255-a1.mlab.com"
   EDXAPP_MONGO_REPLICA_SET: 'rs-ds231255'
   ```
1. Verify that you can create and edit courses as usual.
1. From the LMS shell, run these commands to verify the replica set is enabled:
   ```python
   >>> from xmodule.modulestore.django import modulestore
   >>> modulestore().default_modulestore.db_connection.database.client._rs_client
   True
   >>> modulestore().contentstore.fs_files.database.client._rs_client
   True
   ```

**Reviewers**
- [x] @UmanShahzad 
- [ ] @jdmulloy CC @edx/devops 

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [x] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
