### PR TITLE
Switch to the nginx port used by xqueue (not the insights ports)

### DIFF
--- a/docker/build/xqueue/Dockerfile
+++ b/docker/build/xqueue/Dockerfile
@@ -10,4 +10,4 @@ RUN /edx/app/edx_ansible/venvs/edx_ansible/bin/ansible-playbook xqueue.yml -i '1
 
 COPY docker/build/xqueue/docker-run.sh /
 ENTRYPOINT ["/docker-run.sh"]
-EXPOSE 8110 18110
+EXPOSE 18040

--- a/docker/build/xqueue/ansible_overrides.yml
+++ b/docker/build/xqueue/ansible_overrides.yml
@@ -1,7 +1,6 @@
 ---
-
-DOCKER_TLD: "xqueue"
-
 XQUEUE_SYSLOG_SERVER: "localhost"
-XQUEUE_RABBITMQ_HOSTNAME: "rabbit.{{ DOCKER_TLD }}"
-XQUEUE_MYSQL_HOST: "db.{{ DOCKER_TLD }}"
+XQUEUE_RABBITMQ_HOSTNAME: "edx.devstack.rabbit"
+XQUEUE_MYSQL_HOST: "edx.devstack.mysql"
+xqueue_gunicorn_port: 18040
+xqueue_gunicorn_host: 0.0.0.0


### PR DESCRIPTION
This should probably really be two docker containers, one for consumer and one for gunicorn, but that's next, this is to let me be able to test xqueue's access to rabbit/mysql and get a better docker container going

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).

Override gunicorn to run on the nginx port, this is similar to what
other IDAs do, which is to use runserver and bind to the nginx port.
XQueue has multiple services (consumer and gunicorn) so we'll leave
docker-run.sh for now and just change the port specificed in the
supervisor file.

Bring the mysql/rabbit hostnames to the devstack standard names.