### PR TITLE
TE-2585 Upgrade problem-builder to fix warning

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -482,7 +482,7 @@ EDXAPP_EXTRA_REQUIREMENTS: []
 #   - name: git+https://git.myproject.org/MyProject#egg=MyProject
 EDXAPP_PRIVATE_REQUIREMENTS:
     # For Harvard courses:
-    - name: git+https://github.com/open-craft/problem-builder.git@v2.7.7#egg=xblock-problem-builder==2.7.7
+    - name: git+https://github.com/open-craft/problem-builder.git@0b3255214cbfff4a8b4a210fdf54f7a014a06402#egg=xblock-problem-builder==3.1.2
     # Oppia XBlock
     - name: git+https://github.com/oppia/xblock.git@9f6b95b7eb7dbabb96b77198a3202604f96adf65#egg=oppia-xblock
       extra_args: -e


### PR DESCRIPTION
Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.

This should fix the last warning message that appears for most management command executions.  There's an [open PR](https://github.com/open-craft/problem-builder/pull/199) to tag a new release and upload it to PyPI, but we're getting close to the Hawthorn release and I'm not sure if that will get done in time.