### PR TITLE
Make edx_django_service CONN_MAX_AGE default to 0.

### DIFF
--- a/playbooks/roles/edx_django_service/defaults/main.yml
+++ b/playbooks/roles/edx_django_service/defaults/main.yml
@@ -120,6 +120,7 @@ edx_django_service_caches:
 edx_django_service_default_db_host: 'localhost'
 edx_django_service_default_db_name: '{{ edx_django_service_name }}'
 edx_django_service_default_db_atomic_requests: false
+edx_django_service_default_db_conn_max_age: 60
 edx_django_service_db_user: 'REPLACE-ME'
 edx_django_service_db_password: 'password'
 edx_django_service_db_options:
@@ -135,7 +136,7 @@ edx_django_service_databases:
     HOST: '{{ edx_django_service_default_db_host }}'
     PORT: '3306'
     ATOMIC_REQUESTS: '{{ edx_django_service_default_db_atomic_requests }}'
-    CONN_MAX_AGE: 60
+    CONN_MAX_AGE: '{{ edx_django_service_default_db_conn_max_age }}'
     OPTIONS: '{{ edx_django_service_db_options }}'
 
 edx_django_service_social_auth_edx_oidc_key: '{{ edx_django_service_name }}-key'


### PR DESCRIPTION
The default gunicorn worker class is 'gevent', which is not compatible with django's `CONN_MAX_AGE` because it leaks database connections.

We noticed this problem when our MySQL server stopped accepting new connections with 'too many open connections' error because there were hundreds of stale connections from ecommerce. Setting `CONN_MAX_AGE` to zero fixes the problem for us.

See: https://github.com/benoitc/gunicorn/issues/996#issuecomment-93301359


**Testing instructions**:

1. Spawn a new sandbox using the `edx_sandbox.yml` playbook.
2. Verify that services that are based on the `edx_django_service` role (ecommerce, discovery, analytics_api, credentials, ...) are configured with `CONN_MAX_AGE` value `0`. The configurations can be found in `/edx/etc/<service-name>.yml` file.

**Author notes and concerns**:

This changes the default for `CONN_MAX_AGE` from `60` to `0`, which is not backwards compatible. Since the default configuration of `60` was buggy, I think that's acceptable, but I'm also fine with reverting the default back to `60` as long as the value is overridable, if that's preferred.

**Reviewers**:
- [x] @kaizoku
- [ ] edX

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
