### PR TITLE
Update plugin to handle 64-bit ids DEVOPS-7185

### DIFF
--- a/playbooks/roles/tools_jenkins/defaults/main.yml
+++ b/playbooks/roles/tools_jenkins/defaults/main.yml
@@ -37,7 +37,7 @@ jenkins_tools_plugins:
   - { name: "workflow-scm-step", version: "1.14.2" }
   - { name: "workflow-step-api", version: "1.14.2" }
   - { name: "ghprb", version: "1.35.0" }
-  - { name: "github-api", version: "1.82" }
+  - { name: "github-api", version: "1.90" }
   - { name: "git-client", version: "1.21.0"}
   - { name: "git", version: "2.5.3"}
   - { name: "github", version: "1.21.1" }


### PR DESCRIPTION
Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
---

As noted in the DEVOPS-7185 ticket we can't upgrade the GHPRB plugin because it now requires Jenkins 2. To solve the issue we really only need to upgrade the Github API plugin, which this PR does.
