### PR TITLE
Remove cloudformation references from Readme.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,29 +11,6 @@ ready-to-go.
 Before getting started, please look at the `Open EdX Installation options`_, to
 see which method for deploying OpenEdX is right for you.
 
-Building the platform takes place in two phases:
-
--  Infrastructure provisioning
--  Service configuration
-
-As much as possible, we have tried to keep a clean distinction between
-provisioning and configuration. You are not obliged to use our tools and are
-free to use one, but not the other. The provisioning phase stands-up the
-required resources and tags them with role identifiers so that the
-configuration tool can come in and complete the job.
-
-**Note**: The Cloudformation templates used for infrastructure provisioning are
-no longer maintained. We are working to move to a more modern and flexible
-tool.
-
-The reference platform is provisioned using an Amazon `CloudFormation`_
-template. When the stack has been fully created you will have a new AWS Virtual
-Private Cloud with hosts for the core Open edX services. This template will
-build quite a number of AWS resources that cost money, so please consider this
-before you start.
-
-The configuration phase is managed by `Ansible`_. We have provided a number of
-playbooks that will configure each of the Open edX services.
 
 **Important**: The Open edX configuration scripts need to be run as root on
 your servers and will make changes to service configurations including, but not
@@ -50,7 +27,6 @@ Wiki`_.
 For info on any large recent changes please see the `change log`_.
 
 .. _Open EdX Installation options: https://open.edx.org/installation-options
-.. _CloudFormation: http://aws.amazon.com/cloudformation/
 .. _Ansible: http://ansible.com/
 .. _OpenEdX Wiki: https://openedx.atlassian.net/wiki/display/OpenOPS/Open+edX+Operations+Home
 .. _change log: https://github.com/edx/configuration/blob/master/CHANGELOG.md


### PR DESCRIPTION
Edx no longer uses cloudformation, and the templates haven't been in our repos since 2015.

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
