### PR TITLE
remove edx-east sym link in packer scripts

### DIFF
--- a/util/packer/jenkins_worker.json
+++ b/util/packer/jenkins_worker.json
@@ -51,7 +51,11 @@
     "inline": ["cd {{user `playbook_remote_dir`}}",
       "export CONFIGURATION_VERSION='{{user `remote_branch`}}'",
       "sudo bash ./stop-automatic-updates.sh",
-      "sudo bash ./ansible-bootstrap.sh" ]
+      "sudo bash ./ansible-bootstrap.sh"
+    ]
+  }, {
+    "type": "shell-local",
+    "command": "rm ../../playbooks/edx-east"
   }, {
     "type": "ansible-local",
     "playbook_file": "../../playbooks/jenkins_worker.yml",

--- a/util/packer/jenkins_worker_android.json
+++ b/util/packer/jenkins_worker_android.json
@@ -50,7 +50,11 @@
     "inline": ["cd {{user `playbook_remote_dir`}}",
       "export CONFIGURATION_VERSION='{{user `remote_branch`}}'",
       "sudo bash ./stop-automatic-updates.sh",
-      "sudo bash ./ansible-bootstrap.sh" ]
+      "sudo bash ./ansible-bootstrap.sh"
+    ]
+  }, {
+    "type": "shell-local",
+    "command": "rm ../../playbooks/edx-east"
   }, {
     "type": "ansible-local",
     "playbook_file": "../../playbooks/jenkins_worker_android.yml",

--- a/util/packer/jenkins_worker_loadtest.json
+++ b/util/packer/jenkins_worker_loadtest.json
@@ -50,7 +50,11 @@
     "inline": ["cd {{user `playbook_remote_dir`}}",
       "export CONFIGURATION_VERSION='{{user `remote_branch`}}'",
       "sudo bash ./stop-automatic-updates.sh",
-      "sudo bash ./ansible-bootstrap.sh" ]
+      "sudo bash ./ansible-bootstrap.sh"
+    ]
+  }, {
+    "type": "shell-local",
+    "command": "rm ../../playbooks/edx-east"
   }, {
     "type": "ansible-local",
     "playbook_file": "../../playbooks/jenkins_worker_loadtest_driver.yml",

--- a/util/packer/jenkins_worker_simple.json
+++ b/util/packer/jenkins_worker_simple.json
@@ -51,7 +51,11 @@
     "inline": ["cd {{user `playbook_remote_dir`}}",
       "export CONFIGURATION_VERSION='{{user `remote_branch`}}'",
       "sudo bash ./stop-automatic-updates.sh",
-      "sudo bash ./ansible-bootstrap.sh" ]
+      "sudo bash ./ansible-bootstrap.sh"
+    ]
+  }, {
+    "type": "shell-local",
+    "command": "rm ../../playbooks/edx-east"
   }, {
     "type": "ansible-local",
     "playbook_file": "../../playbooks/jenkins_worker.yml",


### PR DESCRIPTION
Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).

---
A recent change to the repo directory structure has caused the packer builds to fail. The packer build provisioner doesn't handle the edx-east symlink and hits a max recursion error. This PR simply removes the local link so that the roles can be copied to the remote packer builder