### PR TITLE
TE-2646 Upgrade Chrome and Firefox

### DIFF
--- a/docker/build/chrome/Dockerfile
+++ b/docker/build/chrome/Dockerfile
@@ -1,4 +1,4 @@
-FROM selenium/standalone-chrome-debug:3.11.0-californium
+FROM selenium/standalone-chrome-debug:3.14.0-arsenic
 MAINTAINER edxops
 
 USER root

--- a/docker/build/firefox/Dockerfile
+++ b/docker/build/firefox/Dockerfile
@@ -1,4 +1,4 @@
-FROM selenium/standalone-firefox-debug:3.11.0-californium
+FROM selenium/standalone-firefox-debug:3.14.0-arsenic
 MAINTAINER edxops
 
 USER root

--- a/playbooks/roles/browsers/defaults/main.yml
+++ b/playbooks/roles/browsers/defaults/main.yml
@@ -26,22 +26,22 @@ firefox_version: version 59.*
 # FireFox update their apt repos with the latest version, which often causes
 # spurious acceptance test failures.
 browser_s3_deb_pkgs:
-  - name: firefox_59.0.2+build1-0ubuntu0.16.04.1_amd64.deb
-    url: https://s3.amazonaws.com/vagrant.testeng.edx.org/firefox_59.0.2%2Bbuild1-0ubuntu0.16.04.1_amd64.deb
-  - name: google-chrome-stable_55.0.2883.87-1_amd64.deb
-    url: https://s3.amazonaws.com/vagrant.testeng.edx.org/google-chrome-stable_55.0.2883.87-1_amd64.deb
+  - name: firefox_61.0.1+build1-0ubuntu0.16.04.1_amd64.deb
+    url: https://s3.amazonaws.com/vagrant.testeng.edx.org/firefox_61.0.1%2Bbuild1-0ubuntu0.16.04.1_amd64.deb
+  - name: google-chrome-stable_68.0.3440.84-1_amd64.deb
+    url: https://s3.amazonaws.com/vagrant.testeng.edx.org/google-chrome-stable_68.0.3440.84-1_amd64.deb
 
 trusty_browser_s3_deb_pkgs:
   - name: firefox-mozilla-build_42.0-0ubuntu1_amd64.deb
     url: https://s3.amazonaws.com/vagrant.testeng.edx.org/firefox-mozilla-build_42.0-0ubuntu1_amd64.deb
-  - name: google-chrome-stable_59.0.3071.115-1_amd64.deb
-    url: https://s3.amazonaws.com/vagrant.testeng.edx.org/google-chrome-stable_59.0.3071.115-1_amd64.deb
+  - name: google-chrome-stable_68.0.3440.84-1_amd64.deb
+    url: https://s3.amazonaws.com/vagrant.testeng.edx.org/google-chrome-stable_68.0.3440.84-1_amd64.deb
 
 # GeckoDriver
-geckodriver_url: "https://github.com/mozilla/geckodriver/releases/download/v0.20.0/geckodriver-v0.20.0-linux64.tar.gz"
+geckodriver_url: "https://github.com/mozilla/geckodriver/releases/download/v0.21.0/geckodriver-v0.21.0-linux64.tar.gz"
 
 # ChromeDriver
-chromedriver_version: 2.27
+chromedriver_version: 2.41
 chromedriver_url: "http://chromedriver.storage.googleapis.com/{{ chromedriver_version }}/chromedriver_linux64.zip"
 
 # PhantomJS

--- a/playbooks/roles/jenkins_worker/tasks/test_platform_worker.yml
+++ b/playbooks/roles/jenkins_worker/tasks/test_platform_worker.yml
@@ -22,7 +22,7 @@
   register: firefox_version
 - assert:
     that:
-      - "'59' in firefox_version.stdout"
+      - "'61' in firefox_version.stdout"
 
 # Verify the virtualenv tar is newly-built
 - name: Get info on virtualenv tar


### PR DESCRIPTION
Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.

Using headless Chrome 65 in devstack works fine for the a11y tests, using the 2-year-old Chrome 55 in Jenkins hangs after successfully running the first few tests.  Try upgrading both to the latest stable version (68) for better reliability and performance.  Also upgrade Firefox, so the Selenium Docker containers match (regarding Selenium version, etc.); there should be a decent performance improvement vs. the old version.