### PR TITLE
Switch from ansible npm module to raw npm OPS-3134

### DIFF
--- a/playbooks/roles/insights/tasks/main.yml
+++ b/playbooks/roles/insights/tasks/main.yml
@@ -51,12 +51,11 @@
     - install
     - install:system-requirements
 
+# install with the shell command instead of the ansible npm module so we don't accidentally re-write package.json
 - name: install node dependencies
-  npm:
-    executable: "{{ insights_nodeenv_bin }}/npm"
-    path: "{{ insights_code_dir }}"
-    production: yes
-    state: latest
+  shell: "{{ insights_nodeenv_bin }}/npm install"
+  args:
+    chdir: "{{ insights_code_dir }}"
   become_user: "{{ insights_user }}"
   environment: "{{ insights_environment }}"
   tags:


### PR DESCRIPTION
Ansible npm module doesn't properly respect package-lock.json in Node 8
See PR #4292

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
