### PR TITLE
Add nginx server maintenance definition to activate maintenance page …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+- Role: nginx
+  - Added `NGINX_SERVER_MAINTENANCE_FILE_OFF` and `NGINX_SERVER_MAINTENANCE_FILE_ON` to be used to add a server maintenance template on demand.
+  - The maintenance template can be activated with:
+    ```
+    sudo mv /edx/var/nginx/server-static/server-maintenance_off.html /edx/var/nginx/server-static/server-maintenance_on.html
+    ```
+  - The maintenance template can be deactivated with:
+    ```
+    sudo mv /edx/var/nginx/server-static/server-maintenance_on.html /edx/var/nginx/server-static/server-maintenance_off.html
+    ```
+
 - Role: edxapp
   - Added `EDXAPP_LMS_INTERNAL_ROOT_URL` setting (defaults to `EDXAPP_LMS_ROOT_URL`).
 

--- a/playbooks/roles/nginx/defaults/main.yml
+++ b/playbooks/roles/nginx/defaults/main.yml
@@ -56,6 +56,8 @@ NGINX_CMS_PROXY_CONNECT_TIMEOUT: !!null
 NGINX_CMS_PROXY_SEND_TIMEOUT: !!null
 NGINX_CMS_PROXY_READ_TIMEOUT: !!null
 
+NGINX_SERVER_MAINTENANCE_FILE_OFF: server-maintenance_off.html
+NGINX_SERVER_MAINTENANCE_FILE_ON: server-maintenance_on.html
 NGINX_SERVER_ERROR_IMG: 'https://upload.wikimedia.org/wikipedia/commons/thumb/1/11/Pendleton_Sinking_Ship.jpg/640px-Pendleton_Sinking_Ship.jpg'
 NGINX_SERVER_ERROR_IMG_ALT: ''
 NGINX_SERVER_ERROR_LANG: 'en'
@@ -82,6 +84,17 @@ NGINX_SERVER_HTML_FILES:
     img: "{{ NGINX_SERVER_ERROR_IMG }}"
     img_alt: "{{ NGINX_SERVER_ERROR_IMG_ALT }}"
     heading: 'Uh oh, we are having some server issues..'
+    style_h1: "{{ NGINX_SERVER_ERROR_STYLE_H1 }}"
+    style_p_h2: "{{ NGINX_SERVER_ERROR_STYLE_P_H2 }}"
+    style_p: "{{ NGINX_SERVER_ERROR_STYLE_P }}"
+    style_div: "{{ NGINX_SERVER_ERROR_STYLE_DIV }}"
+  - file: "{{ NGINX_SERVER_MAINTENANCE_FILE_OFF }}"
+    lang: "{{ NGINX_SERVER_ERROR_LANG }}"
+    title: 'Server maintenance'
+    msg: 'We are doing some maintenance server tasks. If this page is up for more than 24 hours, let us know at <a href="mailto:{{ EDXAPP_TECH_SUPPORT_EMAIL|default("technical@example.com") }}">{{ EDXAPP_TECH_SUPPORT_EMAIL|default("technical@example.com") }}</a>'
+    img: "{{ NGINX_SERVER_ERROR_IMG }}"
+    img_alt: "{{ NGINX_SERVER_ERROR_IMG_ALT }}"
+    heading: 'We will back soon.'
     style_h1: "{{ NGINX_SERVER_ERROR_STYLE_H1 }}"
     style_p_h2: "{{ NGINX_SERVER_ERROR_STYLE_P_H2 }}"
     style_p: "{{ NGINX_SERVER_ERROR_STYLE_P }}"

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/basic-server-maintenance.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/basic-server-maintenance.j2
@@ -1,0 +1,5 @@
+{% if NGINX_SERVER_MAINTENANCE_FILE_OFF is defined and NGINX_SERVER_MAINTENANCE_FILE_ON is defined %}
+  if (-f {{ nginx_server_static_dir }}/{{ NGINX_SERVER_MAINTENANCE_FILE_ON }}) {
+    return 503;
+  }
+{% endif %}

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/cms.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/cms.j2
@@ -124,6 +124,7 @@ error_page {{ k }} {{ v }};
     {% if EDXAPP_CMS_ENABLE_BASIC_AUTH|bool %}
       {% include "basic-auth.j2" %}
     {% endif %}
+    {% include "basic-server-maintenance.j2" %}
     try_files $uri @proxy_to_cms_app;
   }
 
@@ -146,5 +147,5 @@ error_page {{ k }} {{ v }};
 
   {% include "robots.j2" %}
   {% include "static-files.j2" %}
-
+  {% include "server-maintenance-redirect.j2" %}
 }

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
@@ -177,7 +177,7 @@ error_page {{ k }} {{ v }};
     {% if EDXAPP_LMS_ENABLE_BASIC_AUTH|bool %}
       {% include "basic-auth.j2" %}
     {% endif %}
-
+    {% include "basic-server-maintenance.j2" %}
     try_files $uri @proxy_to_lms_app;
   }
 
@@ -303,5 +303,5 @@ location ~ ^{{ EDXAPP_MEDIA_URL }}/(?P<file>.*) {
   {% include "robots.j2" %}
   {% include "static-files.j2" %}
   {% include "extra_locations_lms.j2" ignore missing %}
-
+  {% include "server-maintenance-redirect.j2" %}
 }

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/server-maintenance-redirect.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/server-maintenance-redirect.j2
@@ -1,0 +1,8 @@
+{% if NGINX_SERVER_MAINTENANCE_FILE_OFF is defined and NGINX_SERVER_MAINTENANCE_FILE_ON is defined %}
+  # Maintenance page
+  error_page 503 @maintenance;
+  location @maintenance {
+    root {{ nginx_server_static_dir }};
+    rewrite ^(.*)$ /{{ NGINX_SERVER_MAINTENANCE_FILE_ON }} break;
+  }
+{% endif %}


### PR DESCRIPTION
…on demand

This feature allows to activate a server maintenance page on the platform on demand. So the user will see this page when accessing the platform.

- Role: nginx
  - Added `NGINX_SERVER_MAINTENANCE_FILE_OFF` and `NGINX_SERVER_MAINTENANCE_FILE_ON` to be used to add a server maintenance template on demand.
  - The maintenance template can be activated with:
    ```
    sudo mv /edx/var/nginx/server-static/server-maintenance_off.html /edx/var/nginx/server-static/server-maintenance_on.html
    ```
  - The maintenance template can be deactivated with:
    ```
    sudo mv /edx/var/nginx/server-static/server-maintenance_on.html /edx/var/nginx/server-static/server-maintenance_off.html
    ```
