### PR TITLE
We don't need to pin back setuptools anymore

### DIFF
--- a/playbooks/roles/xqueue/defaults/main.yml
+++ b/playbooks/roles/xqueue/defaults/main.yml
@@ -127,8 +127,7 @@ xqueue_auth_config:
 
 xqueue_source_repo: "https://github.com/edx/xqueue.git"
 xqueue_version: 'master'
-xqueue_pre_requirements_file:       "{{ xqueue_code_dir }}/pre-requirements.txt"
-xqueue_post_requirements_file:      "{{ xqueue_code_dir }}/requirements.txt"
+xqueue_requirements_file:      "{{ xqueue_code_dir }}/requirements.txt"
 xqueue_openstack_requirements_file: "{{ xqueue_code_dir }}/openstack-requirements.txt"
 
 # These packages are required for the xqueue server,

--- a/playbooks/roles/xqueue/tasks/deploy.yml
+++ b/playbooks/roles/xqueue/tasks/deploy.yml
@@ -68,17 +68,14 @@
     - install
     - install:code
 
-# Install the python pre requirements and post requirements into {{ xqueue_venv_dir }}
-- name: "Install python pre-requirements and post-requirements"
+# Install the python requirements into {{ xqueue_venv_dir }}
+- name: "Install python requirements"
   pip:
-    requirements: "{{ item }}"
+    requirements: "{{ xqueue_requirements_file }}"
     virtualenv: "{{ xqueue_venv_dir }}"
     state: present
     extra_args: "-i {{ COMMON_PYPI_MIRROR_URL }} --exists-action w"
   become_user: "{{ xqueue_user }}"
-  with_items:
-    - "{{ xqueue_pre_requirements_file }}"
-    - "{{ xqueue_post_requirements_file }}"
   tags:
     - install
     - install:app-requirements


### PR DESCRIPTION
We can just use whatever version comes in with the venv setup safely

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
