### PR TITLE
Limit oauth2 by IP to do at most 20 requests/second.

### DIFF
--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
@@ -15,7 +15,7 @@ upstream lms-backend {
 # Make Zone
 limit_req_zone $cookie_{{ EDXAPP_SESSION_COOKIE_NAME }} zone=cookies:10m rate={{ EDXAPP_COURSES_REQUEST_RATE }};
 
-limit_req_zone $binary_remote_addr zone=iplimit:10m rate=20r/s
+limit_req_zone $http_x_forwarded_for zone=iplimit:10m rate=20r/s
 
 {% for agent in EDXAPP_RATE_LIMITED_USER_AGENTS %}
 

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
@@ -15,6 +15,8 @@ upstream lms-backend {
 # Make Zone
 limit_req_zone $cookie_{{ EDXAPP_SESSION_COOKIE_NAME }} zone=cookies:10m rate={{ EDXAPP_COURSES_REQUEST_RATE }};
 
+limit_req_zone $binary_remote_addr zone=iplimit:10m rate=20r/s
+
 {% for agent in EDXAPP_RATE_LIMITED_USER_AGENTS %}
 
 # Map of http user agent with name limit_bot_agent_alias having binary IP of the agent
@@ -245,6 +247,9 @@ error_page {{ k }} {{ v }};
 
   # No basic auth security on oauth2 endpoint
   location /oauth2 {
+    {%- if EDXAPP_ENABLE_RATE_LIMITING -%}
+    limit_req zone=iplimit burst=10;
+    {%- endif %}
     try_files $uri @proxy_to_lms_app;
   }
 


### PR DESCRIPTION
Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).


For reference before the issue this afternoon our total RPM was about 30.  This should be plenty for legit traffic but should slow down the rest.