### PR TITLE
Add devpi and devpi_consumer roles and devpi Docker container.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+- Role: devpi
+  - New role added to configure a devpi service as a pass-through cache for PyPI.
+
+- Role: devpi_consumer
+  - Added role to configure Python containers to use devpi for Docker Devstack
+
 - Role: xqueue
   - Remove S3_BUCKET and S3_PATH_PREFIX - they were deprecated prior to ginkgo
   - Remove SERVICE_VARIANT - it was copied from edxapp but never truly used (except to complicate things)

--- a/docker/build/devpi/Dockerfile
+++ b/docker/build/devpi/Dockerfile
@@ -1,0 +1,44 @@
+# To build this Dockerfile:
+#
+# From the root of configuration:
+#
+# docker build -f docker/build/devpi/Dockerfile .
+#
+# This allows the dockerfile to update /edx/app/edx_ansible/edx_ansible
+# with the currently checked-out configuration repo.
+
+FROM edxops/xenial-common:latest
+MAINTAINER edxops
+
+ARG ARG_DEVPI_SERVER_VERSION=4.4.0
+ARG ARG_DEVPI_WEB_VERSION=3.2.2
+ARG ARG_DEVPI_CLIENT_VERSION=4.0.0
+
+ADD . /edx/app/edx_ansible/edx_ansible
+
+WORKDIR /edx/app/edx_ansible/edx_ansible/docker/plays
+
+RUN apt-get update
+
+COPY docker/build/devstack/ansible_overrides.yml /devstack/ansible_overrides.yml
+
+RUN sudo /edx/app/edx_ansible/venvs/edx_ansible/bin/ansible-playbook devpi.yml \
+    -c local -i '127.0.0.1,' \
+    -t "install,devstack" \
+    --extra-vars="@/devstack/ansible_overrides.yml" \
+    --extra-vars="DEVPI_SERVER_VERSION=$ARG_DEVPI_SERVER_VERSION" \
+    --extra-vars="DEVPI_WEB_VERSION=$ARG_DEVPI_WEB_VERSION" \
+    --extra-vars="DEVPI_CLIENT_VERSION=$ARG_DEVPI_CLIENT_VERSION"
+
+EXPOSE 3141
+VOLUME /data
+
+COPY docker/build/devpi/docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+USER root
+ENV HOME /data
+WORKDIR /data
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["devpi"]

--- a/docker/build/devpi/docker-entrypoint.sh
+++ b/docker/build/devpi/docker-entrypoint.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+function defaults {
+    : ${DEVPI_SERVERDIR="/data/server"}
+    : ${DEVPI_CLIENTDIR="/data/client"}
+
+    echo "DEVPI_SERVERDIR is ${DEVPI_SERVERDIR}"
+    echo "DEVPI_CLIENTDIR is ${DEVPI_CLIENTDIR}"
+
+    export DEVPI_SERVERDIR DEVPI_CLIENTDIR
+}
+
+function initialize_devpi {
+    echo "[RUN]: Initializing devpi-server..."
+    if [ ! -d  $DEVPI_SERVERDIR ]; then
+        devpi-server --restrict-modify root --init --start --host 127.0.0.1 --port 3141
+    else
+        devpi-server --restrict-modify root --start --host 127.0.0.1 --port 3141
+    fi
+    devpi-server --status
+    devpi use http://localhost:3141
+    devpi login root --password=''
+    DEVPI_PASSWORD=`date +%s | sha256sum | base64 | head -c 32`
+    devpi user -m root password="${DEVPI_PASSWORD}"
+    echo "[RUN]: devpi-server password set to '${DEVPI_PASSWORD}'" > $DEVPI_SERVERDIR/.serverpassword
+    devpi index -y -c public pypi_whitelist='*'
+    devpi-server --stop
+    devpi-server --status
+}
+
+defaults
+
+if [ "$1" = 'devpi' ]; then
+    source /home/devpi/venvs/devpi_venv/bin/activate
+
+    if [ ! -f  $DEVPI_SERVERDIR/.serverversion ]; then
+        initialize_devpi
+    fi
+
+    echo "[RUN]: Launching devpi-server..."
+    exec devpi-server --restrict-modify root --host 0.0.0.0 --port 3141
+fi
+
+echo "[RUN]: Builtin command not provided [devpi]"
+echo "[RUN]: $@"
+
+exec "$@"

--- a/docker/plays/devpi.yml
+++ b/docker/plays/devpi.yml
@@ -1,0 +1,12 @@
+# Usage: ansible-playbook devpi.yml -i <admin-host>, -e <secure-repo>/admin/edx_admin.yml -e <secure-repo>/admin/admin.yml
+- name: Configure instance(s)
+  hosts: all
+  become: True
+  gather_facts: True
+  vars:
+    serial_count: 1
+  serial: "{{ serial_count }}"
+  roles:
+    - common_vars
+    - docker
+    - devpi

--- a/docker/plays/edxapp.yml
+++ b/docker/plays/edxapp.yml
@@ -8,6 +8,7 @@
   roles:
     - common_vars
     - docker
+    - devpi_consumer
     - role: nginx
       nginx_sites:
       - lms

--- a/playbooks/roles/devpi/defaults/main.yml
+++ b/playbooks/roles/devpi/defaults/main.yml
@@ -1,0 +1,33 @@
+---
+#
+# edX Configuration
+#
+# github:     https://github.com/edx/configuration
+# wiki:       https://openedx.atlassian.net/wiki/display/OpenOPS
+# code style: https://openedx.atlassian.net/wiki/display/OpenOPS/Ansible+Code+Conventions
+# license:    https://github.com/edx/configuration/blob/master/LICENSE.TXT
+#
+##
+# Defaults for role devpi
+
+devpi_group: devpi
+devpi_user: devpi
+devpi_app_dir: /home/devpi
+devpi_venv_dir: devpi_venv
+devpi_venv_path: "{{ devpi_app_dir }}/venvs/{{ devpi_venv_dir }}"
+
+devpi_environment:
+  PIP_NO_CACHE_DIR: "off"
+  PIP_INDEX_URL: "https://pypi.python.org/simple"
+  PIP_TRUSTED_HOST: "127.0.0.1"
+  VIRTUAL_ENV: "{{ devpi_venv_path }}"
+  PATH: $VIRTUAL_ENV/bin:$PATH
+
+# The versions below are required to be passed-in to the role.
+DEVPI_REQUIREMENTS:
+  - name: devpi-server
+    version: "{{ DEVPI_SERVER_VERSION }}"
+  - name: devpi-web
+    version: "{{ DEVPI_WEB_VERSION }}"
+  - name: devpi-client
+    version: "{{ DEVPI_CLIENT_VERSION }}"

--- a/playbooks/roles/devpi/tasks/main.yml
+++ b/playbooks/roles/devpi/tasks/main.yml
@@ -1,0 +1,63 @@
+---
+#
+# edX Configuration
+#
+# github:     https://github.com/edx/configuration
+# wiki:       https://openedx.atlassian.net/wiki/display/OpenOPS
+# code style: https://openedx.atlassian.net/wiki/display/OpenOPS/Ansible+Code+Conventions
+# license:    https://github.com/edx/configuration/blob/master/LICENSE.TXT
+#
+#
+#
+# Tasks for role devpi
+#
+# Overview:
+#
+#
+# Dependencies:
+#
+#
+# Example play:
+#
+#
+
+- name: Create the application group
+  group:
+    name: "{{ devpi_group }}"
+    state: present
+  tags:
+    - "install"
+
+- name: Create application user
+  user:
+    name: "{{ devpi_user }}"
+    home: "{{ devpi_app_dir }}"
+    group: "{{ devpi_group }}"
+    createhome: no
+    shell: /bin/false
+  tags:
+    - "install"
+
+- name: Create devpi user dirs
+  file:
+    path: "{{ item }}"
+    state: directory
+    owner: "{{ devpi_user }}"
+    group: "{{ devpi_group }}"
+  with_items:
+    - "{{ devpi_app_dir }}"
+    - "{{ devpi_venv_dir }}"
+  tags:
+    - "install"
+
+- name: install python requirements
+  pip:
+    name: "{{ item.name }}"
+    version: "{{ item.version|default(omit) }}"
+    extra_args: "--exists-action w {{ item.extra_args|default('') }}"
+    virtualenv: "{{ devpi_venv_path }}"
+    state: present
+  with_items: "{{ DEVPI_REQUIREMENTS }}"
+  become_user: "{{ devpi_user }}"
+  tags:
+    - "install"

--- a/playbooks/roles/devpi_consumer/defaults/main.yml
+++ b/playbooks/roles/devpi_consumer/defaults/main.yml
@@ -1,0 +1,20 @@
+# Variables for the devpi_consumer role
+# This role allows a host to use the configured devpi server as a primary source for pip
+# Defaults are for Docker Devstack
+#
+
+# This should be a directory, pip.conf will be appended
+DEVPI_PIP_CONF_PATH: /root/.pip
+DEVPI_PIP_CONF_OWNER: root
+DEVPI_PIP_CONF_GROUP: root
+
+DEVPI_HOST: edx.devstack.devpi
+DEVPI_PORT: 3141
+
+# http or https
+#
+DEVPI_PROTOCOL: http
+
+# Use a leading slash, but no trailing slash here
+#
+DEVPI_INDEX: /root/pypi

--- a/playbooks/roles/devpi_consumer/tasks/main.yml
+++ b/playbooks/roles/devpi_consumer/tasks/main.yml
@@ -1,0 +1,22 @@
+- name: create pip conf directory
+  file:
+    path: "{{ DEVPI_PIP_CONF_PATH }}"
+    state: directory
+    owner: "{{ DEVPI_PIP_CONF_OWNER }}"
+    group: "{{ DEVPI_PIP_CONF_GROUP }}"
+  when: devstack is defined and devstack
+  tags:
+    - devstack
+    - devstack:install
+
+- name: write pip.conf to devstack
+  template:
+    src: "pip.conf.j2"
+    dest: "{{ DEVPI_PIP_CONF_PATH }}/pip.conf"
+    owner: "{{ DEVPI_PIP_CONF_OWNER }}"
+    group: "{{ DEVPI_PIP_CONF_GROUP }}"
+    mode: 0744
+  when: devstack is defined and devstack
+  tags:
+    - devstack
+    - devstack:install

--- a/playbooks/roles/devpi_consumer/templates/pip.conf.j2
+++ b/playbooks/roles/devpi_consumer/templates/pip.conf.j2
@@ -1,0 +1,11 @@
+[global]
+index-url = {{ DEVPI_PROTOCOL }}://{{ DEVPI_HOST }}:{{ DEVPI_PORT }}{{ DEVPI_INDEX }}/+simple/
+
+# Enables failover to PyPI if devpi is broken
+extra-index-url = https://pypi.python.org/simple
+
+# This is necessary if you aren't using TLS on the DevPI host
+trusted-host = {{ DEVPI_HOST }}
+
+[search]
+index = {{ DEVPI_PROTOCOL }}://{{ DEVPI_HOST }}:{{ DEVPI_PORT }}{{ DEVPI_INDEX }}/

--- a/util/parsefiles_config.yml
+++ b/util/parsefiles_config.yml
@@ -30,3 +30,4 @@ weights:
   - notes: 2
   - notifier: 2
   - mongo: 1
+  - devpi: 1


### PR DESCRIPTION
Configuration Pull Request
---
https://openedx.atlassian.net/browse/PLAT-1912

devpi is a standalone caching layer in front of PyPI. This PR adds roles to:
- install devpi on an instance
- install pip configuration on an edxapp machine to "pip install" pkgs via the proxy instead of directly via PyPI

Also, adds a Dockerfile and supporting files to build a devpi Docker container that is used in Docker devstack.

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
