### PR TITLE
Allow RabbitMQ to be disabled

### DIFF
--- a/playbooks/edx_sandbox.yml
+++ b/playbooks/edx_sandbox.yml
@@ -28,6 +28,7 @@
     SANDBOX_ENABLE_ECOMMERCE: true
     SANDBOX_ENABLE_ANALYTICS_API: true
     SANDBOX_ENABLE_INSIGHTS: true
+    SANDBOX_ENABLE_RABBITMQ: true
   roles:
     - role: swapfile
       SWAPFILE_SIZE: 4GB
@@ -48,6 +49,7 @@
       when: "'localhost' in EDXAPP_MONGO_HOSTS"
     - role: rabbitmq
       rabbitmq_ip: 127.0.0.1
+      when: SANDBOX_ENABLE_RABBITMQ
     - role: edxapp
       celery_worker: True
     - edxapp


### PR DESCRIPTION
Re-instates the SANDBOX_ENABLE_RABBITMQ to allow RabbitMQ role to be disabled.

Testing instructions:

Provision an edxapp service with
SANDBOX_ENABLE_RABBITMQ: false
Note that RabbitMQ is not provisioned.

Reviewers
  @clemente 
  @edx/devops ?