### PR TITLE
Add jenkins-worker label to the build jenkins docker image

### DIFF
--- a/docker/build/jenkins_build/ansible_overrides.yml
+++ b/docker/build/jenkins_build/ansible_overrides.yml
@@ -38,3 +38,10 @@ jenkins_common_non_plugin_template_files:
 #  - security  # intentionally left commented out
   - seed_config
 
+# Add the jenkins-worker label so that this jenkins master will work
+# out-of-the-box for running most kinds of jobs.  This makes integration
+# testing easier, and is easier for the openedx community.
+jenkins_common_main_labels:
+  - 'dsl-seed-runner'
+  - 'backup-runner'
+  - 'jenkins-worker'  # added this


### PR DESCRIPTION
This will make it easier for us to use this dockerfile for integration
testing, since many jobs already use the jenkins-worker label.

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).

FYI @edx/platform-team 