### PR TITLE
jenkins_common: Programmatically use forked github-api plugin

### DIFF
--- a/playbooks/roles/jenkins_common/tasks/main.yml
+++ b/playbooks/roles/jenkins_common/tasks/main.yml
@@ -279,6 +279,30 @@
     - install:jenkins-configuration
     - jenkins:local-dev
 
+- name: Delete any github-api related files
+  shell: 'rm -r {{ jenkins_common_home }}/plugins/github-api*'
+  become: true
+  become_user: '{{ jenkins_common_user }}'
+  tags:
+    - install
+    - install:base
+    - install:plugins
+    - install:jenkins-configuration
+    - jenkins:local-dev
+
+- name: Get forked github api version from S3
+  get_url:
+    url: https://s3.amazonaws.com/edx-testeng-tools/github-api/github-api.hpi
+    dest: '{{ jenkins_common_home }}/plugins/github-api.hpi'
+  become: true
+  become_user: '{{ jenkins_common_user }}'
+  tags:
+    - install
+    - install:base
+    - install:plugins
+    - install:jenkins-configuration
+    - jenkins:local-dev
+
 - name: Copy secret file credentials
   copy:
     content: "{{ item.content }}"


### PR DESCRIPTION
There's a bug in the github-api plugin due to a change in github's API. This is being fixed in v1.90, but is not yet available in the maven repository (which is currently where we get our plugin jpi files). So for now, I've added our version to S3, and updated the ansible to pull the file from there.

Before pulling down our custom version, we have to make sure there aren't any existing github-api files already in the plugins dir, which get downloaded because its a dependency of other git plugins we use.

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
