### PR TITLE
Change the default favicon through variables

### DIFF
--- a/playbooks/roles/nginx/defaults/main.yml
+++ b/playbooks/roles/nginx/defaults/main.yml
@@ -127,6 +127,8 @@ NGINX_EDXAPP_ERROR_PAGES:
 
 NGINX_EDXAPP_PROXY_INTERCEPT_ERRORS: false
 
+NGINX_EDXAPP_FAVICON_PATH: "/static/images/favicon.ico"
+
 CMS_HOSTNAME: '~^((stage|prod)-)?studio.*'
 
 nginx_template_dir: "edx/app/nginx/sites-available"

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/cms.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/cms.j2
@@ -69,7 +69,7 @@ error_page {{ k }} {{ v }};
   # via hiera.
   client_max_body_size 100M;
   
-  rewrite ^(.*)/favicon.ico$ /static/images/favicon.ico last;
+  rewrite ^(.*)/favicon.ico$ {{ NGINX_EDXAPP_FAVICON_PATH }} last;
 
   {% include "python_lib.zip.j2" %}
   {% include "common-settings.j2" %}

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
@@ -116,7 +116,7 @@ error_page {{ k }} {{ v }};
   # via hiera.
   client_max_body_size 4M;
 
-  rewrite ^(.*)/favicon.ico$ /static/images/favicon.ico last;
+  rewrite ^(.*)/favicon.ico$ {{ NGINX_EDXAPP_FAVICON_PATH }} last;
 
   {% include "python_lib.zip.j2" %}
   {% include "common-settings.j2" %}


### PR DESCRIPTION
This PR adds the capability to change the default favicon for LMS and STUDIO through ansible.


Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
