### PR TITLE
Add CORS static assets in nginx DEVOPS-8273

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 - Role: nginx
+  - Added CORS Access-Control-Allow-Origin for static assets.
+  - Replaced wildcard Access-Control-Allow-Origin header for fonts. Make sure you set EDXAPP_CORS_ORIGIN_WHITELIST to include all your domains.
+
+- Role: nginx
   - Modified robots.txt.j2 to accept the Allow rule.
   - Modified robots.txt.j2 to accept either a single string or a list of strings for agent, disallow, and allow.
 

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/static-files.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/static-files.j2
@@ -21,10 +21,8 @@
     # http://www.red-team-design.com/firefox-doesnt-allow-cross-domain-fonts-by-default
     location ~ "/static/(?P<collected>.*\.[0-9a-f]{12}\.(eot|otf|ttf|woff|woff2)$)" {
         add_header "Cache-Control" $cache_header_long_lived always;
-{% if EDXAPP_CORS_ORIGIN_WHITELIST|length == 0 %}
+{% if EDXAPP_CORS_ORIGIN_WHITELIST|length > 0 %}
         add_header Access-Control-Allow-Origin $cors_origin;
-{% else %}
-        add_header Access-Control-Allow-Origin *;
 {% endif %}
         try_files /staticfiles/$collected /course_static/$collected =404;
     }

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/static-files.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/static-files.j2
@@ -8,6 +8,10 @@
     root {{ edxapp_data_dir }};
     try_files /staticfiles/$file /course_static/$file =404;
 
+{% if EDXAPP_CORS_ORIGIN_WHITELIST|length > 0 %}
+    add_header Access-Control-Allow-Origin $cors_origin;
+{% endif %}
+
     # return a 403 for static files that shouldn't be
     # in the staticfiles directory
     location ~ ^/static/(?:.*)(?:\.xml|\.json|README.TXT) {
@@ -17,7 +21,11 @@
     # http://www.red-team-design.com/firefox-doesnt-allow-cross-domain-fonts-by-default
     location ~ "/static/(?P<collected>.*\.[0-9a-f]{12}\.(eot|otf|ttf|woff|woff2)$)" {
         add_header "Cache-Control" $cache_header_long_lived always;
+{% if EDXAPP_CORS_ORIGIN_WHITELIST|length == 0 %}
+        add_header Access-Control-Allow-Origin $cors_origin;
+{% else %}
         add_header Access-Control-Allow-Origin *;
+{% endif %}
         try_files /staticfiles/$collected /course_static/$collected =404;
     }
 


### PR DESCRIPTION
This adds the CORS header if the whitelist is not empty. I think the existing ```add_header Access-Control-Allow-Origin *;``` for fonts might be a vulnerability, but I'm not sure of the risk of removing it for those who haven't set the whitelist. 

There's also a variable called ENABLE_CORS_HEADERS that doesn't seem to be used anywhere.

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
