### PR TITLE
update permissions for local dev jenkins container

### DIFF
--- a/docker/build/jenkins_build/ansible_overrides.yml
+++ b/docker/build/jenkins_build/ansible_overrides.yml
@@ -62,3 +62,17 @@ jenkins_common_main_labels:
 # only), so we need to bump up the number of executors for some jobs with
 # downstream jobs to work correctly.
 jenkins_common_main_num_executors: 6
+
+# Add basic permissions for a non-authenticated user to be able to view
+# the jenkins instance and its jobs. When used for development, an
+# initial admin password is generated and will be used for job creation.
+# However, in order to get to the login page, these permissions must be
+# configured.
+JENKINS_SECURITY_GROUPS:
+  - NAME: 'anonymous'
+    PERMISSIONS:
+      - 'hudson.model.Hudson.Read'
+      - 'hudson.model.Item.Discover'
+      - 'hudson.model.Item.Read'
+    USERS:
+      - 'anonymous'


### PR DESCRIPTION
Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).

----

After separating the Github Oauth and general security scripts used in this container, the basic permission for an unauthenticated user to see the Jenkins instance and its jobs was not added. Even though the initialization process for Jenkins creates a one-time password for users, they couldn't browse to the login page to add it.
