### PR TITLE
Update sandbox ami, fix edx and mongo repo errors

### DIFF
--- a/util/jenkins/ansible-provision.sh
+++ b/util/jenkins/ansible-provision.sh
@@ -127,7 +127,7 @@ fi
 
 if [[ -z $ami ]]; then
   if [[ $server_type == "full_edx_installation" ]]; then
-    ami="ami-d17c14ab"
+    ami="ami-1544356f"
   elif [[ $server_type == "ubuntu_16.04" || $server_type == "full_edx_installation_from_scratch" ]]; then
     ami="ami-aa2ea6d0"
   fi


### PR DESCRIPTION
This fixes the failing SandboxCIHourly because the old AMI has the old expired version of our edx ppa gpg key. It also incorporates the fix I made in #4250 to correct the Mongo repo key so that apt can verify the mongo packages.

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
