### PR TITLE
remove job config history plugin script from build jenkins

### DIFF
--- a/playbooks/roles/jenkins_build/defaults/main.yml
+++ b/playbooks/roles/jenkins_build/defaults/main.yml
@@ -15,7 +15,6 @@ build_jenkins_configuration_scripts:
   - 4configureGit.groovy
   - 4configureGithub.groovy
   - 4configureHipChat.groovy
-  - 4configureJobConfigHistory.groovy
   - 4configureMailerPlugin.groovy
   - 4configureMaskPasswords.groovy
   - 4configureSecurity.groovy
@@ -306,10 +305,6 @@ build_jenkins_log_list:
         log_level: 'ALL'
       - name: 'hudson.plugins.git.GitSCM'
         log_level: 'ALL'
-
-# job config history
-build_jenkins_history_max_days: '15'
-build_jenkins_history_exclude_pattern: 'queue|nodeMonitors|UpdateCenter|global-build-stats|GhprbTrigger'
 
 # splunk
 build_jenkins_splunk_ignored_jobs: '(^((?!edx-(platform|e2e)|gather).)*$)|.*private.*'

--- a/playbooks/roles/jenkins_build/meta/main.yml
+++ b/playbooks/roles/jenkins_build/meta/main.yml
@@ -19,8 +19,6 @@ dependencies:
     jenkins_common_instance_cap: '{{ build_jenkins_instance_cap }}'
     jenkins_common_seed_name: '{{ build_jenkins_seed_name }}'
     jenkins_common_log_list: '{{ build_jenkins_log_list }}'
-    jenkins_common_history_max_days: '{{ build_jenkins_history_max_days }}'
-    jenkins_common_history_exclude_pattern: '{{ build_jenkins_history_exclude_pattern }}'
     jenkins_common_server_name: '{{ JENKINS_SERVER_NAME }}'
     jenkins_common_splunk_ignored_jobs: '{{ build_jenkins_splunk_ignored_jobs }}'
     jenkins_common_splunk_script_type: '{{ build_jenkins_splunk_script_type }}'


### PR DESCRIPTION
Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).

------------
This was missed when removing the Job Config History plugin.
