### PR TITLE
Minos' default config lives in /edx/etc

### DIFF
--- a/playbooks/retire_host.yml
+++ b/playbooks/retire_host.yml
@@ -44,4 +44,4 @@
   gather_facts: False
   tasks:
     - name: Run minos
-      command: /edx/app/minos/venvs/bin/minos --config /edx/etc/minos/minos.yml --json
+      command: /edx/app/minos/venvs/bin/minos --config /edx/etc/minos.yml --json


### PR DESCRIPTION
Four years ago we moved it there and left a symlink behind, but this playbook wasn't updated.  Now that we've cleaned up the symlink, minos fails to run on new machines.

https://github.com/edx/configuration/pull/1882

When this merges, it will break non-test builds
https://github.com/edx/configuration/pull/4598/