### PR TITLE
Add BLOCK_STRUCTURES_SETTINGS.PRUNING_ACTIVE

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -793,6 +793,8 @@ EDXAPP_BLOCK_STRUCTURES_SETTINGS:
   # Maximum number of retries per task.
   TASK_MAX_RETRIES: 5
 
+  PRUNING_ACTIVE: false
+
 # Configuration settings needed for the LMS to communicate with the Enterprise service.
 EDXAPP_ENTERPRISE_API_URL: "{{ EDXAPP_LMS_INTERNAL_ROOT_URL }}/enterprise/api/v1"
 


### PR DESCRIPTION
# [EDUCATOR-499](https://openedx.atlassian.net/browse/EDUCATOR-499)

Moving this value from a waffle flag to a more standard Open edX Option; defaults to `False` with opt-in allowed via a simple boolean setting.

internal PR to follow shortly

---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR. @jibsheet 
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
