### PR TITLE
Compress prospectus images after build

### DIFF
--- a/playbooks/roles/prospectus/tasks/main.yml
+++ b/playbooks/roles/prospectus/tasks/main.yml
@@ -153,6 +153,19 @@
     - install
     - install:app-requirements
 
+- name: Install pngquant
+  apt:
+    name: "pngquant"
+  tags:
+    - install
+    - install:system-requirements
+
+- name: Compress images
+  shell: "find public -name '*.png' -exec pngquant --skip-if-larger --quality 50-75 --ext .png --force -- {} \\;"
+  args:
+    chdir: "{{ prospectus_code_dir }}"
+  become_user: "{{ prospectus_user }}"
+
 # Copy over the target from the previous build to where it needs to be
 - name: Create data folder
   file:


### PR DESCRIPTION
Compress total size of all images in prospectus from 1.1M to 316K (71% reduction).

This process *is* technically lossy, but I cannot tell the difference in the quality. Compare for yourself:

![edx-masters-aboutgt](https://user-images.githubusercontent.com/1196901/46875916-fded9200-ce0a-11e8-9454-43dc99aa15eb.png) ![edx-masters-aboutgt](https://user-images.githubusercontent.com/1196901/46875937-0940bd80-ce0b-11e8-9a95-7b746f813020.png)

![world_map](https://user-images.githubusercontent.com/1196901/46876006-32614e00-ce0b-11e8-8128-fb14db76af84.png) ![world_map](https://user-images.githubusercontent.com/1196901/46876010-355c3e80-ce0b-11e8-8ab0-4912047fad96.png)

![harleen](https://user-images.githubusercontent.com/1196901/46876042-4907a500-ce0b-11e8-9697-1340bb0427fa.png) ![harleen](https://user-images.githubusercontent.com/1196901/46876043-4a38d200-ce0b-11e8-8a0c-c04804ead430.png)

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
