### PR TITLE
Revert "Update the headers we pass back to deal with gunicorn 19."

### DIFF
--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/cms_proxy.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/cms_proxy.j2
@@ -5,7 +5,7 @@
 {% else %}
     proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
     proxy_set_header X-Forwarded-Port $http_x_forwarded_port;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-For $http_x_forwarded_for;
 {% endif %}
 
     # newrelic-specific header records the time when nginx handles a request.

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms_proxy.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms_proxy.j2
@@ -5,7 +5,7 @@
 {% else %}
     proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
     proxy_set_header X-Forwarded-Port $http_x_forwarded_port;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-For $http_x_forwarded_for;
 {% endif %}
 
     # newrelic-specific header records the time when nginx handles a request.


### PR DESCRIPTION
Reverts edx/configuration#4734

Reverting for now since the gunicorn change has been reverted.