### PR TITLE
Fix the value of the oauth_public_url_root for edx_django_service

### DIFF
--- a/playbooks/roles/edx_django_service/defaults/main.yml
+++ b/playbooks/roles/edx_django_service/defaults/main.yml
@@ -157,7 +157,7 @@ edx_django_service_oauth2_url_root: '{{ COMMON_LMS_BASE_URL }}'
 edx_django_service_oauth2_issuer: '{{ COMMON_LMS_BASE_URL }}'
 edx_django_service_oauth2_logout_url: '{{ COMMON_OAUTH_LOGOUT_URL }}'
 edx_django_service_oauth2_provider_url: '{{ COMMON_OAUTH_PUBLIC_URL_ROOT }}'
-edx_django_service_oauth2_public_url_root: '{{ COMMON_OAUTH_PUBLIC_URL_ROOT }}'
+edx_django_service_oauth2_public_url_root: '{{ COMMON_LMS_BASE_URL }}'
 
 edx_django_service_jwt_audience: '{{ COMMON_JWT_AUDIENCE }}'
 edx_django_service_jwt_issuer: '{{ COMMON_JWT_ISSUER }}'


### PR DESCRIPTION
Configuration Pull Request
---

Didn't know that edx_django_service_oauth2_public_url_root should be LMS_BASE_URL, instead of the URL with `/oauth2/` path

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
