### PR TITLE
Fix sandbox pip runs with new requirements files

### DIFF
--- a/playbooks/roles/edxapp/tasks/deploy.yml
+++ b/playbooks/roles/edxapp/tasks/deploy.yml
@@ -272,28 +272,13 @@
 
 - name: code sandbox | Install base sandbox requirements and create sandbox virtualenv
   pip:
+    chdir: "{{ edxapp_code_dir }}"
     requirements: "{{ sandbox_base_requirements }}"
     virtualenv: "{{ edxapp_sandbox_venv_dir }}"
     state: present
     extra_args: "-i {{ COMMON_PYPI_MIRROR_URL }} --exists-action w"
   become_user: "{{ edxapp_sandbox_user }}"
   when: EDXAPP_PYTHON_SANDBOX
-  tags:
-    - edxapp-sandbox
-    - install
-    - install:app-requirements
-
-- name: code sandbox | Install sandbox requirements into sandbox venv
-  shell: "{{ edxapp_sandbox_venv_dir }}/bin/pip install -i {{ COMMON_PYPI_MIRROR_URL }} --exists-action w -r {{ item }}"
-  args:
-    chdir: "{{ edxapp_code_dir }}"
-  with_items:
-    - "{{ sandbox_local_requirements }}"
-    - "{{ sandbox_post_requirements }}"
-  become_user: "{{ edxapp_sandbox_user }}"
-  when: EDXAPP_PYTHON_SANDBOX
-  register: sandbox_install_output
-  changed_when: sandbox_install_output.stdout is defined and 'installed' in sandbox_install_output.stdout
   tags:
     - edxapp-sandbox
     - install


### PR DESCRIPTION
Configuration Pull Request
---

There are now local packages in the base requirements file, but Ansible hadn't been configured to go to the code directory before calling pip.  Now does this, and no longer needs to install the `edx-sandbox/local.txt` or `edx-sandbox/post.txt` files; these are now placeholders, their former content has been merged into `edx-sandbox/base.txt` by `pip-compile`.

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
