### PR TITLE
nginx: Empty the robots.txt file when there are no rules

### DIFF
--- a/playbooks/roles/nginx/tasks/main.yml
+++ b/playbooks/roles/nginx/tasks/main.yml
@@ -124,7 +124,6 @@
     group: "{{ common_web_user }}"
     mode: 0644
   notify: reload nginx
-  when: NGINX_ROBOT_RULES|length > 0
   tags:
     - install
     - install:configuration


### PR DESCRIPTION
Overview
---
Adding rules to `NGINX_ROBOT_RULES` causes `robots.txt` to be created, however, making the list empty `NGINX_ROBOT_RULES: []` doesn't remove the file nor its contents.

This pull request makes it possible to empty the `robots.txt` file when there are no rules.

Without this change, it's not possible to remove the file or make it empty, it will stay with the last deny/allow rule forever. Unless removed manually.

Checklist
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
