### PR TITLE
SE-333 Allow arbitrary cron jobs to be added via configuration

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -804,6 +804,11 @@ EDXAPP_CLEARSESSIONS_CRON_ENABLED: false
 EDXAPP_CLEARSESSIONS_CRON_HOURS: "14"
 EDXAPP_CLEARSESSIONS_CRON_MINUTES: "0"
 
+# Add additional cron jobs from the given list.
+# See ansible docs for valid options for these items:
+#  https://docs.ansible.com/ansible/latest/modules/cron_module.html
+EDXAPP_ADDITIONAL_CRON_JOBS: []
+
 EDXAPP_VIDEO_IMAGE_MAX_AGE: 31536000
 
 # This is django storage configuration for Video Image settings.

--- a/playbooks/roles/edxapp/tasks/deploy.yml
+++ b/playbooks/roles/edxapp/tasks/deploy.yml
@@ -460,3 +460,7 @@
     minute: "{{ EDXAPP_CLEARSESSIONS_CRON_MINUTES }}"
     day: "*"
   when: EDXAPP_CLEARSESSIONS_CRON_ENABLED
+
+- name: install additional cron jobs
+  cron: "{{ item }}"
+  with_items: "{{ EDXAPP_ADDITIONAL_CRON_JOBS }}"


### PR DESCRIPTION
Adds `EDXAPP_ADDITIONAL_CRON_JOBS`, which provides a fully configurable list of cron jobs to be added.

Default is an empty list, so no additional cron jobs are added.

**JIRA tickets**: SE-126, [OSPR-3007](https://openedx.atlassian.net/browse/OSPR-3007)

**Discussions**: See https://github.com/edx/edx-platform/pull/19047

**Sandbox URL**:  Sandbox being provisioned.

* LMS: https://pr19047.sandbox.opencraft.hosting/
* Studio: https://studio-pr19047.sandbox.opencraft.hosting/

Running [edx-platform/master](https://github.com/edx/edx-platform/commit/33fab4b1e4a5f7d3b388bc8105c6b60abd1d93e0), configured using this branch and the extra configuration below.  Has 2 active VMs (`vm1.pr19047.sandbox.opencraft.hosting`, and `vm2.pr19047.sandbox.opencraft.hosting`)

**Merge deadline**: Would like to get this merged before Ironwood if possible.

**Testing instructions**:

1. On the sandbox, register and activate an account.
1. Enrol in the [Weekly Course Updates test course](https://pr19047.sandbox.opencraft.hosting/courses/course-v1:OpenCraft+Highlights+2018_1/about)
1. With the current configuration, you'll get a scheduled course update in your inbox in a week.

To trigger the email earlier:
1. Login to the sandbox as the `staff` user (it's been elevated to superuser).
1. Visit the [Django Admin Schedules › Schedules ](https://pr19047.sandbox.opencraft.hosting/admin/schedules/schedule) and locate the schedule created for your newly-registered user above.
   Adjust the Start date to backdate it by 1 week.  You should get a single email for Week 1 in your inbox within 24 hours.

**Reviewers**
- [x] @clemente 
- [ ] edX DevOps reviewer[s] TBD

**Settings**
```yaml
EDXAPP_ADDITIONAL_CRON_JOBS:
- name: "Send weekly course highlight emails"
  user: "{{ edxapp_user }}"
  job: "VM1=$(dig vm1.{{ COMMON_DEPLOYMENT }} +short -4); /sbin/ifconfig | grep \"inet addr:${VM1} \" && . {{ edxapp_app_dir }}/edxapp_env && {{ edxapp_venv_bin }}/python {{ edxapp_code_dir }}/manage.py lms send_course_update --settings={{ edxapp_settings }} {{ EDXAPP_SITE_NAME }} >/dev/null 2>&1"
  hour: "0"
  minute: "0"
  day: "*"

configuration_repo_url: https://github.com/open-craft/configuration
configuration_version: jill/addl-crons

## Use default django mailer for scheduled course highlight messages
EDXAPP_ACE_CHANNEL_DEFAULT_EMAIL: "django_email"
EDXAPP_ACE_CHANNEL_SAILTHRU_DEBUG: false
EDXAPP_ACE_CHANNEL_SAILTHRU_TEMPLATE_NAME: "template"
EDXAPP_ACE_CHANNEL_TRANSACTIONAL_EMAIL: "django_email"
EDXAPP_ACE_ENABLED_CHANNELS: ["django_email"]
EDXAPP_ACE_ENABLED_POLICIES: ["bulk_email_optout"]
EDXAPP_DEFAULT_FROM_EMAIL: “jill+highlights@opencraft.com” 
```

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [x] Are you adding any new default values that need to be overridden when this change goes live? No
    - [ ] <strike>Update the appropriate internal repo (be sure to update for all our environments)</strike>
    - [ ] <strike>If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.</strike>
    - [ ] <strike>Add an entry to the CHANGELOG.</strike>
  - [x] Are making a complicated change?  No