### PR TITLE
install libaio for it jenkins

### DIFF
--- a/playbooks/roles/jenkins_it/defaults/main.yml
+++ b/playbooks/roles/jenkins_it/defaults/main.yml
@@ -8,6 +8,8 @@ it_jenkins_main_num_executors: 5
 oracle_path: '/opt/oracle'
 IT_ORACLE_S3_PATH: ''
 IT_ORACLE_INSTANT_CLIENT: ''
+it_oracle_packages:
+  - libaio1
 
 it_jenkins_python_versions:
   - python3.5-dev

--- a/playbooks/roles/jenkins_it/tasks/main.yml
+++ b/playbooks/roles/jenkins_it/tasks/main.yml
@@ -23,3 +23,12 @@
   file:
     path: "oracle_path/{{ IT_ORACLE_INSTANT_CLIENT }}"
     state: absent
+- name: Install oracle specific packages
+  apt:
+    name: '{{ item }}'
+    state: present
+    update_cache: yes
+  with_items: '{{ it_oracle_packages }}'
+  tags:
+    - install
+    - install:system-requirements


### PR DESCRIPTION
Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?

---

I had forgotten to install this package on Jenkins to be able use the Oracle instance client library from within the HRIS integration (for more information, see: https://oracle.github.io/odpi/doc/installation.html#linux)
