### PR TITLE
Fix for when all queues are empty

### DIFF
--- a/util/jenkins/check_celery_progress/check_celery_progress.py
+++ b/util/jenkins/check_celery_progress/check_celery_progress.py
@@ -197,7 +197,8 @@ def check_queues(host, port, environment, deploy, default_threshold, queue_thres
     new_state = build_new_state(old_state, queue_first_items, current_time)
 
     redis_client.delete(QUEUE_AGE_HASH_NAME)
-    redis_client.hmset(QUEUE_AGE_HASH_NAME, pack_state(new_state))
+    if new_state:
+        redis_client.hmset(QUEUE_AGE_HASH_NAME, pack_state(new_state))
 
     for queue_name in queue_names:
         threshold = default_threshold


### PR DESCRIPTION
Fix for this stacktrace

```
Traceback (most recent call last):
  File "./check_celery_progress.py", line 215, in <module>
    check_queues()
  File "/edx/var/jenkins/shiningpanda/jobs/714cead3/virtualenvs/d41d8cd9/lib/python3.5/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/edx/var/jenkins/shiningpanda/jobs/714cead3/virtualenvs/d41d8cd9/lib/python3.5/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/edx/var/jenkins/shiningpanda/jobs/714cead3/virtualenvs/d41d8cd9/lib/python3.5/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/edx/var/jenkins/shiningpanda/jobs/714cead3/virtualenvs/d41d8cd9/lib/python3.5/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "./check_celery_progress.py", line 200, in check_queues
    redis_client.hmset(QUEUE_AGE_HASH_NAME, pack_state(new_state))
  File "/edx/var/jenkins/shiningpanda/jobs/714cead3/virtualenvs/d41d8cd9/lib/python3.5/site-packages/backoff/_sync.py", line 85, in retry
    ret = target(*args, **kwargs)
  File "./check_celery_progress.py", line 75, in hmset
    return self.redis.hmset(*args)
  File "/edx/var/jenkins/shiningpanda/jobs/714cead3/virtualenvs/d41d8cd9/lib/python3.5/site-packages/redis/client.py", line 2007, in hmset
    raise DataError("'hmset' with 'mapping' of length 0")
redis.exceptions.DataError: 'hmset' with 'mapping' of length 0
```

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
