### PR TITLE
Sqoop upgrade from 1.4.6 to 1.4.7

### DIFF
--- a/playbooks/roles/sqoop/defaults/main.yml
+++ b/playbooks/roles/sqoop/defaults/main.yml
@@ -11,10 +11,10 @@
 # Defaults for role sqoop
 #
 
-SQOOP_VERSION: 1.4.6
+SQOOP_VERSION: 1.4.7
 
 # There is no non-alpha version here, this is just the version of sqoop that is compatible with Hadoop 2
-SQOOP_HADOOP_VERSION: 2.0.4-alpha
+SQOOP_HADOOP_VERSION: 2.6.0
 SQOOP_MYSQL_CONNECTOR_VERSION: 5.1.29
 SQOOP_HOME: "{{ HADOOP_COMMON_USER_HOME }}/sqoop"
 SQOOP_CONF: "{{ SQOOP_HOME }}/conf"
@@ -29,7 +29,7 @@ sqoop_base_filename: "sqoop-{{ SQOOP_VERSION }}.bin__hadoop-{{ SQOOP_HADOOP_VERS
 sqoop_dist:
   filename: "{{ sqoop_base_filename }}.tar.gz"
   url: "http://www.apache.org/dist/sqoop/{{ SQOOP_VERSION }}/{{ sqoop_base_filename }}.tar.gz"
-  sha256sum: d582e7968c24ff040365ec49764531cb76dfa22c38add5f57a16a57e70d5d496
+  sha256sum: 64111b136dbadcb873ce17e09201f723d4aea81e5e7c843e400eb817bb26f235
 sqoop_mysql_connector_dist:
   filename: "mysql-connector-java-{{ SQOOP_MYSQL_CONNECTOR_VERSION }}.tar.gz"
   url: "http://dev.mysql.com/get/Downloads/Connector-J/mysql-connector-java-{{ SQOOP_MYSQL_CONNECTOR_VERSION }}.tar.gz"


### PR DESCRIPTION
Configuration Pull Request
---
This pull request bumps sqoop version from 1.4.6 to 1.4.7.


Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
