### PR TITLE
I wondered why /edx/var/log/edxapp/{lms,cms} existed empty

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -905,7 +905,7 @@ EDXAPP_PASSWORD_POLICY_COMPLIANCE_ROLLOUT_CONFIG:
 
 edxapp_data_dir: "{{ COMMON_DATA_DIR }}/edxapp"
 edxapp_app_dir: "{{ COMMON_APP_DIR }}/edxapp"
-edxapp_log_dir: "{{ COMMON_LOG_DIR }}/edxapp"
+edxapp_log_dir: "{{ COMMON_LOG_DIR }}/edx"
 edxapp_venvs_dir: "{{ edxapp_app_dir }}/venvs"
 edxapp_venv_dir: "{{ edxapp_venvs_dir }}/edxapp"
 edxapp_venv_bin: "{{ edxapp_venv_dir }}/bin"
@@ -1163,7 +1163,7 @@ generic_env_config:  &edxapp_generic_env
   FEATURES: "{{ EDXAPP_FEATURES }}"
   WIKI_ENABLED: true
   SYSLOG_SERVER:  "{{ EDXAPP_SYSLOG_SERVER }}"
-  LOG_DIR:  "{{ COMMON_DATA_DIR }}/logs/edx"
+  LOG_DIR:  "{{ edxapp_log_dir }}"
   JWT_ISSUER: "{{ EDXAPP_LMS_ISSUER }}"
   DEFAULT_JWT_ISSUER:
     ISSUER: "{{ EDXAPP_LMS_ISSUER }}"


### PR DESCRIPTION
It was because we had a task to create those subdirs but then passed along LOG_DIR differently.

However, LOG_DIR was wrong because it used /edx/var/logs/edx and logs doesn't exist at all.

Luckily, we use syslog to actually log, and *that* uses /edx/var/log/edx/{lms,cms}/edx.log

edx-platform further mostly ignores LOG_DIR since logsettings doesn't define a file handler, in devstack it just sets logging.NullHandler which sends it to the console


Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).