### PR TITLE
Updated the `read_only` MySQL account to have `SELECT` privileges.

### DIFF
--- a/playbooks/roles/edxlocal/tasks/main.yml
+++ b/playbooks/roles/edxlocal/tasks/main.yml
@@ -68,7 +68,7 @@
   mysql_user:
     name: "{{ COMMON_MYSQL_READ_ONLY_USER }}"
     password: "{{ COMMON_MYSQL_READ_ONLY_PASS }}"
-    priv: "*.*:ALL"
+    priv: "*.*:SELECT"
 
 - name: setup the admin db user
   mysql_user:


### PR DESCRIPTION
Per edx-ops recommendation this account should have more restrictive permissions rather than all available.

Slack (#ops): https://openedx.slack.com/archives/C08B4LZEZ/p1558451093002900
