### PR TITLE
move cors map to common maps file

### DIFF
--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
@@ -44,22 +44,6 @@ geo $http_x_forwarded_for $embargo {
 {%- endif %}
 
 
-{% if EDXAPP_CORS_ORIGIN_WHITELIST|length > 0 %}
-  # The Origin request header indicates where a fetch originates from. It doesn't include any path information,
-  # but only the server name (e.g. https://www.example.com).
-  # See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Origin for details.
-  #
-  # Here we set the value that is included in the Access-Control-Allow-Origin response header. If the origin is one
-  # of our known hosts--served via HTTP or HTTPS--we allow for CORS. Otherwise, we set the "null" value, disallowing CORS.
-  map $http_origin $cors_origin {
-  default "null";
-  {% for host in EDXAPP_CORS_ORIGIN_WHITELIST %}
-    "~*^https?:\/\/{{ host|replace('.', '\.') }}$" $http_origin;
-  {% endfor %}
-  }
-{% endif %}
-
-
 server {
   # LMS configuration file for nginx, templated by ansible
 

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/maps.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/maps.j2
@@ -10,3 +10,20 @@ map $status $cache_header_short_lived {
   default   "max-age=300";
   404       "no-cache";
 }
+
+{% if EDXAPP_CORS_ORIGIN_WHITELIST is defined %}
+  {% if EDXAPP_CORS_ORIGIN_WHITELIST|length > 0 %}
+    # The Origin request header indicates where a fetch originates from. It doesn't include any path information,
+    # but only the server name (e.g. https://www.example.com).
+    # See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Origin for details.
+    #
+    # Here we set the value that is included in the Access-Control-Allow-Origin response header. If the origin is one
+    # of our known hosts--served via HTTP or HTTPS--we allow for CORS. Otherwise, we set the "null" value, disallowing CORS.
+    map $http_origin $cors_origin {
+    default "null";
+    {% for host in EDXAPP_CORS_ORIGIN_WHITELIST %}
+      "~*^https?:\/\/{{ host|replace('.', '\.') }}$" $http_origin;
+    {% endfor %}
+    }
+  {% endif %}
+{% endif %}


### PR DESCRIPTION
when CMS and LMS are deployed separately, https://github.com/edx/configuration/pull/5019 results in the CMS not having the CORS map.