### PR TITLE
Add RETIREMENT_STATES to edxapp to make retirement workflow configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+- Role: edxapp
+  - Added `RETIREMENT_STATES` to generic_env_config to support making the retirement workflow configurable.
+
 - Removed Vagrantfiles for devstack and fullstack, and supporting files.
 
 - Role: xqueue

--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -731,6 +731,13 @@ EDXAPP_RETIRED_USER_SALTS:
   - "OVERRIDE ME WITH A RANDOM VALUE"
   - "ROTATE SALTS BY APPENDING NEW VALUES"
 EDXAPP_RETIREMENT_SERVICE_WORKER_USERNAME: "OVERRIDE THIS WITH A VALID LMS USERNAME"
+# These get loaded into database models per environment via management command
+# These are the required states, environmental overrides are in edx-internal.
+EDXAPP_RETIREMENT_STATES:
+  - "PENDING"
+  - "ERRORED"
+  - "ABORTED"
+  - "COMPLETE"
 
 # Comprehensive Theming
 # Deprecated, maintained for backward compatibility
@@ -1248,6 +1255,7 @@ generic_env_config:  &edxapp_generic_env
   RETIRED_EMAIL_DOMAIN: "{{ EDXAPP_RETIRED_EMAIL_DOMAIN }}"
   RETIRED_USER_SALTS: "{{ EDXAPP_RETIRED_USER_SALTS }}"
   RETIREMENT_SERVICE_WORKER_USERNAME: "{{ EDXAPP_RETIREMENT_SERVICE_WORKER_USERNAME }}"
+  RETIREMENT_STATES: "{{ EDXAPP_RETIREMENT_STATES }}"
 
   PASSWORD_MIN_LENGTH: "{{ EDXAPP_PASSWORD_MIN_LENGTH }}"
   PASSWORD_MAX_LENGTH: "{{ EDXAPP_PASSWORD_MAX_LENGTH }}"


### PR DESCRIPTION
Reviewer note - this variable isn't intended to be overridden within edx, but open source partners might need to. I believe that the placement and lack of variable substitution for this is correct for that use case, but am far from certain of it and happy to shuffle things around if this is not the right way to go about it.

Usage is here: https://github.com/edx/edx-platform/pull/18014

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
