### PR TITLE
Fix packer builds for jenkins_worker

### DIFF
--- a/playbooks/roles/edxlocal/tasks/main.yml
+++ b/playbooks/roles/edxlocal/tasks/main.yml
@@ -41,14 +41,14 @@
     name: "{{ ANALYTICS_API_DATABASES.default.USER }}"
     password: "{{ ANALYTICS_API_DATABASES.default.PASSWORD }}"
     priv: '{{ ANALYTICS_API_DATABASES.default.NAME }}.*:ALL/reports.*:SELECT'
-  when: ANALYTICS_API_DATABASES.default is defined
+  when: ANALYTICS_API_DATABASES is defined and ANALYTICS_API_DATABASES.default is defined
 
 - name: create read-only reports user for the analytics-api
   mysql_user:
     name: "{{ ANALYTICS_API_DATABASES.reports.USER }}"
     password: "{{ ANALYTICS_API_DATABASES.reports.PASSWORD }}"
     priv: '{{ ANALYTICS_API_DATABASES.reports.NAME }}.*:SELECT'
-  when: ANALYTICS_API_DATABASES.reports is defined
+  when: ANALYTICS_API_DATABASES is defined and ANALYTICS_API_DATABASES.reports is defined
 
 - name: create a database for the hive metastore
   mysql_db:

--- a/playbooks/roles/test_build_server/files/test-development-environment.sh
+++ b/playbooks/roles/test_build_server/files/test-development-environment.sh
@@ -46,13 +46,6 @@ case "$1" in
         # Run some of the bok-choy tests
         paver test_bokchoy -t discussion/test_discussion.py::DiscussionTabSingleThreadTest
         paver test_bokchoy -t studio/test_studio_outline.py::WarningMessagesTest::test_unreleased_published_locked --fasttest
-        paver test_bokchoy -t lms/test_lms_matlab_problem.py::MatlabProblemTest --fasttest
-        ;;
-
-    "lettuce")
-        # Run some of the lettuce acceptance tests
-        paver test_acceptance -s lms --extra_args="lms/djangoapps/courseware/features/problems.feature -s 1"
-        paver test_acceptance -s cms --extra_args="cms/djangoapps/contentstore/features/html-editor.feature -s 1" --fasttest
         ;;
 
     "quality")

--- a/playbooks/roles/test_build_server/tasks/main.yml
+++ b/playbooks/roles/test_build_server/tasks/main.yml
@@ -45,4 +45,3 @@
     - "unit"
     - "js"
     - "bokchoy"
-    - "lettuce"


### PR DESCRIPTION
The conditional check `ANALYTICS_API_DATABASES.default is defined` throws an error if `ANALYTICS_API_DATABASES` isn't defined. I don't think this is by design, and was causing our packer builds for jenkins workers to fail for a while. I could initialize `ANALYTICS_API_DATABASES` to be empty in our jenkins_worker role's default, but this seems like a better fix.

Also lettuce tests and the matlab bokchoy tests we were running are a thing of the past.

Build: https://build.testeng.edx.org/job/build-packer-ami/14273/
