### PR TITLE
Add EDX_REST_API_CLIENT_NAME env variable.

### DIFF
--- a/playbooks/roles/edx_django_service/templates/edx/app/app/app.sh.j2
+++ b/playbooks/roles/edx_django_service/templates/edx/app/app/app.sh.j2
@@ -20,5 +20,7 @@ fi
 export NEW_RELIC_LICENSE_KEY="{{ NEWRELIC_LICENSE_KEY }}"
 {% endif -%}
 
+export EDX_REST_API_CLIENT_NAME="{{ COMMON_ENVIRONMENT }}-{{ COMMON_DEPLOYMENT }}-{{ edx_django_service_name }}"
+
 source {{ edx_django_service_home }}/{{ edx_django_service_name }}_env
 {{ executable }} -c {{ edx_django_service_home }}/{{ edx_django_service_name }}_gunicorn.py {{ edx_django_service_gunicorn_extra }} {{ edx_django_service_wsgi_name }}.wsgi:application

--- a/playbooks/roles/edxapp/templates/edx/app/edxapp/cms.sh.j2
+++ b/playbooks/roles/edxapp/templates/edx/app/edxapp/cms.sh.j2
@@ -27,6 +27,7 @@ export DJANGO_SETTINGS_MODULE="{{ EDXAPP_CMS_ENV }}"
 export SERVICE_VARIANT="cms"
 export PATH="{{ edxapp_deploy_path }}"
 export BOTO_CONFIG="{{ edxapp_app_dir }}/.boto"
+export EDX_REST_API_CLIENT_NAME="{{ COMMON_ENVIRONMENT }}-{{ COMMON_DEPLOYMENT }}-studio"
 
 source {{ edxapp_app_dir }}/edxapp_env
 {{ executable }} -c {{ edxapp_app_dir }}/cms_gunicorn.py {{ EDXAPP_CMS_GUNICORN_EXTRA }} cms.wsgi

--- a/playbooks/roles/edxapp/templates/edx/app/edxapp/lms.sh.j2
+++ b/playbooks/roles/edxapp/templates/edx/app/edxapp/lms.sh.j2
@@ -28,6 +28,7 @@ export DJANGO_SETTINGS_MODULE="{{ EDXAPP_LMS_ENV }}"
 export SERVICE_VARIANT="lms"
 export PATH="{{ edxapp_deploy_path }}"
 export BOTO_CONFIG="{{ edxapp_app_dir }}/.boto"
+export EDX_REST_API_CLIENT_NAME="{{ COMMON_ENVIRONMENT }}-{{ COMMON_DEPLOYMENT }}-lms"
 
 source {{ edxapp_app_dir }}/edxapp_env
 {{ executable }} -c {{ edxapp_app_dir }}/lms_gunicorn.py lms.wsgi

--- a/playbooks/roles/edxapp/templates/edx/app/supervisor/conf.d.available/workers.conf.j2
+++ b/playbooks/roles/edxapp/templates/edx/app/supervisor/conf.d.available/workers.conf.j2
@@ -1,7 +1,7 @@
 {% for w in edxapp_workers %}
 [program:{{ w.service_variant }}_{{ w.queue }}_{{ w.concurrency }}]
 
-environment={% if COMMON_ENABLE_NEWRELIC_APP %}NEW_RELIC_APP_NAME={{ EDXAPP_NEWRELIC_WORKERS_APPNAME }},NEW_RELIC_LICENSE_KEY={{ NEWRELIC_LICENSE_KEY }},{% endif -%}CONCURRENCY={{ w.concurrency }},LOGLEVEL=info,DJANGO_SETTINGS_MODULE={{ worker_django_settings_module }},LANG={{ EDXAPP_LANG }},PYTHONPATH={{ edxapp_code_dir }},SERVICE_VARIANT={{ w.service_variant }},BOTO_CONFIG="{{ edxapp_app_dir }}/.boto,"
+environment={% if COMMON_ENABLE_NEWRELIC_APP %}NEW_RELIC_APP_NAME={{ EDXAPP_NEWRELIC_WORKERS_APPNAME }},NEW_RELIC_LICENSE_KEY={{ NEWRELIC_LICENSE_KEY }},{% endif -%}CONCURRENCY={{ w.concurrency }},LOGLEVEL=info,DJANGO_SETTINGS_MODULE={{ worker_django_settings_module }},LANG={{ EDXAPP_LANG }},PYTHONPATH={{ edxapp_code_dir }},SERVICE_VARIANT={{ w.service_variant }},BOTO_CONFIG="{{ edxapp_app_dir }}/.boto,EDX_REST_API_CLIENT_NAME=edx.{{ w.service_variant }}.core.{{ w.queue }},"
 user={{ common_web_user }}
 directory={{ edxapp_code_dir }}
 stdout_logfile={{ supervisor_log_dir }}/%(program_name)s-stdout.log


### PR DESCRIPTION
This is sent as part of the User-Agent by edx-rest-api-client as of version 1.7.2.

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [x] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
