### PR TITLE
Wait for cloud-init to complete before trying to run 'apt' commands

### DIFF
--- a/playbooks/roles/python/tasks/main.yml
+++ b/playbooks/roles/python/tasks/main.yml
@@ -2,6 +2,10 @@
 # xenial+ cloud images don't have python2.7 installed, and ansible doesn't yet
 # support python3.
 
+- name: Wait until cloud-init has finished running
+  raw: test -e /usr/bin/cloud-init && cloud-init status --wait
+  ignore_errors: yes
+
 - name: Update apt-get
   raw: apt-get update -qq
   register: python_update_result


### PR DESCRIPTION
We ran into some race conditions where `cloud-init` was changing `/etc/apt/sources.list` after or while the `apt-get update` command was run from the python role. This caused `python-minimal` to not be found on the next command, `apt-get install python-minimal`.

This PR adds a call to `cloud-init wait` before the `apt-get update` step to make sure `cloud-init` completes before we attempt installing packages.

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
