### PR TITLE
Bump installed jenkins_master version

### DIFF
--- a/playbooks/roles/jenkins_master/defaults/main.yml
+++ b/playbooks/roles/jenkins_master/defaults/main.yml
@@ -6,7 +6,7 @@ jenkins_port: 8080
 jenkins_nginx_port: 80
 jenkins_protocol_https: true
 
-jenkins_version: "1.638"
+jenkins_version: '1.651.3'
 jenkins_deb_url: "https://pkg.jenkins.io/debian-stable/binary/jenkins_{{ jenkins_version }}_all.deb"
 jenkins_deb: "jenkins_{{ jenkins_version }}_all.deb"
 # Jenkins jvm args are set when starting the Jenkins service, e.g., "-Xmx1024m"


### PR DESCRIPTION
It looks like this version disappeared from the downloads page within
the past few weeks. I successfully ran this play less than a month ago,
but it started failing a week or two ago, due to the 404 upon download.

I'm admittedly a bit confused as to why there appears to be at least 3
different minor versions of jenkins in use [1][2][3] (plus a major bump
on the build server?! [4]), so I simply cribbed the version used by the
`tools_jenkins` role.

References:
- [1] jenkins_version: "1.638"
- [2] jenkins_tools_version: "1.651.3"
- [3] jenkins_admin_version: "1.658"
- [4] build_jenkins_version: jenkins_2.60.3

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
