### PR TITLE
BB-1372: Add switch to enable/disable data gathering from ec2 instances 

### DIFF
--- a/playbooks/roles/aws/defaults/main.yml
+++ b/playbooks/roles/aws/defaults/main.yml
@@ -44,3 +44,12 @@ aws_debian_pkgs:
   - python-setuptools
 
 aws_redhat_pkgs: []
+
+# The AWS_GATHER_FACTS switch is used to enable/disable data gathering
+# from ec2 instances.
+# This is needed in some deployments were S3 is being used for file storage but
+# the appserver is in another cloud provider, such as OpenStack.
+# This issues started happening after the ec2_facts role was replaced with
+# the new version `ec2_metadata_facts` that fails when the server is not
+# on AWS, unlike its older counterpart
+AWS_GATHER_FACTS: true

--- a/playbooks/roles/aws/tasks/main.yml
+++ b/playbooks/roles/aws/tasks/main.yml
@@ -27,6 +27,7 @@
 - name: Gather ec2 facts for use in other roles
   action: ec2_metadata_facts
   no_log: True
+  when: COMMON_TAG_EC2_INSTANCE
   tags:
     - deploy
 

--- a/playbooks/roles/aws/tasks/main.yml
+++ b/playbooks/roles/aws/tasks/main.yml
@@ -27,7 +27,7 @@
 - name: Gather ec2 facts for use in other roles
   action: ec2_metadata_facts
   no_log: True
-  when: COMMON_TAG_EC2_INSTANCE
+  when: AWS_GATHER_FACTS
   tags:
     - deploy
 

--- a/playbooks/roles/common_vars/defaults/main.yml
+++ b/playbooks/roles/common_vars/defaults/main.yml
@@ -98,14 +98,7 @@ COMMON_ENABLE_NEWRELIC_INFRASTRUCTURE: False
 # as well
 COMMON_ENABLE_NEWRELIC_APP: False
 COMMON_ENABLE_MINOS: False
-# The COMMON_TAG_EC2_INSTANCE switch is used to enable/disable data gathering
-# from ec2 instances.
-# This is needed in some deployments were S3 is being used for file storage but
-# the appserver is in another cloud provider, such as OpenStack.
-# This issues started happening after the ec2_facts role was replaced with
-# the new version `ec2_metadata_facts` that fails when the server is not
-# on AWS, unlike its older counterpart
-COMMON_TAG_EC2_INSTANCE: True
+COMMON_TAG_EC2_INSTANCE: False
 common_boto_version: '2.48.0'
 common_node_version: '8.9.3'
 common_redhat_pkgs:

--- a/playbooks/roles/common_vars/defaults/main.yml
+++ b/playbooks/roles/common_vars/defaults/main.yml
@@ -98,6 +98,13 @@ COMMON_ENABLE_NEWRELIC_INFRASTRUCTURE: False
 # as well
 COMMON_ENABLE_NEWRELIC_APP: False
 COMMON_ENABLE_MINOS: False
+# The COMMON_TAG_EC2_INSTANCE switch is used to enable/disable data gathering
+# from ec2 instances.
+# This is needed in some deployments were S3 is being used for file storage but
+# the appserver is in another cloud provider, such as OpenStack.
+# This issues started happening after the ec2_facts role was replaced with
+# the new version `ec2_metadata_facts` that fails when the server is not
+# on AWS, unlike its older counterpart
 COMMON_TAG_EC2_INSTANCE: False
 common_boto_version: '2.48.0'
 common_node_version: '8.9.3'

--- a/playbooks/roles/common_vars/defaults/main.yml
+++ b/playbooks/roles/common_vars/defaults/main.yml
@@ -105,7 +105,7 @@ COMMON_ENABLE_MINOS: False
 # This issues started happening after the ec2_facts role was replaced with
 # the new version `ec2_metadata_facts` that fails when the server is not
 # on AWS, unlike its older counterpart
-COMMON_TAG_EC2_INSTANCE: False
+COMMON_TAG_EC2_INSTANCE: True
 common_boto_version: '2.48.0'
 common_node_version: '8.9.3'
 common_redhat_pkgs:

--- a/playbooks/roles/edx_service/tasks/main.yml
+++ b/playbooks/roles/edx_service/tasks/main.yml
@@ -127,7 +127,7 @@
 
 - name: Get instance information
   action: ec2_metadata_facts
-  when: COMMON_TAG_EC2_INSTANCE
+  when: AWS_GATHER_FACTS
   tags:
     - to-remove
 

--- a/playbooks/roles/edx_service/tasks/main.yml
+++ b/playbooks/roles/edx_service/tasks/main.yml
@@ -127,6 +127,7 @@
 
 - name: Get instance information
   action: ec2_metadata_facts
+  when: COMMON_TAG_EC2_INSTANCE
   tags:
     - to-remove
 
@@ -138,7 +139,7 @@
     tags:
       - Name: "version:{{ edx_service_name }}"
         Value: "{{ item.0.DOMAIN }}/{{ item.0.PATH }}/{{ item.0.REPO }} {{ item.1.after |truncate(7,True,'') }}"
-  when: item.1.after is defined and COMMON_TAG_EC2_INSTANCE and edx_service_repos is defined
+  when: COMMON_TAG_EC2_INSTANCE and item.1.after is defined and edx_service_repos is defined
   with_together:
     - "{{ edx_service_repos }}"
     - "{{ code_checkout.results }}"

--- a/playbooks/roles/edx_service/tasks/main.yml
+++ b/playbooks/roles/edx_service/tasks/main.yml
@@ -139,7 +139,7 @@
     tags:
       - Name: "version:{{ edx_service_name }}"
         Value: "{{ item.0.DOMAIN }}/{{ item.0.PATH }}/{{ item.0.REPO }} {{ item.1.after |truncate(7,True,'') }}"
-  when: COMMON_TAG_EC2_INSTANCE and item.1.after is defined and edx_service_repos is defined
+  when: item.1.after is defined and COMMON_TAG_EC2_INSTANCE and edx_service_repos is defined
   with_together:
     - "{{ edx_service_repos }}"
     - "{{ code_checkout.results }}"


### PR DESCRIPTION
This is needed in some deployments were S3 is being used for file 
storage but the appserver is in another cloud provider, such as 
OpenStack.

This issues started happening after the `ec2_facts` role was replaced with 
the new version `ec2_metadata_facts` that fails when the server is not 
on AWS, unlike its older counterpart.

**This keeps the same behaviour as before, but allows disabling fact gathering.**

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
