### PR TITLE
Update sqoop 1.4.6 package download url

### DIFF
--- a/playbooks/roles/sqoop/defaults/main.yml
+++ b/playbooks/roles/sqoop/defaults/main.yml
@@ -28,7 +28,7 @@ sqoop_temporary_dir: /var/tmp
 sqoop_base_filename: "sqoop-{{ SQOOP_VERSION }}.bin__hadoop-{{ SQOOP_HADOOP_VERSION }}"
 sqoop_dist:
   filename: "{{ sqoop_base_filename }}.tar.gz"
-  url: "http://www.apache.org/dist/sqoop/{{ SQOOP_VERSION }}/{{ sqoop_base_filename }}.tar.gz"
+  url: "http://archive.apache.org/dist/sqoop/{{ SQOOP_VERSION }}/{{ sqoop_base_filename }}.tar.gz"
   sha256sum: d582e7968c24ff040365ec49764531cb76dfa22c38add5f57a16a57e70d5d496
 sqoop_mysql_connector_dist:
   filename: "mysql-connector-java-{{ SQOOP_MYSQL_CONNECTOR_VERSION }}.tar.gz"


### PR DESCRIPTION
Configuration Pull Request
---
Since sqoop has been upgraded to 1.4.7 so the package is not available at the official distribution url. I have updated it to use the apache's archive for downloading. 



Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
