### PR TITLE
Use ansible 2.3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Use Ansible 2.3.1.0 so that we can do shallow clones of tags.
+
 - git_clone:
   - The working tree is explicitly checked for modified files, to prevent mysterious failures.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-ansible==2.2.0.0
+ansible==2.3.1.0
 asn1crypto==0.24.0        # via cryptography
 awscli==1.15.19
 bcrypt==3.1.4             # via paramiko

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -1,6 +1,6 @@
 # Standard dependencies for Ansible runs
 
-ansible==2.2.0.0
+ansible==2.3.1.0
 awscli==1.15.19
 boto==2.48.0
 boto3==1.7.14


### PR DESCRIPTION
Configuration Pull Request
---

Ansible 2.2.0.0 cannot do a shallow git checkout of a tag.  This is fixed (https://github.com/ansible/ansible/pull/21712), and available in 2.3.1.0, which is the version used for Ginkgo.  This pull request uses 2.3.1.0 for Hawthorn as well.

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
