### PR TITLE
increase number of executors on it jenkins

### DIFF
--- a/playbooks/roles/jenkins_it/defaults/main.yml
+++ b/playbooks/roles/jenkins_it/defaults/main.yml
@@ -2,6 +2,7 @@ it_jenkins_user_uid: 1002
 it_jenkins_group_gid: 1004
 it_jenkins_version: jenkins_2.89.4
 it_jenkins_jvm_args: '-Djava.awt.headless=true -Xmx16384m -DsessionTimeout=60'
+it_jenkins_main_num_executors: 5
 
 it_jenkins_python_versions:
   - python3.5-dev

--- a/playbooks/roles/jenkins_it/meta/main.yml
+++ b/playbooks/roles/jenkins_it/meta/main.yml
@@ -21,3 +21,4 @@ dependencies:
     jenkins_common_email_replyto: '{{ JENKINS_MAILER_REPLY_TO_ADDRESS }}'
     jenkins_common_python_versions: '{{ it_jenkins_python_versions }}'
     jenkins_common_non_plugin_template_files: '{{ jenkins_it_non_plugin_template_files }}'
+    jenkins_common_main_num_executors: '{{ it_jenkins_main_num_executors }}'


### PR DESCRIPTION
Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).

---

In order to implement the 'sidecar' pattern in Jenkins pipelines (building/running a docker container in parallel to the main build), we need to have more available executors on master. I am bumping them up to 5, an arbitrary value, which seems to cover our needs, seeing that i am the only one using this server so far.