### PR TITLE
Upgrade jenkins_build version to latest LTS: v2.150.2

### DIFF
--- a/playbooks/roles/jenkins_build/defaults/main.yml
+++ b/playbooks/roles/jenkins_build/defaults/main.yml
@@ -1,6 +1,6 @@
 build_jenkins_user_uid: 1002
 build_jenkins_group_gid: 1004
-build_jenkins_version: jenkins_2.89.4
+build_jenkins_version: jenkins_2.150.2
 build_jenkins_jvm_args: '-Djava.awt.headless=true -Xmx16384m -DsessionTimeout=60'
 
 build_jenkins_python_versions:
@@ -132,6 +132,9 @@ build_jenkins_plugins_list:
   - name: 'javadoc'
     version: '1.3'
     group: 'org.jenkins-ci.plugins'
+  - name: 'jdk-tool'
+    version: '1.2'
+    group: 'org.jenkins-ci.plugins'
   - name: 'job-dsl'
     version: '1.70'
     group: 'org.jenkins-ci.plugins'
@@ -214,7 +217,7 @@ build_jenkins_plugins_list:
     version: '1.14'
     group: 'org.jenkins-ci.plugins'
   - name: 'ssh-slaves'
-    version: '1.26'
+    version: '1.28.1'
     group: 'org.jenkins-ci.plugins'
   - name: 'structs'
     version: '1.14'

--- a/playbooks/roles/jenkins_common/templates/config/main_config.yml.j2
+++ b/playbooks/roles/jenkins_common/templates/config/main_config.yml.j2
@@ -29,4 +29,5 @@ FORMATTER:
     DISABLE_SYNTAX_HIGHLIGHTING: {{ jenkins_common_disable_syntax_highlighting }}
 CLI:
     CLI_ENABLED: false
-
+SETUP_WIZARD:
+    SETUP_WIZARD_ENABLED: false


### PR DESCRIPTION
Upgrade our build jenkins to the latest LTS 🎉

Also disables the setup wizard. This is not relevant because we are using ansible for that configuration.

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
