### PR TITLE
 Avoid running the same operation multiple times

### DIFF
--- a/playbooks/roles/demo/tasks/deploy.yml
+++ b/playbooks/roles/demo/tasks/deploy.yml
@@ -58,5 +58,4 @@
   shell: ". {{ demo_edxapp_env }} && {{ demo_edxapp_venv_bin }}/python ./manage.py lms --settings={{ demo_edxapp_settings }} seed_permissions_roles {{ demo_course_id }}"
   args:
     chdir: "{{ demo_edxapp_code_dir }}"
-  with_items: "{{ demo_test_users }}"
   when: demo_checkout.changed


### PR DESCRIPTION
The `item` variable is not used in the "seed the forums for the demo course" task.
The `with_items`'s effect is to execute the exact same command multiple times (once per user in `demo_test_users`).

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
