### PR TITLE
remove regexp from nginx assets location

### DIFF
--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
@@ -237,7 +237,7 @@ error_page {{ k }} {{ v }};
   }
 
 {% if EDXAPP_CORS_ORIGIN_WHITELIST|length > 0 %}
-  location ~ ^/assets/courseware {
+  location /assets/courseware {
     try_files $uri @proxy_to_lms_app;
     add_header 'Access-Control-Allow-Origin' $cors_origin;
     add_header 'Access-Control-Allow-Methods' 'HEAD, GET, OPTIONS';


### PR DESCRIPTION
This PR should change the nginx behavior for courseware assets to send CORS Whitelist headers if a whitelist is defined and matches the origin of a request for a courseware asset.