### PR TITLE
Add futures environment marker to fix Python 3

### DIFF
--- a/playbooks/roles/aws/templates/requirements.txt.j2
+++ b/playbooks/roles/aws/templates/requirements.txt.j2
@@ -9,7 +9,7 @@ boto==2.48.0
 botocore==1.5.21          # via awscli, s3transfer
 colorama==0.3.7           # via awscli
 docutils==0.14            # via awscli, botocore
-futures==3.2.0            # via s3transfer
+futures==3.2.0 ; python_version == "2.7"
 jmespath==0.9.3           # via botocore
 pyasn1==0.4.2             # via rsa
 python-dateutil==2.7.3    # via botocore, s3cmd

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ docopt==0.6.2
 docutils==0.14            # via awscli, botocore
 ecdsa==0.13
 enum34==1.1.6             # via cryptography
-futures==3.2.0            # via s3transfer
+futures==3.2.0 ; python_version == "2.7"
 idna==2.6                 # via cryptography, requests
 ipaddress==1.0.22         # via cryptography
 jinja2==2.8

--- a/requirements/aws.in
+++ b/requirements/aws.in
@@ -2,4 +2,5 @@
 
 awscli==1.11.58
 boto==2.48.0
+futures ; python_version == "2.7"   # via s3transfer
 s3cmd==1.6.1

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -7,6 +7,7 @@ boto3==1.7.14
 datadog==0.8.0
 docopt==0.6.2
 ecdsa==0.13
+futures ; python_version == "2.7"   # via s3transfer
 Jinja2==2.8
 MarkupSafe==1.0
 MySQL-python==1.2.5                 # Needed for the mysql_db module

--- a/requirements/celery.in
+++ b/requirements/celery.in
@@ -4,4 +4,5 @@ awscli==1.14.32
 backoff==1.4.3
 boto3==1.5.4
 click==6.7
+futures ; python_version == "2.7"   # via s3transfer
 redis==2.10.6

--- a/requirements/ses-limits.in
+++ b/requirements/ses-limits.in
@@ -1,4 +1,5 @@
 # Requirements for the SES limits check job
 
-boto3==1.7.14
 awscli==1.15.19
+boto3==1.7.14
+futures ; python_version == "2.7"   # via s3transfer

--- a/requirements3.txt
+++ b/requirements3.txt
@@ -9,7 +9,7 @@ boto3==1.7.14
 botocore==1.10.19         # via awscli, boto3, s3transfer
 colorama==0.3.7           # via awscli
 docutils==0.14            # via awscli, botocore
-futures==3.2.0            # via s3transfer
+futures==3.2.0 ; python_version == "2.7"
 jmespath==0.9.3           # via boto3, botocore
 pyasn1==0.4.2             # via rsa
 python-dateutil==2.7.3    # via botocore

--- a/util/jenkins/requirements-celery.txt
+++ b/util/jenkins/requirements-celery.txt
@@ -11,7 +11,7 @@ botocore==1.8.36          # via awscli, boto3, s3transfer
 click==6.7
 colorama==0.3.7           # via awscli
 docutils==0.14            # via awscli, botocore
-futures==3.2.0            # via s3transfer
+futures==3.2.0 ; python_version == "2.7"
 jmespath==0.9.3           # via boto3, botocore
 pyasn1==0.4.2             # via rsa
 python-dateutil==2.7.3    # via botocore


### PR DESCRIPTION
Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.

Restrict the installation of "futures" to Python 2.7; the latest version hasn't been released for Python 3.x.