### PR TITLE
install python3 on jenkins master and workers

### DIFF
--- a/playbooks/roles/jenkins_build/defaults/main.yml
+++ b/playbooks/roles/jenkins_build/defaults/main.yml
@@ -2,6 +2,10 @@ build_jenkins_user_uid: 1002
 build_jenkins_group_gid: 1004
 build_jenkins_version: jenkins_2.89.4
 build_jenkins_jvm_args: '-Djava.awt.headless=true -Xmx16384m -DsessionTimeout=60'
+
+build_jenkins_python_versions:
+  - python3.5-dev
+
 build_jenkins_configuration_scripts:
   - 1addJarsToClasspath.groovy
   - 2checkInstalledPlugins.groovy

--- a/playbooks/roles/jenkins_build/meta/main.yml
+++ b/playbooks/roles/jenkins_build/meta/main.yml
@@ -29,3 +29,4 @@ dependencies:
     jenkins_common_splunk_enabled: '{{ BUILD_JENKINS_SPLUNK_ENABLED }}'
     jenkins_common_splunk_file_path: '{{ build_jenkins_splunk_file_path }}'
     jenkins_common_email_replyto: '{{ JENKINS_MAILER_REPLY_TO_ADDRESS }}'
+    jenkins_common_python_versions: '{{ build_jenkins_python_versions }}'

--- a/playbooks/roles/jenkins_common/defaults/main.yml
+++ b/playbooks/roles/jenkins_common/defaults/main.yml
@@ -18,6 +18,8 @@ jenkins_common_debian_pkgs:
   - daemon
   - psmisc
 
+jenkins_common_python_versions: []
+
 jenkins_common_configuration_git_url: https://github.com/edx/jenkins-configuration.git
 jenkins_common_jenkins_configuration_branch: master
 jenkins_common_configuration_src_path: src/main/groovy

--- a/playbooks/roles/jenkins_common/tasks/main.yml
+++ b/playbooks/roles/jenkins_common/tasks/main.yml
@@ -10,6 +10,17 @@
     - install
     - install:system-requirements
 
+- name: Install specific versions of python
+  apt:
+    name: '{{ item }}'
+    state: present
+    update_cache: yes
+  with_items: '{{ jenkins_common_python_versions }}'
+  tags:
+    - jenkins
+    - install
+    - install:system-requirements
+
 - name: Create jenkins group with specified gid
   group:
     name: '{{ jenkins_common_group }}'

--- a/playbooks/roles/jenkins_worker/tasks/python.yml
+++ b/playbooks/roles/jenkins_worker/tasks/python.yml
@@ -3,3 +3,11 @@
 # Requests library is required for the github status script.
 - name: Install requests Python library
   pip: name=requests state=present
+
+# Install Python 3.5. For now, do not set it as the default python
+# version
+- name: Install python 3.5
+  apt:
+    name: 'python3.5-dev'
+    state: present
+    update_cache: yes


### PR DESCRIPTION
Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).

-----------

This installs python3.5 (https://packages.ubuntu.com/xenial/python/python3.5) on build jenkins master and jenkins workers. It does not set it as the default python, but makes it present for the ShiningPanda plugin to create virtual environments
