### PR TITLE
Upgrade flower to 0.9.2 and pin celery version

### DIFF
--- a/playbooks/roles/flower/defaults/main.yml
+++ b/playbooks/roles/flower/defaults/main.yml
@@ -24,6 +24,8 @@ flower_venv_dir: "{{ flower_app_dir }}/venvs/flower"
 flower_venv_bin: "{{ flower_venv_dir }}/bin"
 
 flower_python_reqs:
+# Celery version must match version used by edx-platform
+  - "celery==3.1.18"
   - "flower==0.8.3"
   - "redis==2.10.6"
 

--- a/playbooks/roles/flower/defaults/main.yml
+++ b/playbooks/roles/flower/defaults/main.yml
@@ -26,7 +26,7 @@ flower_venv_bin: "{{ flower_venv_dir }}/bin"
 flower_python_reqs:
 # Celery version must match version used by edx-platform
   - "celery==3.1.18"
-  - "flower==0.8.3"
+  - "flower==0.9.2"
   - "redis==2.10.6"
 
 flower_deploy_path: "{{ flower_venv_bin }}:/usr/local/sbin:/usr/local/bin:/usr/bin:/sbin:/bin"

--- a/playbooks/roles/flower/tasks/main.yml
+++ b/playbooks/roles/flower/tasks/main.yml
@@ -53,6 +53,7 @@
     dest: "{{ supervisor_available_dir }}/{{ FLOWER_USER }}.conf"
     owner: "{{ supervisor_user }}"
     group: "{{ supervisor_user }}"
+    mode: 0644
   become_user: "{{ supervisor_user }}"
   notify:
     - restart flower


### PR DESCRIPTION
Need to pin Celery version to match version used by edxapp.

Supervisor config file version needs the correct permissions for supervisor to run flower.

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
