### PR TITLE
curl files from files.edx.org for jenkins worker

### DIFF
--- a/playbooks/roles/jenkins_worker/tasks/system.yml
+++ b/playbooks/roles/jenkins_worker/tasks/system.yml
@@ -17,18 +17,13 @@
   ignore_errors: yes
 
 - name: Get the authorized key that should be used for this machine.
-  authorized_key:
-    user: "{{ jenkins_user }}"
-    state: present
-    key: "{{ jenkins_worker_key_url }}"
+  shell: "curl {{ jenkins_worker_key_url }} -o {{ jenkins_home }}/.ssh/authorized_keys"
   when: jenkins_worker_key_url is defined
-  ignore_errors: yes
 
 - name: Set key permissions
   file:
     path={{ jenkins_home }}/.ssh/authorized_keys
     owner={{ jenkins_user }} group={{ jenkins_group }} mode=400
-  ignore_errors: yes
 
 - name: Install system packages
   apt: pkg={{','.join(jenkins_debian_pkgs)}}


### PR DESCRIPTION
Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).

---
The jenkins worker role is unable to successfully get the keys hosted at files.edx.org-- still trying to figure out why. In the meantime, this should fix the packer job