### PR TITLE
Fix "Using tests as filters is deprecated"

### DIFF
--- a/playbooks/restart_supervisor.yml
+++ b/playbooks/restart_supervisor.yml
@@ -11,5 +11,5 @@
         name: "{{ supervisor_service }}"
         state: restarted
       register: rc
-      until: rc|success
+      until: rc is success
       retries: 5

--- a/playbooks/restart_supervisor.yml
+++ b/playbooks/restart_supervisor.yml
@@ -11,5 +11,5 @@
         name: "{{ supervisor_service }}"
         state: restarted
       register: rc
-      until: rc is success
+      until: rc is succeeded
       retries: 5

--- a/playbooks/roles/analytics_pipeline/tasks/main.yml
+++ b/playbooks/roles/analytics_pipeline/tasks/main.yml
@@ -182,7 +182,7 @@
     - install
     - install:app-requirements
   register: libcp
-  until: libcp is success
+  until: libcp is succeeded
   retries: 6
   delay: 10
 

--- a/playbooks/roles/analytics_pipeline/tasks/main.yml
+++ b/playbooks/roles/analytics_pipeline/tasks/main.yml
@@ -182,7 +182,7 @@
     - install
     - install:app-requirements
   register: libcp
-  until: libcp|success
+  until: libcp is success
   retries: 6
   delay: 10
 

--- a/playbooks/roles/ansible-role/tasks/main.yml
+++ b/playbooks/roles/ansible-role/tasks/main.yml
@@ -6,7 +6,7 @@
 
 - name: Prompt for overwrite
   pause: prompt="Role {{ my_role_name }} exists. Overwrite? Touch any key to continue or <CTRL>-c, then a, to abort."
-  when: role_exists | success
+  when: role_exists is success
 
 - name: Create role directories
   file:

--- a/playbooks/roles/ansible-role/tasks/main.yml
+++ b/playbooks/roles/ansible-role/tasks/main.yml
@@ -6,7 +6,7 @@
 
 - name: Prompt for overwrite
   pause: prompt="Role {{ my_role_name }} exists. Overwrite? Touch any key to continue or <CTRL>-c, then a, to abort."
-  when: role_exists is success
+  when: role_exists is succeeded
 
 - name: Create role directories
   file:

--- a/playbooks/roles/launch_ec2/tasks/main.yml
+++ b/playbooks/roles/launch_ec2/tasks/main.yml
@@ -68,7 +68,7 @@
     record: "{{ dns_name }}.{{ dns_zone }}"
     value: "{{ item.public_dns_name }}"
   register: task_result
-  until: task_result|succeeded
+  until: task_result is succeeded
   retries: 5
   delay: 30
   with_items: "{{ ec2.instances }}"
@@ -84,7 +84,7 @@
     record: "{{ item[1] }}-{{ dns_name }}.{{ dns_zone }}"
     value: "{{ item[0].public_dns_name }}"
   register: task_result
-  until: task_result|succeeded
+  until: task_result is succeeded
   retries: 5
   delay: 30
   with_nested:
@@ -102,7 +102,7 @@
     record: "{{ item[1] }}"
     value: "{{ item[0].public_dns_name }}"
   register: task_result
-  until: task_result|succeeded
+  until: task_result is succeeded
   retries: 5
   delay: 30
   with_nested:

--- a/playbooks/roles/rbenv/tasks/main.yml
+++ b/playbooks/roles/rbenv/tasks/main.yml
@@ -94,7 +94,7 @@
 
 - name: if ruby-build exists, which versions we can install
   command: /usr/local/bin/ruby-build --definitions
-  when: rbuild_present|success
+  when: rbuild_present is success
   register: installable_ruby_vers
   ignore_errors: yes
   tags:

--- a/playbooks/roles/rbenv/tasks/main.yml
+++ b/playbooks/roles/rbenv/tasks/main.yml
@@ -94,7 +94,7 @@
 
 - name: if ruby-build exists, which versions we can install
   command: /usr/local/bin/ruby-build --definitions
-  when: rbuild_present is success
+  when: rbuild_present is succeeded
   register: installable_ruby_vers
   ignore_errors: yes
   tags:

--- a/playbooks/roles/splunkforwarder/tasks/main.yml
+++ b/playbooks/roles/splunkforwarder/tasks/main.yml
@@ -38,7 +38,7 @@
     dest: "/tmp/{{ SPLUNKFORWARDER_DEB }}"
     url: "{{ SPLUNKFORWARDER_PACKAGE_URL }}"
   register: download_deb
-  until: download_deb|succeeded
+  until: download_deb is succeeded
   retries: 5
   when: ansible_distribution in common_debian_variants
 
@@ -52,7 +52,7 @@
     dest: "/tmp/{{ SPLUNKFORWARDER_RPM }}"
     url: "{{ SPLUNKFORWARDER_PACKAGE_URL }}"
   register: download_rpm
-  until: download_rpm|succeeded
+  until: download_rpm is succeeded
   retries: 5
   when: ansible_distribution in common_redhat_variants
 

--- a/playbooks/roles/user/tasks/main.yml
+++ b/playbooks/roles/user/tasks/main.yml
@@ -120,7 +120,7 @@
   when: item.get('state', 'present') == 'present' and item.github is defined
   with_items: "{{ user_info }}"
   register: github_users_return
-  until: github_users_return|succeeded
+  until: github_users_return is succeeded
   retries: 5
 
 - name: Print warning if github user(s) missing ssh key
@@ -144,7 +144,7 @@
     key: "https://github.com/{{ item.name }}.keys"
   when: item.github is defined and item.get('state', 'present') == 'present'
   register: task_result
-  until: task_result|succeeded
+  until: task_result is succeeded
   retries: 5
   with_items: "{{ user_info }}"
 


### PR DESCRIPTION
Fix this deprecation warning in Ansible 2.5

```
[DEPRECATION WARNING]: Using tests as filters is deprecated. Instead of using
`result|succeeded` instead use `result is succeeded`. This feature will be
removed in version 2.9.
```

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
