### PR TITLE
add REGISTRAR_SEGMENT_KEY

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -718,3 +718,6 @@
   - Added `REGISTRAR_BACKEND_SERVICE_EDX_OAUTH2_SECRET` for backend auth.
   - Added `REGISTRAR_SERVICE_USER_EMAIL` to have a registrar service user on LMS
   - Added `REGISTRAR_SERVICE_USER_NAME` to have a registrar service user on LMS
+
+- Role: registrar
+  - Added `REGISTRAR_SEGMENT_KEY` for segment.io event tracking.

--- a/playbooks/roles/registrar/defaults/main.yml
+++ b/playbooks/roles/registrar/defaults/main.yml
@@ -86,6 +86,9 @@ registrar_service_config_overrides:
   LANGUAGE_COOKIE_NAME: '{{ REGISTRAR_LANGUAGE_COOKIE_NAME }}'
   CSRF_COOKIE_SECURE: "{{ REGISTRAR_CSRF_COOKIE_SECURE }}"
 
+# API key for segment.io
+REGISTRAR_SEGMENT_KEY: !!null
+
 # See edx_django_service_automated_users for an example of what this should be
 REGISTRAR_AUTOMATED_USERS: {}
 


### PR DESCRIPTION
Added `REGISTRAR_SEGMENT_KEY` for segment.io event tracking.

[EDUCATOR-4131](https://openedx.atlassian.net/browse/EDUCATOR-4131)

Related:
https://github.com/edx/registrar/pull/39

---

Make sure that the following steps are done before merging:

  - [✖️] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ☑️ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ☑️ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ☑️] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ☑️ ] Add an entry to the CHANGELOG.
  - [ ✖️ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ✖️ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
