### PR TITLE
Estute/te 2881

### DIFF
--- a/playbooks/jenkins_worker_codejail.yml
+++ b/playbooks/jenkins_worker_codejail.yml
@@ -1,0 +1,18 @@
+# Configure a Jenkins worker instance specifically for running tests for
+# CodeJail, which requires specific set up with regards to python execution
+
+- name: Configure instance(s)
+  hosts: jenkins_worker
+  become: True
+  gather_facts: True
+  vars:
+    serial_count: 1
+    codejail_worker: True
+    COMMON_SECURITY_UPDATES: yes
+    SECURITY_UPGRADE_ON_ANSIBLE: true
+  serial: "{{ serial_count }}"
+  roles:
+    - aws
+    - docker-tools
+    - jenkins_worker
+    - codejail

--- a/playbooks/roles/codejail/defaults/main.yml
+++ b/playbooks/roles/codejail/defaults/main.yml
@@ -1,0 +1,12 @@
+---
+codejail_debian_packages:
+  - apparmor-utils
+codejail_python_versions:
+  - python2-7
+  - python3-5
+  - python3-6
+codejail_sandbox_user: 'sandbox'
+codejail_sandbox_group: 'sandbox'
+codejail_sandbox_name_base: 'codejail_sandbox'
+codejail_sandbox_env: '/home/{{ codejail_sandbox_user }}/{{ codejail_sandbox_name_base }}'
+codejail_sandbox_caller: 'ubuntu'

--- a/playbooks/roles/codejail/tasks/main.yml
+++ b/playbooks/roles/codejail/tasks/main.yml
@@ -1,0 +1,34 @@
+---
+- name: Install codejail specific system packages
+  apt:
+    name: '{{ item }}'
+    state: present
+    update_cache: yes
+  with_items: '{{ codejail_debian_packages }}'
+- name: Create group for sandbox user
+  group:
+    name: '{{ codejail_sandbox_group }}'
+    state: present
+    system: yes
+- name: Create sandbox user
+  user:
+    name: '{{ codejail_sandbox_user }}'
+    group: '{{ codejail_sandbox_group }}'
+    state: present
+- name: Create sandboxed virtual environments for every Python installation
+  shell: "virtualenv -p {{ item | replace('-','.') }} --always-copy {{ codejail_sandbox_env }}-{{ item }}"
+  become: true
+  with_items: "{{ codejail_python_versions }}"
+- name: Template sudoers file
+  template:
+    src:  "sudoers-template"
+    dest: "/etc/sudoers.d/01-sandbox"
+- name: Create AppArmor profiles for each Python installation
+  template:
+    src: "apparmor-template"
+    dest: '/etc/apparmor.d/home.{{ codejail_sandbox_user }}.{{ codejail_sandbox_name_base }}-{{ item }}.bin.python'
+  with_items: "{{ codejail_python_versions }}"
+- name: Parse AppArmor profiles
+  shell: 'apparmor_parser /etc/apparmor.d/home.{{ codejail_sandbox_user }}.{{ codejail_sandbox_name_base }}-{{ item }}.bin.python'
+  become: true
+  with_items: "{{ codejail_python_versions }}"

--- a/playbooks/roles/codejail/templates/apparmor-template
+++ b/playbooks/roles/codejail/templates/apparmor-template
@@ -1,0 +1,10 @@
+#include <tunables/global>
+
+{{ codejail_sandbox_env }}-{{ item }}/bin/python {
+    #include <abstractions/base>
+    #include <abstractions/python>
+
+    {{ codejail_sandbox_env }}-{{ item }}/** mr,
+    /tmp/codejail-*/ rix,
+    /tmp/codejail-*/** wrix,
+}

--- a/playbooks/roles/codejail/templates/sudoers-template
+++ b/playbooks/roles/codejail/templates/sudoers-template
@@ -1,0 +1,5 @@
+{% for python_version in codejail_python_versions %}
+{{ codejail_sandbox_caller }} ALL=({{ codejail_sandbox_user }}) SETENV:NOPASSWD:{{ codejail_sandbox_env }}-{{ python_version }}/bin/python
+{% endfor %}
+{{ codejail_sandbox_caller }} ALL=({{ codejail_sandbox_user }}) SETENV:NOPASSWD:/usr/bin/find
+{{ codejail_sandbox_caller }} ALL=(ALL) NOPASSWD:/usr/bin/pkill

--- a/playbooks/roles/jenkins_worker/defaults/main.yml
+++ b/playbooks/roles/jenkins_worker/defaults/main.yml
@@ -21,3 +21,11 @@ packer_url: "https://releases.hashicorp.com/packer/0.8.6/packer_0.8.6_linux_amd6
 
 nodejs_version: "8"
 ansible_distribution_release: "xenial"
+
+jenkins_worker_python_versions:
+  - python2.7
+  - python2.7-dev
+  - python3.5
+  - python3.5-dev
+  - python3.6
+  - python3.6-dev

--- a/playbooks/roles/jenkins_worker/meta/main.yml
+++ b/playbooks/roles/jenkins_worker/meta/main.yml
@@ -1,7 +1,8 @@
 ---
 dependencies:
   - common
-  - jscover
+  - role: jscover
+    when: platform_worker is defined
   - role: oraclejdk
 
   # dependencies for edx-app jenkins worker:
@@ -28,12 +29,12 @@ dependencies:
     # The SDK version used to compile the project | 3 | Android SDK Platform 27
     android_build_targets: "\"platforms;android-27\""
 
-# other android dependencies that cannot be tested via the android sdk manager. instead, stat the android_test_path to test for presence of the package
-# Plateform Tools | 28.0.1 | Android SDK Platform-Tools
-# The BuildTools version | 27.0.3 | Android SDK Build-Tools 27.0.3
-# Additional components 
-# extras;google;m2repository | 58 | Google Repository
-# extras;android;m2repository| 47.0.0 | Android Support Repository
+    # other android dependencies that cannot be tested via the android sdk manager. instead, stat the android_test_path to test for presence of the package
+    # Plateform Tools | 28.0.1 | Android SDK Platform-Tools
+    # The BuildTools version | 27.0.3 | Android SDK Build-Tools 27.0.3
+    # Additional components 
+    # extras;google;m2repository | 58 | Google Repository
+    # extras;android;m2repository| 47.0.0 | Android Support Repository
     android_tools:
     - { package: "\"platform-tools\"", android_test_path: 'platform-tools' }
     - { package: "\"build-tools;27.0.3\"", android_test_path: 'build-tools/27.0.3' }

--- a/playbooks/roles/jenkins_worker/tasks/python.yml
+++ b/playbooks/roles/jenkins_worker/tasks/python.yml
@@ -1,13 +1,24 @@
 ---
+# Versions of Python newer than 3.5 are not available in the default
+# package index for Ubuntu 16.04. Add the deadsnakes PPA for anything
+# newer
+- name: add deadsnakes PPA for newer Python versions
+  apt_repository:
+    repo: "ppa:fkrull/deadsnakes"
+    update_cache: yes
+  when: ansible_distribution_release == 'xenial'
+
+# Install newer versions of python for testing, but do not set them
+# as the default version
+- name: Install python versions
+  apt:
+    name: '{{ item }}'
+    state: present
+    update_cache: yes
+  with_items: '{{ jenkins_worker_python_versions }}'
 
 # Requests library is required for the github status script.
 - name: Install requests Python library
-  pip: name=requests state=present
-
-# Install Python 3.5. For now, do not set it as the default python
-# version
-- name: Install python 3.5
-  apt:
-    name: 'python3.5-dev'
+  pip:
+    name: requests
     state: present
-    update_cache: yes

--- a/util/install/ansible-bootstrap.sh
+++ b/util/install/ansible-bootstrap.sh
@@ -108,7 +108,7 @@ fi
 
 # Required for add-apt-repository
 apt-get install -y software-properties-common
-if [[ "${SHORT_DIST}" != bionic ]] ;then
+if [[ "${SHORT_DIST}" != bionic ]] && [[ "${SHORT_DIST}" != xenial ]];then
   apt-get install -y python-software-properties
 fi
 

--- a/util/packer/jenkins_worker_codejail.json
+++ b/util/packer/jenkins_worker_codejail.json
@@ -1,0 +1,69 @@
+{
+  "variables": {
+    "aws_access_key": "{{env `AWS_ACCESS_KEY_ID`}}",
+    "aws_secret_key": "{{env `AWS_SECRET_ACCESS_KEY`}}",
+    "new_relic_key": "{{env `NEW_RELIC_KEY`}}",
+    "playbook_remote_dir": "/tmp/packer-edx-playbooks",
+    "venv_dir": "/edx/app/edx_ansible/venvs/edx_ansible",
+    "ami": "{{env `JENKINS_WORKER_AMI`}}",
+    "security_group": "{{env `AWS_SECURITY_GROUP`}}",
+    "delete_or_keep": "{{env `DELETE_OR_KEEP_AMI`}}",
+    "remote_branch": "{{env `REMOTE_BRANCH`}}",
+    "jenkins_worker_key_url": "{{env `JENKINS_WORKER_KEY_URL`}}"
+  },
+  "builders": [{
+    "type": "amazon-ebs",
+    "access_key": "{{user `aws_access_key`}}",
+    "secret_key": "{{user `aws_secret_key`}}",
+    "ami_name": "jenkins_worker_codejail-{{isotime | clean_ami_name}}",
+    "instance_type": "m3.medium",
+    "region": "us-east-1",
+    "source_ami": "{{user `ami`}}",
+    "ssh_username": "ubuntu",
+    "ami_description": "jenkins worker codejail",
+    "iam_instance_profile": "jenkins-worker",
+    "security_group_id": "{{user `security_group`}}",
+    "tags": {
+      "delete_or_keep": "{{user `delete_or_keep`}}"
+    },
+    "launch_block_device_mappings": [{
+      "delete_on_termination": true,
+      "device_name": "/dev/sda1",
+      "volume_size": "40",
+      "volume_type": "gp2"
+    }]
+  }],
+  "provisioners": [{
+    "type": "shell",
+    "inline": ["rm -rf {{user `playbook_remote_dir`}}",
+      "mkdir {{user `playbook_remote_dir`}}"]
+  }, {
+    "type": "file",
+    "source": "stop-automatic-updates.sh",
+    "destination": "{{user `playbook_remote_dir`}}/stop-automatic-updates.sh"
+  }, {
+    "type": "file",
+    "source": "../../util/install/ansible-bootstrap.sh",
+    "destination": "{{user `playbook_remote_dir`}}/ansible-bootstrap.sh"
+  }, {
+    "type": "shell",
+    "inline": ["cd {{user `playbook_remote_dir`}}",
+      "export CONFIGURATION_VERSION='{{user `remote_branch`}}'",
+      "sudo bash ./stop-automatic-updates.sh",
+      "sudo bash ./ansible-bootstrap.sh"
+    ]
+  }, {
+    "type": "shell-local",
+    "command": "rm ../../playbooks/edx-east"
+  }, {
+    "type": "ansible-local",
+    "playbook_file": "../../playbooks/jenkins_worker_codejail.yml",
+    "playbook_dir": "../../playbooks",
+    "command": ". {{user `venv_dir`}}/bin/activate && ansible-playbook",
+    "inventory_groups": "jenkins_worker",
+    "extra_arguments": [
+      "-e \"NEWRELIC_LICENSE_KEY={{user `new_relic_key`}} jenkins_worker_key_url='{{user `jenkins_worker_key_url`}}'\"",
+      "-vvv"
+      ]
+  }]
+}


### PR DESCRIPTION
Contained in the PR:
* a role for configuring sandboxed python virtualenvs for using/testing codejail for multiple python versions
* a play and packer script for creating a jenkins worker with this codejail environment

I also stopped installing `python-software-properties` when using xenial as a base OS version. It is flaky and sometimes not available. Builds were often, but not always, failing with:
```
00:00:55.448     amazon-ebs: Package python-software-properties is not available, but is referred to by another package.
00:00:55.449     amazon-ebs: This may mean that the package is missing, has been obsoleted, or
00:00:55.450     amazon-ebs: is only available from another source
00:00:55.451     amazon-ebs: However the following packages replace it:
00:00:55.453     amazon-ebs: software-properties-common
```

Successful build of this role here: https://build.testeng.edx.org/job/build-packer-ami/14003/