### PR TITLE
We can override the DATA_DIR now that edx-platform exposes it

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -935,9 +935,6 @@ edxapp_devstack_logs:
 # Only install packages which are appropriate for this environment
 edxapp_npm_production: "yes"
 
-# TODO: This can be removed once VPC-122 is resolved
-edxapp_legacy_course_data_dir: "{{ edxapp_app_dir }}/data"
-
 edxapp_workers: "{{ EDXAPP_CELERY_WORKERS }}"
 EDXAPP_WORKER_DEFAULT_STOPWAITSECS: 432000
 
@@ -1164,6 +1161,7 @@ generic_env_config:  &edxapp_generic_env
   WIKI_ENABLED: true
   SYSLOG_SERVER:  "{{ EDXAPP_SYSLOG_SERVER }}"
   LOG_DIR:  "{{ edxapp_log_dir }}"
+  DATA_DIR: "{{ edxapp_data_dir }}"
   JWT_ISSUER: "{{ EDXAPP_LMS_ISSUER }}"
   DEFAULT_JWT_ISSUER:
     ISSUER: "{{ EDXAPP_LMS_ISSUER }}"

--- a/playbooks/roles/edxapp/tasks/main.yml
+++ b/playbooks/roles/edxapp/tasks/main.yml
@@ -48,21 +48,6 @@
     - devstack
     - devstack:install
 
-# This is a symlink that has to exist because
-# we currently can't override the DATA_DIR var
-# in edx-platform. TODO: This can be removed once
-# VPC-122 is closed
-- name: make the course data dir
-  file:
-    src: "{{ edxapp_course_data_dir }}"
-    dest: "{{ edxapp_legacy_course_data_dir }}"
-    state: link
-    owner: "{{ edxapp_user }}"
-    group: "{{ common_web_group }}"
-  tags:
-    - install
-    - install:base
-
 - name: create edxapp log dir
   file:
     path: "{{ edxapp_log_dir }}"


### PR DESCRIPTION
https://github.com/edx/edx-platform/pull/18476

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).