### PR TITLE
stop running quality in packer builds

### DIFF
--- a/playbooks/roles/test_build_server/tasks/main.yml
+++ b/playbooks/roles/test_build_server/tasks/main.yml
@@ -46,4 +46,3 @@
     - "js"
     - "bokchoy"
     - "lettuce"
-    - "quality"


### PR DESCRIPTION
Packer builds on jenkins have been failing for a while, due to pylint failures in our smoke test. This will remove them until we are ready to fix these issues. 

Related: https://openedx.atlassian.net/browse/TE-2384