### PR TITLE
Allow Authorization header for CORS calls

### DIFF
--- a/playbooks/roles/edx_django_service/templates/edx/app/nginx/sites-available/concerns/cors-add-header.j2
+++ b/playbooks/roles/edx_django_service/templates/edx/app/nginx/sites-available/concerns/cors-add-header.j2
@@ -1,6 +1,7 @@
     if ($request_method = 'OPTIONS') {
         add_header 'Access-Control-Allow-Origin' $cors_origin;
         add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
+        add_header 'Access-Control-Allow-Headers' 'Authorization';
         add_header 'Access-Control-Max-Age' 86400;
         add_header 'Content-Type' 'text/plain; charset=utf-8';
         add_header 'Content-Length' 0;


### PR DESCRIPTION
The edx-portal is using standard OAuth 2 Authorization bearer token header (for now, may switch to cookies in the future). This needs to be explicitly allowed in the preflight, otherwise we get the error:
> Request header field Authorization is not allowed by Access-Control-Allow-Headers in preflight response.


Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
