### PR TITLE
Add Python 3.6 to tools-jenkins

### DIFF
--- a/playbooks/roles/jenkins_common/defaults/main.yml
+++ b/playbooks/roles/jenkins_common/defaults/main.yml
@@ -91,6 +91,9 @@ jenkins_common_python_installations:
   - PYTHON_ALIAS: 'PYTHON_3.5'
     PYTHON_PATH: '/usr/bin/python3.5'
     PYTHON_PROPERTIES: []
+  - PYTHON_ALIAS: 'PYTHON_3.6'
+    PYTHON_PATH: '/usr/bin/python3.6'
+    PYTHON_PROPERTIES: []
 
 # plugins
 jenkins_common_plugins_list: []

--- a/playbooks/roles/tools_jenkins/tasks/main.yml
+++ b/playbooks/roles/tools_jenkins/tasks/main.yml
@@ -9,12 +9,14 @@
     - install
     - install:system-requirements
 
-- name: install python3.5
+- name: install python3.5 and 3.6
   apt:
     name: "{{ item }}"
   with_items:
     - python3.5
     - python3.5-dev
+    - python3.6
+    - python3.6-dev
   when: ansible_distribution_release == 'trusty'
   tags:
     - install


### PR DESCRIPTION
Need Python 3.6 for edx/py-opt-cli

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
