### PR TITLE
Ability to enable proxy_intercept_errors in nginx.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+- Role: nginx
+  - Added `NGINX_EDXAPP_PROXY_INTERCEPT_ERRORS` to be able to use custom static error pages for error responses from the LMS.
+
 - Role: analytics_api
   - Added `ANALYTICS_API_CORS_ORIGIN_WHITELIST` to allow CORS whitelisting of origins.
 

--- a/playbooks/roles/nginx/defaults/main.yml
+++ b/playbooks/roles/nginx/defaults/main.yml
@@ -114,6 +114,8 @@ NGINX_EDXAPP_ERROR_PAGES:
   "502": "{{ nginx_default_error_page }}"
   "504": "{{ nginx_default_error_page }}"
 
+NGINX_EDXAPP_PROXY_INTERCEPT_ERRORS: false
+
 CMS_HOSTNAME: '~^((stage|prod)-)?studio.*'
 
 nginx_template_dir: "edx/app/nginx/sites-available"

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/cms.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/cms.j2
@@ -30,6 +30,10 @@ server {
 error_page {{ k }} {{ v }};
   {% endfor %}
 
+  {% if NGINX_EDXAPP_PROXY_INTERCEPT_ERRORS %}
+  proxy_intercept_errors on;
+  {% endif %}
+
 {% include "empty_json.j2" %}
 
   listen {{ EDXAPP_CMS_NGINX_PORT }} {{ default_site }};

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
@@ -79,6 +79,10 @@ server {
 error_page {{ k }} {{ v }};
   {% endfor %}
 
+  {% if NGINX_EDXAPP_PROXY_INTERCEPT_ERRORS %}
+  proxy_intercept_errors on;
+  {% endif %}
+
 {% include "empty_json.j2" %}
 
   listen {{ EDXAPP_LMS_NGINX_PORT }} {{ default_site }};


### PR DESCRIPTION
This adds ability to enable `proxy_intercept_errors` in LMS nginx configuration. This is useful if you want to use custom error pages and want all errors (for example 404s) to be handled by responding the error page from nginx rather than the LMS.

This introduces a new ansible variables `NGINX_EDXAPP_PROXY_INTERCEPT_ERRORS`, which defaults to `false` and is backwards compatible.

**Sandbox**
- https://configpr4714.opencraft.hosting/

**Testing Instructions**:

The simplest way to test this is to set `NGINX_EDXAPP_ERROR_PAGES` to use the default sinking ship error for 404 errors. If you also enable `NGING_EDXAPP_PROXY_INTERCEPT_ERRORS`, you should see the sinking ship page even for 404 errors originating from within the LMS.

The sandbox was configured with:

```yaml
NGINX_EDXAPP_ERROR_PAGES:
  '404': /server/server-error.html
NGINX_EDXAPP_PROXY_INTERCEPT_ERRORS: true
```
If you go to https://configpr4714.opencraft.hosting/courses/404, you will see the sinking ship page.
If you visit the same page on an instance that doesn't have `NGINX_EDXAPP_PROXY_INTERCEPT_ERRORS` enabled, you will see the LMS 404 error page instead: https://matjaz.opencraft.hosting/courses/404

**Reviewers**:

- [x] @kaizoku
- [ ] edX

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
