### PR TITLE
DOT Applications need user_id ApplicationAccess scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+- Role: oauth_client_setup
+  - Ensure that created DOT applications have corresponding ApplicationAccess records with user_id scope.
+
 - Role: edx_notes_api
   - Added `EDX_NOTES_API_HOSTNAME` to set a hostname for the edx-notes-api IDA.
 

--- a/playbooks/roles/oauth_client_setup/tasks/main.yml
+++ b/playbooks/roles/oauth_client_setup/tasks/main.yml
@@ -53,6 +53,7 @@
     --redirect-uris "{{ item.url_root }}/complete/edx-oauth2/"
     --client-id {{ item.sso_id }}
     --client-secret {{ item.sso_secret }}
+    --scopes user_id
     {{ item.name }}-sso
     {{ item.username }}
   become_user: "{{ edxapp_user }}"
@@ -72,6 +73,7 @@
     --grant-type client-credentials
     --client-id {{ item.backend_service_id }}
     --client-secret {{ item.backend_service_secret }}
+    --scopes user_id
     {{ item.name }}-backend-service
     {{ item.username }}
   become_user: "{{ edxapp_user }}"


### PR DESCRIPTION
Quick PR to implement change from Robert's March 29th email:

"[...] provisioned [sandboxes] will need an admin record added in order for Ecommerce SSO to continue to work.  (This will also be true for credentials if and when it upgrades its auth-backends to 2.0.0+.)" . Affects registrar, too.

See how these https://oauthscopes.sandbox.edx.org/admin/oauth_dispatch/applicationaccess/ got created automagically.

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
