### PR TITLE
Downgrade ansbile due to git clone bug

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-ansible==2.2.3.0
+ansible==2.2.1.0
 asn1crypto==0.24.0        # via cryptography
 awscli==1.15.19
 bcrypt==3.1.6             # via paramiko

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -1,6 +1,6 @@
 # Standard dependencies for Ansible runs
 
-ansible==2.2.3.0
+ansible==2.2.1.0
 awscli==1.15.19
 boto==2.48.0
 boto3==1.7.14


### PR DESCRIPTION
Sadly I need to downgrade ansible because it breaks when trying to clone git repos for the first time because it tries to print a warning using a function that doesn't exist. The real solution is to upgrade to 2.3.0 or greater, but I don't have time for that right now.

```failed: [10.3.123.4] (item={u'DOMAIN': u'github.com', u'PROTOCOL': u'https', u'DESTINATION': u'/edx/app/designer/designer', u'SSH_KEY': None, u'REPO': u'portal-designer.git', u'VERSION': u'76b21a2be52d1305b89387222d086c366eaa4357', u'PATH': u'edx'}) => {
    "failed": true,
    "invocation": {
        "module_name": "git"
    },
    "item": {
        "DESTINATION": "/edx/app/designer/designer",
        "DOMAIN": "github.com",
        "PATH": "edx",
        "PROTOCOL": "https",
        "REPO": "portal-designer.git",
        "SSH_KEY": null,
        "VERSION": "76b21a2be52d1305b89387222d086c366eaa4357"
    },
    "module_stderr": "Shared connection to 10.3.123.4 closed.\r\n",
    "module_stdout": "Traceback (most recent call last):\r\n  File \"/tmp/ansible_E3oCNp/ansible_module_git.py\", line 1038, in <module>\r\n    main()\r\n  File \"/tmp/ansible_E3oCNp/ansible_module_git.py\", line 952, in main\r\n    clone(git_path, module, repo, dest, remote, depth, version, bare, reference, refspec, verify_commit)\r\n  File \"/tmp/ansible_E3oCNp/ansible_module_git.py\", line 391, in clone\r\n    module.warn(\"Ignoring depth argument. \"\r\nAttributeError: 'AnsibleModule' object has no attribute 'warn'\r\n",
    "msg": "MODULE FAILURE"
```

Interestingly the bug was introduced fixing a but @nedbat submitted to ansbile. ansible/ansible#21316

Line causing break https://github.com/ansible/ansible/pull/21712/files#diff-423dabf0f8d841053684543485e386c9R434

:(

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
