### PR TITLE
Add delay to unattended-upgrades after boot

### DIFF
--- a/playbooks/roles/security/defaults/main.yml
+++ b/playbooks/roles/security/defaults/main.yml
@@ -16,7 +16,7 @@
 #
 security_role_name: security
 # set to true to enable unattended upgrades nightly
-SECURITY_UNATTENDED_UPGRADES: true
+SECURITY_UNATTENDED_UPGRADES: false
 # set to true to upgrade all packages nightly.  false will only upgrade from security repo.
 SECURITY_UPDATE_ALL_PACKAGES: false
 # set to true to run aptitute safe-upgrade whenever ansible is run
@@ -24,6 +24,9 @@ SAFE_UPGRADE_ON_ANSIBLE: false
 # set to true to run unattended-upgrade during ansible runs.  This is expected to only install security udpates.
 SECURITY_UPGRADE_ON_ANSIBLE: false
 
+apt_timer_directories:
+  - path: "/etc/systemd/system/apt-daily.timer.d"
+  - path: "/etc/systemd/system/apt-daily-upgrade.timer.d"
 
 #
 # OS packages
@@ -37,3 +40,4 @@ security_debian_pkgs:
 security_redhat_pkgs:
   - yum-plugin-security
   - yum-cron
+

--- a/playbooks/roles/security/defaults/main.yml
+++ b/playbooks/roles/security/defaults/main.yml
@@ -16,7 +16,7 @@
 #
 security_role_name: security
 # set to true to enable unattended upgrades nightly
-SECURITY_UNATTENDED_UPGRADES: false
+SECURITY_UNATTENDED_UPGRADES: true
 # set to true to upgrade all packages nightly.  false will only upgrade from security repo.
 SECURITY_UPDATE_ALL_PACKAGES: false
 # set to true to run aptitute safe-upgrade whenever ansible is run

--- a/playbooks/roles/security/tasks/security-ubuntu.yml
+++ b/playbooks/roles/security/tasks/security-ubuntu.yml
@@ -30,27 +30,41 @@
     - "systemctl disable apt-daily-upgrade.timer"
   ignore_errors: true
 
-- name: Create directory to override apt-daily.timer unit configs 
+- name: Create directories to override apt-timer units configs 
   file: 
-    path: "/etc/systemd/system/apt-daily.timer.d"
+    path: "{{ item.path }}"
     state: directory
     owner: root
     group: root
     mode: 0755
   when: ansible_distribution_release == 'xenial' and SECURITY_UNATTENDED_UPGRADES
+  with_items: "{{ apt_timer_directories }}"
 
 - name: Add delay to unattended-upgrades after boot
   template:
-    src: "etc/systemd/system/apt-daily.timer.d/override.conf"
-    dest: "/etc/systemd/system/apt-daily.timer.d/override.conf"
+    src: "{{ item.path | regex_replace('^\\/','') }}/override.conf"
+    dest: "{{ item.path }}/override.conf"
     owner: root
     group: root
     mode: 0644
   when: ansible_distribution_release == 'xenial' and SECURITY_UNATTENDED_UPGRADES
+  with_items: "{{ apt_timer_directories }}"
 
-- name: reload systemd configuration
-  command: systemctl daemon-reload
-  when: ansible_distribution_release == 'xenial'
+- name: Enable unattended-upgrades if Xenial (16.04)
+  command: "{{ item }}"
+  when: ansible_distribution_release == 'xenial' and SECURITY_UNATTENDED_UPGRADES
+  with_items:
+   - "systemctl enable apt-daily.timer"
+   - "systemctl enable apt-daily-upgrade.timer"
+  ignore_errors: true
+
+- name: reload systemd units configuration 
+  command: "{{ item }}"
+  when: ansible_distribution_release == 'xenial' and SECURITY_UNATTENDED_UPGRADES
+  with_items:
+   - "systemctl daemon-reload"
+   - "systemctl start apt-daily.timer"
+   - "systemctl start apt-daily-upgrade.timer"
 
 - name: Disable unattended-upgrades
   file:

--- a/playbooks/roles/security/tasks/security-ubuntu.yml
+++ b/playbooks/roles/security/tasks/security-ubuntu.yml
@@ -7,7 +7,6 @@
     update_cache: yes
   with_items: "{{ security_debian_pkgs }}"
 
-
 - name: Update all system packages
   apt:
     upgrade: safe
@@ -30,6 +29,28 @@
     - "systemctl disable apt-daily.timer"
     - "systemctl disable apt-daily-upgrade.timer"
   ignore_errors: true
+
+- name: Create directory to override apt-daily.timer unit configs 
+  file: 
+    path: "/etc/systemd/system/apt-daily.timer.d"
+    state: directory
+    owner: root
+    group: root
+    mode: 0755
+  when: ansible_distribution_release == 'xenial' and SECURITY_UNATTENDED_UPGRADES
+
+- name: Add delay to unattended-upgrades after boot
+  template:
+    src: "etc/systemd/system/apt-daily.timer.d/override.conf"
+    dest: "/etc/systemd/system/apt-daily.timer.d/override.conf"
+    owner: root
+    group: root
+    mode: 0644
+  when: ansible_distribution_release == 'xenial' and SECURITY_UNATTENDED_UPGRADES
+
+- name: reload systemd configuration
+  command: systemctl daemon-reload
+  when: ansible_distribution_release == 'xenial'
 
 - name: Disable unattended-upgrades
   file:

--- a/playbooks/roles/security/templates/etc/systemd/system/apt-daily-upgrade.timer.d/override.conf
+++ b/playbooks/roles/security/templates/etc/systemd/system/apt-daily-upgrade.timer.d/override.conf
@@ -3,4 +3,4 @@ OnCalendar=
 Persistent=false
 OnBootSec=1d
 OnUnitActiveSec=1d
-RandomizedDelaySec=0
+RandomizedDelaySec=60m

--- a/playbooks/roles/security/templates/etc/systemd/system/apt-daily.timer.d/override.conf
+++ b/playbooks/roles/security/templates/etc/systemd/system/apt-daily.timer.d/override.conf
@@ -1,0 +1,2 @@
+[Timer]
+OnBootSec=2h


### PR DESCRIPTION
Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
