### PR TITLE
run different lettuce tests on packer builds

### DIFF
--- a/playbooks/roles/test_build_server/files/test-development-environment.sh
+++ b/playbooks/roles/test_build_server/files/test-development-environment.sh
@@ -51,7 +51,7 @@ case "$1" in
 
     "lettuce")
         # Run some of the lettuce acceptance tests
-        paver test_acceptance -s lms --extra_args="lms/djangoapps/courseware/features/problems.feature -s 1"
+        paver test_acceptance -s lms --extra_args="lms/djangoapps/courseware/features/lti.feature -s 1"
         paver test_acceptance -s cms --extra_args="cms/djangoapps/contentstore/features/html-editor.feature -s 1" --fasttest
         ;;
 


### PR DESCRIPTION
Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
---

The packer jobs have been failing for a while now, because one of tests run as part of a sanity check has been removed (a lettuce test). Part of me just wanted to stop running lettuce tests on the new workers all together, but I figured I should do the right thing and keep them until we are fully rid of lettuce, just in case.