### PR TITLE
Revert "install pipeline plugin (aka. workflow-aggregator) into build jenkins"

### DIFF
--- a/playbooks/roles/jenkins_build/defaults/main.yml
+++ b/playbooks/roles/jenkins_build/defaults/main.yml
@@ -224,9 +224,6 @@ build_jenkins_plugins_list:
   - name: 'workflow-cps'
     version: '2.45'
     group: 'org.jenkins-ci.plugins.workflow'
-  - name: 'workflow-aggregator'
-    version: '2.5'
-    group: 'org.jenkins-ci.plugins.workflow'
 
 # ghprb
 build_jenkins_ghprb_white_list_phrase: '.*[Aa]dd\W+to\W+whitelist.*'


### PR DESCRIPTION
Reverts edx/configuration#4438

Adding this plugin causes plugin incompatibilities which breaks almost all jenkins init scripts.