### PR TITLE
upgrade shiningpanda plugin on build jenkins

### DIFF
--- a/playbooks/roles/jenkins_build/defaults/main.yml
+++ b/playbooks/roles/jenkins_build/defaults/main.yml
@@ -186,7 +186,7 @@ build_jenkins_plugins_list:
     version: '1.42'
     group: 'org.jenkins-ci.plugins'
   - name: 'shiningpanda'
-    version: '0.21'
+    version: '0.23'
     group: 'org.jenkins-ci.plugins'
   - name: 'splunk-devops'
     version: '1.6.4'


### PR DESCRIPTION
Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
---

Troy needs an upgraded version of virtualenv/pip to handle the syntax in a requirements file for the GDPR retirement job. Upgrading the ShiningPanda plugin to 0.23 will do the trick.
