### PR TITLE
TE-2546 Remove references to obsolete requirements files

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -1428,47 +1428,25 @@ edx_platform_repo: "https://{{ COMMON_GIT_MIRROR }}/edx/edx-platform.git"
 # `edx_platform_version` can be anything that git recognizes as a commit
 # reference, including a tag, a branch name, or a commit hash
 edx_platform_version: 'release'
-pre_requirements_file:    "{{ edxapp_code_dir }}/requirements/edx/pre.txt"
-github_requirements_file: "{{ edxapp_code_dir }}/requirements/edx/github.txt"
 custom_requirements_file:   "{{ edxapp_code_dir }}/requirements/edx/custom.txt"
-local_requirements_file:  "{{ edxapp_code_dir }}/requirements/edx/local.txt"
 base_requirements_file:   "{{ edxapp_code_dir }}/requirements/edx/base.txt"
 django_requirements_file:   "{{ edxapp_code_dir }}/requirements/edx/django.txt"
-post_requirements_file:   "{{ edxapp_code_dir }}/requirements/edx/post.txt"
-paver_requirements_file:   "{{ edxapp_code_dir }}/requirements/edx/paver.txt"
 openstack_requirements_file: "{{ edxapp_code_dir }}/requirements/edx/openstack.txt"
 
 sandbox_base_requirements:  "{{ edxapp_code_dir }}/requirements/edx-sandbox/base.txt"
-sandbox_local_requirements: "{{ edxapp_code_dir }}/requirements/edx-sandbox/local.txt"
-sandbox_post_requirements:  "{{ edxapp_code_dir }}/requirements/edx-sandbox/post.txt"
 
 # The Python requirements files in the order they should be installed.  This order should
-# match the order of PYTHON_REQ_FILES in edx-platform/pavelib/prereqs.py.  (Also check the
-# edx-solutions fork of edx-platform when if you consider reordering this list.)
-# private_requirements_file is not included in this list, since it is only installed
-# conditionally based on the value of EDXAPP_INSTALL_PRIVATE_REQUIREMENTS.
+# match the order of PYTHON_REQ_FILES in edx-platform/pavelib/prereqs.py.
 edxapp_requirements_files:
-  - "{{ pre_requirements_file }}"
-  - "{{ github_requirements_file }}"
   - "{{ custom_requirements_file }}"
-  - "{{ local_requirements_file }}"
   - "{{ base_requirements_file }}"
-  - "{{ django_requirements_file }}"
-  - "{{ post_requirements_file }}"
-  - "{{ paver_requirements_file }}"
 
 # All edxapp requirements files potentially containing Github URLs.  When using a custom
 # Github mirror, occurrences of "github.com" are replaced by the custom mirror in these
 # files.
 edxapp_requirements_with_github_urls:
-  - "{{ pre_requirements_file }}"
-  - "{{ github_requirements_file }}"
   - "{{ custom_requirements_file }}"
   - "{{ base_requirements_file }}"
-  - "{{ post_requirements_file }}"
-  - "{{ paver_requirements_file }}"
-  - "{{ sandbox_post_requirements }}"
-  - "{{ sandbox_local_requirements }}"
   - "{{ sandbox_base_requirements }}"
 
 edxapp_chrislea_ppa: "ppa:chris-lea/node.js"

--- a/playbooks/roles/edxapp/tasks/deploy.yml
+++ b/playbooks/roles/edxapp/tasks/deploy.yml
@@ -221,8 +221,6 @@
     chdir: "{{ edxapp_code_dir }}"
   with_items:
   - "{{ sandbox_base_requirements }}"
-  - "{{ sandbox_local_requirements }}"
-  - "{{ sandbox_post_requirements }}"
   become_user: "{{ edxapp_user }}"
   when: not EDXAPP_PYTHON_SANDBOX
   tags:

--- a/playbooks/roles/edxapp/vars/devstack.yml
+++ b/playbooks/roles/edxapp/vars/devstack.yml
@@ -1,18 +1,9 @@
 ---
 # The only difference between these requirements and the role defaults is the
-# presence of the "development.txt" and "testing.txt" files. These two sets
-# of requirements should not be used in production.
+# use of "development.txt" instead of "base.txt". This set of requirements
+# should not be used in production.
 development_requirements_file:   "{{ edxapp_code_dir }}/requirements/edx/development.txt"
-testing_requirements_file:   "{{ edxapp_code_dir }}/requirements/edx/testing.txt"
 
 edxapp_requirements_files:
-  - "{{ pre_requirements_file }}"
-  - "{{ github_requirements_file }}"
   - "{{ custom_requirements_file }}"
-  - "{{ local_requirements_file }}"
-  - "{{ base_requirements_file }}"
-  - "{{ django_requirements_file }}"
-  - "{{ post_requirements_file }}"
-  - "{{ paver_requirements_file }}"
   - "{{ development_requirements_file }}"
-  - "{{ testing_requirements_file }}"

--- a/playbooks/roles/jenkins_worker/tasks/python_platform_worker.yml
+++ b/playbooks/roles/jenkins_worker/tasks/python_platform_worker.yml
@@ -22,10 +22,7 @@
     virtualenv: "{{ jenkins_home }}/edx-venv"
     virtualenv_command: virtualenv
   with_items:
-    - pre.txt
-    - github.txt
-    - base.txt
-    - paver.txt
+    - django.txt
     - testing.txt
   become_user: "{{ jenkins_user }}"
 


### PR DESCRIPTION
Configuration Pull Request
---

Removed references to obsolete and redundant requirements files in edx-platform after the pip-tools conversion.  This should slightly speed up deployments and let us delete the obsolete files.

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
