### PR TITLE
remove redundant CORS headers we set these in middleware

### DIFF
--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
@@ -240,17 +240,6 @@ error_page {{ k }} {{ v }};
     try_files $uri @proxy_to_lms_app;
   }
 
-{% if EDXAPP_CORS_ORIGIN_WHITELIST|length > 0 %}
-  location /assets/courseware {
-    try_files $uri @proxy_to_lms_app;
-    add_header 'Access-Control-Allow-Origin' $cors_origin;
-    add_header 'Access-Control-Allow-Methods' 'HEAD, GET, OPTIONS';
-
-    # Inform downstream caches to take certain headers into account when reading/writing to cache.
-    add_header 'Vary' 'Accept-Encoding,Origin';
-  }
-{% endif %}
-
   # No basic auth security on the heartbeat url, so that ELB can use it
   location /heartbeat {
     # If /edx/var/nginx/server-static/maintenance_heartbeat.txt exists serve an


### PR DESCRIPTION
These headers are set in gunicorn, not at the nginx layer. make sure to turn on the `ENABLE_CORS_HEADERS` feature flag and populate your `CORS_ORIGIN_WHITELIST`