### PR TITLE
Update analytic-api LMS_BASE_URL to include trailing slash

### DIFF
--- a/playbooks/roles/analytics_api/defaults/main.yml
+++ b/playbooks/roles/analytics_api/defaults/main.yml
@@ -144,7 +144,7 @@ analytics_api_service_config_overrides:
   API_AUTH_TOKEN: '{{ ANALYTICS_API_AUTH_TOKEN }}'
   STATICFILES_DIRS: ['static']
   STATIC_ROOT: "{{ COMMON_DATA_DIR }}/{{ analytics_api_service_name }}/staticfiles"
-  LMS_BASE_URL: "{{ ANALYTICS_API_LMS_BASE_URL | default('http://127.0.0.1:8000') }}"
+  LMS_BASE_URL: "{{ ANALYTICS_API_LMS_BASE_URL | default('http://127.0.0.1:8000/') }}"
 
   # db config
   ANALYTICS_DATABASE: '{{ ANALYTICS_DB_CONFIG_ALIAS }}'

--- a/util/jenkins/ansible-provision.sh
+++ b/util/jenkins/ansible-provision.sh
@@ -299,7 +299,7 @@ EDXAPP_ECOMMERCE_PUBLIC_URL_ROOT: "https://ecommerce-${deploy_host}"
 EDXAPP_ECOMMERCE_API_URL: "https://ecommerce-${deploy_host}/api/v2"
 EDXAPP_COURSE_CATALOG_API_URL: "https://catalog-${deploy_host}/api/v1"
 
-ANALYTICS_API_LMS_BASE_URL: "https://{{ EDXAPP_LMS_BASE }}"
+ANALYTICS_API_LMS_BASE_URL: "https://{{ EDXAPP_LMS_BASE }}/"
 
 # NOTE: This is the same as DISCOVERY_URL_ROOT below
 ECOMMERCE_DISCOVERY_SERVICE_URL: "https://discovery-${deploy_host}"


### PR DESCRIPTION
Analytics API requires a trailing slash on the LMS_BASE_URL as indicated in the README

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
