### PR TITLE
Fix analytics-api name in new relic

### DIFF
--- a/playbooks/roles/analytics_api/defaults/main.yml
+++ b/playbooks/roles/analytics_api/defaults/main.yml
@@ -33,6 +33,8 @@ analytics_api_code_dir: "{{ analytics_api_home }}/{{ analytics_api_service_name 
 analytics_api_wsgi_name: "analyticsdataserver"
 analytics_api_hostname: "analytics-api"
 
+analytics_api_newrelic_appname: 'analytics-api'
+
 #
 # OS packages
 #

--- a/playbooks/roles/analytics_api/meta/main.yml
+++ b/playbooks/roles/analytics_api/meta/main.yml
@@ -41,3 +41,4 @@ dependencies:
     edx_django_service_use_python3: false
     edx_django_service_wsgi_name: '{{ analytics_api_wsgi_name }}'
     edx_django_service_hostname: '~^((stage|prod)-)?{{ analytics_api_hostname }}.*'
+    edx_django_service_newrelic_appname: '{{ COMMON_ENVIRONMENT }}-{{ COMMON_DEPLOYMENT }}-{{ analytics_api_newrelic_appname }}'


### PR DESCRIPTION
The role name changed to analytics_api for consistency but this fixes the newrelic
name back to analytics-api as monitoring is already set up against this name

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
