### PR TITLE
add jenkins to docker group

### DIFF
--- a/playbooks/roles/jenkins_common/defaults/main.yml
+++ b/playbooks/roles/jenkins_common/defaults/main.yml
@@ -1,5 +1,6 @@
 jenkins_common_user: jenkins
 jenkins_common_group: jenkins
+jenkins_common_groups: '{{ jenkins_common_group }}'
 jenkins_common_home: /var/lib/jenkins
 jenkins_common_config_path: '{{ jenkins_common_home }}/init-configs'
 jenkins_common_port: 8080

--- a/playbooks/roles/jenkins_common/tasks/main.yml
+++ b/playbooks/roles/jenkins_common/tasks/main.yml
@@ -45,7 +45,7 @@
     name: '{{ jenkins_common_user }}'
     append: yes
     uid: '{{ jenkins_common_user_uid }}'
-    groups: '{{ jenkins_common_group }}'
+    groups:  '{{ jenkins_common_groups }}'
   when: jenkins_common_user_uid is defined
   tags:
     - install
@@ -55,7 +55,7 @@
   user:
     name: '{{ jenkins_common_user }}'
     append: yes
-    groups: '{{ jenkins_common_group }}'
+    groups:  '{{ jenkins_common_groups }}'
   when: jenkins_common_user_uid is not defined or not jenkins_common_user_uid
   tags:
     - install

--- a/playbooks/roles/jenkins_it/defaults/main.yml
+++ b/playbooks/roles/jenkins_it/defaults/main.yml
@@ -1,5 +1,6 @@
 it_jenkins_user_uid: 1002
 it_jenkins_group_gid: 1004
+it_jenkins_groups: 'jenkins,docker'
 it_jenkins_version: jenkins_2.89.4
 it_jenkins_jvm_args: '-Djava.awt.headless=true -Xmx16384m -DsessionTimeout=60'
 

--- a/playbooks/roles/jenkins_it/meta/main.yml
+++ b/playbooks/roles/jenkins_it/meta/main.yml
@@ -5,6 +5,7 @@ dependencies:
     jenkins_common_version: '{{ it_jenkins_version }}'
     jenkins_common_user_uid: '{{ it_jenkins_user_uid }}'
     jenkins_common_group_gid: '{{ it_jenkins_group_gid }}'
+    jenkins_common_groups: '{{ it_jenkins_groups }}'
     jenkins_common_jvm_args: '{{ it_jenkins_jvm_args }}'
     jenkins_common_configuration_scripts: '{{ it_jenkins_configuration_scripts }}'
     jenkins_common_template_files: '{{ it_jenkins_template_files }}'


### PR DESCRIPTION
I want to run the Docker cli on IT jenkins, but it needs root. Adding the jenkins user to the docker group should get around that. This creates a wrapper variable, jenkins_common_groups, which defaults to 'jenkins', but can be loaded with more than one group id, if you want. No change should be needed for any of the other Jenkii.

