### PR TITLE
Allow nginx to be templated but not enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+- Role: edxapp
+  - EDXAPP_NGINX_SKIP_ENABLE_SITES added to allow you to not sync in the lms or cms nginx configuration.  Instead you can enable them during deployment.
+  - EDXAPP_NGINX_DEFAULT_SITES added to allow you to mark both lms and cms as defaults, best paired with picking which site to enable during deployment.
+
 - Role: XQueue
   - Convert to a yaml config (instead of xqueue.auth.json and xqueue.env.json we get xqueue.yml and it lives by default in /edx/etc/xqueue.yml like standard IDAs)
   - Add XQUEUE_DEFAULT_FILE_STORAGE so that you can specify S3 or Swift in your config

--- a/playbooks/edxapp.yml
+++ b/playbooks/edxapp.yml
@@ -15,11 +15,11 @@
      nginx_sites:
      - lms
      - cms
-     nginx_default_sites:
-     - lms
+     nginx_default_sites: "{{ EDXAPP_NGINX_DEFAULT_SITES }}"
      nginx_extra_sites: "{{ NGINX_EDXAPP_EXTRA_SITES }}"
      nginx_extra_configs: "{{ NGINX_EDXAPP_EXTRA_CONFIGS }}"
      nginx_redirects: "{{ NGINX_EDXAPP_CUSTOM_REDIRECTS }}"
+     nginx_skip_enable_sites: "{{ EDXAPP_NGINX_SKIP_ENABLE_SITES }}"
    - edxapp
    - role: devstack_sqlite_fix
      when: devstack is defined and devstack

--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -327,6 +327,16 @@ EDXAPP_COURSES_REQUEST_BURST_RATE: 10
 EDXAPP_COURSES_USER_AGENT_BURST_RATE: 5
 EDXAPP_RATE_LIMITED_USER_AGENTS: []
 
+# Consumed in the edxapp.yml playbook
+# to pass to nginx as nginx_skip_enable_sites
+EDXAPP_NGINX_SKIP_ENABLE_SITES: False
+
+# If the LMS and Studio run on the same machine / nginx, it makes sense to have
+# a default (usually the LMS).  If you run on separate machines, you'll want to mark
+# them both as defaults.
+EDXAPP_NGINX_DEFAULT_SITES:
+  - 'lms'
+
 EDXAPP_LANG: 'en_US.UTF-8'
 EDXAPP_LANGUAGE_CODE : 'en'
 EDXAPP_LANGUAGE_COOKIE: 'openedx-language-preference'

--- a/playbooks/roles/minos/tasks/main.yml
+++ b/playbooks/roles/minos/tasks/main.yml
@@ -34,15 +34,6 @@
 #     - minos 
 #
 
-#TODO: remove
-- name: Maintain backwards-compatable config location
-  file:
-    src: "{{ COMMON_CFG_DIR  }}/{{ minos_service_name }}.yml"
-    dest: "{{ COMMON_CFG_DIR  }}/{{ minos_service_name }}/{{ minos_service_name }}.yml"
-    state: link
-    owner: root
-    group: root
-
 - name: Create minos config directory
   file:
     path: "{{ minos_voter_cfg }}"

--- a/playbooks/roles/nginx/defaults/main.yml
+++ b/playbooks/roles/nginx/defaults/main.yml
@@ -3,6 +3,10 @@
 # These are paramters to the role
 # and should be overridden
 nginx_sites: []
+# If you want to install multiple sites with nginx_site but enable
+# them yourself (if you're using a single build for multiple deploys)
+# you can skip having them link into sites-enabled and do it during boot.
+nginx_skip_enable_sites: False
 nginx_redirects: {}
 nginx_extra_sites: []
 nginx_extra_configs: []

--- a/playbooks/roles/nginx/tasks/main.yml
+++ b/playbooks/roles/nginx/tasks/main.yml
@@ -166,6 +166,7 @@
     owner: root
     group: root
   with_items: "{{ nginx_sites }}"
+  when: not nginx_skip_enable_sites
   notify: reload nginx
   tags:
     - install
@@ -342,7 +343,7 @@
     - install
     - install:configuration
 
-- name: Set up nginx access log rotation
+- name: Set up nginx error log rotation
   template:
     src: "etc/logrotate.d/edx_logrotate_nginx_error.j2"
     dest: "/etc/logrotate.d/nginx-error"

--- a/playbooks/roles/supervisor/files/pre_supervisor_checks.py
+++ b/playbooks/roles/supervisor/files/pre_supervisor_checks.py
@@ -20,6 +20,10 @@ MIGRATION_COMMANDS = {
         'credentials':   ". {env_file}; sudo -E -u credentials {python} {code_dir}/manage.py showmigrations",
         'discovery':     ". {env_file}; sudo -E -u discovery {python} {code_dir}/manage.py showmigrations",
     }
+NGINX_ENABLE = {
+        'lms':  "sudo ln -sf /edx/app/nginx/sites-available/lms /etc/nginx/sites-enabled/lms",
+        'cms':  "sudo ln -sf /edx/app/nginx/sites-available/cms /etc/nginx/sites-enabled/cms",
+    }
 HIPCHAT_USER = "PreSupervisor"
 
 # Max amount of time to wait for tags to be applied.
@@ -250,6 +254,13 @@ if __name__ == '__main__':
                 report.append("Enabling service: {}".format(service))
             else:
                 raise Exception("No conf available for service: {}".format(link_location))
+
+            if service in NGINX_ENABLE:
+                subprocess.call(NGINX_ENABLE[service], shell=True)
+                report.append("Enabling nginx: {}".format(service))
+            # We have to reload the new config files
+            subprocess.call("/bin/systemctl reload nginx", shell=True)
+
     except AWSConnectionError as ae:
         msg = "{}: ERROR : {}".format(prefix, ae)
         if notify:


### PR DESCRIPTION
If you set nginx_skip_enable_sites it will not symlink the items in
nginx_sites.  This means you have to make that change later.  EdX does it
with our pre_supervisor script, the same code that checks on migrations
being complete and also symlinks in supervisor processes to run.


Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).