### PR TITLE
install and configure email extension plugin on jenkins

### DIFF
--- a/playbooks/roles/jenkins_build/defaults/main.yml
+++ b/playbooks/roles/jenkins_build/defaults/main.yml
@@ -19,6 +19,7 @@ build_jenkins_configuration_scripts:
   - 4configureMaskPasswords.groovy
   - 4configureSecurity.groovy
   - 4configureSplunk.groovy
+  - 5configureEmailExtension.groovy
   - 5createLoggers.groovy
 
 # plugins
@@ -79,6 +80,9 @@ build_jenkins_plugins_list:
     group: 'org.jenkins-ci.plugins'
   - name: 'ec2'
     version: '1.28'
+    group: 'org.jenkins-ci.plugins'
+  - name: 'email-ext'
+    version: '2.62'
     group: 'org.jenkins-ci.plugins'
   - name: 'envinject'
     version: '2.1.5'

--- a/playbooks/roles/jenkins_build/meta/main.yml
+++ b/playbooks/roles/jenkins_build/meta/main.yml
@@ -28,3 +28,4 @@ dependencies:
     jenkins_common_splunk_event_source: '{{ build_jenkins_splunk_event_source }}'
     jenkins_common_splunk_enabled: '{{ BUILD_JENKINS_SPLUNK_ENABLED }}'
     jenkins_common_splunk_file_path: '{{ build_jenkins_splunk_file_path }}'
+    jenkins_common_email_replyto: '{{ JENKINS_MAILER_REPLY_TO_ADDRESS }}'

--- a/playbooks/roles/jenkins_common/defaults/main.yml
+++ b/playbooks/roles/jenkins_common/defaults/main.yml
@@ -27,6 +27,7 @@ jenkins_common_configuration_scripts: []
 jenkins_common_non_plugin_template_files:
   - credentials
   - ec2_config
+  - email_ext_config
   - ghprb_config
   - git_config
   - github_config
@@ -188,6 +189,33 @@ JENKINS_MAILER_REPLY_TO_ADDRESS: 'jenkins'
 JENKINS_MAILER_DEFAULT_SUFFIX: '@example.com'
 JENKINS_MAILER_SMTP_AUTH_USERNAME: ''
 JENKINS_MAILER_SMTP_AUTH_PASSWORD: ''
+
+# email ext plugin
+jenkins_common_email_advanced_properties: ''
+jenkins_common_email_content_type: 'text/plain'
+jenkins_common_default_email_subject: '${PROJECT_NAME} #${BUILD_NUMBER} is ${BUILD_STATUS}'
+jenkins_common_email_emergency_reroute: ''
+jenkins_common_email_replyto: ''
+jenkins_common_email_debug_mode: 'false'
+jenkins_common_email_max_attachment_size: 10
+jenkins_common_email_default_recipients: ''
+jenkins_common_email_add_precedence_bulk: 'true'
+jenkins_common_email_allowed_domains: ''
+jenkins_common_email_excluded_committers: ''
+jenkins_common_email_require_admin_for_template_testing: 'true'
+jenkins_common_email_watching_enabled: ''
+jenkins_common_email_allow_unregistered_enabled: ''
+jenkins_common_email_use_list_id: ''
+jenkins_common_email_list_id: ''
+jenkins_common_email_triggers:
+    - 'AbortedTrigger'
+    - 'FailureTrigger'
+    - 'FixedTrigger'
+# if you wish to set the following 3 values, supply paths to
+# individual files with the content you want to specify
+jenkins_common_email_default_body_path: ''
+jenkins_common_email_default_presend_script_path: ''
+jenkins_common_email_default_postsend_script_path: ''
 
 # mask passwords
 JENKINS_MASK_PASSWORDS_CLASSES: []

--- a/playbooks/roles/jenkins_common/templates/config/email_ext_config.yml.j2
+++ b/playbooks/roles/jenkins_common/templates/config/email_ext_config.yml.j2
@@ -1,0 +1,24 @@
+---
+ADV_PROPERTIES: '{{ jenkins_common_email_advanced_properties }}'
+DEFAULT_CONTENT_TYPE: '{{ jenkins_common_email_content_type }}'
+DEFAULT_SUBJECT: '{{ jenkins_common_default_email_subject }}'
+DEFAULT_BODY_PATH: '{{ jenkins_common_email_default_body_path }}'
+EMERGENCY_REROUTE: '{{ jenkins_common_email_emergency_reroute }}'
+DEFAULT_REPLYTO: '{{ jenkins_common_email_replyto }}'
+DEFAULT_PRESEND_SCRIPT_PATH: '{{ jenkins_common_email_default_presend_script_path }}'
+DEFAULT_POSTSEND_SCRIPT_PATH: '{{ jenkins_common_email_default_postsend_script_path }}'
+DEBUG_MODE: '{{ jenkins_common_email_debug_mode }}'
+MAX_ATTACHMENT_SIZE: '{{ jenkins_common_email_max_attachment_size }}'
+DEFAULT_RECIPIENTS: '{{ jenkins_common_email_default_recipients }}'
+ADD_PRECEDENCE_BULK: '{{ jenkins_common_email_add_precedence_bulk }}'
+ALLOWED_DOMAINS: '{{ jenkins_common_email_allowed_domains }}'
+EXCLUDED_COMMITTERS: '{{ jenkins_common_email_excluded_committers }}'
+REQUIRE_ADMIN_FOR_TEMPLATE_TESTING: '{{ jenkins_common_email_require_admin_for_template_testing }}'
+WATCHING_ENABLED: '{{ jenkins_common_email_watching_enabled }}'
+ALLOW_UNREGISTERED_ENABLED: '{{ jenkins_common_email_allow_unregistered_enabled }}'
+USE_LIST_ID: '{{ jenkins_common_email_use_list_id }}'
+LIST_ID': '{{ jenkins_common_email_list_id }}'
+TRIGGERS:
+{% for trigger in jenkins_common_email_triggers %}
+    - '{{ trigger }}'
+{% endfor %}


### PR DESCRIPTION
Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).



This will install and configure the email extension plugin, which will give us finer grained control over the content of emails sent out by Jenkins.