### PR TITLE
Jenkins_worker container should install testing.txt not development.txt

### DIFF
--- a/docker/build/jenkins_worker/Dockerfile
+++ b/docker/build/jenkins_worker/Dockerfile
@@ -17,7 +17,6 @@ ADD . /edx/app/edx_ansible/edx_ansible
 WORKDIR /edx/app/edx_ansible/edx_ansible/docker/plays
 
 COPY docker/build/jenkins_worker/ansible_overrides.yml /jenkins_worker/ansible_overrides.yml
-COPY docker/build/edxapp/devstack.yml /
 COPY docker/build/devstack/ansible_overrides.yml /devstack/ansible_overrides.yml
 
 ARG OPENEDX_RELEASE=master
@@ -27,7 +26,6 @@ RUN sudo /edx/app/edx_ansible/venvs/edx_ansible/bin/ansible-playbook edxapp.yml 
     -t 'install,assets,devstack,jenkins-worker' \
     --extra-vars="edx_platform_version=${OPENEDX_RELEASE}" \
     --extra-vars="@/jenkins_worker/ansible_overrides.yml" \
-    --extra-vars="@/devstack.yml" \
     --extra-vars="@/devstack/ansible_overrides.yml"
 
 # Run the mongo play

--- a/docker/build/jenkins_worker/ansible_overrides.yml
+++ b/docker/build/jenkins_worker/ansible_overrides.yml
@@ -14,6 +14,9 @@ devstack: true
 edxapp_debian_pkgs_extra:
   - mongodb-clients
 edxapp_npm_production: 'no'
+edxapp_requirements_files:
+  - "{{ testing_requirements_file }}"
 migrate_db: false
 mongo_enable_journal: false
 service_variants_enabled: []
+testing_requirements_file: "{{ edxapp_code_dir }}/requirements/edx/testing.txt"


### PR DESCRIPTION
Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
