### PR TITLE
TE-2803 Remove edx-platform clone and pip cache from xdist worker image

### DIFF
--- a/docker/build/jenkins_worker/Dockerfile
+++ b/docker/build/jenkins_worker/Dockerfile
@@ -26,7 +26,8 @@ RUN sudo /edx/app/edx_ansible/venvs/edx_ansible/bin/ansible-playbook edxapp.yml 
     -t 'install,assets,devstack' \
     --extra-vars="edx_platform_version=${OPENEDX_RELEASE}" \
     --extra-vars="@/jenkins_worker/ansible_overrides.yml" \
-    --extra-vars="@/devstack/ansible_overrides.yml"
+    --extra-vars="@/devstack/ansible_overrides.yml" \
+    && rm -rf /edx/app/edxapp/.cache /edx/app/edxapp/edx-platform
 
 # Add sshd to enable jenkins master to ssh into containers
 RUN apt-get update \


### PR DESCRIPTION
Configuration Pull Request
---

Remove a large amount of data from the `jenkins_worker` image which slows down launching on ECS (because it pulls the image from the registry for each instantiation).  We need to do a fresh git checkout for each PR anyway, and the pip cache only contains packages which were already installed.