### PR TITLE
Remove redundant expires DEVOPS-8738

### DIFF
--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/static-files.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/static-files.j2
@@ -38,8 +38,6 @@
         try_files /staticfiles/$collected /course_static/$collected =404;
     }
 
-    # Expire other static files immediately (there should be very few / none of these)
-    expires epoch;
     {% include "static-files-extra.j2" ignore missing %}
 
     # Non-hashed files (there should be very few / none of these)


### PR DESCRIPTION
I'm not sure if this will actually fix the issue reported, but this should be done anyways to match master. The ```add_header "Cache-Control" $cache_header_short_lived always;``` line below it should accomplish the same thing more properly. I wonder if this expires setting was over ridding the add_header lines in the location blocks above.

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
