### PR TITLE
Allow ecommerce and discovery to be disabled on sandbox servers

### DIFF
--- a/playbooks/edx_sandbox.yml
+++ b/playbooks/edx_sandbox.yml
@@ -24,6 +24,8 @@
     DISCOVERY_URL_ROOT: 'http://localhost:{{ DISCOVERY_NGINX_PORT }}'
     ecommerce_create_demo_data: true
     credentials_create_demo_data: true
+    SANDBOX_ENABLE_DISCOVERY: true
+    SANDBOX_ENABLE_ECOMMERCE: true
   roles:
     - role: swapfile
       SWAPFILE_SIZE: 4GB
@@ -47,9 +49,11 @@
     - role: edxapp
       celery_worker: True
     - edxapp
-    - ecommerce
+    - role: ecommerce
+      when: SANDBOX_ENABLE_ECOMMERCE
     - role: ecomworker
       ECOMMERCE_WORKER_BROKER_HOST: 127.0.0.1
+      when: SANDBOX_ENABLE_ECOMMERCE
     - analytics_api
     - insights
     # not ready yet: - edx_notes_api
@@ -59,7 +63,8 @@
     - role: elasticsearch
       when: "'localhost' in EDXAPP_ELASTIC_SEARCH_CONFIG|map(attribute='host')"
     - forum
-    - discovery
+    - role: discovery
+      when: SANDBOX_ENABLE_DISCOVERY
     - role: notifier
       NOTIFIER_DIGEST_TASK_INTERVAL: 5
     - role: xqueue


### PR DESCRIPTION
Re-instates the `SANDBOX_ENABLE_ECOMMERCE` and `SANDBOX_ENABLE_DISCOVERY` variables, to allow `ecommerce` and `discovery` roles to be disabled.

* 3f496fb1e3ddf0ea8c0fea46eee5996f1ee0123c removed `SANDBOX_ENABLE_ECOMMERCE`, making `ecommerce` install unconditionally.  Not sure why?
* a7130a2ad6acf12b969a174d541fc088d4f6308d added the `discovery` role, installed unconditionally

**JIRA tickets**: [OSPR-2162](https://openedx.atlassian.net/browse/OSPR-2162)

**Sandbox URL**: 

* LMS: https://hawthorn-beta.sandbox.opencraft.hosting/
* Studio: https://studio-hawthorn-beta.sandbox.opencraft.hosting/

**Merge deadline**: needed before Hawthorn is cut

**Testing instructions**:

1. Provision an edxapp service with
   ```yaml
   SANDBOX_ENABLE_DISCOVERY: false
   SANDBOX_ENABLE_ECOMMERCE: false
   ```
1. Note that neither the ecommerce nor discovery services are provisioned.

**Reviewers**
- [x] @tomaszgy
- [ ] @edx/devops ?
CC @nedbat 

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
