### PR TITLE
[BB-710] Specify forum mongodb access settings for edxapp to be able to anonymize data in mongodb

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -82,6 +82,17 @@ EDXAPP_MONGO_LMS_READ_PREFERENCE: 'secondaryPreferred'
 EDXAPP_LMS_DRAFT_DOC_STORE_READ_PREFERENCE: '{{ EDXAPP_MONGO_CMS_READ_PREFERENCE }}'
 EDXAPP_LMS_SPLIT_DOC_STORE_READ_PREFERENCE: '{{ EDXAPP_MONGO_LMS_READ_PREFERENCE }}'
 
+# MongoDB used in forum (cs_comments_service)
+FORUM_MONGO_USER: 'cs_comments_service'
+FORUM_MONGO_PASSWORD: 'password'
+FORUM_MONGO_HOSTS:
+  - 'localhost'
+FORUM_MONGO_TAGS: !!null
+FORUM_MONGO_PORT: 27017
+FORUM_MONGO_DB_NAME: 'cs_comments_service'
+FORUM_MONGO_USE_SSL: False
+FORUM_MONGO_URL: "mongodb://{{ FORUM_MONGO_USER }}:{{ FORUM_MONGO_PASSWORD }}@{%- for host in FORUM_MONGO_HOSTS -%}{{ host }}:{{ FORUM_MONGO_PORT }}{%- if not loop.last -%},{%- endif -%}{%- endfor -%}/{{ FORUM_MONGO_DATABASE }}{%- if FORUM_MONGO_TAGS -%}?tags={{ FORUM_MONGO_TAGS }}{%- endif -%}"
+
 EDXAPP_MYSQL_DB_NAME: 'edxapp'
 EDXAPP_MYSQL_USER: 'edxapp001'
 EDXAPP_MYSQL_USER_ADMIN: 'root'
@@ -1322,6 +1333,7 @@ lms_env_config:
   ACE_ROUTING_KEY: "{{ EDXAPP_ACE_ROUTING_KEY }}"
   ENTERPRISE_TAGLINE: "{{ EDXAPP_ENTERPRISE_TAGLINE }}"
   ANALYTICS_API_URL: "{{ EDXAPP_LMS_ANALYTICS_API_URL }}"
+  FORUM_MONGO_URL: "{{ FORUM_MONGO_URL }}"
 
 cms_auth_config:
   <<: *edxapp_generic_auth


### PR DESCRIPTION
Configuration Pull Request
---

This PR adds the following settings (pretty much mirrored from the forum role) to the edxapp role:
- `FORUM_MONGO_USER`
- `FORUM_MONGO_PASSWORD`
- `FORUM_MONGO_HOSTS`
- `FORUM_MONGO_TAGS`
- `FORUM_MONGO_PORT`
- `FORUM_MONGO_DB_NAME`
- `FORUM_MONGO_USE_SSL`
- `FORUM_MONGO_URL`

However, only `FORUM_MONGO_URL` is exported to the edx settings (`lms.env.json`).
Values for these settings should always be set to the same values as set for the forum role - I need a direct access to the forum's mongodb to anonymize some data that is not changeable through the current set of APIs.

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
