### PR TITLE
Revert "Update splunk forwarder role so it can be installed on Amazon Linux OS"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,3 @@
-- Role: splunkforwarder
-  - Updated the role so the splunkforwarder can be installed on Amazon Linux OS environment, which is a RHEL variant
-
-- Role: server_utils
-  - Update to only do things for debian varient environment
-
 - Role: xqueue
   - Added `XQUEUE_SESSION_ENGINE` to allow a configurable xqueue session engine.
   - Added `XQUEUE_CACHES` to allow a configurable xqueue cache.

--- a/playbooks/roles/server_utils/tasks/main.yml
+++ b/playbooks/roles/server_utils/tasks/main.yml
@@ -24,11 +24,10 @@
 - name: Check for expired edx key
   command: "apt-key list | grep {{ SERVER_UTILS_EDX_PPA_KEY_ID }}"
   register: ppa_key_status
-  when: ansible_distribution in common_debian_variants
 
 - name: remove expired edx key
   command: "sudo apt-key adv --keyserver {{ SERVER_UTILS_EDX_PPA_KEY_SERVER }} --recv-keys {{ SERVER_UTILS_EDX_PPA_KEY_ID }}"
-  when: ansible_distribution in common_debian_variants and "'expired' in  ppa_key_status.stdout"
+  when: "'expired' in  ppa_key_status.stdout"
 
 - name: Install ubuntu system packages
   apt:
@@ -37,4 +36,4 @@
     state: present 
     update_cache: yes
   with_items: "{{ server_utils_debian_pkgs }}"
-  when: ansible_distribution in common_debian_variants
+  when: ansible_distribution == 'Ubuntu'

--- a/playbooks/roles/splunkforwarder/defaults/main.yml
+++ b/playbooks/roles/splunkforwarder/defaults/main.yml
@@ -18,7 +18,6 @@ splunk_role_name: 'splunk'
 
 SPLUNKFORWARDER_PACKAGE_URL: !!null
 SPLUNKFORWARDER_DEB: !!null
-SPLUNKFORWARDER_RPM: !!null
 SPLUNKFORWARDER_PASSWORD: !!null
 
 # A list of dicts with the following keys:

--- a/playbooks/roles/splunkforwarder/tasks/main.yml
+++ b/playbooks/roles/splunkforwarder/tasks/main.yml
@@ -21,7 +21,7 @@
 #
 #
 
-# Install Splunk Forwarder for common_debian_variants
+# Install Splunk Forwarder
 - name: Install splunkforwarder specific system packages
   apt:
     name: "{{ item }}"
@@ -31,34 +31,18 @@
     - splunk
     - install
     - update
-  when: ansible_distribution in common_debian_variants
 
 - name: Download the splunk deb
   get_url:
     dest: "/tmp/{{ SPLUNKFORWARDER_DEB }}"
     url: "{{ SPLUNKFORWARDER_PACKAGE_URL }}"
-  register: download_package
-  until: download_package|succeeded
+  register: download_deb
+  until: download_deb|succeeded
   retries: 5
-  when: ansible_distribution in common_debian_variants
 
 - name: Install splunk forwarder
   shell: "gdebi -nq /tmp/{{ SPLUNKFORWARDER_DEB }}"
-  when: ansible_distribution in common_debian_variants and download_package.changed
-
-# Install Splunk Forwarder for common_redhat_variants
-- name: Download the splunk rpm
-  get_url:
-    dest: "/tmp/{{ SPLUNKFORWARDER_RPM }}"
-    url: "{{ SPLUNKFORWARDER_PACKAGE_URL }}"
-  register: download_package
-  until: download_package|succeeded
-  retries: 5
-  when: ansible_distribution in common_redhat_variants
-
-- name: Install splunk forwarder
-  shell: "rpm -i /tmp/{{ SPLUNKFORWARDER_RPM }}"
-  when: ansible_distribution in common_redhat_variants and download_package.changed
+  when: download_deb.changed
 
 - name: Create splunk user
   user:
@@ -67,7 +51,7 @@
     state: present
     append: yes
     groups: syslog,adm
-  when: download_package.changed
+  when: download_deb.changed
 
 # Need to start splunk manually so that it can create various files
 # and directories that aren't created till the first run and are needed
@@ -76,19 +60,19 @@
   shell: "{{ splunkforwarder_output_dir }}/bin/splunk start --accept-license --answer-yes --no-prompt"
   args:
     creates: "{{ splunkforwarder_output_dir }}/var/lib/splunk"
-  when: download_package.changed
+  when: download_deb.changed
   register: started_manually
 
 - name: Stop splunk manually
   shell: "{{ splunkforwarder_output_dir }}/bin/splunk stop --accept-license --answer-yes --no-prompt"
-  when: download_package.changed and started_manually.changed
+  when: download_deb.changed and started_manually.changed
 
 - name: Create boot script
   shell: "{{ splunkforwarder_output_dir }}/bin/splunk enable boot-start -user splunk --accept-license --answer-yes --no-prompt"
   args:
     creates: /etc/init.d/splunk
   register: create_boot_script
-  when: download_package.changed
+  when: download_deb.changed
   notify: restart splunkforwarder
 
 - name: Ensure splunk forder permissions
@@ -98,12 +82,12 @@
     recurse: yes
     owner: splunk
     group: splunk
-  when: download_package.changed
+  when: download_deb.changed
   notify: restart splunkforwarder
 
 - name: Update admin pasword
   shell: "{{ splunkforwarder_output_dir }}/bin/splunk edit user admin -password '{{ SPLUNKFORWARDER_PASSWORD }}' -auth admin:changeme --accept-license --answer-yes --no-prompt"
-  when: download_package.changed
+  when: download_deb.changed
   notify: restart splunkforwarder
 
 - name: Add chkconfig to init script
@@ -113,7 +97,7 @@
     line: "# chkconfig: 235 98 55"
     insertafter: "#!/bin/sh"
     state: present
-  when: download_package.changed and create_boot_script.changed
+  when: download_deb.changed and create_boot_script.changed
   notify: restart splunkforwarder
 
 - name: Make sure necessary dirs exist


### PR DESCRIPTION
Reverts edx/configuration#4407

Registering the same variable for the deb and rpm download causes the user creation and splunk start to never happen on an ubuntu box, this is preventing me from building IDAs from scratch.

Please feel free to make a fix PR instead, but I'd like to move forward with my testing and I'm currently blocked.