### PR TITLE
Fix the splunk forwarder install role so it can be run on both Ubuntu and RHEL

### DIFF
--- a/playbooks/roles/splunkforwarder/tasks/main.yml
+++ b/playbooks/roles/splunkforwarder/tasks/main.yml
@@ -37,28 +37,28 @@
   get_url:
     dest: "/tmp/{{ SPLUNKFORWARDER_DEB }}"
     url: "{{ SPLUNKFORWARDER_PACKAGE_URL }}"
-  register: download_package
-  until: download_package|succeeded
+  register: download_deb
+  until: download_deb|succeeded
   retries: 5
   when: ansible_distribution in common_debian_variants
 
 - name: Install splunk forwarder
   shell: "gdebi -nq /tmp/{{ SPLUNKFORWARDER_DEB }}"
-  when: ansible_distribution in common_debian_variants and download_package.changed
+  when: ansible_distribution in common_debian_variants and download_deb.changed
 
 # Install Splunk Forwarder for common_redhat_variants
 - name: Download the splunk rpm
   get_url:
     dest: "/tmp/{{ SPLUNKFORWARDER_RPM }}"
     url: "{{ SPLUNKFORWARDER_PACKAGE_URL }}"
-  register: download_package
-  until: download_package|succeeded
+  register: download_rpm
+  until: download_rpm|succeeded
   retries: 5
   when: ansible_distribution in common_redhat_variants
 
 - name: Install splunk forwarder
   shell: "rpm -i /tmp/{{ SPLUNKFORWARDER_RPM }}"
-  when: ansible_distribution in common_redhat_variants and download_package.changed
+  when: ansible_distribution in common_redhat_variants and download_rpm.changed
 
 - name: Create splunk user
   user:
@@ -67,7 +67,7 @@
     state: present
     append: yes
     groups: syslog,adm
-  when: download_package.changed
+  when: download_rpm.changed or download_deb.changed
 
 # Need to start splunk manually so that it can create various files
 # and directories that aren't created till the first run and are needed
@@ -76,19 +76,19 @@
   shell: "{{ splunkforwarder_output_dir }}/bin/splunk start --accept-license --answer-yes --no-prompt"
   args:
     creates: "{{ splunkforwarder_output_dir }}/var/lib/splunk"
-  when: download_package.changed
+  when: download_rpm.changed or download_deb.changed
   register: started_manually
 
 - name: Stop splunk manually
   shell: "{{ splunkforwarder_output_dir }}/bin/splunk stop --accept-license --answer-yes --no-prompt"
-  when: download_package.changed and started_manually.changed
+  when: (download_rpm.changed or download_deb.changed) and started_manually.changed
 
 - name: Create boot script
   shell: "{{ splunkforwarder_output_dir }}/bin/splunk enable boot-start -user splunk --accept-license --answer-yes --no-prompt"
   args:
     creates: /etc/init.d/splunk
   register: create_boot_script
-  when: download_package.changed
+  when: download_rpm.changed or download_deb.changed
   notify: restart splunkforwarder
 
 - name: Ensure splunk forder permissions
@@ -98,12 +98,12 @@
     recurse: yes
     owner: splunk
     group: splunk
-  when: download_package.changed
+  when: download_rpm.changed or download_deb.changed
   notify: restart splunkforwarder
 
 - name: Update admin pasword
   shell: "{{ splunkforwarder_output_dir }}/bin/splunk edit user admin -password '{{ SPLUNKFORWARDER_PASSWORD }}' -auth admin:changeme --accept-license --answer-yes --no-prompt"
-  when: download_package.changed
+  when: download_rpm.changed or download_deb.changed
   notify: restart splunkforwarder
 
 - name: Add chkconfig to init script
@@ -113,7 +113,7 @@
     line: "# chkconfig: 235 98 55"
     insertafter: "#!/bin/sh"
     state: present
-  when: download_package.changed and create_boot_script.changed
+  when: (download_rpm.changed or download_deb.changed) and create_boot_script.changed
   notify: restart splunkforwarder
 
 - name: Make sure necessary dirs exist


### PR DESCRIPTION
Fix the splunk forwarder install role so it can be run on both Ubuntu and RHEL
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
(https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
