### PR TITLE
Prevent reconfiguring alarms OPS-2545

### DIFF
--- a/util/jenkins/check-celery-queues.py
+++ b/util/jenkins/check-celery-queues.py
@@ -129,21 +129,26 @@ def check_queues(host, port, environment, deploy, max_metrics, threshold,
         treat_missing_data = "missing"
         statistic = "Maximum"
         actions = [sns_arn]
-        alarm_name = "{} queue length over threshold".format(queue)
-
-        # Always create/configure alert to keep config up to date
-        cloudwatch.put_metric_alarm(AlarmName=alarm_name,
-                                    AlarmDescription=alarm_name,
-                                    Namespace=namespace,
-                                    MetricName=metric_name,
-                                    Dimensions=dimensions,
-                                    Period=period,
-                                    EvaluationPeriods=evaluation_periods,
-                                    TreatMissingData=treat_missing_data,
-                                    Threshold=threshold,
-                                    ComparisonOperator=comparison_operator,
-                                    Statistic=statistic,
-                                    AlarmActions=actions)
+        alarm_name = "{}-{} {} queue length over threshold".format(environment,
+                                                                   deploy,
+                                                                   queue)
+        if len(cloudwatch.describe_alarms_for_metric(Namespace=namespace,
+                                                     MetricName=metric_name,
+                                                     Dimensions=dimensions)
+                ['MetricAlarms']) < 1:
+            print('Creating new alarm "{}"'.format(alarm_name))
+            cloudwatch.put_metric_alarm(AlarmName=alarm_name,
+                                        AlarmDescription=alarm_name,
+                                        Namespace=namespace,
+                                        MetricName=metric_name,
+                                        Dimensions=dimensions,
+                                        Period=period,
+                                        EvaluationPeriods=evaluation_periods,
+                                        TreatMissingData=treat_missing_data,
+                                        Threshold=threshold,
+                                        ComparisonOperator=comparison_operator,
+                                        Statistic=statistic,
+                                        AlarmActions=actions)
 
 
 if __name__ == '__main__':

--- a/util/jenkins/check-celery-queues.py
+++ b/util/jenkins/check-celery-queues.py
@@ -100,7 +100,8 @@ def check_queues(host, port, environment, deploy, max_metrics, threshold,
 
     if len(all_queues) > max_metrics:
         # TODO: Use proper logging framework
-        print("Warning! Too many metrics, refusing to publish more than {}".format(max_metrics))
+        print("Warning! Too many metrics, refusing to publish more than {}"
+            .format(max_metrics))
 
     # Take first max_metrics number of queues from all_queues and remove
     # queues that aren't in redis


### PR DESCRIPTION
This changes the script to only create new alaem, but not reconfigure existing alarms. This will allow us to tweak the alarm threshold in CloudWatch without the script undoing it.

We should talk about what the default threshold should be.

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
