### PR TITLE
Set celery worker hostnames

### DIFF
--- a/playbooks/roles/ecomworker/templates/edx/app/ecomworker/ecomworker.sh.j2
+++ b/playbooks/roles/ecomworker/templates/edx/app/ecomworker/ecomworker.sh.j2
@@ -17,4 +17,4 @@ export NEW_RELIC_LICENSE_KEY='{{ NEWRELIC_LICENSE_KEY }}'
 
 source {{ ecommerce_worker_home }}/{{ ecommerce_worker_service_name }}_env
 # We exec so that celery is the child of supervisor and can be managed properly
-exec {{ executable }} -A ecommerce_worker worker --app ecommerce_worker.celery_app:app --concurrency={{ ECOMMERCE_WORKER_CONCURRENCY }} --loglevel=info --queue=ecommerce.fulfillment,ecommerce.email_marketing
+exec {{ executable }} -A ecommerce_worker worker --app ecommerce_worker.celery_app:app --concurrency={{ ECOMMERCE_WORKER_CONCURRENCY }} --loglevel=info --hostname=ecomworker.%%h --queue=ecommerce.fulfillment,ecommerce.email_marketing

--- a/playbooks/roles/registrar/templates/edx/app/supervisor/conf.d.available/registrar-workers.conf.j2
+++ b/playbooks/roles/registrar/templates/edx/app/supervisor/conf.d.available/registrar-workers.conf.j2
@@ -7,7 +7,7 @@ directory={{ registrar_code_dir }}
 stdout_logfile={{ supervisor_log_dir }}/%(program_name)s-stdout.log
 stderr_logfile={{ supervisor_log_dir }}/%(program_name)s-stderr.log
 
-command={{ registrar_app_dir }}/worker.sh worker -A {{ w.service_variant }} --app registrar.celery:app --loglevel=info --queue={{ w.queue }} --hostname=edx.{{ w.service_variant }}.core.{{ w.queue }}.%%h --concurrency={{ w.concurrency }} {{ '--maxtasksperchild ' + w.max_tasks_per_child|string if w.max_tasks_per_child is defined else '' }} {{ '--without-heartbeat' if not REGISTRAR_CELERY_HEARTBEAT_ENABLED|bool else '' }}
+command={{ registrar_app_dir }}/worker.sh worker -A {{ w.service_variant }} --app registrar.celery:app --loglevel=info --queue={{ w.queue }} --hostname=registrar.{{ w.queue }}.%%h --concurrency={{ w.concurrency }} {{ '--maxtasksperchild ' + w.max_tasks_per_child|string if w.max_tasks_per_child is defined else '' }} {{ '--without-heartbeat' if not REGISTRAR_CELERY_HEARTBEAT_ENABLED|bool else '' }}
 killasgroup=true
 stopwaitsecs={{ w.stopwaitsecs | default(REGISTRAR_WORKER_DEFAULT_STOPWAITSECS) }}
 ; Set autorestart to `true`. The default value for autorestart is `unexpected`, but celery < 4.x will exit


### PR DESCRIPTION
Currently ecomworker and notifier show up in Celery/Flower as ```celery@ip-10-*-*-*``` so it's not immediately obvious what type of worker they are. This fixes that. The hostname is currently set for registrar, but the name is overly complex.

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
