### PR TITLE
Allow us to set a custom cloudwatch dictionary for the metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+- XQueue
+  - Expose CLOUDWATCH_QUEUE_COUNT_METRIC which is defined XQueue's settings.py for further dictionary structure
+
 - nginx:
   - remove nginx_cfg - an internal variable that was really only used for the edx-release nginx site, which served version.{html,json} off of a nonstandard port.  The file it served was never populated.
 

--- a/playbooks/roles/xqueue/defaults/main.yml
+++ b/playbooks/roles/xqueue/defaults/main.yml
@@ -70,6 +70,11 @@ XQUEUE_CONSUMER_DELAY: 10
 
 INSIGHTS_CSRF_COOKIE_SECURE: false
 
+# This dictionary is defined in XQueue's settings.py
+# If you want to set up cloudwatch metrics/alarms this allows
+# you a custom setting.
+XQUEUE_CLOUDWATCH_QUEUE_COUNT_METRICS: !!null
+
 # This block of config is dropped into /edx/etc/xqueue.yml
 # and is read in by xqueue.XQUEUE_SETTINGS
 XQUEUE_CONFIG:
@@ -110,6 +115,8 @@ XQUEUE_CONFIG:
       CONN_MAX_AGE: "{{ XQUEUE_MYSQL_CONN_MAX_AGE }}"
       OPTIONS: "{{ XQUEUE_MYSQL_OPTIONS }}"
   NEWRELIC_LICENSE_KEY: "{{ NEWRELIC_LICENSE_KEY | default('') }}"
+  CLOUDWATCH_QUEUE_COUNT_METRICS: "{{ XQUEUE_CLOUDWATCH_QUEUE_COUNT_METRICS }}"
+
 
 XQUEUE_VERSION: "master"
 XQUEUE_GIT_IDENTITY: !!null


### PR DESCRIPTION
OPS-2998


Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).