### PR TITLE
Fix issue with rubygems 3.0.0 by pinning it to 2.7.8

### DIFF
--- a/playbooks/roles/rbenv/defaults/main.yml
+++ b/playbooks/roles/rbenv/defaults/main.yml
@@ -6,6 +6,7 @@ rbenv_rake_version: '10.4.2'
 rbenv_root: "{{ rbenv_dir }}/.rbenv"
 rbenv_gem_root: "{{ rbenv_dir }}/.gem"
 rbenv_gem_bin: "{{ rbenv_gem_root }}/bin"
+rbenv_rubygems_version: '2.7.8'
 rbenv_bin: "{{ rbenv_dir }}/.rbenv/bin"
 rbenv_shims: "{{ rbenv_root }}/shims"
 rbenv_path: "{{ rbenv_bin }}:{{ rbenv_shims }}:{{ rbenv_gem_bin }}:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"

--- a/playbooks/roles/rbenv/tasks/main.yml
+++ b/playbooks/roles/rbenv/tasks/main.yml
@@ -163,6 +163,14 @@
     - install
     - install:base
 
+- name: update rubygems
+  shell: "gem update --system {{ rbenv_rubygems_version }}"
+  become_user: "{{ rbenv_user }}"
+  environment: "{{ rbenv_environment }}"
+  tags:
+    - install
+    - install:base
+
 - name: install bundler
   shell: "gem install bundler -v {{ rbenv_bundler_version }}"
   become_user: "{{ rbenv_user }}"
@@ -187,14 +195,6 @@
     - install
     - install:base
 
-- name: update rubygems
-  shell: "gem install rubygems-update && update_rubygems"
-  become_user: "{{ rbenv_user }}"
-  environment: "{{ rbenv_environment }}"
-  tags:
-    - install
-    - install:base
-    
 - name: rehash
   shell: "rbenv rehash"
   become_user: "{{ rbenv_user }}"


### PR DESCRIPTION
Provisioning of forum service is failing with rubygems 3.0.0.

(cherry picked from commit e27ec8e6e59fabad55d3d52c54cf2beffce30e0b)

Failure when deploying `forums` AMI looks related to, but not the same as, the issue noted in https://github.com/edx/configuration/pull/4912
```
Error installing rubygems-update: rubygems-update requires Ruby version >= 2.3.0.
```

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
