### PR TITLE
update jinja2

### DIFF
--- a/playbooks/roles/aws/templates/requirements.txt.j2
+++ b/playbooks/roles/aws/templates/requirements.txt.j2
@@ -4,9 +4,9 @@
 #
 #    make upgrade
 #
-awscli==1.16.159
+awscli==1.16.169
 boto==2.49.0
-botocore==1.12.149        # via awscli, s3transfer
+botocore==1.12.159        # via awscli, s3transfer
 colorama==0.3.9           # via awscli
 docutils==0.14            # via awscli, botocore
 futures==3.2.0 ; python_version == "2.7"
@@ -19,4 +19,4 @@ rsa==3.4.2                # via awscli
 s3cmd==1.6.1
 s3transfer==0.2.0         # via awscli
 six==1.12.0               # via python-dateutil
-urllib3==1.24.3           # via botocore
+urllib3==1.25.3           # via botocore

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ certifi==2019.3.9         # via requests
 cffi==1.12.3              # via bcrypt, cryptography, pynacl
 chardet==3.0.4            # via requests
 colorama==0.3.7           # via awscli
-cryptography==2.6.1       # via paramiko
+cryptography==2.7         # via ansible, paramiko
 datadog==0.8.0
 decorator==4.4.0          # via datadog, networkx
 docopt==0.6.2
@@ -25,7 +25,7 @@ enum34==1.1.6             # via cryptography
 futures==3.2.0 ; python_version == "2.7"
 idna==2.6                 # via requests
 ipaddress==1.0.22         # via cryptography
-jinja2==2.8
+jinja2==2.10.1
 jmespath==0.9.4           # via boto3, botocore
 markupsafe==1.0
 mysql-python==1.2.5

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -8,7 +8,7 @@ datadog==0.8.0
 docopt==0.6.2
 ecdsa==0.13
 futures ; python_version == "2.7"   # via s3transfer
-Jinja2==2.8
+Jinja2==2.10.1
 MarkupSafe==1.0
 MySQL-python==1.2.5                 # Needed for the mysql_db module
 networkx==1.11

--- a/util/elasticsearch/requirements.txt
+++ b/util/elasticsearch/requirements.txt
@@ -6,5 +6,5 @@
 #
 deepdiff==3.1.0
 elasticsearch==0.4.5
-jsonpickle==1.1           # via deepdiff
-urllib3==1.25.2           # via elasticsearch
+jsonpickle==1.2           # via deepdiff
+urllib3==1.25.3           # via elasticsearch

--- a/util/jenkins/check_celery_progress/requirements.txt
+++ b/util/jenkins/check_celery_progress/requirements.txt
@@ -31,4 +31,4 @@ requests==2.22.0          # via opsgenie-sdk
 rsa==3.4.2                # via awscli
 s3transfer==0.1.13        # via awscli, boto3
 six==1.12.0               # via opsgenie-sdk, python-dateutil
-urllib3==1.25.2           # via opsgenie-sdk, requests
+urllib3==1.25.3           # via opsgenie-sdk, requests

--- a/util/vpc-tools/requirements.txt
+++ b/util/vpc-tools/requirements.txt
@@ -11,4 +11,4 @@ docopt==0.6.2
 idna==2.8                 # via requests
 python-simple-hipchat==0.2
 requests==2.22.0
-urllib3==1.25.2           # via requests
+urllib3==1.25.3           # via requests


### PR DESCRIPTION
PROD-343
---
### Description
This PR upgrades the jinja2 to the latest version. For more information, please see PROD-343.

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
