### PR TITLE
Remove default oauth2 public urls from the default yml config

### DIFF
--- a/playbooks/roles/edx_django_service/defaults/main.yml
+++ b/playbooks/roles/edx_django_service/defaults/main.yml
@@ -154,7 +154,6 @@ edx_django_service_oidc_logout_url: '{{ COMMON_OAUTH_LOGOUT_URL }}'
 edx_django_service_oidc_issuer: '{{ COMMON_OIDC_ISSUER }}'
 
 edx_django_service_oauth2_url_root: '{{ COMMON_LMS_BASE_URL }}'
-edx_django_service_oauth2_public_url_root: '{{ COMMON_LMS_BASE_URL }}'
 edx_django_service_oauth2_issuer: '{{ COMMON_LMS_BASE_URL }}'
 edx_django_service_oauth2_logout_url: '{{ COMMON_OAUTH_LOGOUT_URL }}'
 edx_django_service_oauth2_provider_url: '{{ COMMON_OAUTH_PUBLIC_URL_ROOT }}'
@@ -200,7 +199,6 @@ edx_django_service_config_default:
   SOCIAL_AUTH_EDX_OAUTH2_ISSUER: '{{ edx_django_service_oauth2_issuer }}'
   SOCIAL_AUTH_EDX_OAUTH2_URL_ROOT: '{{ edx_django_service_oauth2_url_root }}'
   SOCIAL_AUTH_EDX_OAUTH2_LOGOUT_URL: '{{ edx_django_service_oauth2_logout_url }}'
-  SOCIAL_AUTH_EDX_OAUTH2_PUBLIC_URL_ROOT: '{{ edx_django_service_oauth2_public_url_root }}'
 
   BACKEND_SERVICE_EDX_OAUTH2_KEY: '{{ edx_django_service_backend_service_edx_oauth2_key }}'
   BACKEND_SERVICE_EDX_OAUTH2_SECRET: '{{ edx_django_service_backend_service_edx_oauth2_secret }}'


### PR DESCRIPTION
This prevents a default value for SOCIAL_AUTH_EDX_OAUTH2_PUBLIC_URL_ROOT
from being loaded into stage/prod.  Thanks to Matt Tuchfarber for
bringing this to our attention.

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
