### PR TITLE
CloudWatch is throwing errors when we go past 20

### DIFF
--- a/util/jenkins/check-celery-queues.py
+++ b/util/jenkins/check-celery-queues.py
@@ -69,7 +69,7 @@ class CwBotoWrapper(object):
 @click.option('--environment', '-e', required=True)
 @click.option('--deploy', '-d', required=True,
               help="Deployment (i.e. edx or edge)")
-@click.option('--max-metrics', default=30,
+@click.option('--max-metrics', default=20,
               help='Maximum number of CloudWatch metrics to publish')
 @click.option('--threshold', default=50,
               help='Default maximum queue length before alarm notification is'


### PR DESCRIPTION
OPS-3196


Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).