### PR TITLE
Make the notes docker image use devstack settings by default

### DIFF
--- a/docker/build/edxapp/ansible_overrides.yml
+++ b/docker/build/edxapp/ansible_overrides.yml
@@ -37,3 +37,6 @@ edxapp_environment_extra:
   SELENIUM_PORT: '4444'
 
 EDXAPP_XQUEUE_URL: 'http://edx.devstack.xqueue:18040'
+
+EDXAPP_ENABLE_EDXNOTES: true
+EDXAPP_EDXNOTES_INTERNAL_API: 'http://edx.devstack.edx_notes_api:18120/api/v1'

--- a/docker/build/notes/ansible_overrides.yml
+++ b/docker/build/notes/ansible_overrides.yml
@@ -4,3 +4,8 @@ EDX_NOTES_API_MYSQL_HOST: 'db'
 EDX_NOTES_API_ELASTICSEARCH_URL: 'http://es:9200/'
 COMMON_MYSQL_MIGRATE_USER: '{{ EDX_NOTES_API_MYSQL_DB_USER }}'
 COMMON_MYSQL_MIGRATE_PASS: '{{ EDX_NOTES_API_MYSQL_DB_PASSWORD }}'
+
+# For the docker image, force it to use the devstack settings instead of the
+# default production settings (notesserver.settings.yaml_config).
+# This is also consistent with all other IDAs.
+EDX_NOTES_API_DJANGO_SETTINGS_MODULE: 'notesserver.settings.devstack'


### PR DESCRIPTION
This is the status quo for all other IDAs, and also this is required for
our current devstack tooling which just assumes the default settings are
for devstack.

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
