### PR TITLE
Upgrade jenkins plugins

### DIFF
--- a/playbooks/roles/jenkins_build/defaults/main.yml
+++ b/playbooks/roles/jenkins_build/defaults/main.yml
@@ -20,7 +20,6 @@ build_jenkins_configuration_scripts:
   - 4configureGHPRB.groovy
   - 4configureGit.groovy
   - 4configureGithub.groovy
-  - 4configureHipChat.groovy
   - 4configureMailerPlugin.groovy
   - 4configureMaskPasswords.groovy
   - 4configureSecurity.groovy
@@ -47,7 +46,7 @@ build_jenkins_plugins_list:
     version: '1.5'
     group: 'org.jenkins-ci.plugins'
   - name: 'bouncycastle-api'
-    version: '2.16.1'
+    version: '2.16.3'
     group: 'org.jenkins-ci.plugins'
   - name: 'build-flow-plugin'
     version: '0.20'
@@ -133,9 +132,6 @@ build_jenkins_plugins_list:
   - name: 'groovy-postbuild'
     version: '2.4'
     group: 'org.jvnet.hudson.plugins'
-  - name: 'hipchat'
-    version: '0.1.9'
-    group: 'org.jvnet.hudson.plugins'
   - name: 'hockeyapp'
     version: '1.2.2'
     group: 'org.jenkins-ci.plugins'
@@ -149,7 +145,7 @@ build_jenkins_plugins_list:
     version: '1.67'
     group: 'org.jenkins-ci.plugins'
   - name: 'junit'
-    version: '1.24'
+    version: '1.26'
     group: 'org.jenkins-ci.plugins'
   - name: 'ldap'
     version: '1.20'
@@ -170,7 +166,7 @@ build_jenkins_plugins_list:
     version: '3.1.2'
     group: 'org.jenkins-ci.main'
   - name: 'monitoring'
-    version: '1.71.0'
+    version: '1.74.0'
     group: 'org.jvnet.hudson.plugins'
   - name: 'multiple-scms'
     version: '0.6'
@@ -179,7 +175,7 @@ build_jenkins_plugins_list:
     version: '1.7.2'
     group: 'org.jenkins-ci.plugins'
   - name: 'pam-auth'
-    version: '1.2'
+    version: '1.4'
     group: 'org.jenkins-ci.plugins'
   - name: 'parameterized-trigger'
     version: '2.35.2'
@@ -197,8 +193,11 @@ build_jenkins_plugins_list:
     version: '2.9'
     group: 'org.jenkins-ci.plugins'
   - name: 'rebuild'
-    version: '1.25'
+    version: '1.29'
     group: 'com.sonyericsson.hudson.plugins.rebuild'
+  - name: 'resource-disposer'
+    version: '0.12'
+    group: 'org.jenkins-ci.plugins'
   - name: 'run-condition'
     version: '1.0'
     group: 'org.jenkins-ci.plugins'
@@ -215,7 +214,7 @@ build_jenkins_plugins_list:
     version: '1.6.4'
     group: 'com.splunk.splunkins'
   - name: 'ssh-agent'
-    version: '1.14'
+    version: '1.17'
     group: 'org.jenkins-ci.plugins'
   - name: 'ssh-credentials'
     version: '1.14'
@@ -284,9 +283,6 @@ build_jenkins_ghprb_cron_schedule: 'H/5 * * * *'
 
 # github
 JENKINS_GITHUB_CONFIG: ''
-
-# hipchat
-build_jenkins_hipchat_room: 'testeng'
 
 # ec2
 build_jenkins_instance_cap: '500'

--- a/playbooks/roles/jenkins_build/defaults/main.yml
+++ b/playbooks/roles/jenkins_build/defaults/main.yml
@@ -284,6 +284,9 @@ build_jenkins_ghprb_cron_schedule: 'H/5 * * * *'
 # github
 JENKINS_GITHUB_CONFIG: ''
 
+# hipchat
+build_jenkins_hipchat_room: 'testeng'
+
 # ec2
 build_jenkins_instance_cap: '500'
 

--- a/playbooks/roles/jenkins_common/tasks/main.yml
+++ b/playbooks/roles/jenkins_common/tasks/main.yml
@@ -67,7 +67,6 @@
     state: directory
     owner: "{{ jenkins_common_user }}"
     group: "{{ jenkins_common_group }}"
-    recurse: true
     mode: 0700
   tags:
     - install


### PR DESCRIPTION
This PR:

1- Upgrades a variety of Jenkins plugins
2- Removes the hipchat configuration script from our configuration (but doesn't completely gut hipchat from jenkins_common role just yet).
3- Tweaks the jenkins_common main task to stop recursively `chmod`ing the jenkins home dir. This was causing issues when run on a system that already had jenkins-configuration checked out. Basically, since it was recursive, the jenkins-configuration repo's permissions were being changed by this command, and when it came time to do the git checkout, ansible failed due to local changes having been made:

`fatal: [test_jenkins]: FAILED! => {"before": "914b2fd04b797823956dd92855cfe8552320965f", "changed": false, "failed": true, "msg": "Local modifications exist in repository (force=no).", "warnings": []}` 

This tweak fixes the ansible without changing the desired behavior (jenkins home and subdirs are still only accessible by the jenkins user)