### PR TITLE
Have update_users only happen when services are running

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - Role: xqueue
   - Remove S3_BUCKET and S3_PATH_PREFIX - they were deprecated prior to ginkgo
   - Remove SERVICE_VARIANT - it was copied from edxapp but never truly used (except to complicate things)
+  - The manage_users management command is only run when disable_edx_services is false (previously this play would try
+    to update databases while building images, where services are generally disabled).
 
 - Role: edxapp
   - Added `ENTERPRISE_REPORTING_SECRET` to CMS auth settings to allow edx-enterprise migrations to run.

--- a/playbooks/roles/xqueue/tasks/deploy.yml
+++ b/playbooks/roles/xqueue/tasks/deploy.yml
@@ -102,6 +102,7 @@
 - name: Create users
   shell: "SERVICE_VARIANT=xqueue {{ xqueue_venv_bin }}/django-admin.py update_users --settings=xqueue.{{ XQUEUE_SETTINGS }} --pythonpath={{ xqueue_code_dir }}"
   become_user: "{{ xqueue_user }}"
+  when: not disable_edx_services
   tags:
     - manage
     - manage:app-users


### PR DESCRIPTION
Right now, it would run unless you are skip-tags'ing it (which is sort
of what we do in docker builds) or if the image has access to a database
(which is what happens during production builds).  It should instead be
explicitly requested.  I would remove it entirely, but we really want it
to run during sandbox builds, which use the ansible role.

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).