### PR TITLE
Add defaut writable gradebook URL env variable.

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -916,6 +916,9 @@ EDXAPP_MAINTENANCE_BANNER_TEXT: "Sample banner message"
 EDXAPP_PASSWORD_POLICY_COMPLIANCE_ROLLOUT_CONFIG:
   ENFORCE_COMPLIANCE_ON_LOGIN: false
 
+# Needed to link the LMS instructor dashboard to the writable gradebook micro-frontend
+EDXAPP_LMS_WRITABLE_GRADEBOOK_URL: null
+
 #-------- Everything below this line is internal to the role ------------
 
 #Use YAML references (& and *) and hash merge <<: to factor out shared settings
@@ -1427,6 +1430,7 @@ lms_env_config:
   GOOGLE_SITE_VERIFICATION_ID: "{{ EDXAPP_GOOGLE_SITE_VERIFICATION_ID }}"
   STATIC_URL_BASE: "{{ EDXAPP_LMS_STATIC_URL_BASE }}"
   X_FRAME_OPTIONS: "{{ EDXAPP_X_FRAME_OPTIONS }}"
+  WRITABLE_GRADEBOOK_URL: "{{ EDXAPP_LMS_WRITABLE_GRADEBOOK_URL }}"
 
 cms_auth_config:
   <<: *edxapp_generic_auth


### PR DESCRIPTION
https://openedx.atlassian.net/browse/EDUCATOR-3657

This is to point to the LMS at the new Gradebook frontend.
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
