### PR TITLE
Allow uninstall XBlocks via EDXAPP_EXTRA_REQUIREMENTS

### DIFF
--- a/playbooks/roles/edxapp/tasks/deploy.yml
+++ b/playbooks/roles/edxapp/tasks/deploy.yml
@@ -171,7 +171,7 @@
     version: "{{ item.version|default(omit) }}"
     extra_args: "--exists-action w {{ item.extra_args|default('') }}"
     virtualenv: "{{ edxapp_venv_dir }}"
-    state: present
+    state: "{{ item.state|default('present') }}"
   with_items: "{{ EDXAPP_EXTRA_REQUIREMENTS }}"
   become_user: "{{ edxapp_user }}"
   tags:


### PR DESCRIPTION
Configuration Pull Request
---

This pull request makes it possible to store the edxapp pip uninstalls within the server vars instead of doing it manually.

It can be used like the following:

```#!yaml
EDXAPP_EXTRA_REQUIREMENTS:
  - name: 'git+https://github.com/owais/django-webpack-loader.git#egg=django-webpack-loader'
  - name: 'lti-consumer-xblock'
    state: 'absent'
```


---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
