### PR TITLE
update ff container to 3.11

### DIFF
--- a/docker/build/chrome/Dockerfile
+++ b/docker/build/chrome/Dockerfile
@@ -1,4 +1,4 @@
-FROM selenium/standalone-chrome-debug:3.4.0-einsteinium
+FROM selenium/standalone-chrome-debug:3.11.0-californium
 MAINTAINER edxops
 
 USER root

--- a/docker/build/firefox/Dockerfile
+++ b/docker/build/firefox/Dockerfile
@@ -1,4 +1,4 @@
-FROM selenium/standalone-firefox-debug:3.4.0-einsteinium
+FROM selenium/standalone-firefox-debug:3.11.0-californium
 MAINTAINER edxops
 
 USER root

--- a/util/parsefiles_config.yml
+++ b/util/parsefiles_config.yml
@@ -40,3 +40,5 @@ weights:
   - analytics_pipeline_hadoop_resourcemanager: 2
   - analytics_pipeline_spark_master: 1
   - analytics_pipeline_spark_worker: 1
+  - chrome: 1
+  - firefox: 1


### PR DESCRIPTION
This will sync the FF versions between docker devstack and Jenkins.  Build Jenkins currently runs Firefox 59.0.2 whereas the latest Firefox container in the edxops group in Dockerhub is 59.0.1. We are seeing some possible discrepancies in behavior of bokchoy tests while trying to debug them, so we should sync these to be able have reproducible tests.

Also, the firefox container was not being built as part of the CI for this repo