### PR TITLE
index paver timing logs for jenkins flow jobs

### DIFF
--- a/playbooks/edx-east/jenkins_build.yml
+++ b/playbooks/edx-east/jenkins_build.yml
@@ -42,6 +42,14 @@
         crcSalt: '<SOURCE>'
         blacklist: coverage|private|subset|specific|custom|special|\.gz$
 
+      - source: '/var/lib/jenkins/jobs/edx-platform-*/builds/*/archive/test_root/log/timing.*.log'
+        index: 'testeng'
+        recursive: true
+        sourcetype: 'json_timing_log'
+        followSymlink: false
+        crcSalt: '<SOURCE>'
+        blacklist: coverage|private|subset|specific|custom|special|\.gz$
+
       - source: '/var/log/jenkins/jenkins.log'
         index: 'testeng'
         recursive: false


### PR DESCRIPTION
Flow jobs are not indexing paver timing jobs, which means we cannot gather any metrics on how the bok choy db caching work will help time to feedback.

According to the splunk documentation:
```
* "..." recurses through directories. This means that /foo/.../bar will match
  foo/bar, foo/1/bar, foo/1/2/bar, etc.
```
We are currently indexing the following paver timing logs for platform jobs:
```
'/var/lib/jenkins/jobs/edx-platform-*/builds/*/archive/.../test_root/log/timing.*.log'
```
Following the documentation, the following files on build jenkins should be indexed to splunk, but are not:
```
:~$ tree /var/lib/jenkins/jobs/edx-platform-bok-choy-pr/builds/48836/archive/
/var/lib/jenkins/jobs/edx-platform-bok-choy-pr/builds/48836/archive/
├── reports
│   └── bok_choy
│       └── shard_9
│           └── xunit.xml
└── test_root
    └── log
        └── timing.paver.1515617501.log
```
The paver timing data IS being correctly indexed and sent to splunk for NON-flow jobs. The only difference between flow and non flow jobs is one directory level in the index path (.../archives/edx-platform/test-root vs ...artifacts/test_root):
```
:~$ tree /var/lib/jenkins/jobs/edx-platform-accessibility-pr/builds/45865/archive/edx-platform/test_root/
/var/lib/jenkins/jobs/edx-platform-accessibility-pr/builds/45865/archive/edx-platform/test_root/
└── log
    └── timing.paver.1515614029.log
```
The '...' operator should be able to handle this difference in paths, but it apparently does not. I propose we temporarily add the hardcoded index path in this pull request so we can reindex the last two weeks' worth of data. Then, we should standardize the platform jobs so they all archive the same filepaths.
