### PR TITLE
Add the MAINTENANCE_BANNER_TEXT variable to generic_env_config

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -834,6 +834,9 @@ EDXAPP_PARENTAL_CONSENT_AGE_LIMIT: 13
 EDXAPP_SCORM_PKG_STORAGE_DIR: !!null
 EDXAPP_SCORM_PLAYER_LOCAL_STORAGE_ROOT: !!null
 
+# maintenance banner message (only actually enabled via waffle switch)
+EDXAPP_MAINTENANCE_BANNER_TEXT: "Sample banner message"
+
 #-------- Everything below this line is internal to the role ------------
 
 #Use YAML references (& and *) and hash merge <<: to factor out shared settings
@@ -1223,6 +1226,7 @@ generic_env_config:  &edxapp_generic_env
   POLICY_CHANGE_GRADES_ROUTING_KEY: "{{ EDXAPP_POLICY_CHANGE_GRADES_ROUTING_KEY }}"
   PROCTORING_SETTINGS: "{{ EDXAPP_PROCTORING_SETTINGS }}"
   EXTRA_MIDDLEWARE_CLASSES: "{{ EDXAPP_EXTRA_MIDDLEWARE_CLASSES }}"
+  MAINTENANCE_BANNER_TEXT: "{{ EDXAPP_MAINTENANCE_BANNER_TEXT }}"
 
 lms_auth_config:
   <<: *edxapp_generic_auth


### PR DESCRIPTION
Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [x] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).

---

corresponds with https://github.com/edx/edx-platform/pull/17769 which makes use of this variable in edx-platform.