### PR TITLE
Don't use ansible module to install xqwatcher requirements.

### DIFF
--- a/playbooks/roles/xqwatcher/tasks/code_jail.yml
+++ b/playbooks/roles/xqwatcher/tasks/code_jail.yml
@@ -85,11 +85,7 @@
     - install:code
 
 - name: Install course specific python requirements
-  pip:
-    requirements: "{{ xqwatcher_app_data }}/{{ item.QUEUE_CONFIG.HANDLERS[0].CODEJAIL.name }}-requirements.txt"
-    virtualenv: "{{ xqwatcher_app_dir }}/venvs/{{ item.QUEUE_CONFIG.HANDLERS[0].CODEJAIL.name }}"
-    state: present
-    extra_args: "{{ XQWATCHER_PIP_EXTRA_ARGS }}"
+  shell: "{{ xqwatcher_app_dir }}/venvs/{{ item.QUEUE_CONFIG.HANDLERS[0].CODEJAIL.name }}/bin/pip install {{ XQWATCHER_PIP_EXTRA_ARGS }} -r {{ xqwatcher_app_data }}/{{ item.QUEUE_CONFIG.HANDLERS[0].CODEJAIL.name }}-requirements.txt"
   with_items: "{{ XQWATCHER_COURSES }}"
   tags:
     - install


### PR DESCRIPTION
There is a bug in the pip module in the current version of ansible that makes it not
work with python3 virtualenvs.  The bug is fixed in ansible 2.3.2.

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
