### PR TITLE
Fix set_real_ip_from variable nginx (OPS-2235)

### DIFF
--- a/playbooks/roles/edx_django_service/templates/edx/app/nginx/sites-available/concerns/django_admin_access_from_restricted_cidrs.j2
+++ b/playbooks/roles/edx_django_service/templates/edx/app/nginx/sites-available/concerns/django_admin_access_from_restricted_cidrs.j2
@@ -1,7 +1,7 @@
 {% if NGINX_DJANGO_ADMIN_ACCESS_CIDRS and EDX_DJANGO_SERVICE_ENABLE_DJANGO_ADMIN_RESTRICTION %}
   location /admin {
     real_ip_header X-Forwarded-For;
-    set_real_ip_from {{ NGINX_REAL_IP_CIDRS }};
+    set_real_ip_from {{ NGINX_TRUSTED_IP_CIDRS }};
     {% for cidr in NGINX_DJANGO_ADMIN_ACCESS_CIDRS %}
       allow {{ cidr }};
     {% endfor %}

--- a/playbooks/roles/nginx/defaults/main.yml
+++ b/playbooks/roles/nginx/defaults/main.yml
@@ -182,5 +182,5 @@ NGINX_EDXAPP_LMS_APP_EXTRA: ""
 
 # List of subnet or IP addressess to allow to access django admin 
 NGINX_DJANGO_ADMIN_ACCESS_CIDRS: []
-# Set trusted network subnets or IP addresses of ELB request are coming from
-NGINX_REAL_IP_CIDRS: "0.0.0.0/0"
+# Set trusted network subnets or IP addresses to send correct replacement addresses
+NGINX_TRUSTED_IP_CIDRS: "0.0.0.0/0"

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/cms.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/cms.j2
@@ -116,7 +116,7 @@ error_page {{ k }} {{ v }};
 {% if NGINX_DJANGO_ADMIN_ACCESS_CIDRS and EDXAPP_ENABLE_DJANGO_ADMIN_RESTRICTION %}
   location /admin {
     real_ip_header X-Forwarded-For;
-    set_real_ip_from {{ NGINX_REAL_IP_CIDRS }};
+    set_real_ip_from {{ NGINX_TRUSTED_IP_CIDRS }};
     {% for cidr in NGINX_DJANGO_ADMIN_ACCESS_CIDRS %}
       allow {{ cidr }};
     {% endfor %}

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
@@ -283,7 +283,7 @@ location ~ ^{{ EDXAPP_MEDIA_URL }}/(?P<file>.*) {
 {% if NGINX_DJANGO_ADMIN_ACCESS_CIDRS and EDXAPP_ENABLE_DJANGO_ADMIN_RESTRICTION %}
   location /admin {
     real_ip_header X-Forwarded-For;
-    set_real_ip_from {{ NGINX_REAL_IP_CIDRS }};
+    set_real_ip_from {{ NGINX_TRUSTED_IP_CIDRS }};
     {% for cidr in NGINX_DJANGO_ADMIN_ACCESS_CIDRS %}
       allow {{ cidr }};
     {% endfor %}


### PR DESCRIPTION
Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
