### PR TITLE
Bump jenkins heap size to 16 gb

### DIFF
--- a/playbooks/roles/jenkins_build/defaults/main.yml
+++ b/playbooks/roles/jenkins_build/defaults/main.yml
@@ -1,7 +1,7 @@
 build_jenkins_user_uid: 1002
 build_jenkins_group_gid: 1004
 build_jenkins_version: jenkins_2.89.4
-build_jenkins_jvm_args: '-Djava.awt.headless=true -Xmx8192m'
+build_jenkins_jvm_args: '-Djava.awt.headless=true -Xmx16384m'
 build_jenkins_configuration_scripts:
   - 1addJarsToClasspath.groovy
   - 2checkInstalledPlugins.groovy


### PR DESCRIPTION
Configuration Pull Request
---

Our build jenkins machine is consistently using 80-90% of our memory (8 Gb). We should increase the machine size and the heap size.

An m3.2xlarge machine has 30 Gb of available memory. Jenkins is our only resource intensive process running, so there really shouldn't be any issue giving it 16 gb of memory.
