### PR TITLE
Add queue age tracking to cloudwatch

### DIFF
--- a/util/jenkins/check_celery_progress/check_celery_progress.py
+++ b/util/jenkins/check_celery_progress/check_celery_progress.py
@@ -7,6 +7,9 @@ import zlib
 import redis
 import click
 import backoff
+import boto3
+import botocore
+from itertools import zip_longest
 from celery import Celery
 from opsgenie.swagger_client import AlertApi
 from opsgenie.swagger_client import configuration
@@ -81,6 +84,17 @@ class RedisWrapper(object):
         return self.redis.hmset(*args)
 
 
+class CwBotoWrapper(object):
+    def __init__(self):
+        self.client = boto3.client('cloudwatch')
+
+    @backoff.on_exception(backoff.expo,
+                          (botocore.exceptions.ClientError),
+                          max_tries=MAX_TRIES)
+    def put_metric_data(self, *args, **kwargs):
+        return self.client.put_metric_data(*args, **kwargs)
+
+
 def pretty_json(obj):
     return json.dumps(obj, indent=4, sort_keys=True)
 
@@ -153,11 +167,6 @@ def build_new_state(old_state, queue_first_items, current_time):
     return new_state
 
 
-def should_create_alert(first_occurance_time, current_time, threshold):
-    time_delta = current_time - first_occurance_time
-    return time_delta.total_seconds() > threshold
-
-
 def generate_alert_message(environment, deploy, queue_name, threshold):
     return str.format("{}-{} {} queue is stale. Stationary for over {}s", environment, deploy, queue_name, threshold)
 
@@ -223,11 +232,11 @@ def generate_info(
     do_alert,
     first_occurance_time,
     current_time,
+    next_task_age,
     threshold,
     default_threshold,
     jenkins_build_url,
 ):
-    time_delta = (current_time - first_occurance_time).seconds
     next_task = "Key missing"
     args = "Key missing"
     kwargs = "Key missing"
@@ -245,35 +254,37 @@ def generate_info(
         dedent("""
             =============================================
             queue_name = {}
-            correlation_id = {}
+            ---------------------------------------------
             do_alert = {}
-            first_occurance_time = {}
-            current_time = {}
-            time_delta = {} seconds
             threshold = {} seconds
             default_threshold = {} seconds
             jenkins_build_url = {}
+            current_time = {}
             ---------------------------------------------
-            active_tasks = {}
-            ---------------------------------------------
-            next_task = {}
+            Next Task:
+            first_occurance_time = {}
+            age = {} seconds
+            correlation_id = {}
+            task_name = {}
             args = {}
             kwargs = {}
+            ---------------------------------------------
+            active_tasks = {}
             =============================================
         """),
         queue_name,
-        correlation_id,
         do_alert,
-        first_occurance_time,
-        current_time,
-        time_delta,
         threshold,
         default_threshold,
         jenkins_build_url,
-        active_tasks,
+        current_time,
+        first_occurance_time,
+        next_task_age,
+        correlation_id,
         next_task,
         args,
         kwargs,
+        active_tasks,
     )
     return output
 
@@ -329,7 +340,10 @@ def get_active_tasks(celery_client, queue_workers, queue_name):
               + ' {queue_name} {threshold}. May be used multiple times.')
 @click.option('--opsgenie-api-key', '-k', envvar='OPSGENIE_API_KEY', required=True)
 @click.option('--jenkins-build-url', '-j', envvar='BUILD_URL', required=False)
-def check_queues(host, port, environment, deploy, default_threshold, queue_threshold, opsgenie_api_key, jenkins_build_url):
+@click.option('--max-metrics', default=20,
+              help='Maximum number of CloudWatch metrics to publish')
+def check_queues(host, port, environment, deploy, default_threshold, queue_threshold, opsgenie_api_key,
+                 jenkins_build_url, max_metrics):
     ret_val = 0
     thresholds = dict(queue_threshold)
     print("Default Threshold (seconds): {}".format(default_threshold))
@@ -339,6 +353,13 @@ def check_queues(host, port, environment, deploy, default_threshold, queue_thres
     redis_client = RedisWrapper(host=host, port=port, socket_timeout=timeout,
                                 socket_connect_timeout=timeout)
     celery_control = celery_connection(host, port).control
+    cloudwatch = CwBotoWrapper()
+
+    namespace = "celery/{}-{}".format(environment, deploy)
+    metric_name = 'next_task_age'
+    dimension = 'queue'
+    next_task_age_metric_data = []
+
     queue_names = set([k.decode() for k in redis_client.keys()
                        if (redis_client.type(k) == b'list' and
                            not k.decode().endswith(".pidbox") and
@@ -389,7 +410,18 @@ def check_queues(host, port, environment, deploy, default_threshold, queue_thres
             ret_val = 1
         redacted_body = {'task': body.get('task'), 'args': 'REDACTED', 'kwargs': 'REDACTED'}
         active_tasks, redacted_active_tasks = get_active_tasks(celery_control, queue_workers, queue_name)
-        do_alert = should_create_alert(first_occurance_time, current_time, threshold)
+        next_task_age = (current_time - first_occurance_time).total_seconds()
+        do_alert = next_task_age > threshold
+
+        next_task_age_metric_data.append({
+            'MetricName': metric_name,
+            'Dimensions': [{
+                "Name": dimension,
+                "Value": queue_name
+            }],
+            'Value': next_task_age,
+            'Unit': 'Seconds',
+        })
 
         info = generate_info(
             queue_name,
@@ -399,6 +431,7 @@ def check_queues(host, port, environment, deploy, default_threshold, queue_thres
             do_alert,
             first_occurance_time,
             current_time,
+            next_task_age,
             threshold,
             default_threshold,
             jenkins_build_url,
@@ -411,6 +444,7 @@ def check_queues(host, port, environment, deploy, default_threshold, queue_thres
             do_alert,
             first_occurance_time,
             current_time,
+            next_task_age,
             threshold,
             default_threshold,
             jenkins_build_url,
@@ -423,6 +457,7 @@ def check_queues(host, port, environment, deploy, default_threshold, queue_thres
             close_alert(opsgenie_api_key, environment, deploy, queue_name)
             new_state[queue_name]['alert_created'] = False
 
+
     for queue_name in set(old_state.keys()) - set(new_state.keys()):
         print("DEBUG: Checking cleared queue {}".format(queue_name))
         if old_state[queue_name]['alert_created']:
@@ -434,7 +469,25 @@ def check_queues(host, port, environment, deploy, default_threshold, queue_thres
         # Temp Debugging
         print("DEBUG: new_state pushed to redis\n{}\n".format(pretty_state(new_state)))
 
+    # Push next_task_age data to cloudwatch for tracking
+    if len(next_task_age_metric_data) > 0:
+        for metric_data_grouped in grouper(next_task_age_metric_data, max_metrics):
+            print("next_task_age_metric_data {}".format(next_task_age_metric_data))
+            cloudwatch.put_metric_data(Namespace=namespace, MetricData=next_task_age_metric_data)
+
     sys.exit(ret_val)
+
+
+# Stolen right from the itertools recipes
+# https://docs.python.org/3/library/itertools.html#itertools-recipes
+def grouper(iterable, n, fillvalue=None):
+    "Collect data into fixed-length chunks or blocks"
+    # grouper('ABCDEFG', 3, 'x') --> ABC DEF Gxx"
+    args = [iter(iterable)] * n
+    chunks = zip_longest(*args, fillvalue=fillvalue)
+    # Remove Nones in function
+    for chunk in chunks:
+        yield [v for v in chunk if v is not None]
 
 
 if __name__ == '__main__':

--- a/util/jenkins/update_celery_monitoring/update_celery_monitoring.py
+++ b/util/jenkins/update_celery_monitoring/update_celery_monitoring.py
@@ -134,10 +134,10 @@ def check_queues(host, port, environment, deploy, max_metrics, threshold,
     thresholds = dict(queue_threshold)
 
     timeout = 1
-    namespace = "celery/{}-{}".format(environment, deploy)
     redis_client = RedisWrapper(host=host, port=port, socket_timeout=timeout,
                                 socket_connect_timeout=timeout)
     cloudwatch = CwBotoWrapper()
+    namespace = "celery/{}-{}".format(environment, deploy)
     metric_name = 'queue_length'
     dimension = 'queue'
     response = cloudwatch.list_metrics(Namespace=namespace,
@@ -169,7 +169,8 @@ def check_queues(host, port, environment, deploy, max_metrics, threshold,
                 "Name": dimension,
                 "Value": queue_name
             }],
-            'Value': redis_client.llen(queue_name)
+            'Value': redis_client.llen(queue_name),
+            'Unit': 'Count',
         })
 
     if len(metric_data) > 0:


### PR DESCRIPTION
Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
