### PR TITLE
Updates path to no longer use old prospectus repo code directory

### DIFF
--- a/playbooks/roles/prospectus/defaults/main.yml
+++ b/playbooks/roles/prospectus/defaults/main.yml
@@ -36,7 +36,6 @@ NGINX_PROSPECTUS_PROXY_INTERCEPT_ERRORS: true
 
 # task vars
 PROSPECTUS_GIT_IDENTITY: "none"
-prospectus_build_server_repo_path: '{{ COMMON_APP_DIR }}/prospectus'
 prospectus_repo: 'git@github.com:edx/prospectus.git'
 prospectus_version: 'master'
 prospectus_environment: 'development'

--- a/playbooks/roles/prospectus/tasks/main.yml
+++ b/playbooks/roles/prospectus/tasks/main.yml
@@ -8,7 +8,7 @@
 - name: Remove old git repo
   file:
     state: absent
-    path: "{{ prospectus_build_server_repo_path }}/"
+    path: "{{ prospectus_code_dir }}/"
 
 - name: Remove old app repo
   file:
@@ -80,7 +80,7 @@
 - name: Add prospectus configuration file
   template:
     src: ".env.environment.j2"
-    dest: "{{ prospectus_build_server_repo_path }}/config/.env.{{ prospectus_environment }}"
+    dest: "{{ prospectus_code_dir }}/config/.env.{{ prospectus_environment }}"
     mode: "0644"
     owner: "{{ prospectus_user }}"
     group: "{{ prospectus_user }}"


### PR DESCRIPTION
Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
