### PR TITLE
SE-1014 Campus.il Updates seed job template to deal with latest job-dsl library

### DIFF
--- a/playbooks/roles/jenkins_analytics/templates/seedJob.groovy
+++ b/playbooks/roles/jenkins_analytics/templates/seedJob.groovy
@@ -13,15 +13,17 @@ job('{{ jenkins_seed_job.name }}') {
       remote {
         url('{{ scm.url }}')
         branch("{{ scm.branch | default('master') }}")
-        {% if scm.dest %}
-          relativeTargetDir('{{ scm.dest }}')
-        {% endif %}
         {% if scm.credential_id %}
           credentials('{{ scm.credential_id }}')
         {% endif %}
       }
-      clean(true)
-      pruneBranches(true)
+      extensions {
+        {% if scm.dest %}
+          relativeTargetDirectory('{{ scm.dest }}')
+        {% endif %}
+        cleanAfterCheckout()
+        pruneBranches()
+      }
     }
     {% endif %}
   {% endfor %}


### PR DESCRIPTION
When setting up a new Jenkins server for olivex, I encountered some issues with the seed job generated by the template in this repository.

The issues are most likely related to changes in the underlying [job-dsl-plugin](https://jenkinsci.github.io/job-dsl-plugin/#path/multiJob) version, but instead of reverting that to an older version, we upgraded the seed job template to bring it in line with the DSLs in https://github.com/edx/jenkins-job-dsl, e.g. [AnalyticsConstants.groovy](https://github.com/edx/jenkins-job-dsl/blob/master/src/main/groovy/org/edx/jenkins/dsl/AnalyticsConstants.groovy).

**JIRA tickets**: [OSPR-3383](https://openedx.atlassian.net/browse/OSPR-3383)

**Discussions**: See also https://github.com/edx-olive/configuration/pull/4

**Merge deadline**: "None"

**Testing instructions**:

1. Provision a new jenkins server [configured to use the analytics seed job](https://github.com/edx/configuration/tree/master/playbooks/roles/jenkins_analytics/), e.g.
   ```
   ansible-playbook -i '<instance_ip>' \
         -e @/path/to/private/jenkins-extra-vars.yml analytics-jenkins.yml
   ```

Or see instead the [olivex stage jenkins service](https://github.com/edx-olive/olive-internal/wiki#admin-hosts) whose analytics jobs were provisioned using these updates.

**Reviewers**
- [ ] @pkulkark
- [ ] @edx/devops  TBD

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? No.
 - [ ] Are you making a complicated change? No.
 - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?  N/A