### PR TITLE
Disable lms and cms servers on jenkins_worker container

### DIFF
--- a/docker/build/jenkins_worker/ansible_overrides.yml
+++ b/docker/build/jenkins_worker/ansible_overrides.yml
@@ -1,24 +1,19 @@
 ---
-EDXAPP_SETTINGS: 'devstack_docker'
-
-MONGO_AUTH: false
-
-devstack: true
-migrate_db: false
-mongo_enable_journal: false
-edxapp_npm_production: "no"
-
+COMMON_SECURITY_UPDATES: true
+EDXAPP_INSTALL_PRIVATE_REQUIREMENTS: true
+EDXAPP_LMS_BASE_SCHEME: http
 EDXAPP_LMS_GUNICORN_EXTRA_CONF: 'reload = True'
-
 EDXAPP_NO_PREREQ_INSTALL: 0
 EDXAPP_OAUTH_ENFORCE_SECURE: false
-EDXAPP_LMS_BASE_SCHEME: http
-COMMON_SECURITY_UPDATES: true
+EDXAPP_PYTHON_SANDBOX: false
+EDXAPP_SETTINGS: devstack_docker
+MONGO_AUTH: false
 SECURITY_UPGRADE_ON_ANSIBLE: true
 
-EDXAPP_INSTALL_PRIVATE_REQUIREMENTS: true
-
-EDXAPP_PYTHON_SANDBOX: false
-
+devstack: true
 edxapp_debian_pkgs_extra:
   - mongodb-clients
+edxapp_npm_production: 'no'
+migrate_db: false
+mongo_enable_journal: false
+service_variants_enabled: []

--- a/playbooks/roles/edxapp/templates/cms_gunicorn.py.j2
+++ b/playbooks/roles/edxapp/templates/cms_gunicorn.py.j2
@@ -1,5 +1,5 @@
 """
-gunicorn configuration file: http://docs.gunicorn.org/en/develop/configure.html
+gunicorn configuration file: http://docs.gunicorn.org/en/stable/configure.html
 
 {{ ansible_managed }}
 """

--- a/playbooks/roles/edxapp/templates/lms_gunicorn.py.j2
+++ b/playbooks/roles/edxapp/templates/lms_gunicorn.py.j2
@@ -1,5 +1,5 @@
 """
-gunicorn configuration file: http://docs.gunicorn.org/en/develop/configure.html
+gunicorn configuration file: http://docs.gunicorn.org/en/stable/configure.html
 
 {{ ansible_managed }}
 """


### PR DESCRIPTION
Configuration Pull Request
---

This pretty much just adds `service_variants_enabled: []` to the ansible overrides for the jenkins_worker docker to avoid installing lms and cms as services. These were getting launched by supervisor and hogging a lot of resources on the container, and we shouldn't need them.

I also tried to organize the ansible_vars better and added links that aren't broken to the `lms_gunicorn` and `cms_gunicorn` templates... which I happened to stumble upon.
