### PR TITLE
Install xblock-problem-builder from PyPI

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -482,7 +482,7 @@ EDXAPP_EXTRA_REQUIREMENTS: []
 #   - name: git+https://git.myproject.org/MyProject#egg=MyProject
 EDXAPP_PRIVATE_REQUIREMENTS:
     # For Harvard courses:
-    - name: git+https://github.com/open-craft/problem-builder.git@0b3255214cbfff4a8b4a210fdf54f7a014a06402#egg=xblock-problem-builder==3.1.2
+    - name: xblock-problem-builder==3.1.3
     # Oppia XBlock
     - name: git+https://github.com/oppia/xblock.git@9f6b95b7eb7dbabb96b77198a3202604f96adf65#egg=oppia-xblock
       extra_args: -e


### PR DESCRIPTION
Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.

xblock-problem-builder has been [released to PyPI](https://github.com/open-craft/problem-builder/pull/199), so we can switch away from the GitHub URL installation now.