### PR TITLE
Bump html publisher plugin

### DIFF
--- a/playbooks/roles/jenkins_build/defaults/main.yml
+++ b/playbooks/roles/jenkins_build/defaults/main.yml
@@ -120,7 +120,7 @@ build_jenkins_plugins_list:
     version: '1.2.2'
     group: 'org.jenkins-ci.plugins'
   - name: 'htmlpublisher'
-    version: '1.10'
+    version: '1.14'
     group: 'org.jenkins-ci.plugins'
   - name: 'javadoc'
     version: '1.3'


### PR DESCRIPTION
This is needed to have more than one HTML report on a build, which we will need for python pipeline jobs.. since the shining panda plugin doesn't support pipelines (which we currently use for coverage.py reports), and we have a diff cov report as well.

This should not install any new plugins as its dependencies are already on jenkins currently.

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
