### PR TITLE
go-agent-frontend ssh keys

### DIFF
--- a/docker/build/go-agent-frontend/Dockerfile
+++ b/docker/build/go-agent-frontend/Dockerfile
@@ -2,3 +2,11 @@ FROM edxops/go-agent:latest
 
 RUN curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash - && \
     apt-get update && apt-get install -y nodejs
+
+# !!!!NOTICE!!!! ---- Runner of this pipeline take heed!! You must replace go_github_key.pem with the REAL key material
+# that can checkout private github repositories used as pipeline materials. The key material here is faked and is only
+# used to pass CI!
+# setup the github identity
+ADD docker/build/go-agent/files/go_github_key.pem /home/go/.ssh/id_rsa
+RUN chmod 600 /home/go/.ssh/id_rsa && \
+    chown go:go /home/go/.ssh/id_rsa


### PR DESCRIPTION
This change will allow the frontend docker containers to connect to github with a private ssh key.