### PR TITLE
Restrict migration tasks to single host.

### DIFF
--- a/playbooks/roles/analytics_api/tasks/main.yml
+++ b/playbooks/roles/analytics_api/tasks/main.yml
@@ -70,6 +70,7 @@
   become_user: "{{ analytics_api_user }}"
   environment: "{{ analytics_api_environment }}"
   when: migrate_db is defined and migrate_db|lower == "yes"
+  run_once: yes
   tags:
     - migrate
     - migrate:db

--- a/playbooks/roles/ansible-role-django-ida/templates/tasks/main.yml.j2
+++ b/playbooks/roles/ansible-role-django-ida/templates/tasks/main.yml.j2
@@ -60,6 +60,7 @@
   sudo_user: "{{ '{{' }} {{ role_name }}_user }}"
   environment: "{{ '{{' }} {{ role_name }}_migration_environment }}"
   when: migrate_db is defined and migrate_db|lower == "yes"
+  run_once: yes
   tags:
     - migrate
     - migrate:db

--- a/playbooks/roles/edx_django_service/tasks/main.yml
+++ b/playbooks/roles/edx_django_service/tasks/main.yml
@@ -124,6 +124,7 @@
   environment: "{{ edx_django_service_environment }}"
   with_items: '{{ edx_django_service_post_migrate_commands }}'
   when: migrate_db is defined and migrate_db|lower == "yes" and item.when | bool
+  run_once: yes
   tags:
     - migrate
     - migrate:db

--- a/playbooks/roles/edx_django_service/tasks/main.yml
+++ b/playbooks/roles/edx_django_service/tasks/main.yml
@@ -111,6 +111,7 @@
   become_user: "{{ edx_django_service_user }}"
   environment: "{{ edx_django_service_migration_environment }}"
   when: migrate_db is defined and migrate_db|lower == "yes"
+  run_once: yes
   tags:
     - migrate
     - migrate:db

--- a/playbooks/roles/edx_notes_api/tasks/main.yml
+++ b/playbooks/roles/edx_notes_api/tasks/main.yml
@@ -67,6 +67,7 @@
   environment:
     EDXNOTES_CONFIG_ROOT: "{{ COMMON_CFG_DIR }}"
   when: migrate_db is defined and migrate_db|lower == "yes"
+  run_once: yes
   tags:
     - migrate
     - migrate:db

--- a/playbooks/roles/edxapp/tasks/service_variant_config.yml
+++ b/playbooks/roles/edxapp/tasks/service_variant_config.yml
@@ -129,6 +129,7 @@
 - name: migrate
   command: "{{ COMMON_BIN_DIR }}/edxapp-migrate-{{ item }}"
   when: migrate_db is defined and migrate_db|lower == "yes" and COMMON_MYSQL_MIGRATE_PASS and item != "lms-preview"
+  run_once: yes
   environment:
     DB_MIGRATION_USER: "{{ COMMON_MYSQL_MIGRATE_USER }}"
     DB_MIGRATION_PASS: "{{ COMMON_MYSQL_MIGRATE_PASS }}"

--- a/playbooks/roles/forum/tasks/deploy.yml
+++ b/playbooks/roles/forum/tasks/deploy.yml
@@ -67,6 +67,7 @@
   become_user: "{{ forum_user }}"
   environment: "{{ forum_base_env }}"
   when: migrate_db is defined and migrate_db|lower == "yes"
+  run_once: yes
   tags:
     - migrate
     - migrate:db
@@ -78,6 +79,7 @@
   become_user: "{{ forum_user }}"
   environment: "{{ forum_base_env }}"
   when: migrate_db is defined and migrate_db|lower == "yes" and FORUM_REBUILD_INDEX|bool
+  run_once: yes
   tags:
     - migrate
     - migrate:db

--- a/playbooks/roles/insights/tasks/main.yml
+++ b/playbooks/roles/insights/tasks/main.yml
@@ -70,6 +70,7 @@
   become_user: "{{ insights_user }}"
   environment: "{{ insights_environment }}"
   when: migrate_db is defined and migrate_db|lower == "yes"
+  run_once: yes
   tags:
     - migrate
     - migrate:db

--- a/playbooks/roles/xqueue/tasks/deploy.yml
+++ b/playbooks/roles/xqueue/tasks/deploy.yml
@@ -94,6 +94,7 @@
     DB_MIGRATION_USER: "{{ COMMON_MYSQL_MIGRATE_USER }}"
     DB_MIGRATION_PASS: "{{ COMMON_MYSQL_MIGRATE_PASS }}"
   when: migrate_db is defined and migrate_db|lower == "yes" and COMMON_MYSQL_MIGRATE_PASS
+  run_once: yes
   tags:
     - migrate
     - migrate:db


### PR DESCRIPTION
Note: this PR was filed on behalf of @xitij2000.

We want to run deployments on multiple servers in parallel with identical Ansible configurations. The migrations can't run concurrently on multiple servers, since this would lead to conflicts, so we want to restrict them to a single server. If the migrations fail, the playbook should stop for all servers, which it does with this patch applied.

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
