### PR TITLE
Update which timeout we're overriding.

### DIFF
--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/cms.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/cms.j2
@@ -12,7 +12,7 @@ upstream cms-backend {
 
 server {
   # CMS configuration file for nginx, templated by ansible
-  proxy_connect_timeout {{ EDXAPP_CMS_NGINX_TIMEOUT }};
+  proxy_read_timeout {{ EDXAPP_CMS_NGINX_TIMEOUT }};
       
   # Proxy to a remote maintanence page
   {% if NGINX_EDXAPP_ENABLE_S3_MAINTENANCE %}


### PR DESCRIPTION
The connect timeout was the wrong setting.  The one we meant to update
was the read time out which indicates how long to wait on a quiet transmission
before declaring the connection dead.

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
