### PR TITLE
stop using ansible npm module

### DIFF
--- a/playbooks/roles/edxapp/tasks/deploy.yml
+++ b/playbooks/roles/edxapp/tasks/deploy.yml
@@ -247,12 +247,11 @@
     - install
     - install:app-requirements
 
+#install with the shell command instead of the ansible npm module so we don't accidentally re-write package.json 
 - name: install node dependencies
-  npm:
-    executable: "{{ edxapp_nodeenv_bin }}/npm"
-    path: "{{ edxapp_code_dir }}"
-    production: "{{ edxapp_npm_production }}"
-    state: latest
+  shell: "{{ edxapp_nodeenv_bin }}/npm install"
+  args:
+    chdir: "{{ edxapp_code_dir }}"
   environment: "{{ edxapp_environment }}"
   become_user: "{{ edxapp_user }}"
   tags:


### PR DESCRIPTION
The Ansible NPM module always upgrades all installed packages when running with "state: latest".  Despite what the docs say, "state: present" doesn't install all packages. As of the current version of npm, running 'npm upgrade' re-writes packge.json and package-lock.json, which results in local modifications to our git repo during our build process.  This causes subsequent builds to fail.

We've stopped using the npm ansible module in other apps due to this issue. 