### PR TITLE
Override the Jetty default of 30m to 60m

### DIFF
--- a/playbooks/roles/jenkins_build/defaults/main.yml
+++ b/playbooks/roles/jenkins_build/defaults/main.yml
@@ -1,7 +1,7 @@
 build_jenkins_user_uid: 1002
 build_jenkins_group_gid: 1004
 build_jenkins_version: jenkins_2.89.4
-build_jenkins_jvm_args: '-Djava.awt.headless=true -Xmx16384m'
+build_jenkins_jvm_args: '-Djava.awt.headless=true -Xmx16384m -DsessionTimeout=60'
 build_jenkins_configuration_scripts:
   - 1addJarsToClasspath.groovy
   - 2checkInstalledPlugins.groovy


### PR DESCRIPTION
Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).

Helpful if you're using the loadtest drivers