### PR TITLE
Allow nginx.conf to override map_hash sizes

### DIFF
--- a/playbooks/prospectus.yml
+++ b/playbooks/prospectus.yml
@@ -19,6 +19,9 @@
       nginx_default_sites:
       - prospectus
       PROSPECTUS_NGINX_PORT: 8000
+      NGINX_OVERRIDE_DEFAULT_MAP_HASH_SIZE: True
+      NGINX_MAP_HASH_MAX_SIZE: 4096
+      NGINX_MAP_HASH_BUCKET_SIZE: 128
     - role: prospectus
     - role: splunkforwarder
       when: COMMON_ENABLE_SPLUNKFORWARDER

--- a/playbooks/roles/nginx/defaults/main.yml
+++ b/playbooks/roles/nginx/defaults/main.yml
@@ -13,6 +13,11 @@ nginx_extra_configs: []
 NGINX_EDXAPP_EXTRA_SITES: []
 NGINX_EDXAPP_EXTRA_CONFIGS: []
 
+# Override these vars to alter the memory allocated to map_hash
+NGINX_OVERRIDE_DEFAULT_MAP_HASH_SIZE: False
+NGINX_MAP_HASH_MAX_SIZE: 2048
+NGINX_MAP_HASH_BUCKET_SIZE: 64
+
 # Override these vars for adding user to nginx.htpasswd
 NGINX_USERS:
   - name: "{{ COMMON_HTPASSWD_USER }}"
@@ -184,7 +189,7 @@ NGINX_EDXAPP_CMS_APP_EXTRA: ""
 # Extra settings to add to site configuration for LMS
 NGINX_EDXAPP_LMS_APP_EXTRA: ""
 
-# List of subnet or IP addressess to allow to access admin endpoints 
+# List of subnet or IP addressess to allow to access admin endpoints
 NGINX_ADMIN_ACCESS_CIDRS: []
 
 # Set trusted network subnets or IP addresses to send correct replacement addresses

--- a/playbooks/roles/nginx/templates/etc/nginx/nginx.conf.j2
+++ b/playbooks/roles/nginx/templates/etc/nginx/nginx.conf.j2
@@ -18,6 +18,10 @@ http {
         tcp_nodelay on;
         keepalive_timeout 65;
         types_hash_max_size 2048;
+        {% if NGINX_OVERRIDE_DEFAULT_MAP_HASH_SIZE %}
+        map_hash_max_size {{ NGINX_MAP_HASH_MAX_SIZE }};
+        map_hash_bucket_size {{ NGINX_MAP_HASH_BUCKET_SIZE }};
+        {% endif %}
         # increase header buffer for for https://edx-wiki.atlassian.net/browse/LMS-467&gt
         # see http://orensol.com/2009/01/18/nginx-and-weird-400-bad-request-responses/
         large_client_header_buffers 4 16k;


### PR DESCRIPTION
Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
