### PR TITLE
Reverts PRs #5050 and #5051

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -718,6 +718,3 @@
   - Added `REGISTRAR_BACKEND_SERVICE_EDX_OAUTH2_SECRET` for backend auth.
   - Added `REGISTRAR_SERVICE_USER_EMAIL` to have a registrar service user on LMS
   - Added `REGISTRAR_SERVICE_USER_NAME` to have a registrar service user on LMS
-
-- Role: edx_django_service
-  - Added `SOCIAL_AUTH_EDX_OAUTH2_PUBLIC_URL_ROOT` for oauth2

--- a/playbooks/roles/edx_django_service/defaults/main.yml
+++ b/playbooks/roles/edx_django_service/defaults/main.yml
@@ -157,7 +157,6 @@ edx_django_service_oauth2_url_root: '{{ COMMON_LMS_BASE_URL }}'
 edx_django_service_oauth2_issuer: '{{ COMMON_LMS_BASE_URL }}'
 edx_django_service_oauth2_logout_url: '{{ COMMON_OAUTH_LOGOUT_URL }}'
 edx_django_service_oauth2_provider_url: '{{ COMMON_OAUTH_PUBLIC_URL_ROOT }}'
-edx_django_service_oauth2_public_url_root: '{{ COMMON_LMS_BASE_URL }}'
 
 edx_django_service_jwt_audience: '{{ COMMON_JWT_AUDIENCE }}'
 edx_django_service_jwt_issuer: '{{ COMMON_JWT_ISSUER }}'
@@ -203,7 +202,6 @@ edx_django_service_config_default:
   SOCIAL_AUTH_EDX_OAUTH2_ISSUER: '{{ edx_django_service_oauth2_issuer }}'
   SOCIAL_AUTH_EDX_OAUTH2_URL_ROOT: '{{ edx_django_service_oauth2_url_root }}'
   SOCIAL_AUTH_EDX_OAUTH2_LOGOUT_URL: '{{ edx_django_service_oauth2_logout_url }}'
-  SOCIAL_AUTH_EDX_OAUTH2_PUBLIC_URL_ROOT: '{{ edx_django_service_oauth2_public_url_root }}'
 
   BACKEND_SERVICE_EDX_OAUTH2_KEY: '{{ edx_django_service_backend_service_edx_oauth2_key }}'
   BACKEND_SERVICE_EDX_OAUTH2_SECRET: '{{ edx_django_service_backend_service_edx_oauth2_secret }}'


### PR DESCRIPTION
Reverts PRs #5050 and #5051

We don't set the public URL outside of devstack as it breaks stage/prod

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
