### PR TITLE
Add an exception for health check in Prospectus.

### DIFF
--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/prospectus.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/prospectus.j2
@@ -15,6 +15,11 @@ server {
 
   root {{ PROSPECTUS_DATA_DIR }};
 
+  # Ignore the rollout group headers for the health check endpoint.
+  location /HealthCheck {
+    try_files $uri $uri/index.html @backend;
+  }
+
   location / {
     if ($http_x_rollout_group !~ "test") {
       proxy_pass {{ PROSPECTUS_PROXY_PASS }};


### PR DESCRIPTION
This PR adds an nginx override for the specific HealthCheck endpoint so that it ignores the cookie/headers that are otherwise needed.

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [x] A DevOps team member has approved the PR.