### PR TITLE
Allow analytics_api and insights to be disabled on sandbox servers

### DIFF
--- a/playbooks/edx_sandbox.yml
+++ b/playbooks/edx_sandbox.yml
@@ -26,6 +26,8 @@
     credentials_create_demo_data: true
     SANDBOX_ENABLE_DISCOVERY: true
     SANDBOX_ENABLE_ECOMMERCE: true
+    SANDBOX_ENABLE_ANALYTICS_API: true
+    SANDBOX_ENABLE_INSIGHTS: true
   roles:
     - role: swapfile
       SWAPFILE_SIZE: 4GB
@@ -54,8 +56,10 @@
     - role: ecomworker
       ECOMMERCE_WORKER_BROKER_HOST: 127.0.0.1
       when: SANDBOX_ENABLE_ECOMMERCE
-    - analytics_api
-    - insights
+    - role: analytics_api
+      when: SANDBOX_ENABLE_ANALYTICS_API
+    - role: insights
+      when: SANDBOX_ENABLE_INSIGHTS
     # not ready yet: - edx_notes_api
     - demo
     - oauth_client_setup
@@ -81,4 +85,3 @@
       when: POSTFIX_QUEUE_EXTERNAL_SMTP_HOST != ''
     - role: datadog-uninstall
       when: not COMMON_ENABLE_DATADOG
-


### PR DESCRIPTION
Make provisioning of analytics_api and insights optional in sandbox
---

This PR adds two flags: `SANDBOX_ENABLE_ANALYTICS_API` and `SANDBOX_ENABLE_INSIGHTS` to allow analytics_api and insights to be disabled on sandbox servers.

It's a PR similar to https://github.com/edx/configuration/pull/4295.

**Sandbox URL:**

LMS: https://hawthorn-beta.sandbox.opencraft.hosting
Studio: https://studio-hawthorn-beta.sandbox.opencraft.hosting

**Merge deadline:** needed before Hawthorn is cut

**Testing instructions:**

1. Provision an edxapp service with:
```yaml
SANDBOX_ENABLE_ANALYTICS_API: false
SANDBOX_ENABLE_INSIGHTS: false
```
Note that neither the analytics_api nor insights services are provisioned.

Signed-off-by: Tomasz Gargas <tomasz@opencraft.com>

**Reviewers:**
- [ ] @pomegranited 
- [ ] edX reviewer: @edx/devops

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? (_tomaszgy's comment: No, the default values can be used on production._)
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).