### PR TITLE
bump the number of executors on the jenkins build docker image

### DIFF
--- a/docker/build/jenkins_build/ansible_overrides.yml
+++ b/docker/build/jenkins_build/ansible_overrides.yml
@@ -45,3 +45,8 @@ jenkins_common_main_labels:
   - 'dsl-seed-runner'
   - 'backup-runner'
   - 'jenkins-worker'  # added this
+
+# We're running all our jobs on the Jenkins Master by default (one container
+# only), so we need to bump up the number of executors for some jobs with
+# downstream jobs to work correctly.
+jenkins_common_main_num_executors: 6


### PR DESCRIPTION
This image isn't configured to spawn extra workers, so just bump the
number of executors on the master instance so that certain jobs (which
trigger downstream jobs) will work.

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
