### PR TITLE
This is hardcoded as the id and here

### DIFF
--- a/playbooks/roles/datadog/defaults/main.yml
+++ b/playbooks/roles/datadog/defaults/main.yml
@@ -3,7 +3,7 @@ DATADOG_API_KEY: "SPECIFY_KEY_HERE"
 
 datadog_agent_version: '1:5.10.1-1'
 
-datadog_apt_key: "0x226AE980C7A7DA52"
+datadog_apt_key: "0x382E94DE"
 datadog_debian_pkgs:
   - apparmor-utils
   - build-essential


### PR DESCRIPTION
This was failing on clean builds that need the id and url to match
I thought about only specifying the id, but ansible suggests specifying both http://docs.ansible.com/ansible/latest/apt_key_module.html#notes

https://github.com/edx/configuration/pull/4364

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).