### PR TITLE
Add fake heartbeat to CMS nginx config OPS-3164

### DIFF
--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/cms.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/cms.j2
@@ -93,6 +93,12 @@ error_page {{ k }} {{ v }};
 
   # No basic auth security on the heartbeat url, so that ELB can use it
   location /heartbeat {
+    # If /edx/var/nginx/server-static/maintenance_heartbeat.txt exists serve an
+    # empty 200 so the instance stays in the load balancer to serve the
+    # maintenance page
+    if (-f /edx/var/nginx/server-static/maintenance_heartbeat.txt) {
+       return 200;
+    }
     try_files $uri @proxy_to_cms_app;
   }
 


### PR DESCRIPTION
Need to also add heartbeat fake to CMS nginx config.

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
