### PR TITLE
TE-2560 Add Warnings plugin to build Jenkins

### DIFF
--- a/playbooks/roles/jenkins_build/defaults/main.yml
+++ b/playbooks/roles/jenkins_build/defaults/main.yml
@@ -24,6 +24,9 @@ build_jenkins_configuration_scripts:
 
 # plugins
 build_jenkins_plugins_list:
+  - name: 'analysis-core'
+    version: '1.95'
+    group: 'org.jvnet.hudson.plugins'
   - name: 'ansicolor'
     version: '0.5.2'
     group: 'org.jenkins-ci.plugins'
@@ -31,7 +34,7 @@ build_jenkins_plugins_list:
     version: '1.8'
     group: 'org.jenkins-ci.plugins'
   - name: 'antisamy-markup-formatter'
-    version: '1.3'
+    version: '1.5'
     group: 'org.jenkins-ci.plugins'
   - name: 'bouncycastle-api'
     version: '2.16.1'
@@ -207,6 +210,9 @@ build_jenkins_plugins_list:
   - name: 'ssh-slaves'
     version: '1.26'
     group: 'org.jenkins-ci.plugins'
+  - name: 'structs'
+    version: '1.14'
+    group: 'org.jenkins-ci.plugins'
   - name: 'subversion'
     version: '2.10.3'
     group: 'org.jenkins-ci.plugins'
@@ -231,6 +237,9 @@ build_jenkins_plugins_list:
   - name: 'violations'
     version: '0.7.11'
     group: 'org.jenkins-ci.plugins'
+  - name: 'warnings'
+    version: '4.68'
+    group: 'org.jvnet.hudson.plugins'
   - name: 'workflow-aggregator'
     version: '2.5'
     group: 'org.jenkins-ci.plugins.workflow'


### PR DESCRIPTION
Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.

Adding the `Warnings` plugin and its dependencies to build Jenkins.  This is a newer replacement for the `Violations` plugin, which we've been using but is no longer supported.  Leaving `Violations` installed for now, since we have historical job runs that use it.

Both plugins are for visualizing and drilling down into reports generated by static code analysis tools like pycodestyle and pylint.