### PR TITLE
Make sure JWT signing keys are treated as strings.

### DIFF
--- a/playbooks/roles/edx_django_service/defaults/main.yml
+++ b/playbooks/roles/edx_django_service/defaults/main.yml
@@ -158,7 +158,7 @@ edx_django_service_jwt_auth:
     - AUDIENCE: '{{ edx_django_service_jwt_audience }}'
       ISSUER: '{{ edx_django_service_jwt_issuer }}'
       SECRET_KEY: '{{ edx_django_service_jwt_secret_key }}'
-  JWT_PUBLIC_SIGNING_JWK_SET: '{{ COMMON_JWT_PUBLIC_SIGNING_JWK_SET }}'
+  JWT_PUBLIC_SIGNING_JWK_SET: '{{ COMMON_JWT_PUBLIC_SIGNING_JWK_SET|string }}'
 
 edx_django_service_extra_apps: []
 

--- a/playbooks/roles/edx_notes_api/defaults/main.yml
+++ b/playbooks/roles/edx_notes_api/defaults/main.yml
@@ -85,7 +85,7 @@ edx_notes_api_service_config:
       - AUDIENCE: '{{ COMMON_JWT_AUDIENCE }}'
         ISSUER: '{{ COMMON_JWT_ISSUER }}'
         SECRET_KEY: '{{ COMMON_JWT_SECRET_KEY }}'
-    JWT_PUBLIC_SIGNING_JWK_SET: '{{ COMMON_JWT_PUBLIC_SIGNING_JWK_SET }}'
+    JWT_PUBLIC_SIGNING_JWK_SET: '{{ COMMON_JWT_PUBLIC_SIGNING_JWK_SET|string }}'
 
 #
 # vars are namespace with the module name.

--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -368,7 +368,7 @@ EDXAPP_LMS_ISSUER: "{{ COMMON_JWT_ISSUER }}"
 EDXAPP_JWT_EXPIRATION: 30  # Number of seconds until expiration
 EDXAPP_JWT_AUDIENCE: "{{ COMMON_JWT_AUDIENCE }}"
 EDXAPP_JWT_SECRET_KEY: "{{ COMMON_JWT_SECRET_KEY }}"
-EDXAPP_JWT_PUBLIC_SIGNING_JWK_SET: "{{ COMMON_JWT_PUBLIC_SIGNING_JWK_SET }}"
+EDXAPP_JWT_PUBLIC_SIGNING_JWK_SET: "{{ COMMON_JWT_PUBLIC_SIGNING_JWK_SET|string }}"
 
 # See https://github.com/edx/edx-platform/blob/master/openedx/core/djangoapps/oauth_dispatch/docs/decisions/0008-use-asymmetric-jwts.rst
 EDXAPP_JWT_SIGNING_ALGORITHM: !!null
@@ -1204,9 +1204,9 @@ generic_env_config:  &edxapp_generic_env
       - ISSUER: "{{ EDXAPP_LMS_ISSUER }}"
         AUDIENCE: "{{ EDXAPP_JWT_AUDIENCE }}"
         SECRET_KEY: "{{ EDXAPP_JWT_SECRET_KEY }}"
-    JWT_PUBLIC_SIGNING_JWK_SET: "{{ EDXAPP_JWT_PUBLIC_SIGNING_JWK_SET }}"
+    JWT_PUBLIC_SIGNING_JWK_SET: "{{ EDXAPP_JWT_PUBLIC_SIGNING_JWK_SET|string }}"
     JWT_SIGNING_ALGORITHM: "{{ EDXAPP_JWT_SIGNING_ALGORITHM }}"
-    JWT_PRIVATE_SIGNING_JWK: "{{ EDXAPP_JWT_PRIVATE_SIGNING_JWK }}"
+    JWT_PRIVATE_SIGNING_JWK: "{{ EDXAPP_JWT_PRIVATE_SIGNING_JWK|string }}"
 
   #must end in slash (https://docs.djangoproject.com/en/1.4/ref/settings/#media-url)
   MEDIA_URL:  "{{ EDXAPP_MEDIA_URL }}/"


### PR DESCRIPTION
Open EdX has [recently moved to asymmetrically encrypted JWT keys](https://github.com/edx/edx-platform/blob/master/openedx/core/djangoapps/oauth_dispatch/docs/decisions/0008-use-asymmetric-jwts.rst). This requires `COMMON_JWT_PUBLIC_SIGNING_JWK_SET` and `EDXAPP_JWT_PRIVATE_SIGNING_JWK` variables to be set to JSON serialized representation of the keys.

When using interpolation, ansible automatically converts strings that look like JSON (ex: `'{"key":"val"}'`) into YAML dicts. This conversion breaks code in edx-platform, which expects that the JWT key settings are provided as [JSON encoded strings](https://github.com/edx/edx-platform/blob/42d445c9011d74c8266a167a0e0baec24e0816b8/lms/envs/devstack.py#L240-L258).

This PR adds `string` filters to every place in the codebase where one of the ansible variables containing JWT keys gets used in interpolation, to make sure that the values remain plain strings after interpolation.

**Test Instructions**:

1. Set `COMMON_JWT_PUBLIC_SIGNING_JWK_SET` and `EDXAPP_JWT_PRIVATE_SIGNING_JWK` to desired values in form of strings of JSON, for example:
```
COMMON_JWT_PUBLIC_SIGNING_JWK_SET: '{"keys": [{"kid": "test_key", "e": "AQAB", "kty": "RSA", "n": "z4Gum0m6T0CcMN6h0CGvJIOSuS96Jo77WbYGnc5jQyWBC3LMv1o_v10u5xb7uwTGVkp56E21mnHWso3T7xAaXJiAGN5tcYJRnOVFvhTDJT3CjZYoU5HI-c81OiMEYs4r7sT__5TyGsSRvEH3LCO6oe8meAESFvOywjDGKeTHGFT2b8xRCD0HUokp6u8DBR1hV_JogZHjJA5yWt3HC9uuSQupVHPhAgdcOHmN0_Teejvxh1tMEL9K6flviIsxbsLoLDyV2TKN02EC8LXLhvluU8r69nujaJmjnmclSjILMQC2FdzH04r41a6w8ocTHOcVIifViWJxeAKsXMfkWRH0HQ"}]}'
EDXAPP_JWT_PRIVATE_SIGNING_JWK: '{"e": "AQAB", "d": "CsvOu5YZqytrpPBEX3mNLPtqfBeQBacNRUTe8cFt8S2nmeKia_dEV07AFLZhqQCN2Cn-TzuRzgQLvVT7OJYwJO6rRX_3Fj-HQwA7wXC_mXWt5GNyXCy61eJ1vL1bKk_bQcw-nHvRn9pn0bFl7IY8XNX-PKKjoA2UWJ2khcP5JtcWudoKoFFWKj9VffO-7VFhD7K08V6LoYFFukzee8ezoSzJrUVy8vLeO7QYia8eutWN9_YKbOLo_1ZXeiKsMA8_2Qn0Lo2a-_e5cUux1z8s-XUJPtiEHgIXebYysFdzbvzHp1Hu4-ziDsmlDCI7cbMQ0b6SLXK-uKjCWtDNDoVLaQ", "n": "z4Gum0m6T0CcMN6h0CGvJIOSuS96Jo77WbYGnc5jQyWBC3LMv1o_v10u5xb7uwTGVkp56E21mnHWso3T7xAaXJiAGN5tcYJRnOVFvhTDJT3CjZYoU5HI-c81OiMEYs4r7sT__5TyGsSRvEH3LCO6oe8meAESFvOywjDGKeTHGFT2b8xRCD0HUokp6u8DBR1hV_JogZHjJA5yWt3HC9uuSQupVHPhAgdcOHmN0_Teejvxh1tMEL9K6flviIsxbsLoLDyV2TKN02EC8LXLhvluU8r69nujaJmjnmclSjILMQC2FdzH04r41a6w8ocTHOcVIifViWJxeAKsXMfkWRH0HQ", "q": "_BwiDux-WgCLp4eCg5BfVcB-kmKWBtdHASS-ZFXdpquDHsYl1VfBAPFZ4Hq2V2ZHdZJ7SoPfIod4SlQ4GCg8LRpSeHjK-FIulbfKd_ZjtCGKpwbDrOzXmbwVfATR-A-KESXMtS0d8iSYQdC0xXZGjLxAqzT_iDfbcXg9bQQvQiU", "p": "0rVcLYwfMTCeKPd_uiTkTpf6B3rJjsb6I_f4BeIuWYkePaIY8sPyXgNIuiW1pYtr7j59NfrEDKmA6k6I3lI5e0mjTIG8oHEiGo8eQdTxYcfwWo1dTtSitpSBazcjKkdEtM81k-PgSstP_pFshzQ0yxUR8oaestz5wAB6LwGr_Jk", "kid": "test_key", "kty": "RSA"}'
```
2. Deploy a new sandbox without changes from this PR. Notice that when trying to log into the LMS, you get the "We couldn't sign you in. This site is currently unavailable due to a server error. Please try again in a few minutes." error. You can check the `lms.env.json` file to see that the `JWT_PUBLIC_SIGNING_JWK_SET` and `JWT_PRIVATE_SIGNING_JWK` values under `JWT_AUTH` are JSON dicts instead of strings.
3. Checkout the changes from this branch and deploy another sandbox. Verify that the LMS login now works correctly and the relevant settings in `lms.env.json` file are represented as strings.

**Reviewers**:
- [ ] @SSPJ 
- [ ] edX reviewer (TBD)

---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
