### PR TITLE
upgrade Jenkins to Firefox 59, geckodriver 0.20

### DIFF
--- a/playbooks/roles/browsers/defaults/main.yml
+++ b/playbooks/roles/browsers/defaults/main.yml
@@ -20,14 +20,14 @@ browser_deb_pkgs:
     - xvfb
 
 # Firefox for Xenial
-firefox_version: version 45.*
+firefox_version: version 59.*
 
 # Packages we host in S3 to ensure correct browser version Both Chrome and
 # FireFox update their apt repos with the latest version, which often causes
 # spurious acceptance test failures.
 browser_s3_deb_pkgs:
-  - name: firefox_45.0.2+build1-0ubuntu1_amd64
-    url: https://s3.amazonaws.com/vagrant.testeng.edx.org/firefox_45.0.2%2Bbuild1-0ubuntu1_amd64.deb
+  - name: firefox_59.0.1+build1-0ubuntu0.16.04.1_amd64.deb
+    url: https://s3.amazonaws.com/vagrant.testeng.edx.org/firefox_59.0.1%2Bbuild1-0ubuntu0.16.04.1_amd64.deb
   - name: google-chrome-stable_55.0.2883.87-1_amd64.deb
     url: https://s3.amazonaws.com/vagrant.testeng.edx.org/google-chrome-stable_55.0.2883.87-1_amd64.deb
 
@@ -36,6 +36,9 @@ trusty_browser_s3_deb_pkgs:
     url: https://s3.amazonaws.com/vagrant.testeng.edx.org/firefox-mozilla-build_42.0-0ubuntu1_amd64.deb
   - name: google-chrome-stable_59.0.3071.115-1_amd64.deb
     url: https://s3.amazonaws.com/vagrant.testeng.edx.org/google-chrome-stable_59.0.3071.115-1_amd64.deb
+
+# GeckoDriver
+geckodriver_url: "https://github.com/mozilla/geckodriver/releases/download/v0.20.0/geckodriver-v0.20.0-linux64.tar.gz"
 
 # ChromeDriver
 chromedriver_version: 2.27

--- a/playbooks/roles/browsers/files/geckodriver
+++ b/playbooks/roles/browsers/files/geckodriver
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+/usr/local/bin/geckodriver-bin "$@" --marionette-port 2828

--- a/playbooks/roles/browsers/tasks/main.yml
+++ b/playbooks/roles/browsers/tasks/main.yml
@@ -80,6 +80,61 @@
     - install
     - install:system-requirements
 
+- name: download GeckoDriver
+  get_url:
+    url: "{{ geckodriver_url }}"
+    dest: /tmp/geckodriver.tar.gz
+  register: download_geckodriver
+  tags:
+    - install
+    - install:system-requirements
+
+- name: unzip GeckoDriver tarfile
+  shell: tar -xvf /tmp/geckodriver.tar.gz -C /usr/local/bin/
+  args:
+    chdir: /var/tmp
+  when: download_geckodriver.changed
+  tags:
+    - install
+    - install:system-requirements
+
+- name: Rename geckodriver to geckodriver-bin
+  command: mv /usr/local/bin/geckodriver /usr/local/bin/geckodriver-bin
+  tags:
+    - install
+    - install:system-requirements
+
+- name: make GeckoDriver binary executable
+  file:
+    path: /usr/local/bin/geckodriver-bin
+    mode: 0755
+  when: download_geckodriver.changed
+  tags:
+    - install
+    - install:system-requirements
+
+- name: verify GeckoDriver location and mode
+  stat:
+    path: /usr/local/bin/geckodriver-bin
+  register: geckodriver
+  tags:
+    - install
+    - install:system-requirements
+
+- name: Add geckodriver wrapper script
+  copy:
+    src: "../files/geckodriver"
+    dest: "/usr/local/bin/geckodriver"
+    mode: 0755
+
+- assert:
+    that:
+      - "geckodriver.stat.exists"
+      - "geckodriver.stat.mode == '0755'"
+  tags:
+    - install
+    - install:system-requirements
+
 - name: download ChromeDriver
   get_url:
     url: "{{ chromedriver_url }}"

--- a/playbooks/roles/jenkins_worker/tasks/test_platform_worker.yml
+++ b/playbooks/roles/jenkins_worker/tasks/test_platform_worker.yml
@@ -22,7 +22,7 @@
   register: firefox_version
 - assert:
     that:
-      - "'45.0.2' in firefox_version.stdout"
+      - "'59' in firefox_version.stdout"
 
 # Verify the virtualenv tar is newly-built
 - name: Get info on virtualenv tar


### PR DESCRIPTION
This updates the Jenkins workers to use Firefox 59 and geckodriver 0.20.

Additionally, this fixes the issue of newer version of Firefox hanging during Selenium tests. It follows the advice of https://github.com/mozilla/geckodriver/issues/1058#issuecomment-347830930 - namely, include a wrapper script to force geckodriver to connect to marionette on a specific port.