### PR TITLE
ansible lineinfile parameter fix

### DIFF
--- a/playbooks/roles/newrelic_infrastructure/tasks/main.yml
+++ b/playbooks/roles/newrelic_infrastructure/tasks/main.yml
@@ -91,7 +91,7 @@
 
 - name: Run newrelic display name script on boot
   lineinfile:
-    path: "/etc/rc.local"
+    dest: "/etc/rc.local"
     line: "/edx/bin/write_nr_display_name_config.sh"
     insertbefore: "exit 0"
     mode: "u+x,g+x"


### PR DESCRIPTION
According to the docs, the parameter for the file in ansible's line in file module changed in 2.3.  The old version was 'dest', the new version is 'path'.  Since we're running an older ansible, this failed to deploy.