### PR TITLE
Security: Move the hard-coded whitelists of allowed hosts into Ansible configuration

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -790,6 +790,10 @@ EDXAPP_SESSION_SAVE_EVERY_REQUEST: false
 
 EDXAPP_SESSION_COOKIE_SECURE: false
 
+# TODO: bbeggs remove this before prod, temp fix to get load testing running
+EDXAPP_LMS_ALLOWED_HOSTS: ["*", "{{ EDXAPP_LMS_SITE_NAME }}", "{{ EDXAPP_PREVIEW_LMS_BASE }}"]
+EDXAPP_CMS_ALLOWED_HOSTS: ["*", "{{ EDXAPP_CMS_SITE_NAME }}"]
+
 # Optionally add a cron job to run the "clearsessions" management command to delete expired sessions
 # Hours and minutes follow cron syntax.
 # E.g. "15,19" hours and "0" minutes will run it at 15:00 and 19:00.
@@ -1412,6 +1416,7 @@ lms_env_config:
   ANALYTICS_API_URL: "{{ EDXAPP_LMS_ANALYTICS_API_URL }}"
   GOOGLE_SITE_VERIFICATION_ID: "{{ EDXAPP_GOOGLE_SITE_VERIFICATION_ID }}"
   STATIC_URL_BASE: "{{ EDXAPP_LMS_STATIC_URL_BASE }}"
+  LMS_ALLOWED_HOSTS: "{{ EDXAPP_LMS_ALLOWED_HOSTS }}"
 
 cms_auth_config:
   <<: *edxapp_generic_auth
@@ -1452,6 +1457,7 @@ cms_env_config:
   ALTERNATE_WORKER_QUEUES: "lms"
   COURSE_IMPORT_EXPORT_BUCKET: "{{ EDXAPP_IMPORT_EXPORT_BUCKET }}"
   STATIC_URL_BASE: "{{ EDXAPP_CMS_STATIC_URL_BASE }}"
+  CMS_ALLOWED_HOSTS: "{{ EDXAPP_CMS_ALLOWED_HOSTS }}"
 
 # install dir for the edx-platform repo
 edxapp_code_dir: "{{ edxapp_app_dir }}/edx-platform"


### PR DESCRIPTION
Provides a whitelist of allowed hostnames to mitigate a host header attack.  Removes the hard-coded lists from edx-platform/lms/envs/aws.py and edx-platform/cms/envs/aws.py and moves them into Ansible configuration.

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
