### PR TITLE
stop clobbering oracle install on it jenkins

### DIFF
--- a/playbooks/roles/jenkins_it/tasks/main.yml
+++ b/playbooks/roles/jenkins_it/tasks/main.yml
@@ -15,7 +15,10 @@
     - install
     - install:system-requirements
 - name: unzip instant client
-  shell: "unzip {{ oracle_path }}/{{ IT_ORACLE_INSTANT_CLIENT }} -d {{ oracle_path }}"
+  unarchive:
+    src: "{{ oracle_path }}/{{ IT_ORACLE_INSTANT_CLIENT }}"
+    dest: "{{ oracle_path }}"
+    creates: "{{ oracle_path }}/instantclient_12_2"
   tags:
     - install
     - install:system-requirements


### PR DESCRIPTION
Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?

---

Caught this trying to do a full reinstall. Ansible was trying to reinstall oracle over the existing installation and failing. This will now skip the unarchive step if it's target is present.