### PR TITLE
[Ginkgo] Fix issue with rubygems >= 3.0.0 by pinning it to 2.7.9

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -57,3 +57,4 @@ Bill DeRusha <bill@edx.org>
 Jillian Vogel <jill@opencraft.com>
 Zubair Afzal <zubair.afzal@arbisoft.com>
 Kyle McCormick <kylemccor@gmail.com>
+Mostafa Hussein <mostafa.hussein91@gmail.com>

--- a/playbooks/roles/rbenv/defaults/main.yml
+++ b/playbooks/roles/rbenv/defaults/main.yml
@@ -3,6 +3,7 @@
 rbenv_version: 'v1.0.0'
 rbenv_bundler_version: '1.11.2'
 rbenv_rake_version: '10.4.2'
+rbenv_rubygems_version: '2.7.9'
 rbenv_root: "{{ rbenv_dir }}/.rbenv"
 rbenv_gem_root: "{{ rbenv_dir }}/.gem"
 rbenv_gem_bin: "{{ rbenv_gem_root }}/bin"

--- a/playbooks/roles/rbenv/tasks/main.yml
+++ b/playbooks/roles/rbenv/tasks/main.yml
@@ -188,13 +188,13 @@
     - install:base
 
 - name: update rubygems
-  shell: "gem install rubygems-update && update_rubygems"
+  shell: "gem update --system {{ rbenv_rubygems_version }}"
   become_user: "{{ rbenv_user }}"
   environment: "{{ rbenv_environment }}"
   tags:
     - install
     - install:base
-    
+
 - name: rehash
   shell: "rbenv rehash"
   become_user: "{{ rbenv_user }}"

--- a/playbooks/roles/rbenv/tasks/main.yml
+++ b/playbooks/roles/rbenv/tasks/main.yml
@@ -188,7 +188,7 @@
     - install:base
 
 - name: update rubygems
-  shell: "gem install rubygems-update -v {{ rbenv_rubygems_version }} && update_rubygems"
+  shell: "gem install rubygems-update -v {{ rbenv_rubygems_version }} && update_rubygems _{{ rbenv_rubygems_version }}_"
   become_user: "{{ rbenv_user }}"
   environment: "{{ rbenv_environment }}"
   tags:

--- a/playbooks/roles/rbenv/tasks/main.yml
+++ b/playbooks/roles/rbenv/tasks/main.yml
@@ -188,7 +188,7 @@
     - install:base
 
 - name: update rubygems
-  shell: "gem update --system {{ rbenv_rubygems_version }}"
+  shell: "gem install rubygems-update -v {{ rbenv_rubygems_version }} && update_rubygems"
   become_user: "{{ rbenv_user }}"
   environment: "{{ rbenv_environment }}"
   tags:


### PR DESCRIPTION
As Ginkgo needs ruby version 1.9.3 we wont be able to use rubygems with version higher than 2.7.9 otherwise we will face a compatibility issue

It could be solved by using `gem install rubygems-update -v '< 3.0.0'` but i preferred to follow the same way in this PR #5012  to make it as some kind of a standard fix