### PR TITLE
Add role to call the "clearsessions" management command

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -754,6 +754,14 @@ EDXAPP_SESSION_SAVE_EVERY_REQUEST: false
 
 EDXAPP_SESSION_COOKIE_SECURE: false
 
+# Optionally add a cron job to run the "clearsessions" management command to delete expired sessions
+# Hours and minutes follow cron syntax.
+# E.g. "15,19" hours and "0" minutes will run it at 15:00 and 19:00.
+#      "*" hours and "5" minutes  will run it every hour at past 5 minutes.
+EDXAPP_CLEARSESSIONS_CRON_ENABLED: false
+EDXAPP_CLEARSESSIONS_CRON_HOURS: "14"
+EDXAPP_CLEARSESSIONS_CRON_MINUTES: "0"
+
 EDXAPP_VIDEO_IMAGE_MAX_AGE: 31536000
 
 # This is django storage configuration for Video Image settings.

--- a/playbooks/roles/edxapp/tasks/deploy.yml
+++ b/playbooks/roles/edxapp/tasks/deploy.yml
@@ -446,3 +446,13 @@
   tags:
     - install
     - install:base
+
+- name: install cron job to run clearsessions
+  cron:
+    name: "clear expired Django sessions"
+    user: "{{ edxapp_user }}"
+    job: "{{ edxapp_venv_bin }}/python {{ edxapp_code_dir }}/manage.py lms clearsessions --settings={{ edxapp_settings }} >/dev/null 2>&1"
+    hour: "{{ EDXAPP_CLEARSESSIONS_CRON_HOURS }}"
+    minute: "{{ EDXAPP_CLEARSESSIONS_CRON_MINUTES }}"
+    day: "*"
+  when: EDXAPP_CLEARSESSIONS_CRON_ENABLED


### PR DESCRIPTION
This adds a task to periodically remove expired Django sessions (which can slow down the DB).

Disabled by default. The running frequency can be adjusted only hourly, not daily/weekly/monthly.

There was a similar PR to do the same but with a celery task (much more complex): https://github.com/edx/edx-platform/pull/17331

How to test this:
1. Add a tag to the task in `tasks.yml`, under the `when`, to be able to later run only this task:
```
  tags:
    - onlythis
```
2. Find some sandbox where Open edX it's already installed
3. From your local development machine, do `ansible-playbook -i "PUT.SOME.IP.HERE," --user YOUR_SSH_USER --tags onlythis  edx_sandbox.yml -e EDXAPP_CLEARSESSIONS_CRON_HOURS="5,20" -e EDXAPP_CLEARSESSIONS_CRON_MINUTES="5" -e EDXAPP_CLEARSESSIONS_CRON_ENABLED=true -vvv --check`
4. Check the crontab: login as `edxapp` and do `crontab -l`
5. Try it also in a new deployment, or without `--check`
6. Try it without the parameter to verify it's disabled
7. To verify that it deletes sessions, you can create some expired ones with [these instructions]( https://github.com/edx/edx-platform/pull/17331), or you can trust Django.

---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
