### PR TITLE
fix name of splunk config script

### DIFF
--- a/playbooks/roles/jenkins_build/defaults/main.yml
+++ b/playbooks/roles/jenkins_build/defaults/main.yml
@@ -18,7 +18,7 @@ build_jenkins_configuration_scripts:
   - 4configureJobConfigHistory.groovy
   - 4configureMailerPlugin.groovy
   - 4configureMaskPasswords.groovy
-  - 4configureSplunkPlugin.groovy
+  - 4configureSplunk.groovy
   - 5createLoggers.groovy
 
 # plugins


### PR DESCRIPTION
Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).

------
Missed this in my testing somehow. Real name of script here: https://github.com/edx/jenkins-configuration/blob/master/src/main/groovy/4configureSplunk.groovy
