### PR TITLE
base_ami_id overrides ami_id if its set

### DIFF
--- a/playbooks/continuous_delivery/launch_instance.yml
+++ b/playbooks/continuous_delivery/launch_instance.yml
@@ -58,10 +58,10 @@
       launch_ami_id: "{{ ami_id }}"
     when: ami_id is defined
 
-  - name: Use base_ami_id if ami_id is not available
+  - name: Use base_ami_id if base_ami_id is available
     set_fact:
       launch_ami_id: "{{ base_ami_id }}"
-    when: ami_id is not defined
+    when: base_ami_id is defined
 
   - name: Launch EC2 instance
     ec2:


### PR DESCRIPTION
the base_ami_id variable is ignored if there is a running, active instance of the service that is being built.  sometimes, we need to override the ami_id.