### PR TITLE
Ability to use a custom template for static nginx pages.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 - Role: nginx
   - Added `NGINX_EDXAPP_PROXY_INTERCEPT_ERRORS` to be able to use custom static error pages for error responses from the LMS.
+  - Added `NGINX_SERVER_HTML_FILES_TEMPLATE` to make the error file template configurable.
+  - Added `NGINX_SERVER_STATIC_FILES` to allow copying static contents to the server static folder. Can be used to deploy static contents for the error pages for example.
 
 - Role: analytics_api
   - Added `basic_auth_exempted_paths` configuration for enterprise api endpoints

--- a/playbooks/roles/nginx/defaults/main.yml
+++ b/playbooks/roles/nginx/defaults/main.yml
@@ -67,6 +67,7 @@ NGINX_SERVER_ERROR_STYLE_H1: 'font-family: "Helvetica Neue",Helvetica,Roboto,Ari
 NGINX_SERVER_ERROR_STYLE_P_H2: 'font-family: "Helvetica Neue",Helvetica,Roboto,Arial,sans-serif; margin-bottom: .3em; line-height: 1.25em; text-rendering: optimizeLegibility; font-weight: bold; font-size: 1.8em; color: #5b5e63;'
 NGINX_SERVER_ERROR_STYLE_P: 'font-family: Georgia,Cambria,"Times New Roman",Times,serif; margin: auto; margin-bottom: 1em; font-weight: 200; line-height: 1.4em; font-size: 1.1em; max-width: 80%;'
 NGINX_SERVER_ERROR_STYLE_DIV: 'margin: auto; width: 800px; text-align: center; padding:20px 0px 0px 0px;'
+NGINX_SERVER_HTML_FILES_TEMPLATE: "edx/var/nginx/server-static/server-template.j2"
 NGINX_SERVER_HTML_FILES:
   - file: rate-limit.html
     lang: "{{ NGINX_SERVER_ERROR_LANG }}"
@@ -90,6 +91,8 @@ NGINX_SERVER_HTML_FILES:
     style_p_h2: "{{ NGINX_SERVER_ERROR_STYLE_P_H2 }}"
     style_p: "{{ NGINX_SERVER_ERROR_STYLE_P }}"
     style_div: "{{ NGINX_SERVER_ERROR_STYLE_DIV }}"
+
+NGINX_SERVER_STATIC_FILES: []
 
 NGINX_APT_REPO: deb http://nginx.org/packages/ubuntu/ {{ ansible_distribution_release }} nginx
 

--- a/playbooks/roles/nginx/tasks/main.yml
+++ b/playbooks/roles/nginx/tasks/main.yml
@@ -240,7 +240,7 @@
 
 - name: Create NGINX server templates
   template:
-    src: "edx/var/nginx/server-static/server-template.j2"
+    src: "{{ NGINX_SERVER_HTML_FILES_TEMPLATE }}"
     dest: "{{ nginx_server_static_dir }}/{{ item.file }}"
     owner: root
     group: "{{ common_web_user }}"
@@ -249,6 +249,18 @@
   tags:
     - install
     - install:configuration
+
+- name: Copy static files
+  copy:
+    src: "{{ item }}"
+    dest: "{{ nginx_server_static_dir }}"
+    owner: "{{ common_web_user }}"
+    group: "{{ common_web_user }}"
+    mode: "0640"
+  with_items: "{{ NGINX_SERVER_STATIC_FILES }}"
+  tags:
+     - install
+     - install:configuration
 
 - name: Write out htpasswd file
   htpasswd:


### PR DESCRIPTION
Currently the static HTML page template is hardcoded. The static HTML pages generated from this template can be used as custom error pages and clients often require more customization to their error pages than the hardcoded template provides.
This commit allows specifying a different template using the new  ansible`NGINX_SERVER_HTML_FILES_TEMPLATE` variable.

This commit also allows specifying static files (or folders) to be copied to the nginx static files location using the new `NGINX_SERVER_STATIC_FILES` ansible variable. This is useful when you are using a custom template for your error pages and want to add some static content such as images or external CSS files.

**Sandbox**
- https://configpr4715.opencraft.hosting/

**Testing Instructions**:

I verified this by spawning a sandbox with these settings:

```yaml
NGINX_SERVER_HTML_FILES_TEMPLATE: '/var/www/configuration-pr-4715/template.j2'
NGINX_SERVER_HTML_FILES:
  - file: server-error.html
    text: 'Something bad happened. We were not able to serve your request.'
NGINX_SERVER_STATIC_FILES:
  - '/var/www/configuration-pr-4715/styles'
```
I created `/var/www/configuration-pr-4715/template.j2` file with these contents on the machine that runs ansible:

```html
<!DOCTYPE html>
<html lang="en">

<head>
    <meta charset="UTF-8">
    <meta name="viewport" content="width=device-width, initial-scale=1.0">
    <meta http-equiv="X-UA-Compatible" content="ie=edge">
    <title>Server Error</title>
    <link rel="stylesheet" href="/server/styles/styles.css">
</head>

<body>
    <main>
        <h1>
          {{ item.text }}
        </h1>
    </main>
</body>

</html>
```

I also created `/var/www/configuration-pr-4715/styles/styles.css` file with some CSS styles.

On the sandbox I verified that the https://configpr4715.opencraft.hosting/server/server-error.html file was created from the custom template, and references the `styles.css` file, which was successfully uploaded to the correct folder.

**Reviewers**:

- [ ] @kaizoku
- [ ] edX

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
