### PR TITLE
Install OpenStack Python requirements if using OpenStack settings

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -1405,6 +1405,7 @@ base_requirements_file:   "{{ edxapp_code_dir }}/requirements/edx/base.txt"
 django_requirements_file:   "{{ edxapp_code_dir }}/requirements/edx/django.txt"
 post_requirements_file:   "{{ edxapp_code_dir }}/requirements/edx/post.txt"
 paver_requirements_file:   "{{ edxapp_code_dir }}/requirements/edx/paver.txt"
+openstack_requirements_file: "{{ edxapp_code_dir }}/requirements/edx/openstack.txt"
 
 sandbox_base_requirements:  "{{ edxapp_code_dir }}/requirements/edx-sandbox/base.txt"
 sandbox_local_requirements: "{{ edxapp_code_dir }}/requirements/edx-sandbox/local.txt"

--- a/playbooks/roles/edxapp/tasks/deploy.yml
+++ b/playbooks/roles/edxapp/tasks/deploy.yml
@@ -132,7 +132,7 @@
 - name: Stat each Python requirements file to ensure it exists
   stat:
     path: "{{ item }}"
-  with_items: "{{ edxapp_requirements_files }}"
+  with_items: "{{ edxapp_requirements_files }} + {{ [openstack_requirements_file] if EDXAPP_SETTINGS == 'openstack' else [] }}"
   register: python_requirement_files
   tags:
     - install


### PR DESCRIPTION
This PR conditionally includes the OpenStack requirements while installing Python requirements if OpenStack settings are being used. This replaces #3522 but fixes only part of the problem that pull request addressed. We will create a new pull request to address syncing logs. 

**JIRA tickets**: [OSPR-2076](https://openedx.atlassian.net/browse/OSPR-2076)

**Dependencies**: None

**Sandbox URL**: 
*    LMS: https://openstack-requirements.sandbox.stage.opencraft.hosting/
*    Studio: https://studio-openstack-requirements.sandbox.stage.opencraft.hosting/
NOTE: These sandboxes do not have a valid certificate for HTTPS.

**Merge deadline**: ASAP We would love to have this included in Hawthorne

**Testing instructions**:
1. Launch instance using EDXAPP_SETTINGS == 'openstack'
2. OpenStack requirements should be installed along with other Python requirements 
3. Launch instance using EDXAPP_SETTINGS != 'openstack'
4. OpenStack requirements should *not* be installed

**Reviewers**
- [x] @clemente 
- [ ] edX reviewer[s] TBD

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
