### PR TITLE
Monitor correct end of queue

### DIFF
--- a/util/jenkins/check_celery_progress/check_celery_progress.py
+++ b/util/jenkins/check_celery_progress/check_celery_progress.py
@@ -312,7 +312,10 @@ def check_queues(host, port, environment, deploy, default_threshold, queue_thres
     current_time = datetime.datetime.now()
 
     for queue_name in queue_names:
-        queue_first_item = redis_client.lindex(queue_name, 0)
+        # Use -1 to get end of queue, running redis monitor shows that celery
+        # uses BRPOP to pull items off the right end of the queue, so that's
+        # what we should be monitoring
+        queue_first_item = redis_client.lindex(queue_name, -1)
         # Check that queue_first_item is not None which is the case if the queue is empty
         if queue_first_item is not None:
             queue_first_items[queue_name] = json.loads(queue_first_item.decode("utf-8"))


### PR DESCRIPTION
Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
