### PR TITLE
clean up groovy scripts

### DIFF
--- a/playbooks/roles/jenkins_common/tasks/main.yml
+++ b/playbooks/roles/jenkins_common/tasks/main.yml
@@ -363,3 +363,30 @@
     - install:plugins
     - install:jenkins-configuration
     - jenkins:promote-to-production
+
+- name: Wait until the Jenkins service has fully initialized
+  uri:
+    url: "http://127.0.0.1:{{ jenkins_common_port }}"
+    status_code: 200
+  register: result
+  until: result.status == 200
+  retries: 30
+  delay: 1
+  tags:
+    - install:base
+    - install:plugins
+    - install:jenkins-configuration
+
+- name: Delete any existing jenkins-configuration folders to avoid unwanted configuration
+  file:
+    path: '{{ item }}'
+    owner: '{{ jenkins_common_user }}'
+    group: '{{ jenkins_common_group }}'
+    state: absent
+  with_items:
+    - '{{ jenkins_common_home }}/init.groovy.d'
+    - '{{ jenkins_common_config_path }}'
+  tags:
+    - install:base
+    - install:plugins
+    - install:jenkins-configuration


### PR DESCRIPTION
There was some code to do this in the past, but it was removed. Perhaps it was a branch? Either way, this codifies the removal of the init scripts, rather than manually removing them, which can be error prone. This is not an option for local-dev, because it does not use systemd.