### PR TITLE
Fix packer builds

### DIFF
--- a/playbooks/jenkins_worker_android.yml
+++ b/playbooks/jenkins_worker_android.yml
@@ -9,6 +9,7 @@
   vars:
     serial_count: 1
     android_worker: True
+    jenkins_groups: "jenkins"
     COMMON_SECURITY_UPDATES: yes
     SECURITY_UPGRADE_ON_ANSIBLE: true
   serial: "{{ serial_count }}"


### PR DESCRIPTION
The default includes the group "docker" in this variable, which fails with android because docker doesn't get installed.
