### PR TITLE
remove lms lettuce test in packer builds

### DIFF
--- a/playbooks/roles/test_build_server/files/test-development-environment.sh
+++ b/playbooks/roles/test_build_server/files/test-development-environment.sh
@@ -51,7 +51,6 @@ case "$1" in
 
     "lettuce")
         # Run some of the lettuce acceptance tests
-        paver test_acceptance -s lms --extra_args="lms/djangoapps/courseware/features/problems.feature -s 1"
         paver test_acceptance -s cms --extra_args="cms/djangoapps/contentstore/features/html-editor.feature -s 1" --fasttest
         ;;
 

--- a/playbooks/roles/test_build_server/files/test-development-environment.sh
+++ b/playbooks/roles/test_build_server/files/test-development-environment.sh
@@ -44,9 +44,9 @@ case "$1" in
     "bokchoy")
 
         # Run some of the bok-choy tests
-        paver test_bokchoy -t discussion/test_discussion.py::DiscussionTabSingleThreadTest
-        paver test_bokchoy -t studio/test_studio_outline.py::WarningMessagesTest::test_unreleased_published_locked --fasttest
-        paver test_bokchoy -t lms/test_lms_matlab_problem.py::MatlabProblemTest --fasttest
+        paver test_bokchoy -t discussion/test_discussion.py::DiscussionTabSingleThreadTest 2> /dev/null
+        paver test_bokchoy -t studio/test_studio_outline.py::WarningMessagesTest::test_unreleased_published_locked --fasttest 2> /dev/null
+        paver test_bokchoy -t lms/test_lms_matlab_problem.py::MatlabProblemTest --fasttest 2> /dev/null
         ;;
 
     "quality")

--- a/playbooks/roles/test_build_server/files/test-development-environment.sh
+++ b/playbooks/roles/test_build_server/files/test-development-environment.sh
@@ -25,33 +25,33 @@ case "$1" in
 
         # Now we can run a subset of the tests via paver.
         # Run some of the common/lib unit tests
-        paver test_lib -t common/lib/xmodule/xmodule/tests/test_stringify.py >> /dev/null 2>null1
+        paver test_lib -t common/lib/xmodule/xmodule/tests/test_stringify.py >> /dev/null 2>&1
 
         # Generate some coverage reports
-        paver coverage >> /dev/null 2>null1
+        paver coverage >> /dev/null 2>&1
 
         # Run some of the djangoapp unit tests
-        paver test_system -t lms/djangoapps/courseware/tests/tests.py >> /dev/null 2>null1
-        paver test_system -t cms/djangoapps/course_creators/tests/test_views.py >> /dev/null 2>null1
+        paver test_system -t lms/djangoapps/courseware/tests/tests.py >> /dev/null 2>&1
+        paver test_system -t cms/djangoapps/course_creators/tests/test_views.py >> /dev/null 2>&1
         ;;
 
     "js")
 
         # Run some of the javascript unit tests
-        paver test_js_run -s lms-coffee >> /dev/null 2>null1
+        paver test_js_run -s lms-coffee >> /dev/null 2>&1
         ;;
 
     "bokchoy")
 
         # Run some of the bok-choy tests
-        paver test_bokchoy -t discussion/test_discussion.py::DiscussionTabSingleThreadTest >> /dev/null 2>null1
-        paver test_bokchoy -t studio/test_studio_outline.py::WarningMessagesTest::test_unreleased_published_locked --fasttest >> /dev/null 2>null1
-        paver test_bokchoy -t lms/test_lms_matlab_problem.py::MatlabProblemTest --fasttest >> /dev/null 2>null1
+        paver test_bokchoy -t studio/test_studio_outline.py::WarningMessagesTest::test_unreleased_published_locked --fasttest >> /dev/null 2>&1
+        paver test_bokchoy -t lms/test_lms_matlab_problem.py::MatlabProblemTest --fasttest >> /dev/null 2>&1
+        paver test_bokchoy -t discussion/test_discussion.py::DiscussionTabSingleThreadTest >> /dev/null 2>&1
         ;;
 
     "quality")
         # Generate quality reports
-        paver run_quality >> /dev/null 2>null1
+        paver run_quality >> /dev/null 2>&1
         ;;
 
     *)

--- a/playbooks/roles/test_build_server/files/test-development-environment.sh
+++ b/playbooks/roles/test_build_server/files/test-development-environment.sh
@@ -25,20 +25,20 @@ case "$1" in
 
         # Now we can run a subset of the tests via paver.
         # Run some of the common/lib unit tests
-        paver test_lib -t common/lib/xmodule/xmodule/tests/test_stringify.py
+        paver test_lib -t common/lib/xmodule/xmodule/tests/test_stringify.py 2> /dev/null
 
         # Generate some coverage reports
-        paver coverage
+        paver coverage 2> /dev/null
 
         # Run some of the djangoapp unit tests
-        paver test_system -t lms/djangoapps/courseware/tests/tests.py
-        paver test_system -t cms/djangoapps/course_creators/tests/test_views.py
+        paver test_system -t lms/djangoapps/courseware/tests/tests.py 2> /dev/null
+        paver test_system -t cms/djangoapps/course_creators/tests/test_views.py 2> /dev/null
         ;;
 
     "js")
 
         # Run some of the javascript unit tests
-        paver test_js_run -s lms-coffee
+        paver test_js_run -s lms-coffee 2> /dev/null
         ;;
 
     "bokchoy")
@@ -51,7 +51,7 @@ case "$1" in
 
     "quality")
         # Generate quality reports
-        paver run_quality
+        paver run_quality 2> /dev/null
         ;;
 
     *)

--- a/playbooks/roles/test_build_server/files/test-development-environment.sh
+++ b/playbooks/roles/test_build_server/files/test-development-environment.sh
@@ -25,33 +25,33 @@ case "$1" in
 
         # Now we can run a subset of the tests via paver.
         # Run some of the common/lib unit tests
-        paver test_lib -t common/lib/xmodule/xmodule/tests/test_stringify.py 2> /dev/null
+        paver test_lib -t common/lib/xmodule/xmodule/tests/test_stringify.py >> /dev/null 2>null1
 
         # Generate some coverage reports
-        paver coverage 2> /dev/null
+        paver coverage >> /dev/null 2>null1
 
         # Run some of the djangoapp unit tests
-        paver test_system -t lms/djangoapps/courseware/tests/tests.py 2> /dev/null
-        paver test_system -t cms/djangoapps/course_creators/tests/test_views.py 2> /dev/null
+        paver test_system -t lms/djangoapps/courseware/tests/tests.py >> /dev/null 2>null1
+        paver test_system -t cms/djangoapps/course_creators/tests/test_views.py >> /dev/null 2>null1
         ;;
 
     "js")
 
         # Run some of the javascript unit tests
-        paver test_js_run -s lms-coffee 2> /dev/null
+        paver test_js_run -s lms-coffee >> /dev/null 2>null1
         ;;
 
     "bokchoy")
 
         # Run some of the bok-choy tests
-        paver test_bokchoy -t discussion/test_discussion.py::DiscussionTabSingleThreadTest 2> /dev/null
-        paver test_bokchoy -t studio/test_studio_outline.py::WarningMessagesTest::test_unreleased_published_locked --fasttest 2> /dev/null
-        paver test_bokchoy -t lms/test_lms_matlab_problem.py::MatlabProblemTest --fasttest 2> /dev/null
+        paver test_bokchoy -t discussion/test_discussion.py::DiscussionTabSingleThreadTest >> /dev/null 2>null1
+        paver test_bokchoy -t studio/test_studio_outline.py::WarningMessagesTest::test_unreleased_published_locked --fasttest >> /dev/null 2>null1
+        paver test_bokchoy -t lms/test_lms_matlab_problem.py::MatlabProblemTest --fasttest >> /dev/null 2>null1
         ;;
 
     "quality")
         # Generate quality reports
-        paver run_quality 2> /dev/null
+        paver run_quality >> /dev/null 2>null1
         ;;
 
     *)

--- a/playbooks/roles/test_build_server/files/test-development-environment.sh
+++ b/playbooks/roles/test_build_server/files/test-development-environment.sh
@@ -49,11 +49,6 @@ case "$1" in
         paver test_bokchoy -t lms/test_lms_matlab_problem.py::MatlabProblemTest --fasttest
         ;;
 
-    "lettuce")
-        # Run some of the lettuce acceptance tests
-        paver test_acceptance -s cms --extra_args="cms/djangoapps/contentstore/features/html-editor.feature -s 1" --fasttest
-        ;;
-
     "quality")
         # Generate quality reports
         paver run_quality

--- a/playbooks/roles/test_build_server/tasks/main.yml
+++ b/playbooks/roles/test_build_server/tasks/main.yml
@@ -45,4 +45,3 @@
     - "unit"
     - "js"
     - "bokchoy"
-    - "lettuce"


### PR DESCRIPTION
Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).

----

`lms/djangoapps/courseware/features/problems.feature` was removed from master recently, causing the build-packer-ami jobs to fail. There are only a few lettuce tests left in the platform, but until we are fully lettuce-free, we should still make sure that we can run it at least one. 
