### PR TITLE
Don't default to the first instance

### DIFF
--- a/playbooks/active_instances_in_asg.py
+++ b/playbooks/active_instances_in_asg.py
@@ -27,6 +27,7 @@ import sys
 from collections import defaultdict
 from os import environ
 from itertools import chain
+import random
 
 class ActiveInventory():
 
@@ -85,7 +86,7 @@ class ActiveInventory():
 
         for group in active_groups.keys():
             for group_instance in groups_to_instances[group]:
-                instance = ec2.describe_instances(InstanceIds=[group_instance])['Reservations'][0]['Instances'][0]
+                instance = random.choice(ec2.describe_instances(InstanceIds=[group_instance])['Reservations'][0]['Instances'])
                 if 'PrivateIpAddress' in instance:
                     print("{},".format(instance['PrivateIpAddress']))
                     return # We only want a single IP


### PR DESCRIPTION
Random still means we can use the same machine multiple times, but this
is better than trying to track the "previous" machine and rotate, since
we have no good way to do that.


Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).