### PR TITLE
check for and replace expired key

### DIFF
--- a/playbooks/roles/server_utils/defaults/main.yml
+++ b/playbooks/roles/server_utils/defaults/main.yml
@@ -39,3 +39,6 @@ server_utils_debian_pkgs:
   - netcat
 
 server_utils_redhat_pkgs: []
+
+SERVER_UTILS_EDX_PPA_KEY_ID: "69464050"
+SERVER_UTILS_EDX_PPA_KEY_SERVER: "keyserver.ubuntu.com"

--- a/playbooks/roles/server_utils/tasks/main.yml
+++ b/playbooks/roles/server_utils/tasks/main.yml
@@ -21,6 +21,14 @@
 #
 #
 
+- name: Check for expired edx key
+  command: "apt-key list | grep {{ SERVER_UTILS_EDX_PPA_KEY_ID }}"
+  register: ppa_key_status
+
+- name: remove expired edx key
+  command: "sudo apt-key adv --keyserver {{ SERVER_UTILS_EDX_PPA_KEY_SERVER }} --recv-keys {{ SERVER_UTILS_EDX_PPA_KEY_ID }}"
+  when: "'expired' in  ppa_key_status.stdout"
+
 - name: Install ubuntu system packages
   apt:
     name: "{{ item }}"


### PR DESCRIPTION
The server utils role runs first, and is the first attempt to run "apt-get update", which fails if the existing server has our expired ppa key.  This should detect the expired key and replace it with the updated one.