### PR TITLE
Add counting of workers to celery/redis monitoring

### DIFF
--- a/util/jenkins/check-celery-queues.py
+++ b/util/jenkins/check-celery-queues.py
@@ -62,6 +62,38 @@ class CwBotoWrapper(object):
     def put_metric_alarm(self, *args, **kwargs):
         return self.client.put_metric_alarm(*args, **kwargs)
 
+class Ec2BotoWrapper(object):
+    def __init__(self):
+        self.client = boto3.client('ec2')
+
+    @backoff.on_exception(backoff.expo,
+                          (botocore.exceptions.ClientError),
+                          max_tries=max_tries)
+    def describe_instances(self, *args, **kwargs):
+        return self.client.describe_instances(*args, **kwargs)
+
+def count_workers(environment, deploy, play, cluster):
+    ec2 = Ec2BotoWrapper()
+
+    num_workers = len(ec2.describe_instances(
+        Filters=[
+            {'Name': 'tag:environment', 'Values': [environment]},
+            {'Name': 'tag:deployment', 'Values': [deploy]},
+            {'Name': 'tag:play', 'Values': [play]},
+            {'Name': 'tag:cluster', 'Values': [cluster]},
+            {'Name': 'instance-state-name', 'Values': ['running']},
+        ]
+    )['Reservations'])
+    metric_data = {
+        'MetricName': 'count',
+        'Dimensions': [{
+            "Name": "workers",
+            "Value": play
+        }],
+        'Value': num_workers
+    }
+
+    return metric_data
 
 @click.command()
 @click.option('--host', '-h', default='localhost',
@@ -154,6 +186,10 @@ def check_queues(host, port, environment, deploy, max_metrics, threshold,
                                         InsufficientDataActions=actions,
                                         OKActions=actions,
                                         AlarmActions=actions)
+
+    # Track number of worker instances so it can be graphed in CloudWatch
+    workers_metric_data = count_workers(environment, deploy, 'edxapp', 'worker')
+    cloudwatch.put_metric_data(Namespace=namespace, MetricData=[workers_metric_data])
 
 # Stolen right from the itertools recipes
 # https://docs.python.org/3/library/itertools.html#itertools-recipes


### PR DESCRIPTION
This will let us have graph the number of workers in a Cloudwatch dashboard, along with queue size and ASG average CPU.

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
