### PR TITLE
add android label to jenkins container

### DIFF
--- a/docker/build/jenkins_build/ansible_overrides.yml
+++ b/docker/build/jenkins_build/ansible_overrides.yml
@@ -47,10 +47,16 @@ jenkins_common_non_plugin_template_files:
 # Add the jenkins-worker label so that this jenkins master will work
 # out-of-the-box for running most kinds of jobs.  This makes integration
 # testing easier, and is easier for the openedx community.
+# Also add the android-worker label so that android testing can be done
+# easily on a local dev environment. NOTE: this also requires running
+# playbooks/android_sdk.yml in order to have all of the necessary Android
+# compilation and testing tools, but isn't necessary for most cases and
+# therefore should be omitted from normal builds of this container.
 jenkins_common_main_labels:
   - 'dsl-seed-runner'
   - 'backup-runner'
   - 'jenkins-worker'  # added this
+  - 'android-worker'
 
 # We're running all our jobs on the Jenkins Master by default (one container
 # only), so we need to bump up the number of executors for some jobs with


### PR DESCRIPTION
Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
-----------

The Android jobs are restricted to run only on android-workers, which have the android sdk installed. For local development, everything is run on the master node, so we need to put the android-worker label on master.

See: https://github.com/edx/configuration/pull/4743