### PR TITLE
Update node version for prospectus.

### DIFF
--- a/playbooks/roles/prospectus/defaults/main.yml
+++ b/playbooks/roles/prospectus/defaults/main.yml
@@ -29,7 +29,7 @@ PROSPECTUS_GIT_IDENTITY: "none"
 prospectus_repo: 'ssh://git@github.com/edx/prospectus.git'
 prospectus_version: 'master'
 edx_django_service_use_python3: false
-prospectus_node_version:  '{{ common_node_version }}'
+prospectus_node_version:  '10.16.0'
 prospectus_service_name: 'prospectus'
 prospectus_home: '{{ COMMON_APP_DIR }}/{{ prospectus_service_name }}'
 prospectus_venv_dir: '{{ prospectus_home }}/venvs/{{ prospectus_service_name }}'


### PR DESCRIPTION
`common_node_version` is a few LTS versions out of date, and we would like to be more up to date. Previous attempts to update `common_node_version` broke on sandboxes for unclear reasons: https://github.com/edx/configuration/pull/4933
https://github.com/edx/edx-platform/pull/19567