### PR TITLE
update dsl plugin version for build jenkins

### DIFF
--- a/docker/build/jenkins_build/ansible_overrides.yml
+++ b/docker/build/jenkins_build/ansible_overrides.yml
@@ -18,6 +18,7 @@ build_jenkins_configuration_scripts:
   - 4configureJobConfigHistory.groovy
   - 4configureMailerPlugin.groovy
   - 4configureMaskPasswords.groovy
+  - 4configureSecurity.groovy
   - 5addSeedJob.groovy  # added this
   - 5createLoggers.groovy
 
@@ -28,6 +29,7 @@ jenkins_common_non_plugin_template_files:
   - ghprb_config
   - git_config
   - github_config
+  # - github_oauth # intentionally commented out
   - hipchat_config
   - job_config_history
   - log_config
@@ -35,7 +37,7 @@ jenkins_common_non_plugin_template_files:
   - main_config
   - mask_passwords_config
   - properties_config
-#  - security  # intentionally left commented out
+  - security
   - seed_config
 
 # Add the jenkins-worker label so that this jenkins master will work

--- a/playbooks/roles/jenkins_build/defaults/main.yml
+++ b/playbooks/roles/jenkins_build/defaults/main.yml
@@ -129,7 +129,7 @@ build_jenkins_plugins_list:
     version: '2.10'
     group: 'org.jenkins-ci.plugins'
   - name: 'job-dsl'
-    version: '1.47'
+    version: '1.67'
     group: 'org.jenkins-ci.plugins'
   - name: 'junit'
     version: '1.24'

--- a/playbooks/roles/jenkins_build/defaults/main.yml
+++ b/playbooks/roles/jenkins_build/defaults/main.yml
@@ -18,6 +18,7 @@ build_jenkins_configuration_scripts:
   - 4configureJobConfigHistory.groovy
   - 4configureMailerPlugin.groovy
   - 4configureMaskPasswords.groovy
+  - 4configureSecurity.groovy
   - 4configureSplunk.groovy
   - 5createLoggers.groovy
 

--- a/playbooks/roles/jenkins_common/defaults/main.yml
+++ b/playbooks/roles/jenkins_common/defaults/main.yml
@@ -30,6 +30,7 @@ jenkins_common_non_plugin_template_files:
   - ghprb_config
   - git_config
   - github_config
+  - github_oauth
   - hipchat_config
   - job_config_history
   - log_config
@@ -123,13 +124,11 @@ JENKINS_MASTER_SSH_LIST: []
 JENKINS_CUSTOM_SSH_LIST: []
 
 # security
+jenkins_common_dsl_script_security_enabled: true
 jenkins_common_security_agent_protocols:
   - 'JNLP4-connect'
 jenkins_common_security_agent_jnlp_tcp_port: 0
-jenkins_common_security_scopes: 'read:org,user:email'
 
-JENKINS_SECURITY_CLIENT_ID: ''
-JENKINS_SECURITY_CLIENT_SECRET: ''
 JENKINS_SECURITY_GROUPS: []
 
 # git
@@ -143,6 +142,13 @@ jenkins_common_github_configs:
     USE_CUSTOM_API_URL: false
     GITHUB_API_URL: ''
     CACHE_SIZE: 20
+
+# github oauth settings
+
+jenkins_common_security_scopes: 'read:org,user:email'
+
+JENKINS_SECURITY_CLIENT_ID: ''
+JENKINS_SECURITY_CLIENT_SECRET: ''
 
 # hipchat
 jenkins_common_hipchat_room: ''

--- a/playbooks/roles/jenkins_common/templates/config/github_oauth.yml.j2
+++ b/playbooks/roles/jenkins_common/templates/config/github_oauth.yml.j2
@@ -1,0 +1,6 @@
+---
+GITHUB_WEB_URI: 'https://github.com'
+GITHUB_API_URI: 'https://api.github.com'
+CLIENT_ID: '{{ JENKINS_SECURITY_CLIENT_ID }}'
+CLIENT_SECRET: '{{ JENKINS_SECURITY_CLIENT_SECRET }}'
+SCOPES: '{{ jenkins_common_security_scopes }}'

--- a/playbooks/roles/jenkins_common/templates/config/security.yml.j2
+++ b/playbooks/roles/jenkins_common/templates/config/security.yml.j2
@@ -5,12 +5,6 @@ AGENT_SETTINGS:
       - {{ protocol }}
 {% endfor %}
     JNLP_TCP_PORT: {{ jenkins_common_security_agent_jnlp_tcp_port }}
-OAUTH_SETTINGS:
-  GITHUB_WEB_URI: 'https://github.com'
-  GITHUB_API_URI: 'https://api.github.com'
-  CLIENT_ID: '{{ JENKINS_SECURITY_CLIENT_ID }}'
-  CLIENT_SECRET: '{{ JENKINS_SECURITY_CLIENT_SECRET }}'
-  SCOPES: '{{ jenkins_common_security_scopes }}'
 SECURITY_GROUPS:
 {% for group in JENKINS_SECURITY_GROUPS %}
   - NAME: '{{ group.NAME }}'
@@ -23,3 +17,4 @@ SECURITY_GROUPS:
       - {{ user }}
 {% endfor %}
 {% endfor %}
+DSL_SCRIPT_SECURITY_ENABLED: {{ jenkins_common_dsl_script_security_enabled }}


### PR DESCRIPTION
Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
-----
This updates the DSL plugin version to 1.67. I have intentionally not upgraded to the latest (1.69) as it drops support for the build flow plugin, and we are not yet ready to move to pipelines for everything. The required changes to the DSL scripts can be found here: https://github.com/edx/jenkins-job-dsl/pull/358