### PR TITLE
Setting up a jenkins worker docker image

### DIFF
--- a/docker/build/jenkins_worker/Dockerfile
+++ b/docker/build/jenkins_worker/Dockerfile
@@ -1,0 +1,58 @@
+# To build this Dockerfile:
+#
+# From the root of configuration:
+#
+# docker build -f docker/build/jenkins_worker/Dockerfile .
+#
+# This allows the dockerfile to update /edx/app/edx_ansible/edx_ansible
+# with the currently checked-out configuration repo.
+
+# Run the edxapp play with custom ansible overrides
+ARG BASE_IMAGE_TAG=latest
+FROM edxops/xenial-common:${BASE_IMAGE_TAG}
+MAINTAINER edxops
+USER root
+
+ADD . /edx/app/edx_ansible/edx_ansible
+WORKDIR /edx/app/edx_ansible/edx_ansible/docker/plays
+
+COPY docker/build/jenkins_worker/ansible_overrides.yml /jenkins_worker/ansible_overrides.yml
+COPY docker/build/edxapp/devstack.yml /
+COPY docker/build/devstack/ansible_overrides.yml /devstack/ansible_overrides.yml
+
+ARG OPENEDX_RELEASE=master
+ENV OPENEDX_RELEASE=${OPENEDX_RELEASE}
+RUN sudo /edx/app/edx_ansible/venvs/edx_ansible/bin/ansible-playbook edxapp.yml \
+    -c local -i '127.0.0.1,' \
+    -t 'install,assets,devstack,jenkins-worker' \
+    --extra-vars="edx_platform_version=${OPENEDX_RELEASE}" \
+    --extra-vars="@/jenkins_worker/ansible_overrides.yml" \
+    --extra-vars="@/devstack.yml" \
+    --extra-vars="@/devstack/ansible_overrides.yml"
+
+# Run the mongo play
+COPY docker/build/mongo/ansible_overrides.yml /mongo/ansible_overrides.yml
+
+RUN mkdir -p /data/db
+WORKDIR /edx/app/edx_ansible/edx_ansible/docker/plays
+RUN /edx/app/edx_ansible/venvs/edx_ansible/bin/ansible-playbook mongo.yml \
+    -i '127.0.0.1,' -c local \
+    -t 'install' \
+    --extra-vars="@/mongo/ansible_overrides.yml"
+
+# Add sshd to enable jenkins master to ssh into containers
+RUN apt-get update \
+  && apt-get install -y openssh-server \
+  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+ARG JENKINS_WORKER_KEY_URL=https://files.edx.org/testeng/jenkins.keys
+RUN mkdir /var/run/sshd \
+  && groupadd ubuntu \
+  && useradd -ms /bin/bash ubuntu -g ubuntu -d /home/ubuntu \
+  && curl ${JENKINS_WORKER_KEY_URL} --create-dirs -o /home/ubuntu/.ssh/authorized_keys
+
+RUN chown -R ubuntu /home/ubuntu
+RUN chown ubuntu /edx/app/edxapp/edx-platform
+CMD ["/edx/app/supervisor/venvs/supervisor/bin/supervisord", "-n", "--configuration", "/edx/app/supervisor/supervisord.conf"]
+
+EXPOSE 22

--- a/docker/build/jenkins_worker/ansible_overrides.yml
+++ b/docker/build/jenkins_worker/ansible_overrides.yml
@@ -1,0 +1,24 @@
+---
+EDXAPP_SETTINGS: 'devstack_docker'
+
+MONGO_AUTH: false
+
+devstack: true
+migrate_db: false
+mongo_enable_journal: false
+edxapp_npm_production: "no"
+
+EDXAPP_LMS_GUNICORN_EXTRA_CONF: 'reload = True'
+
+EDXAPP_NO_PREREQ_INSTALL: 0
+EDXAPP_OAUTH_ENFORCE_SECURE: false
+EDXAPP_LMS_BASE_SCHEME: http
+COMMON_SECURITY_UPDATES: true
+SECURITY_UPGRADE_ON_ANSIBLE: true
+
+EDXAPP_INSTALL_PRIVATE_REQUIREMENTS: true
+
+EDXAPP_PYTHON_SANDBOX: false
+
+edxapp_debian_pkgs_extra:
+  - mongodb-clients

--- a/playbooks/roles/edxapp/tasks/service_variant_config.yml
+++ b/playbooks/roles/edxapp/tasks/service_variant_config.yml
@@ -66,6 +66,40 @@
     - install
     - install:configuration
 
+# write the supervisor script for mongod and sshd
+# this should only be run when provisioning a jenkins-worker container
+- name: Set ignore_jenkins_worker_command when no tags present
+  set_fact: ignore_jenkins_worker_command=true
+
+- name: writing mongod and sshd supervisor scripts
+  template:
+    src: "edx/app/supervisor/conf.d.available/{{ item }}.j2"
+    dest: "{{ supervisor_available_dir }}/{{ item }}"
+    owner: "{{ supervisor_user }}"
+    group: "{{ supervisor_user }}"
+    mode: 0644
+  become_user: "{{ supervisor_user }}"
+  with_items:
+    - mongod.conf
+    - sshd.conf
+  when: 'ignore_jenkins_worker_command is not defined'
+  tags:
+    - jenkins-worker
+
+- name: "enable mongod and sshd supervisor script"
+  file:
+    src: "{{ supervisor_available_dir }}/{{ item }}.conf"
+    dest: "{{ supervisor_cfg_dir }}/{{ item }}.conf"
+    state: link
+    force: yes
+  become_user: "{{ supervisor_user }}"
+  with_items:
+    - mongod
+    - sshd
+  when: 'ignore_jenkins_worker_command is not defined'
+  tags:
+    - jenkins-worker
+
 # Enable the supervisor jobs
 - name: "enable {{ item }} supervisor script"
   file:

--- a/playbooks/roles/edxapp/templates/edx/app/supervisor/conf.d.available/mongod.conf.j2
+++ b/playbooks/roles/edxapp/templates/edx/app/supervisor/conf.d.available/mongod.conf.j2
@@ -1,0 +1,5 @@
+[program:mongod]
+command=mongod --smallfiles --nojournal --storageEngine wiredTiger
+stdout_logfile={{ supervisor_log_dir }}/%(program_name)s-stdout.log
+stderr_logfile={{ supervisor_log_dir }}/%(program_name)s-stderr.log
+autorestart=true

--- a/playbooks/roles/edxapp/templates/edx/app/supervisor/conf.d.available/sshd.conf.j2
+++ b/playbooks/roles/edxapp/templates/edx/app/supervisor/conf.d.available/sshd.conf.j2
@@ -1,0 +1,5 @@
+[program:sshd]
+command=/usr/sbin/sshd -D
+stdout_logfile={{ supervisor_log_dir }}/%(program_name)s-stdout.log
+stderr_logfile={{ supervisor_log_dir }}/%(program_name)s-stderr.log
+autorestart=true

--- a/util/parsefiles_config.yml
+++ b/util/parsefiles_config.yml
@@ -32,6 +32,7 @@ weights:
   - mongo: 1
   - devpi: 1
   - jenkins_build: 8
+  - jenkins_worker: 22
   - analytics_pipeline: 8
   - analytics_pipeline_hadoop_datanode: 2
   - analytics_pipeline_hadoop_namenode: 3


### PR DESCRIPTION
This Dockerfile is to be used for building jenkins-worker containers. The plan is to have an EC2 instance on Jenkins spin up a number of these containers, and shard out tests via pytest-xdist.

This file was designed with just unittests in mind to start. Since these assume mongo is running, the Dockerfile also runs the mongo play. And since the EC2 instance will need to ssh into the containers, it also sets up sshd. If you think it makes more sense to work towards keeping a multicontainer approach (might be tricky with fargate), let me know... I figured a "fat" container at least made sense to get the ball rolling.

I plan on keeping the same subnet/ security group for these containers as we use for our EC2 workers, so I decided to create the user ubuntu (in order to keep our ssh config simple... as the user/key will be the same this way).

The dockerfile will depend on the argument `JENKINS_WORKER_KEY_URL`, which points to a url with our desired ssh public key.