### PR TITLE
Enable deprecation warnings for Django 1.11 apps.

### DIFF
--- a/playbooks/roles/edx_django_service/templates/edx/app/app/app.sh.j2
+++ b/playbooks/roles/edx_django_service/templates/edx/app/app/app.sh.j2
@@ -5,9 +5,9 @@
 {% set edx_django_service_venv_bin = edx_django_service_venv_dir + "/bin" %}
 
 {% if COMMON_ENABLE_NEWRELIC_APP %}
-{% set executable = edx_django_service_venv_bin + '/newrelic-admin run-program ' + edx_django_service_venv_bin + '/gunicorn' %}
+{% set executable = ' -Wd ' + edx_django_service_venv_bin + '/newrelic-admin run-program ' + edx_django_service_venv_bin + '/gunicorn' %}
 {% else %}
-{% set executable = edx_django_service_venv_bin + '/gunicorn' %}
+{% set executable = ' -Wd ' + edx_django_service_venv_bin + '/gunicorn' %}
 {% endif %}
 
 {% if COMMON_ENABLE_NEWRELIC_APP %}

--- a/playbooks/roles/edxapp/templates/cms.conf.j2
+++ b/playbooks/roles/edxapp/templates/cms.conf.j2
@@ -1,9 +1,9 @@
 [program:cms]
 
 {% if COMMON_ENABLE_NEWRELIC_APP -%}
-{% set executable = edxapp_venv_dir + '/bin/newrelic-admin run-program ' + edxapp_venv_dir + '/bin/gunicorn' -%}
+{% set executable = ' -Wd ' + edxapp_venv_dir + '/bin/newrelic-admin run-program ' + edxapp_venv_dir + '/bin/gunicorn' -%}
 {% else -%}
-{% set executable = edxapp_venv_dir + '/bin/gunicorn' -%}
+{% set executable = ' -Wd ' + edxapp_venv_dir + '/bin/gunicorn' -%}
 {% endif -%}
 
 command={{ executable }} -c {{ edxapp_app_dir }}/cms_gunicorn.py {{ EDXAPP_CMS_GUNICORN_EXTRA }} cms.wsgi

--- a/playbooks/roles/edxapp/templates/cms.conf.j2
+++ b/playbooks/roles/edxapp/templates/cms.conf.j2
@@ -1,9 +1,9 @@
 [program:cms]
 
 {% if COMMON_ENABLE_NEWRELIC_APP -%}
-{% set executable = ' -Wd ' + edxapp_venv_dir + '/bin/newrelic-admin run-program ' + edxapp_venv_dir + '/bin/gunicorn' -%}
+{% set executable = edxapp_venv_dir + '/bin/newrelic-admin run-program ' + edxapp_venv_dir + '/bin/gunicorn' + ' -Wd ' -%}
 {% else -%}
-{% set executable = ' -Wd ' + edxapp_venv_dir + '/bin/gunicorn' -%}
+{% set executable = edxapp_venv_dir + '/bin/gunicorn' + ' -Wd ' -%}
 {% endif -%}
 
 command={{ executable }} -c {{ edxapp_app_dir }}/cms_gunicorn.py {{ EDXAPP_CMS_GUNICORN_EXTRA }} cms.wsgi

--- a/playbooks/roles/edxapp/templates/lms.conf.j2
+++ b/playbooks/roles/edxapp/templates/lms.conf.j2
@@ -1,9 +1,9 @@
 [program:lms]
 
 {% if COMMON_ENABLE_NEWRELIC_APP -%}
-{% set executable = edxapp_venv_dir + '/bin/newrelic-admin run-program ' + edxapp_venv_dir + '/bin/gunicorn' -%}
+{% set executable = ' -Wd ' + edxapp_venv_dir + '/bin/newrelic-admin run-program ' + edxapp_venv_dir + '/bin/gunicorn' -%}
 {% else -%}
-{% set executable = edxapp_venv_dir + '/bin/gunicorn' -%}
+{% set executable = ' -Wd ' + edxapp_venv_dir + '/bin/gunicorn' -%}
 {% endif -%}
 
 command={{ executable }} -c {{ edxapp_app_dir }}/lms_gunicorn.py lms.wsgi

--- a/playbooks/roles/edxapp/templates/lms.conf.j2
+++ b/playbooks/roles/edxapp/templates/lms.conf.j2
@@ -1,9 +1,9 @@
 [program:lms]
 
 {% if COMMON_ENABLE_NEWRELIC_APP -%}
-{% set executable = ' -Wd ' + edxapp_venv_dir + '/bin/newrelic-admin run-program ' + edxapp_venv_dir + '/bin/gunicorn' -%}
+{% set executable = edxapp_venv_dir + '/bin/newrelic-admin run-program ' + edxapp_venv_dir + '/bin/gunicorn' + ' -Wd ' -%}
 {% else -%}
-{% set executable = ' -Wd ' + edxapp_venv_dir + '/bin/gunicorn' -%}
+{% set executable = edxapp_venv_dir + '/bin/gunicorn' + ' -Wd ' -%}
 {% endif -%}
 
 command={{ executable }} -c {{ edxapp_app_dir }}/lms_gunicorn.py lms.wsgi


### PR DESCRIPTION
Configuration Pull Request
---
https://openedx.atlassian.net/browse/PLAT-1350

@feanil I don't necessarily think this change is the best way to go about turning on these warnings in production Django apps - but it's similar to the approach in this edx-platform PR:

https://github.com/edx/edx-platform/pull/16799

So I made this PR to start the conversation. Can you suggest a better way to do this?

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
