### PR TITLE
Remove basic auth from login page.

### DIFF
--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
@@ -158,10 +158,6 @@ error_page {{ k }} {{ v }};
   # determine whether a user on their site is logged into edX.
   # The most common image to use is favicon.ico.
   location /login {
-    {% if EDXAPP_LMS_ENABLE_BASIC_AUTH|bool %}
-      {% include "basic-auth.j2" %}
-    {% endif %}
-
     if ( $arg_next ~* "favicon.ico" ) {
       access_log off;
       return 403;


### PR DESCRIPTION
Basic auth on the login page is preventing the refresh token flow from working for frontend apps.