### PR TITLE
Require OPENEDX_RELEASE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+- Installation
+  - OPENEDX_RELEASE is now required, to prevent accidental installation of master.
+
 - XQueue
   - Expose CLOUDWATCH_QUEUE_COUNT_METRIC which is defined XQueue's settings.py for further dictionary structure
 

--- a/util/install/sandbox.sh
+++ b/util/install/sandbox.sh
@@ -9,11 +9,17 @@
 ##
 
 ##
-## Sanity check
+## Sanity checks
 ##
+
+if [[ ! $OPENEDX_RELEASE ]]; then
+    echo "You must define OPENEDX_RELEASE"
+    exit
+fi
+
 if [[ `lsb_release -rs` != "16.04" ]]; then
-   echo "This script is only known to work on Ubuntu 16.04, exiting...";
-   exit;
+    echo "This script is only known to work on Ubuntu 16.04, exiting..."
+    exit
 fi
 
 ##


### PR DESCRIPTION
People sometimes try to install Open edX, but accidentally don't define OPENEDX_RELEASE, and get master installed instead.  Let's make that an error instead.


Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
