### PR TITLE
Add users role with COMMON_USER_INFO to ad_hoc

### DIFF
--- a/playbooks/roles/ad_hoc_reporting/meta/main.yml
+++ b/playbooks/roles/ad_hoc_reporting/meta/main.yml
@@ -16,4 +16,7 @@ dependencies:
     user_info: "{{ AD_HOC_REPORTING_USER_INFO }}"
     tags:
       - users
-
+  - role: user
+    user_info: "{{ COMMON_USER_INFO }}"
+    tags:
+      - users


### PR DESCRIPTION
I want to merge this to master first and then cherry-pick onto yonkers-ginko.

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
