### PR TITLE
Allow packer job to use bokchoy db cache for smoke tests

### DIFF
--- a/playbooks/roles/test_build_server/defaults/main.yml
+++ b/playbooks/roles/test_build_server/defaults/main.yml
@@ -17,3 +17,6 @@
 test_build_server_user: jenkins
 test_build_server_repo_path: /home/jenkins
 test_edx_platform_version: master
+
+DB_CACHE_ACCESS_KEY_ID: ''
+DB_CACHE_SECRET_ACCESS_KEY: ''

--- a/playbooks/roles/test_build_server/tasks/main.yml
+++ b/playbooks/roles/test_build_server/tasks/main.yml
@@ -36,6 +36,13 @@
     dest: "{{ test_build_server_repo_path }}"
     mode: 0755
 
+- name: Configure the boto profile to pull the db cache for paver testing
+  template:
+    src: "boto.j2"
+    dest: "{{ test_build_server_repo_path }}/.boto"
+    owner: "{{ test_build_server_user }}"
+    mode: 0600
+
 - name: Validate build environment
   shell: "bash test-development-environment.sh {{ item }}"
   args:
@@ -46,3 +53,8 @@
     - "js"
     - "bokchoy"
     - "lettuce"
+
+- name: Remove boto profile from ami
+  file:
+    state: absent
+    path: "{{ test_build_server_repo_path }}/.boto"

--- a/playbooks/roles/test_build_server/templates/boto.j2
+++ b/playbooks/roles/test_build_server/templates/boto.j2
@@ -1,0 +1,3 @@
+[Credentials]
+aws_access_key_id = {{ DB_CACHE_ACCESS_KEY_ID }}
+aws_secret_access_key = {{ DB_CACHE_SECRET_ACCESS_KEY }}

--- a/util/packer/jenkins_worker.json
+++ b/util/packer/jenkins_worker.json
@@ -2,6 +2,8 @@
   "variables": {
     "aws_access_key": "{{env `AWS_ACCESS_KEY_ID`}}",
     "aws_secret_key": "{{env `AWS_SECRET_ACCESS_KEY`}}",
+    "db_cache_access_key": "{{env `DB_CACHE_ACCESS_KEY_ID`}}",
+    "db_cache_secret_key": "{{env `DB_CACHE_SECRET_ACCESS_KEY`}}",
     "new_relic_key": "{{env `NEW_RELIC_KEY`}}",
     "playbook_remote_dir": "/tmp/packer-edx-playbooks",
     "venv_dir": "/edx/app/edx_ansible/venvs/edx_ansible",
@@ -69,7 +71,7 @@
     "command": ". {{user `venv_dir`}}/bin/activate && ansible-playbook",
     "inventory_groups": "jenkins_worker",
     "extra_arguments": [
-      "-e \"role=test_build_server test_edx_platform_version={{user `test_platform_version`}}\"",
+      "-e \"role=test_build_server test_edx_platform_version={{user `test_platform_version`}} DB_CACHE_ACCESS_KEY_ID={{ user `db_cache_access_key` }} DB_CACHE_SECRET_ACCESS_KEY={{ user `db_cache_secret_key` }}\"",
       "-vvv"
       ]
     }]


### PR DESCRIPTION
Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).

Summary
---

Our packer job was failing because of the recent paver work we did with respect to bokchoy database caching. As part of the ansible, we run a series of smoke tests on the new image (including a few bokchoy tests). During these tests, it tries to get our cache bucket from s3 but fails (due to a lack of credentials), which causes an Error.

This change temporarily adds a .boto file to the new image so that it can access s3, and removes it at the end (as this information should not be left on the image). I didn't want to use the environment option in the module that kicks off these tests because the keys would be leaked in the logs, and turning on "no_log" is not an adequate solution because it would give us no insight in the event of a test failure.
