### PR TITLE
Allow 'automated' and 'edx_service' roles to run multiple times.

### DIFF
--- a/playbooks/roles/automated/meta/main.yml
+++ b/playbooks/roles/automated/meta/main.yml
@@ -1,0 +1,12 @@
+---
+#
+# edX Configuration
+#
+# github:     https://github.com/edx/configuration
+# wiki:       https://openedx.atlassian.net/wiki/display/OpenOPS
+# code style: https://openedx.atlassian.net/wiki/display/OpenOPS/Ansible+Code+Conventions
+# license:    https://github.com/edx/configuration/blob/master/LICENSE.TXT
+#
+
+# Allow this role to be duplicated in dependencies.
+allow_duplicates: yes

--- a/playbooks/roles/edx_service/meta/main.yml
+++ b/playbooks/roles/edx_service/meta/main.yml
@@ -30,3 +30,6 @@ dependencies:
     GIT_REPOS: "{{ edx_service_repos }}"
     git_home: "{{ edx_service_home }}"
     when: edx_service_repos is defined
+
+# Allow this role to be duplicated in dependencies.
+allow_duplicates: yes


### PR DESCRIPTION
Allow `automated` and `edx_service` roles to be run multiple times.

This fixes a bug where running the `edx_sandbox.yml` playbook would fail with the following error:

```
Traceback (most recent call last):
  File "manage.py", line 15, in <module>
    execute_from_command_line(sys.argv)
  ... snip ...
  File "/edx/app/discovery/discovery/course_discovery/settings/production.py", line 31, in <module>
    with open(CONFIG_FILE, encoding='utf-8') as f:
FileNotFoundError: [Errno 2] No such file or directory: '/edx/etc/discovery.yml'
make: *** [migrate] Error 1
```

This error started occurring after https://github.com/edx/configuration/pull/3941 was merged. The `edx_django_service` role used to only be used for the `discovery` role in `edx_sandbox.yml` until then, but since that PR has been merged, it's being used by both `ecommerce` and `discovery`.

The `edx_django_service` role depends on `automated` and `edx_service` roles. The `edx_service` role further depends on `add_user` and `git_clone` roles.

From the ansible log it can be seen that the first time the `edx_django_service` role runs (as a dependency of `ecommerce`, everything works fine, but the second time `edx_django_service` runs as a dependency of `discovery`, both `automated` and `edx_service` tasks are skipped (although the `add_user` and `git_clone` dependencies of `edx_service` still run, because they are already marked with `allow_duplicates: true`).

Setting `allow_duplicates: true` on `automated` and `edx_service` roles fixes the problem.

**Testing instructions**:

1. Without this patch, try to spawn a new sandbox using the `edx_sandbox.yml` playbook. Note it fails on the `discovery` step.
2. Pull this patch and try again. The build should now succeed.

**Reviewers**
- [ ] @UmanShahzad 
- [ ] edX reviewer[s] TBD

---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
