### PR TITLE
Whitelist XBlock APIs to avoid OAuth2-basic auth conflict

### DIFF
--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
@@ -230,6 +230,16 @@ error_page {{ k }} {{ v }};
     try_files $uri @proxy_to_lms_app;
   }
 
+  # No basic auth on the XBlock View endpoint, which can use OAuth2
+  location ~ ^/courses/.*/xblock/.*/view/ {
+    try_files $uri @proxy_to_lms_app;
+  }
+
+  # No basic auth on XBlock handlers, which can use OAuth2
+  location ~ ^/courses/.*/xblock/.*/handler/ {
+    try_files $uri @proxy_to_lms_app;
+  }
+
   # No basic auth security on assets
   location /c4x {
     try_files $uri @proxy_to_lms_app;


### PR DESCRIPTION
As of the following two PRs, two different XBlock APIs can be called using OAuth2 and not just session authentication:
* https://github.com/edx/edx-platform/pull/19260 xblock_view API (merged)
* https://github.com/edx/edx-platform/pull/19253 xblock_handler API (pending review)

However, the fix in this PR is also required to use those APIs with OAuth2 in cases where basic authentication is also enabled for the LMS. Otherwise, the basic auth header conflicts with the OAuth2 bearer token header.

**Test instructions and sandbox**:

http://149.202.167.150/ is a sandbox (deployed using this branch of edx/configuration) that has basic auth enabled (try accessing it in a browser)

However, the APIs are still working via OAuth2:

Get a new access token:
```
curl -X POST -d "client_id=codereview&client_secret=nepoemases&grant_type=password&username=honor&password=edx" http://149.202.167.150/oauth2/access_token/
```
Then substitute that access token into the following commands to test both APIs:
```
curl -F 'saved_video_position=00:02:02' -v http://149.202.167.150/courses/course-v1:edX+DemoX+Demo_Course/xblock/block-v1:edX+DemoX+Demo_Course+type@video+block@0b9e39477cf34507a7a48f74be381fdd/handler/xmodule_handler/save_user_state -H 'Authorization: Bearer {access_token}'
```
```
curl -v http://149.202.167.150/courses/course-v1:edX+DemoX+Demo_Course/xblock/block-v1:edX+DemoX+Demo_Course+type@html+block@c2f7008c9ccf4bd09d5d800c98fb0722/view/student_view -H 'Authorization: Bearer {access_token}'
```



---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] ~~Are you adding any new default values that need to be overridden when this change goes live? If so:~~
    - [ ] ~~Update the appropriate internal repo (be sure to update for all our environments)~~
    - [ ] ~~If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.~~
    - [ ] ~~Add an entry to the CHANGELOG.~~
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
