### PR TITLE
Support named releases of analytics_pipeline and notes images

### DIFF
--- a/docker/build/analytics_pipeline/Dockerfile
+++ b/docker/build/analytics_pipeline/Dockerfile
@@ -1,4 +1,5 @@
-FROM edxops/xenial-common:latest
+ARG BASE_IMAGE_TAG=latest
+FROM edxops/xenial-common:${BASE_IMAGE_TAG}
 MAINTAINER edxops
 
 USER root
@@ -117,7 +118,12 @@ RUN chown hadoop:hadoop /etc/bootstrap.sh \
     && chown -R hadoop:hadoop /edx/app/hadoop
 
 # Analytics pipeline
+ARG OPENEDX_RELEASE=master
+ENV OPENEDX_RELEASE=${OPENEDX_RELEASE}
 RUN git clone https://github.com/edx/edx-analytics-pipeline \
+    && cd edx-analytics-pipeline \
+    && git checkout ${OPENEDX_RELEASE} \
+    && cd .. \
     && cp /var/tmp/edx-analytics-pipeline/Makefile /var/tmp/Makefile \
     && cp -r /var/tmp/edx-analytics-pipeline/requirements /var/tmp/requirements \
     && rm -rf /var/tmp/edx-analytics-pipeline

--- a/docker/build/notes/Dockerfile
+++ b/docker/build/notes/Dockerfile
@@ -7,10 +7,13 @@
 # This allows the dockerfile to update /edx/app/edx_ansible/edx_ansible
 # with the currently checked-out configuration repo.
 
-FROM edxops/xenial-common:latest
+ARG BASE_IMAGE_TAG=latest
+FROM edxops/xenial-common:${BASE_IMAGE_TAG}
 MAINTAINER edxops
 
-ENV NOTES_VERSION=master
+ARG OPENEDX_RELEASE=master
+ENV OPENEDX_RELEASE=${OPENEDX_RELEASE}
+ENV NOTES_VERSION=${OPENEDX_RELEASE}
 ENV REPO_OWNER=edx
 
 ADD . /edx/app/edx_ansible/edx_ansible
@@ -25,5 +28,5 @@ RUN sudo /edx/app/edx_ansible/venvs/edx_ansible/bin/ansible-playbook notes.yml \
     --extra-vars="EDX_NOTES_API_VERSION=$NOTES_VERSION" \
     --extra-vars="COMMON_GIT_PATH=$REPO_OWNER"
 
-USER root 
+USER root
 CMD ["/edx/app/supervisor/venvs/supervisor/bin/supervisord", "-n", "--configuration", "/edx/app/supervisor/supervisord.conf"]


### PR DESCRIPTION
Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.

The `analytics_pipeline` and `notes` images were added to devstack before hawthorn.master was cut, but their Dockerfiles didn't support being built for named releases.  Fixed this so we can add builder jobs for them.