### PR TITLE
ARCH-279: Remove unused legacy jwt-secret-keys.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Role: ecommerce
+  - Remove unused JWT_SECRET_KEYS. 
 
 - Role: ecommerce
   - Transformed the JWT_ISSUERS to match the format expected by edx-drf-extensions jwt_decode_handler. 

--- a/playbooks/roles/ecommerce/defaults/main.yml
+++ b/playbooks/roles/ecommerce/defaults/main.yml
@@ -51,11 +51,6 @@ ECOMMERCE_JWT_ISSUERS:
     SECRET_KEY: "{{ COMMON_JWT_SECRET_KEY }}"
 
 ECOMMERCE_JWT_LEEWAY: 1
-# NOTE: We have an array of keys to allow for support of multiple when, for example,
-# we change keys. This will ensure we continue to operate with JWTs issued signed with the old key
-# while migrating to the new key.
-ECOMMERCE_JWT_SECRET_KEYS:
-  - '{{ COMMON_JWT_SECRET_KEY }}'
 
 # Used to automatically configure OAuth2 Client
 ECOMMERCE_SOCIAL_AUTH_EDX_OIDC_KEY: 'ecommerce-key'
@@ -174,7 +169,6 @@ ecommerce_service_config_overrides:
     JWT_LEEWAY: '{{ ECOMMERCE_JWT_LEEWAY }}'
     JWT_DECODE_HANDLER: '{{ ECOMMERCE_JWT_DECODE_HANDLER }}'
     JWT_ISSUERS: '{{ ECOMMERCE_JWT_ISSUERS }}'
-    JWT_SECRET_KEYS: '{{ ECOMMERCE_JWT_SECRET_KEYS }}'
 
   AFFILIATE_COOKIE_KEY: '{{ ECOMMERCE_AFFILIATE_COOKIE_NAME }}'
 


### PR DESCRIPTION
ARCH-279

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [x] A DevOps team member has approved the PR.
  - [x] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [x] Update the appropriate internal repo (be sure to update for all our environments)
    - [x] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [x] Add an entry to the CHANGELOG.
  - [x] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
