### PR TITLE
Pass New Relic configuration down to the xqueue config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
   - Removed RabbitMQ in earlier changes in XQueue itself, we don't need any of the configuration
     XQUEUE_RABBITMQ_USER XQUEUE_RABBITMQ_PASS XQUEUE_RABBITMQ_VHOST XQUEUE_RABBITMQ_HOSTNAME 
     XQUEUE_RABBITMQ_PORT XQUEUE_RABBITMQ_TLS
-
+  - Added NEWRELIC_APPNAME and NEWRELIC_LICENSE_KEY to the configuration files consumed by XQueue.
+    Useful for external utilities that are reporting NR metrics.
     
 - Role edx_django_service
   - Added maintenance page under the flag EDX_DJANGO_SERVICE_ENABLE_S3_MAINTENANCE.

--- a/playbooks/roles/xqueue/defaults/main.yml
+++ b/playbooks/roles/xqueue/defaults/main.yml
@@ -91,6 +91,7 @@ xqueue_env_config:
   LOCAL_LOGLEVEL: "{{ XQUEUE_LOCAL_LOGLEVEL }}"
   UPLOAD_BUCKET: "{{ XQUEUE_UPLOAD_BUCKET }}"
   UPLOAD_PATH_PREFIX: "{{ XQUEUE_UPLOAD_PATH_PREFIX }}"
+  NEWRELIC_APPNAME: "{{ XQUEUE_NEWRELIC_APPNAME }}"
 
 xqueue_auth_config:
   AWS_ACCESS_KEY_ID:  "{{ XQUEUE_AWS_ACCESS_KEY_ID }}"
@@ -115,6 +116,7 @@ xqueue_auth_config:
       ATOMIC_REQUESTS: True
       CONN_MAX_AGE: "{{ XQUEUE_MYSQL_CONN_MAX_AGE }}"
       OPTIONS: "{{ XQUEUE_MYSQL_OPTIONS }}"
+  NEWRELIC_LICENSE_KEY: "{{ NEWRELIC_LICENSE_KEY | default('') }}"
 
 xqueue_source_repo: "https://github.com/edx/xqueue.git"
 xqueue_version: 'master'


### PR DESCRIPTION
Previously these were only used for supervisor - also pass down.
XQueue uses this previous config when connecting to NR from management
commands that are run outside of transactions.
It also needs the license key to ensure that the agent is connected.


Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).