### PR TITLE
Bump to firefox 59.0.2 on workers

### DIFF
--- a/playbooks/roles/browsers/defaults/main.yml
+++ b/playbooks/roles/browsers/defaults/main.yml
@@ -26,8 +26,8 @@ firefox_version: version 59.*
 # FireFox update their apt repos with the latest version, which often causes
 # spurious acceptance test failures.
 browser_s3_deb_pkgs:
-  - name: firefox_59.0.1+build1-0ubuntu0.16.04.1_amd64.deb
-    url: https://s3.amazonaws.com/vagrant.testeng.edx.org/firefox_59.0.1%2Bbuild1-0ubuntu0.16.04.1_amd64.deb
+  - name: firefox_59.0.2+build1-0ubuntu0.16.04.1_amd64.deb
+    url: https://s3.amazonaws.com/vagrant.testeng.edx.org/firefox_59.0.2%2Bbuild1-0ubuntu0.16.04.1_amd64.deb
   - name: google-chrome-stable_55.0.2883.87-1_amd64.deb
     url: https://s3.amazonaws.com/vagrant.testeng.edx.org/google-chrome-stable_55.0.2883.87-1_amd64.deb
 


### PR DESCRIPTION
Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
