### PR TITLE
Replce 'migrate --list' with 'showmigrations'.

### DIFF
--- a/playbooks/roles/automated/tasks/main.yml
+++ b/playbooks/roles/automated/tasks/main.yml
@@ -26,9 +26,9 @@
 # EDXAPP_AUTOMATED_USERS:
 #   ecom:
 #     sudo_commands:
-#       - command: "/edx/app/edxapp/venvs/edxapp/bin/python /edx/app/edxapp/edx-platform/manage.py lms migrate --list --settings=aws"
+#       - command: "/edx/app/edxapp/venvs/edxapp/bin/python /edx/app/edxapp/edx-platform/manage.py lms showmigrations --settings=aws"
 #         sudo_user: "edxapp"
-#       - command: "/edx/app/edxapp/venvs/edxapp/bin/python /edx/app/edxapp/edx-platform/manage.py cms migrate --list --settings=aws"
+#       - command: "/edx/app/edxapp/venvs/edxapp/bin/python /edx/app/edxapp/edx-platform/manage.py cms showmigrations --settings=aws"
 #         sudo_user: "edxapp"
 #     authorized_keys:
 #       - 'ssh-rsa <REDACTED> ecom+admin@example.com'
@@ -62,7 +62,7 @@
     mode: "0440"
     validate: 'visudo -cf %s'
   with_dict: "{{ AUTOMATED_USERS }}"
-  
+
 - name: Create .ssh directory
   file:
     path: "/home/{{ item.key }}/.ssh"
@@ -71,7 +71,7 @@
     owner: "{{ item.key }}"
     group: "{{ item.key }}"
   with_dict: "{{ AUTOMATED_USERS }}"
-    
+
 - name: Build authorized_keys file
   template:
     src: "home/automator/.ssh/authorized_keys.j2"
@@ -80,7 +80,7 @@
     owner: "{{ item.key }}"
     group: "{{ item.key }}"
   with_dict: "{{ AUTOMATED_USERS }}"
-    
+
 - name: Build known_hosts file
   file:
     path: "/home/{{ item.key }}/.ssh/known_hosts"

--- a/playbooks/roles/edx_django_service/defaults/main.yml
+++ b/playbooks/roles/edx_django_service/defaults/main.yml
@@ -191,7 +191,7 @@ edx_django_service_config: '{{ edx_django_service_config_default|combine(edx_dja
 edx_django_service_automated_users:
   automated_user:
     sudo_commands:
-      - command: '{{ edx_django_service_venv_dir }}/python {{ edx_django_service_code_dir }}/manage.py migrate --list'
+      - command: '{{ edx_django_service_venv_dir }}/python {{ edx_django_service_code_dir }}/manage.py showmigrations'
         sudo_user: '{{ edx_django_service_user }}'
     authorized_keys:
       - 'SSH authorized key'

--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -412,7 +412,7 @@ EDXAPP_SANDBOX_ENFORCE: true
 EDXAPP_AUTOMATED_USERS:
   automated_user:
     sudo_commands:
-      - command: "{{ edxapp_venv_bin }}/python {{ edxapp_code_dir }}/manage.py lms migrate --list --settings={{ edxapp_settings }}"
+      - command: "{{ edxapp_venv_bin }}/python {{ edxapp_code_dir }}/manage.py lms showmigrations --settings={{ edxapp_settings }}"
         sudo_user: "edxapp"
     authorized_keys:
       - "SSH authorized key"

--- a/playbooks/roles/edxapp/templates/edx/bin/edxapp-migrate-cms.j2
+++ b/playbooks/roles/edxapp/templates/edx/bin/edxapp-migrate-cms.j2
@@ -4,8 +4,25 @@ if [[ -z "${NO_EDXAPP_SUDO:-}" ]]; then
     SUDO='sudo -E -u {{ edxapp_user }} env "PATH=$PATH"'
 fi
 
+remove_unwanted_args () {
+  ARGS=("")
+  args_to_remove="(--list|--noinput)"
+  for var in "$@"; do
+    # Ignore known unneeded arguments
+    if [[ "$var" =~ $args_to_remove ]]; then
+      continue
+    fi
+    ARGS+=("$var")
+  done
+}
+
 {% for db in cms_auth_config.DATABASES.keys() %}
   {%- if db != 'read_replica' %}
-${SUDO:-} {{ edxapp_venv_bin }}/python manage.py cms migrate --database {{ db }} --noinput --settings $EDX_PLATFORM_SETTINGS $@
+if [[ $@ =~ .*--list.* ]]; then
+  remove_unwanted_args $@
+  ${SUDO:-} {{ edxapp_venv_bin }}/python manage.py cms showmigrations --database {{ db }} --settings $EDX_PLATFORM_SETTINGS ${ARGS[@]}
+else
+  ${SUDO:-} {{ edxapp_venv_bin }}/python manage.py cms migrate --database {{ db }} --noinput --settings $EDX_PLATFORM_SETTINGS $@
+fi
   {% endif %}
 {% endfor %}

--- a/playbooks/roles/edxapp/templates/edx/bin/edxapp-migrate-lms.j2
+++ b/playbooks/roles/edxapp/templates/edx/bin/edxapp-migrate-lms.j2
@@ -4,8 +4,25 @@ if [[ -z "${NO_EDXAPP_SUDO:-}" ]]; then
     SUDO='sudo -E -u {{ edxapp_user }} env "PATH=$PATH"'
 fi
 
+remove_unwanted_args () {
+  ARGS=("")
+  args_to_remove="(--list|--noinput)"
+  for var in "$@"; do
+    # Ignore known unneeded arguments
+    if [[ "$var" =~ $args_to_remove ]]; then
+      continue
+    fi
+    ARGS+=("$var")
+  done
+}
+
 {% for db in lms_auth_config.DATABASES.keys() %}
   {%- if db != 'read_replica' %}
-${SUDO:-} {{ edxapp_venv_bin }}/python manage.py lms migrate --database {{ db }} --noinput --settings $EDX_PLATFORM_SETTINGS $@
+if [[ $@ =~ .*--list.* ]]; then
+  remove_unwanted_args $@
+  ${SUDO:-} {{ edxapp_venv_bin }}/python manage.py lms showmigrations --database {{ db }} --settings $EDX_PLATFORM_SETTINGS ${ARGS[@]}
+else
+  ${SUDO:-} {{ edxapp_venv_bin }}/python manage.py lms migrate --database {{ db }} --noinput --settings $EDX_PLATFORM_SETTINGS $@
+fi
   {% endif %}
 {% endfor %}

--- a/playbooks/roles/supervisor/files/pre_supervisor_checks.py
+++ b/playbooks/roles/supervisor/files/pre_supervisor_checks.py
@@ -13,7 +13,7 @@ import time
 MIGRATION_COMMANDS = {
         'lms':     "/edx/bin/edxapp-migrate-lms --noinput --list",
         'cms':     "/edx/bin/edxapp-migrate-cms --noinput --list",
-        'xqueue':  "SERVICE_VARIANT=xqueue sudo -E -u xqueue {python} {code_dir}/manage.py migrate --noinput --list --settings=xqueue.aws_settings",
+        'xqueue':  "SERVICE_VARIANT=xqueue sudo -E -u xqueue {python} {code_dir}/manage.py showmigrations --settings=xqueue.aws_settings",
         'ecommerce':     ". {env_file}; sudo -E -u ecommerce {python} {code_dir}/manage.py showmigrations",
         'insights':      ". {env_file}; sudo -E -u insights {python} {code_dir}/manage.py showmigrations",
         'analytics_api': ". {env_file}; sudo -E -u analytics_api {python} {code_dir}/manage.py showmigrations",


### PR DESCRIPTION
Configuration Pull Request
---
https://openedx.atlassian.net/browse/PLAT-1429
The --list option on migrate is removed in Django 1.10.
This PR is the second try of this reverted PR: https://github.com/edx/configuration/pull/4217

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
