### PR TITLE
Security: Add X-Content-Type-Options header which was missing for fonts

### DIFF
--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/static-files.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/static-files.j2
@@ -18,6 +18,10 @@
     location ~ "/static/(?P<collected>.*\.[0-9a-f]{12}\.(eot|otf|ttf|woff|woff2)$)" {
         add_header "Cache-Control" $cache_header_long_lived always;
         add_header Access-Control-Allow-Origin *;
+        
+        # Prevent the browser from doing MIME-type sniffing
+        add_header X-Content-Type-Options nosniff;
+         
         try_files /staticfiles/$collected /course_static/$collected =404;
     }
 


### PR DESCRIPTION
Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
