### PR TITLE
Support CORS OPTION preflights

### DIFF
--- a/playbooks/roles/edx_django_service/templates/edx/app/nginx/sites-available/concerns/cors-add-header.j2
+++ b/playbooks/roles/edx_django_service/templates/edx/app/nginx/sites-available/concerns/cors-add-header.j2
@@ -1,2 +1,11 @@
-    add_header 'Access-Control-Allow-Origin' $cors_origin;
-    add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
+    if ($request_method = 'OPTIONS') {
+        add_header 'Access-Control-Allow-Origin' $cors_origin;
+        add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
+        add_header 'Access-Control-Max-Age' 86400;
+        add_header 'Content-Type' 'text/plain; charset=utf-8';
+        add_header 'Content-Length' 0;
+        return 204;
+    }
+    
+    add_header 'Access-Control-Allow-Origin' $cors_origin always;
+    add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS' always;

--- a/playbooks/roles/edx_django_service/templates/edx/app/nginx/sites-available/concerns/proxy-to-app.j2
+++ b/playbooks/roles/edx_django_service/templates/edx/app/nginx/sites-available/concerns/proxy-to-app.j2
@@ -5,9 +5,6 @@ location / {
 }
 
 location ~ ^/({{ edx_django_service_basic_auth_exempted_paths | join('|') }})/ {
-  {% if edx_django_service_allow_cors_headers %}
-    {% include 'concerns/cors-add-header.j2' %}
-  {% endif %}
   try_files $uri @proxy_to_app;
 }
 
@@ -16,6 +13,11 @@ location ~ ^/({{ edx_django_service_basic_auth_exempted_paths | join('|') }})/ {
 {% include "concerns/django_admin_access_from_restricted_cidrs.j2" %}
 
 location @proxy_to_app {
+
+{% if edx_django_service_allow_cors_headers %}
+  {% include 'concerns/cors-add-header.j2' %}
+{% endif %}
+
 {% if NGINX_SET_X_FORWARDED_HEADERS %}
   proxy_set_header X-Forwarded-Proto $scheme;
   proxy_set_header X-Forwarded-Port $server_port;


### PR DESCRIPTION
This PR addresses 3 issues that came up when testing CORS XHRs to the analytics-data-api from a new microfrontend (edx-portal)

1. For CORS requests that require OPTION preflights (such as those with non-standard headers like an Authentication bearer token header) the preflight was getting proxied to the application. The application would return a 404 since there was no route for an OPTION request. The browser is expecting a status code in the 200s. We are now returning a 204 (No Content) directly from nginx, no need to proxy to the app for those.

2. By default nginx will not add_header for error status codes. This means a 404 will not come back with the necessary CORS headers and would be blocked by the browser. This can be fixed by adding `always` to the add_header directive:
> If the always parameter is specified (1.7.5), the header field will be added regardless of the response code

3. It moves the `cors_add_header` template to the `proxy_to_app` location. Nginx has an "odd" inheritance scheme for add_header: 
> There could be several add_header directives. These directives are inherited from the previous level if and only if there are no add_header directives defined on the current level

Because the proxy_to_app is a separate location, and even though it contains no add_header directives (only proxy_set_header), the headers were still not being added.


---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).