### PR TITLE
Moved Nginx log format name override

### DIFF
--- a/playbooks/roles/nginx/defaults/main.yml
+++ b/playbooks/roles/nginx/defaults/main.yml
@@ -42,6 +42,10 @@ NGINX_SSL_PROTOCOLS: "TLSv1 TLSv1.1 TLSv1.2"
 NGINX_DH_PARAMS_PATH: "/etc/ssl/private/dhparams.pem"
 NGINX_DH_KEYSIZE: 2048
 
+# This can be one of 'p_combined' or 'ssl_combined' by default. If you
+# wish to specify your own format then define it in a configuration file
+# located under `nginx_conf_dir` and then use the format name specified
+# in your configuration file.
 NGINX_LOG_FORMAT_NAME: 'p_combined'
 # When set to False, nginx will pass X-Forwarded-For, X-Forwarded-Port,
 # and X-Forwarded-Proto headers through to the backend unmodified.

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/xqueue.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/xqueue.j2
@@ -9,6 +9,9 @@ server {
 
   {% include "common-settings.j2" %}
 
+  access_log {{ nginx_log_dir }}/access.log {{ NGINX_LOG_FORMAT_NAME }};
+  error_log {{ nginx_log_dir }}/error.log error;
+
   location / {
     {% if XQUEUE_ENABLE_BASIC_AUTH|bool %}
       {% include "basic-auth.j2" %}

--- a/playbooks/roles/nginx/templates/etc/nginx/nginx.conf.j2
+++ b/playbooks/roles/nginx/templates/etc/nginx/nginx.conf.j2
@@ -33,7 +33,7 @@ http {
         # Logging Settings
         ##
 
-        log_format {{ NGINX_LOG_FORMAT_NAME }} '$http_x_forwarded_for - $remote_addr - $remote_user $http_x_forwarded_proto [$time_local]  '
+        log_format p_combined '$http_x_forwarded_for - $remote_addr - $remote_user $http_x_forwarded_proto [$time_local]  '
                             '"$request" $status $body_bytes_sent $request_time '
                             '"$http_referer" "$http_user_agent"';
 


### PR DESCRIPTION
When the `NGINX_LOG_FORMAT_NAME` var is set to something different than `p_combined` it breaks the Nginx configuration as there is no long a `p_combined` format defined for the main nginx config. This also prevents users from being able to specify their own format and using it throughout the various Nginx configs.

Removed the `NGINX_LOG_FORMAT_NAME` setting from the `log_format` definition to allow for the default log format to function properly. Users can define an alternate format with a different name and pass that via the `NGINX_LOG_FORMAT_NAME` to be used in the CMS/LMS etc.

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
