### PR TITLE
Fix missing boto configuration on GCP VMs

### DIFF
--- a/playbooks/roles/demo/tasks/deploy.yml
+++ b/playbooks/roles/demo/tasks/deploy.yml
@@ -10,7 +10,7 @@
   register: demo_checkout
 
 - name: import demo course
-  shell: "{{ demo_edxapp_venv_bin }}/python ./manage.py cms --settings={{ demo_edxapp_settings }} import {{ demo_edxapp_course_data_dir }} {{ demo_code_dir }}"
+  shell: ". {{ edxapp_app_dir }}/edxapp_env && {{ demo_edxapp_venv_bin }}/python ./manage.py cms --settings={{ demo_edxapp_settings }} import {{ demo_edxapp_course_data_dir }} {{ demo_code_dir }}"
   args:
     chdir: "{{ demo_edxapp_code_dir }}"
   become_user: "{{ common_web_user }}"
@@ -31,7 +31,7 @@
     demo_test_admin_and_staff_users: "{{ demo_test_and_staff_users + SANDBOX_EDXAPP_USERS }}"
 
 - name: create some test users
-  shell: "{{ demo_edxapp_venv_bin }}/python ./manage.py lms --settings={{ demo_edxapp_settings }} --service-variant lms manage_user {{ item.username}} {{ item.email }} --initial-password-hash {{ item.hashed_password | quote }}{% if item.is_staff %} --staff{% endif %}{% if item.is_superuser %} --superuser{% endif %}"
+  shell: ". {{ edxapp_app_dir }}/edxapp_env && {{ demo_edxapp_venv_bin }}/python ./manage.py lms --settings={{ demo_edxapp_settings }} --service-variant lms manage_user {{ item.username}} {{ item.email }} --initial-password-hash {{ item.hashed_password | quote }}{% if item.is_staff %} --staff{% endif %}{% if item.is_superuser %} --superuser{% endif %}"
   args:
     chdir: "{{ demo_edxapp_code_dir }}"
   become_user: "{{ common_web_user }}"
@@ -39,7 +39,7 @@
   when: demo_checkout.changed
 
 - name: enroll test users in the demo course
-  shell: "{{ demo_edxapp_venv_bin }}/python ./manage.py lms --settings={{ demo_edxapp_settings }} --service-variant lms enroll_user_in_course -e {{ item.email }} -c {{ demo_course_id }}"
+  shell: ". {{ edxapp_app_dir }}/edxapp_env && {{ demo_edxapp_venv_bin }}/python ./manage.py lms --settings={{ demo_edxapp_settings }} --service-variant lms enroll_user_in_course -e {{ item.email }} -c {{ demo_course_id }}"
   args:
     chdir: "{{ demo_edxapp_code_dir }}"
   become_user: "{{ common_web_user }}"
@@ -48,14 +48,14 @@
   when: demo_checkout.changed
 
 - name: add test users to the certificate whitelist
-  shell: "{{ demo_edxapp_venv_bin }}/python ./manage.py lms --settings={{ demo_edxapp_settings }} --service-variant lms cert_whitelist -a {{ item.email }} -c {{ demo_course_id }}"
+  shell: ". {{ edxapp_app_dir }}/edxapp_env && {{ demo_edxapp_venv_bin }}/python ./manage.py lms --settings={{ demo_edxapp_settings }} --service-variant lms cert_whitelist -a {{ item.email }} -c {{ demo_course_id }}"
   args:
     chdir: "{{ demo_edxapp_code_dir }}"
   with_items: "{{ demo_test_users }}"
   when: demo_checkout.changed
 
 - name: seed the forums for the demo course
-  shell: "{{ demo_edxapp_venv_bin }}/python ./manage.py lms --settings={{ demo_edxapp_settings }} seed_permissions_roles {{ demo_course_id }}"
+  shell: ". {{ edxapp_app_dir }}/edxapp_env && {{ demo_edxapp_venv_bin }}/python ./manage.py lms --settings={{ demo_edxapp_settings }} seed_permissions_roles {{ demo_course_id }}"
   args:
     chdir: "{{ demo_edxapp_code_dir }}"
   with_items: "{{ demo_test_users }}"

--- a/playbooks/roles/edxapp/tasks/deploy.yml
+++ b/playbooks/roles/edxapp/tasks/deploy.yml
@@ -431,7 +431,7 @@
     - manage
 
 - name: create service worker users
-  shell: "{{ edxapp_venv_bin }}/python ./manage.py lms --settings={{ edxapp_settings }} --service-variant lms manage_user {{ item.username}} {{ item.email }} --unusable-password {% if item.is_staff %} --staff{% endif %}"
+  shell: ". {{ edxapp_app_dir }}/edxapp_env && {{ edxapp_venv_bin }}/python ./manage.py lms --settings={{ edxapp_settings }} --service-variant lms manage_user {{ item.username}} {{ item.email }} --unusable-password {% if item.is_staff %} --staff{% endif %}"
   args:
     chdir: "{{ edxapp_code_dir }}"
   become_user: "{{ common_web_user }}"
@@ -442,7 +442,7 @@
     - manage:db
 
 - name: reindex all courses
-  shell: "{{ edxapp_venv_bin }}/python ./manage.py cms reindex_course --setup --settings={{ edxapp_settings }}"
+  shell: ". {{ edxapp_app_dir }}/edxapp_env && {{ edxapp_venv_bin }}/python ./manage.py cms reindex_course --setup --settings={{ edxapp_settings }}"
   args:
     chdir: "{{ edxapp_code_dir }}"
   become_user: "{{ common_web_user }}"
@@ -455,7 +455,7 @@
   cron:
     name: "clear expired Django sessions"
     user: "{{ edxapp_user }}"
-    job: "{{ edxapp_venv_bin }}/python {{ edxapp_code_dir }}/manage.py lms clearsessions --settings={{ edxapp_settings }} >/dev/null 2>&1"
+    job: ". {{ edxapp_app_dir }}/edxapp_env && {{ edxapp_venv_bin }}/python {{ edxapp_code_dir }}/manage.py lms clearsessions --settings={{ edxapp_settings }} >/dev/null 2>&1"
     hour: "{{ EDXAPP_CLEARSESSIONS_CRON_HOURS }}"
     minute: "{{ EDXAPP_CLEARSESSIONS_CRON_MINUTES }}"
     day: "*"


### PR DESCRIPTION
Configuration Pull Request
---

Fixes #4770 

When installing `open-release/hawthorn.2` using the [`native.sh`](https://openedx.atlassian.net/wiki/spaces/OpenOPS/pages/146440579/Native+Open+edX+Ubuntu+16.04+64+bit+Installation) on an Ubuntu 16.04 Google Cloud Platform machine I get the error below.

This PR fixes it by adding the proper `edxapp_environment` to the relevant commands so `BOTO_CONFIG` is set to the correct default continuing what #3792 introduced.

### TODO

 - [ ] [@nedbat's](https://github.com/edx/configuration/pull/4812#issuecomment-435172054) "Is there a more conventional way to get the edxapp settings: there's no other place in the playbooks that sources edxapp_env like this."


### Checklist

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).


### The Log!

```
TASK [edxapp : create service worker users] ************************************
failed: [localhost] (item={u'username': u'enterprise_worker', u'is_superuser': False, u'is_staff': True, u'email': u'enterprise_worker@example.com'}) => {"changed": true, "cmd": "/edx/app/edxapp/venvs/edxapp/bin/python ./manage.py lms --settings=aws --service-variant lms manage_user enterprise_worker enterprise_worker@example.com --unusable-password  --staff
delta": "0:00:05.953172
end": "2018-10-02 08:04:14.164140
failed": true, "item": {"email": "enterprise_worker@example.com
is_staff": true, "is_superuser": false, "username": "enterprise_worker"}, "rc": 1, "start": "2018-10-02 08:04:08.210968
stderr": "Traceback (most recent call last):
  File "./manage.py", line 118, in <module>
    startup.run()
  File "/edx/app/edxapp/edx-platform/lms/startup.py", line 19, in run
    django.setup()
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/__init__.py", line 27, in setup
    apps.populate(settings.INSTALLED_APPS)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/apps/registry.py", line 108, in populate
    app_config.import_models()
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/apps/config.py", line 202, in import_models
    self.models_module = import_module(models_module_name)
  File "/usr/lib/python2.7/importlib/__init__.py", line 37, in import_module
    __import__(name)
  File "/edx/app/edxapp/edx-platform/common/djangoapps/student/models.py", line 55, in <module>
    from lms.djangoapps.certificates.models import GeneratedCertificate
  File "/edx/app/edxapp/edx-platform/lms/djangoapps/certificates/models.py", line 69, in <module>
    from lms.djangoapps.instructor_task.models import InstructorTask
  File "/edx/app/edxapp/edx-platform/lms/djangoapps/instructor_task/models.py", line 23, in <module>
    from boto.exception import BotoServerError
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/boto/__init__.py", line 1216, in <module>
    boto.plugin.load_plugins(config)
AttributeError: 'module' object has no attribute 'plugin'
stderr_lines": ["Traceback (most recent call last):
  File "./manage.py", line 118, in <module>
    startup.run()
  File "/edx/app/edxapp/edx-platform/lms/startup.py", line 19, in run
    django.setup()
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/__init__.py", line 27, in setup
    apps.populate(settings.INSTALLED_APPS)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/apps/registry.py", line 108, in populate
    app_config.import_models()
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/apps/config.py", line 202, in import_models
    self.models_module = import_module(models_module_name)
  File "/usr/lib/python2.7/importlib/__init__.py", line 37, in import_module
    __import__(name)
  File "/edx/app/edxapp/edx-platform/common/djangoapps/student/models.py", line 55, in <module>
    from lms.djangoapps.certificates.models import GeneratedCertificate
  File "/edx/app/edxapp/edx-platform/lms/djangoapps/certificates/models.py", line 69, in <module>
    from lms.djangoapps.instructor_task.models import InstructorTask
  File "/edx/app/edxapp/edx-platform/lms/djangoapps/instructor_task/models.py", line 23, in <module>
    from boto.exception import BotoServerError
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/boto/__init__.py", line 1216, in <module>
    boto.plugin.load_plugins(config)
AttributeError: 'module' object has no attribute 'plugin'"], "stdout": "
stdout_lines": []}
``` 

