### PR TITLE
Add custom thresholds to redis monitoring script OPS-2721

### DIFF
--- a/util/jenkins/check-celery-queues.py
+++ b/util/jenkins/check-celery-queues.py
@@ -159,6 +159,8 @@ def check_queues(host, port, environment, deploy, max_metrics, threshold,
                                         Threshold=queue_threshold,
                                         ComparisonOperator=comparison_operator,
                                         Statistic=statistic,
+                                        InsufficientDataActions=actions,
+                                        OKActions=actions,
                                         AlarmActions=actions)
 
 

--- a/util/jenkins/check-celery-queues.py
+++ b/util/jenkins/check-celery-queues.py
@@ -133,11 +133,9 @@ def check_queues(host, port, environment, deploy, max_metrics, threshold,
         queue_threshold = threshold
         if queue in thresholds:
             queue_threshold = thresholds[queue]
-        # Period of 300 is 5 minutes
-        period = 300
-        # 6 periods of 5 min each is 30 minutes
-        # so queue must be over threshold for 30 minutes
-        evaluation_periods = 6
+        # Period is in seconds
+        period = 60
+        evaluation_periods = 15
         comparison_operator = "GreaterThanThreshold"
         treat_missing_data = "notBreaching"
         statistic = "Maximum"

--- a/util/jenkins/check-celery-queues.py
+++ b/util/jenkins/check-celery-queues.py
@@ -108,7 +108,7 @@ def check_queues(host, port, environment, deploy, max_metrics, threshold,
     if len(all_queues) > max_metrics:
         # TODO: Use proper logging framework
         print("Warning! Too many metrics, refusing to publish more than {}"
-            .format(max_metrics))
+              .format(max_metrics))
 
     # Take first max_metrics number of queues from all_queues and remove
     # queues that aren't in redis

--- a/util/jenkins/check-celery-queues.py
+++ b/util/jenkins/check-celery-queues.py
@@ -72,10 +72,17 @@ class CwBotoWrapper(object):
 @click.option('--max-metrics', default=30,
               help='Maximum number of CloudWatch metrics to publish')
 @click.option('--threshold', default=50,
-              help='Maximum queue length before alarm notification is sent')
+              help='Default maximum queue length before alarm notification is'
+              + ' sent')
+@click.option('--queue-threshold', type=(str, int), multiple=True,
+              help='Threshold per queue in format --queue-threshold'
+              + ' {queue_name} {threshold}. May be used multiple times')
 @click.option('--sns-arn', '-s', help='ARN for SNS alert topic', required=True)
 def check_queues(host, port, environment, deploy, max_metrics, threshold,
-                 sns_arn):
+                 queue_threshold, sns_arn):
+
+    thresholds = dict(queue_threshold)
+
     timeout = 1
     namespace = "celery/{}-{}".format(environment, deploy)
     redis_client = RedisWrapper(host=host, port=port, socket_timeout=timeout,
@@ -123,10 +130,16 @@ def check_queues(host, port, environment, deploy, max_metrics, threshold,
 
     for queue in queues:
         dimensions = [{'Name': dimension, 'Value': queue}]
+        queue_threshold = threshold
+        if queue in thresholds:
+            queue_threshold = thresholds[queue]
+        # Period of 300 is 5 minutes
         period = 300
-        evaluation_periods = 1
+        # 6 periods of 5 min each is 30 minutes
+        # so queue must be over threshold for 30 minutes
+        evaluation_periods = 6
         comparison_operator = "GreaterThanThreshold"
-        treat_missing_data = "missing"
+        treat_missing_data = "notBreaching"
         statistic = "Maximum"
         actions = [sns_arn]
         alarm_name = "{}-{} {} queue length over threshold".format(environment,
@@ -145,7 +158,7 @@ def check_queues(host, port, environment, deploy, max_metrics, threshold,
                                         Period=period,
                                         EvaluationPeriods=evaluation_periods,
                                         TreatMissingData=treat_missing_data,
-                                        Threshold=threshold,
+                                        Threshold=queue_threshold,
                                         ComparisonOperator=comparison_operator,
                                         Statistic=statistic,
                                         AlarmActions=actions)

--- a/util/jenkins/requirements-celery.txt
+++ b/util/jenkins/requirements-celery.txt
@@ -3,3 +3,4 @@ redis==2.10.6
 click==6.7
 boto3==1.5.4
 backoff==1.4.3
+awscli==1.14.32


### PR DESCRIPTION
Configuration Pull Request
---

Add --queue-threshold option to allow custom per queue threshold settings.

---
Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
