### PR TITLE
[server_utils] Only receive PPA key if it isn't expired

### DIFF
--- a/playbooks/roles/server_utils/tasks/main.yml
+++ b/playbooks/roles/server_utils/tasks/main.yml
@@ -28,7 +28,7 @@
 
 - name: remove expired edx key
   command: "sudo apt-key adv --keyserver {{ SERVER_UTILS_EDX_PPA_KEY_SERVER }} --recv-keys {{ SERVER_UTILS_EDX_PPA_KEY_ID }}"
-  when: ansible_distribution in common_debian_variants and "'expired' in  ppa_key_status.stdout"
+  when: ansible_distribution in common_debian_variants and 'expired' in ppa_key_status.stdout
 
 - name: Install ubuntu system packages
   apt:


### PR DESCRIPTION
Sometimes this task fails due to networking issues, but it shouldn't run
unconditionally anyway.

Example failed run:

https://travis-ci.org/edx/devstack/jobs/390853584

The task runs despite the string "expired" not existing in the previous task stdout.

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
