### PR TITLE
Reload nginx earlier in the process

### DIFF
--- a/playbooks/roles/supervisor/files/pre_supervisor_checks.py
+++ b/playbooks/roles/supervisor/files/pre_supervisor_checks.py
@@ -222,6 +222,12 @@ if __name__ == '__main__':
 
     try:
         for service in services_for_instance(instance_id):
+            if service in NGINX_ENABLE:
+                subprocess.call(NGINX_ENABLE[service], shell=True)
+                report.append("Enabling nginx: {}".format(service))
+            # We have to reload the new config files
+            subprocess.call("/bin/systemctl reload nginx", shell=True)
+
             if service in MIGRATION_COMMANDS:
                 services = {
                     "lms": {'python': args.edxapp_python, 'env_file': args.edxapp_env, 'code_dir': args.edxapp_code_dir},
@@ -254,12 +260,6 @@ if __name__ == '__main__':
                 report.append("Enabling service: {}".format(service))
             else:
                 raise Exception("No conf available for service: {}".format(link_location))
-
-            if service in NGINX_ENABLE:
-                subprocess.call(NGINX_ENABLE[service], shell=True)
-                report.append("Enabling nginx: {}".format(service))
-            # We have to reload the new config files
-            subprocess.call("/bin/systemctl reload nginx", shell=True)
 
     except AWSConnectionError as ae:
         msg = "{}: ERROR : {}".format(prefix, ae)


### PR DESCRIPTION
While we test migrations, nginx can serve random hosts to the ELB and
begin serving traffic before lms/cms have linked in and been started by
supervisor.

This should restore the previous behavior where /heartbeat would fail to
connect to the backend when supervisor isn't live yet.