### PR TITLE
Stop having edxapp: for edxapp:lms edxapp:cms

### DIFF
--- a/playbooks/edx-east/ora2.yml
+++ b/playbooks/edx-east/ora2.yml
@@ -26,9 +26,6 @@
       environment:
         PATH: "{{ edxapp_deploy_path }}"
       become_user: "{{ edxapp_user }}"
-      notify:
-        - "restart edxapp"
-        - "restart workers"
       tags:
         - deploy
 
@@ -39,15 +36,14 @@
       environment:
         DB_MIGRATION_USER: "{{ edxapp_mysql_user }}"
         DB_MIGRATION_PASS: "{{ edxapp_mysql_password }}"
-      notify:
-        - "restart edxapp"
-        - "restart workers"
       tags:
         - deploy
 
-  handlers:
-    - name: restart edxapp
-      shell: "{{ supervisorctl_path }} restart edxapp:"
+    - name: restart lms
+      shell: "{{ supervisorctl_path }} restart lms"
+
+    - name: restart studio
+      shell: "{{ supervisorctl_path }} restart cms"
 
     - name: restart workers
       shell: "{{ supervisorctl_path }} restart edxapp_worker:"

--- a/playbooks/roles/edxapp/tasks/deploy.yml
+++ b/playbooks/roles/edxapp/tasks/deploy.yml
@@ -349,12 +349,15 @@
 
 - name: ensure edxapp has started
   supervisorctl:
-    name: "edxapp:"
+    name: "{{ item }}"
     supervisorctl_path: "{{ supervisor_ctl }}"
     config: "{{ supervisor_cfg }}"
     state: started
   become_user: "{{ supervisor_service_user }}"
   when: celery_worker is not defined and not disable_edx_services
+  with_items:
+    - 'lms'
+    - 'cms'
   tags:
     - manage
 
@@ -404,12 +407,15 @@
 
 - name: restart edxapp
   supervisorctl:
-    name: "edxapp:"
+    name: "{{ item }}"
     supervisorctl_path: "{{ supervisor_ctl }}"
     config: "{{ supervisor_cfg }}"
     state: restarted
   when: edxapp_installed is defined and celery_worker is not defined and not disable_edx_services
   become_user: "{{ supervisor_service_user }}"
+  with_items:
+    - 'lms'
+    - 'cms'
   tags:
     - manage
 

--- a/playbooks/roles/edxapp/tasks/service_variant_config.yml
+++ b/playbooks/roles/edxapp/tasks/service_variant_config.yml
@@ -30,8 +30,8 @@
     - install
     - install:configuration
 
-# write the supervisor script for edxapp and celery workers
-- name: writing edxapp and celery supervisor scripts
+# write the supervisor script for celery workers
+- name: writing celery supervisor scripts
   template:
     src: "edx/app/supervisor/conf.d.available/{{ item }}.j2"
     dest: "{{ supervisor_available_dir }}/{{ item }}"
@@ -40,8 +40,17 @@
     mode: 0644
   become_user: "{{ supervisor_user }}"
   with_items:
-    - edxapp.conf
     - workers.conf
+  tags:
+    - install
+    - install:configuration
+
+# clean out an old edxapp.conf file which we don't use now.
+# this can be deleted after we build things from scratch.
+- name: clean out old edxapp.conf
+  file:
+    path: "{{ supervisor_available_dir }}/edxapp.conf"
+    state: "absent"
   tags:
     - install
     - install:configuration
@@ -66,18 +75,6 @@
     force: yes
   become_user: "{{ supervisor_user }}"
   with_items: "{{ service_variants_enabled }}"
-  when: celery_worker is not defined and not disable_edx_services
-  tags:
-    - install
-    - install:configuration
-
-- name: enable edxapp supervisor script
-  file:
-    src: "{{ supervisor_available_dir }}/edxapp.conf"
-    dest: "{{ supervisor_cfg_dir }}/edxapp.conf"
-    state: link
-    force: yes
-  become_user: "{{ supervisor_user }}"
   when: celery_worker is not defined and not disable_edx_services
   tags:
     - install

--- a/playbooks/roles/edxapp/templates/edx/app/supervisor/conf.d.available/edxapp.conf.j2
+++ b/playbooks/roles/edxapp/templates/edx/app/supervisor/conf.d.available/edxapp.conf.j2
@@ -1,2 +1,0 @@
-[group:edxapp]
-programs={{ ",".join(service_variants_enabled) }}


### PR DESCRIPTION
Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).

As we move to deploying cms and lms separately, we don't need a group.
Having the group specified in each lms.conf cms.conf supervisor config
doesn't work on sandboxes, so I just cleaned up everything that uses
them on sandboxes.