### PR TITLE
update new relic and infrastructure regularly

### DIFF
--- a/playbooks/roles/newrelic/tasks/main.yml
+++ b/playbooks/roles/newrelic/tasks/main.yml
@@ -43,7 +43,7 @@
   apt:
     name: "{{ item }}"
     install_recommends: yes
-    state: present
+    state: latest
   with_items: "{{ newrelic_debian_pkgs }}"
   when: ansible_distribution == 'Ubuntu'
 
@@ -56,7 +56,7 @@
 - name: Install newrelic related system packages for Amazon
   yum:
     name: "{{ item }}"
-    state: present
+    state: latest
     update_cache: yes
   with_items: "{{ newrelic_redhat_pkgs }}"
   when: ansible_distribution == 'Amazon'

--- a/playbooks/roles/newrelic_infrastructure/defaults/main.yml
+++ b/playbooks/roles/newrelic_infrastructure/defaults/main.yml
@@ -22,3 +22,15 @@ NEWRELIC_INFRASTRUCTURE_DEBIAN_KEY_URL: 'https://download.newrelic.com/infrastru
 # Any extra config you want to specify
 # https://docs.newrelic.com/docs/infrastructure/new-relic-infrastructure/configuration/infrastructure-config-file-template-newrelic-infrayml
 NEWRELIC_INFRASTRUCTURE_EXTRA_CONFIG: ''
+NEWRELIC_INFRASTRUCTURE_AMAZON_REPO: 'https://download.newrelic.com/infrastructure_agent/linux/yum/el/6/x86_64/newrelic-infra.repo'
+
+#
+# OS packages
+#
+
+newrelic_infrastructure_debian_pkgs:
+  - newrelic-infra
+
+newrelic_infrastructure_redhat_pkgs:
+  - newrelic-infra
+

--- a/playbooks/roles/newrelic_infrastructure/tasks/main.yml
+++ b/playbooks/roles/newrelic_infrastructure/tasks/main.yml
@@ -38,6 +38,7 @@
   tags:
     - install
     - install:app-requirements
+  when: ansible_distribution == 'Ubuntu'
 
 - name: Install apt repository for New Relic Infrastructure
   apt_repository:
@@ -47,13 +48,38 @@
   tags:
     - install
     - install:app-requirements
+  when: ansible_distribution == 'Ubuntu'
 
-- name: Install New Relic Infrastructure agent
+- name: Install newrelic related system packages for Ubuntu
   apt:
-    name: "newrelic-infra"
+    name: "{{ item }}"
+    install_recommends: yes
+    state: latest
   tags:
     - install
-    - install:code
+    - install:app-requirements
+  with_items: "{{ newrelic_infrastructure_debian_pkgs }}"
+  when: ansible_distribution == 'Ubuntu'
+
+- name: Configure the New Relic Servers yum repository
+  yum:
+    name: "{{ NEWRELIC_AMAZON_REPO }}"
+    state: present
+  tags:
+    - install
+    - install:app-requirements
+  when: ansible_distribution == 'Amazon'
+
+- name: Install newrelic related system packages for Amazon
+  yum:
+    name: "{{ item }}"
+    state: latest
+    update_cache: yes
+  with_items: "{{ newrelic_infrastructure_redhat_pkgs }}"
+  tags:
+    - install
+    - install:app-requirements
+  when: ansible_distribution == 'Amazon'
 
 - name: Restart the infrastructure agent if the license key changes
   service:


### PR DESCRIPTION
This will automatically get the latest NR package on rebuild for all apps that use newrelic and for systems using newrelic infrastructure.   I've also added support for ec2 linux following the instructions at https://blog.newrelic.com/2017/09/25/installing-infrastructure-agent-aws/