### PR TITLE
Colons not allowed for git over ssh in ansible

### DIFF
--- a/playbooks/roles/prospectus/defaults/main.yml
+++ b/playbooks/roles/prospectus/defaults/main.yml
@@ -36,7 +36,7 @@ NGINX_PROSPECTUS_PROXY_INTERCEPT_ERRORS: true
 
 # task vars
 PROSPECTUS_GIT_IDENTITY: "none"
-prospectus_repo: 'git@github.com:edx/prospectus.git'
+prospectus_repo: 'ssh://git@github.com/edx/prospectus.git'
 prospectus_version: 'master'
 prospectus_environment: 'development'
 edx_django_service_use_python3: false


### PR DESCRIPTION
SSH urls cannot be copied directly from GitHub, and need to be properly formatted according to, https://github.com/ansible/ansible/issues/33908.

Local success: 
```
changed: [localhost] => {
    "after": "4696b33ddf6c92cdf1a9424902eb5b64f10a397e", 
    "before": null, 
    "changed": true, 
    "invocation": {
        "module_args": {
            "accept_hostkey": true, 
            "bare": false, 
            "clone": true, 
            "depth": null, 
            "dest": "/edx/app/prospectus/prospectus", 
            "executable": null, 
            "force": false, 
            "key_file": null, 
            "recursive": true, 
            "reference": null, 
            "refspec": null, 
            "remote": "origin", 
            "repo": "ssh://git@github.com/edx/prospectus.git", 
            "ssh_opts": null, 
            "track_submodules": false, 
            "umask": null, 
            "update": true, 
            "verify_commit": false, 
            "version": "master"
        }, 
        "module_name": "git"
    }, 
    "warnings": []
}

Playbook Deploy edX Prospectus Service finished: 2018-09-17 16:06:57.268131, 169 total tasks.  0:07:20.033014 elapsed. 
```

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
