### PR TITLE
Consolidate edxapp update assets scripts.

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -887,7 +887,6 @@ edxapp_aa_command: "{% if EDXAPP_SANDBOX_ENFORCE %}aa-enforce{% else %}aa-compla
 edxapp_helper_scripts:
     - edxapp-migrate
     - edxapp-runserver
-    - edxapp-update-assets
     - edxapp-shell
 
 edxapp_environment_default:

--- a/playbooks/roles/edxapp/tasks/service_variant_config.yml
+++ b/playbooks/roles/edxapp/tasks/service_variant_config.yml
@@ -108,6 +108,16 @@
     - install
     - install:configuration
 
+- name: create script to compile and update assets
+  template:
+    src: "edx/bin/edxapp-update-assets.j2"
+    dest: "{{ COMMON_BIN_DIR }}/edxapp-update-assets"
+    owner: "{{ edxapp_user }}"
+    mode: 0755
+  tags:
+    - install
+    - install:configuration
+
 # migrate when the migrate user is overridden in extra vars
 - name: migrate
   command: "{{ COMMON_BIN_DIR }}/edxapp-migrate-{{ item }}"
@@ -139,10 +149,9 @@
     - assets
 
 # Gather assets using paver if possible
-- name: "gather {{ item }} static assets with paver"
-  command: "{{ COMMON_BIN_DIR }}/edxapp-update-assets-{{ item }}"
-  when: celery_worker is not defined and not devstack and item != "lms-preview"
-  with_items: "{{ service_variants_enabled }}"
+- name: "gather static assets with paver"
+  command: "{{ COMMON_BIN_DIR }}/edxapp-update-assets"
+  when: celery_worker is not defined and not devstack
   tags:
     - gather_static_assets
     - assets

--- a/playbooks/roles/edxapp/templates/edx/bin/edxapp-update-assets-cms.j2
+++ b/playbooks/roles/edxapp/templates/edx/bin/edxapp-update-assets-cms.j2
@@ -1,3 +1,0 @@
-{% include "edxapp_common.j2" %}
-
-sudo -E -H -u {{ edxapp_user }} env "PATH=$PATH" {{ edxapp_venv_bin }}/paver update_assets cms --settings $EDX_PLATFORM_SETTINGS

--- a/playbooks/roles/edxapp/templates/edx/bin/edxapp-update-assets-lms.j2
+++ b/playbooks/roles/edxapp/templates/edx/bin/edxapp-update-assets-lms.j2
@@ -1,3 +1,0 @@
-{% include "edxapp_common.j2" %}
-
-sudo -E -H -u {{ edxapp_user }} env "PATH=$PATH" {{ edxapp_venv_bin }}/paver update_assets lms --settings $EDX_PLATFORM_SETTINGS

--- a/playbooks/roles/edxapp/templates/edx/bin/edxapp-update-assets.j2
+++ b/playbooks/roles/edxapp/templates/edx/bin/edxapp-update-assets.j2
@@ -1,0 +1,3 @@
+{% include "edxapp_common.j2" %}
+
+sudo -E -H -u {{ edxapp_user }} env "PATH=$PATH" {{ edxapp_venv_bin }}/paver update_assets --settings $EDX_PLATFORM_SETTINGS


### PR DESCRIPTION
The asset compilation scripts edxapp-update-assets-lms and
edxapp-update-assets-cms duplicate a lot of work between them. Running
webpack twice also seems to cause an intermittent error where the
second build results in a different bundle hash than the first.

It is possible to run "paver update_assets" without specifying "lms" or
"cms", in which case it just compiles it all at the same time. This
removes the duplicate invocations of webpack and should speed the build
overall.

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [x] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
