### PR TITLE
Fixes for Ansible >= 2.6

### DIFF
--- a/playbooks/callback_plugins/sqs.py
+++ b/playbooks/callback_plugins/sqs.py
@@ -15,6 +15,10 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
+# From https://github.com/ansible/ansible/issues/31527#issuecomment-335495855
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
 
 import os
 import sys

--- a/playbooks/callback_plugins/task_timing.py
+++ b/playbooks/callback_plugins/task_timing.py
@@ -1,3 +1,7 @@
+# From https://github.com/ansible/ansible/issues/31527#issuecomment-335495855
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
 import collections
 from datetime import datetime, timedelta
 import json

--- a/playbooks/roles/vhost/tasks/main.yml
+++ b/playbooks/roles/vhost/tasks/main.yml
@@ -114,7 +114,7 @@
     line: "PasswordAuthentication {{ COMMON_SSH_PASSWORD_AUTH }}"
   register: sshd_config_line2
 
-- name: Restart ssh
+- name: Restart ssh (ubuntu/debian)
   service:
     name: ssh
     state: restarted
@@ -123,7 +123,7 @@
     (sshd_config_line1.changed or sshd_config_line2.changed) and
     ansible_distribution in common_debian_variants
 
-- name: Restart ssh
+- name: Restart ssh (redhat)
   service:
     name: sshd
     state: restarted


### PR DESCRIPTION
These are fixes that we need for newer ansible that should still work on 2.2

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
