### PR TITLE
Revert "Fix the value of the oauth_public_url_root for edx_django_service"

### DIFF
--- a/playbooks/roles/edx_django_service/defaults/main.yml
+++ b/playbooks/roles/edx_django_service/defaults/main.yml
@@ -157,7 +157,7 @@ edx_django_service_oauth2_url_root: '{{ COMMON_LMS_BASE_URL }}'
 edx_django_service_oauth2_issuer: '{{ COMMON_LMS_BASE_URL }}'
 edx_django_service_oauth2_logout_url: '{{ COMMON_OAUTH_LOGOUT_URL }}'
 edx_django_service_oauth2_provider_url: '{{ COMMON_OAUTH_PUBLIC_URL_ROOT }}'
-edx_django_service_oauth2_public_url_root: '{{ COMMON_LMS_BASE_URL }}'
+edx_django_service_oauth2_public_url_root: '{{ COMMON_OAUTH_PUBLIC_URL_ROOT }}'
 
 edx_django_service_jwt_audience: '{{ COMMON_JWT_AUDIENCE }}'
 edx_django_service_jwt_issuer: '{{ COMMON_JWT_ISSUER }}'


### PR DESCRIPTION
Reverts edx/configuration#5051

We don't set the Public URL Root except in devstack.