### PR TITLE
stop updating node packages in ansible

### DIFF
--- a/playbooks/roles/edxapp/tasks/deploy.yml
+++ b/playbooks/roles/edxapp/tasks/deploy.yml
@@ -252,7 +252,7 @@
     executable: "{{ edxapp_nodeenv_bin }}/npm"
     path: "{{ edxapp_code_dir }}"
     production: "{{ edxapp_npm_production }}"
-    state: latest
+    state: present
   environment: "{{ edxapp_environment }}"
   become_user: "{{ edxapp_user }}"
   tags:

--- a/playbooks/roles/insights/tasks/main.yml
+++ b/playbooks/roles/insights/tasks/main.yml
@@ -56,7 +56,7 @@
     executable: "{{ insights_nodeenv_bin }}/npm"
     path: "{{ insights_code_dir }}"
     production: yes
-    state: latest
+    state: present
   become_user: "{{ insights_user }}"
   environment: "{{ insights_environment }}"
   tags:


### PR DESCRIPTION
The previous setting ("latest") was updating packages to their latest version on every deploy.  This worked, but was un-desired, until the node 8 upgrade when npm started updating package.json and package-lock.json when it updated packages.   We have decided that we do not want ansible to update packages past the specified version on build.