### PR TITLE
Add sqlite fix role to jenkins worker as dependency.

### DIFF
--- a/playbooks/roles/devstack_sqlite_fix/tasks/main.yml
+++ b/playbooks/roles/devstack_sqlite_fix/tasks/main.yml
@@ -4,11 +4,6 @@
     path: "{{ SQLITE_FIX_TMP_DIR }}"
     state: directory
     mode: 0775
-  when: devstack is defined and devstack
-  tags:
-    - devstack
-    - devstack:install
-
 
 # Tasks to download and upgrade pysqlite to prevent segfaults when testing in devstack
 - name: Download and unzip sqlite autoconf update
@@ -16,45 +11,25 @@
     src: "{{ SQLITE_AUTOCONF_URL }}"
     dest: "{{ SQLITE_FIX_TMP_DIR }}"
     remote_src: yes
-  when: devstack is defined and devstack
-  tags:
-    - devstack
-    - devstack:install
 
 - name: Download and unzip pysqlite update
   unarchive:
     src: "{{ PYSQLITE_URL }}"
     dest: "{{ SQLITE_FIX_TMP_DIR }}"
     remote_src: yes
-  when: devstack is defined and devstack
-  tags:
-    - devstack
-    - devstack:install
 
 # Copy module doesn't support recursive dir copies for remote_src: yes
 - name: Copy pysqlite autoconf into pyslite update dir
   command: "cp -av . {{ PYSQLITE_TMP_PATH }}/"
   args:
     chdir: "{{ SQLITE_TMP_PATH }}"
-  when: devstack is defined and devstack
-  tags:
-    - devstack
-    - devstack:install
 
 - name: Build and install pysqlite update
   command: "python setup.py build_static install"
   args:
     chdir: "{{ PYSQLITE_TMP_PATH }}"
-  when: devstack is defined and devstack
-  tags:
-    - devstack
-    - devstack:install
 
 - name: Clean up pysqlite install artifacts
   file:
     state: absent
     path: "{{ SQLITE_FIX_TMP_DIR }}/"
-  when: devstack is defined and devstack
-  tags:
-    - devstack
-    - devstack:install

--- a/playbooks/roles/jenkins_worker/meta/main.yml
+++ b/playbooks/roles/jenkins_worker/meta/main.yml
@@ -8,6 +8,8 @@ dependencies:
   # dependencies for edx-app jenkins worker:
   - role: edxapp_common
     when: platform_worker is defined
+  - role: devstack_sqlite_fix
+    when: platform_worker is defined
 
   # dependencies for android worker
   - role: android_sdk


### PR DESCRIPTION
Configuration Pull Request
---
This configuration change adds the sqlite upgrade fix to Jenkins workers, as we're seeing sqlite3 crashes during Django 1.9+ testing.

@macdiesel @bmedx The `tags` and `with` were added in this PR: https://github.com/edx/configuration/pull/4021 . This PR removes the tags to use the fix elsewhere - will this change cause devstack problems?

@estute @jzoldak Does this change look OK for the Jenkins workers?

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
