### PR TITLE
do not copy security config for local jenkins dev

### DIFF
--- a/playbooks/roles/jenkins_common/tasks/main.yml
+++ b/playbooks/roles/jenkins_common/tasks/main.yml
@@ -173,12 +173,12 @@
     - install:base
     - install:jenkins-configuration
 
-- name: Copy all init scripts other than oauth for local dev
+- name: Copy all init scripts other than oauth and security for local dev
   command: 'cp {{ jenkins_common_git_home }}/jenkins-configuration/{{ jenkins_common_configuration_src_path }}/{{ item }} {{ jenkins_common_home }}/init.groovy.d/'
   with_items: '{{ jenkins_common_configuration_scripts }}'
   become: true
   become_user: '{{ jenkins_common_user }}'
-  when: 'item != "4configureGHOAuth.groovy" and init_scripts_copied is not defined'
+  when: 'item != "4configureGHOAuth.groovy" and item != "4configureSecurity.groovy" and init_scripts_copied is not defined'
   tags:
     - jenkins:local-dev
 
@@ -212,14 +212,14 @@
     - install:base
     - install:jenkins-configuration
 
-- name: For local dev, copy any config files other than oauth
+- name: For local dev, copy any config files other than oauth and security
   template:
     src: '{{ role_path }}/templates/config/{{ item }}.yml.j2'
     dest: '{{ jenkins_common_config_path }}/{{ item }}.yml'
     owner: '{{ jenkins_common_user }}'
     group: '{{ jenkins_common_group }}'
   with_items: '{{ jenkins_common_non_plugin_template_files }}'
-  when: 'item != "security" and templates_copied is not defined'
+  when: 'item != "github_oauth" and item != "security" and templates_copied is not defined'
   tags:
     - jenkins:local-dev
 


### PR DESCRIPTION
Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).

--------
In the past, we exlcuded the security configuration from Jenkins when doing local development because it also sets up github oauth. We have since split the oauth config out of security config, the security config is being included in local development, but this leads to a problem: since we do not have oauth AND do not specify a generic 'admin' user in our permissions, you can't actually do anything on the box.

This makes sure that neither github oauth or security are included in a local dev box

To be honest, I would like to have an override for this so that a local dev environment has a generic admin/permission set so that you can more accurately test, but this unblocks me in my current work.