### PR TITLE
Remove service_variant from registrar

### DIFF
--- a/playbooks/roles/registrar/defaults/main.yml
+++ b/playbooks/roles/registrar/defaults/main.yml
@@ -146,7 +146,6 @@ REGISTRAR_NEWRELIC_WORKERS_APPNAME: registrar-workers
 worker_django_settings_module: "{{ REGISTRAR_DJANGO_SETTINGS_MODULE }}"
 REGISTRAR_CELERY_WORKERS:
   - queue: '{{ registrar_celery_default_queue }}'
-    service_variant: registrar
     concurrency: 1
     monitor: True
 registrar_workers: "{{ REGISTRAR_CELERY_WORKERS }}"

--- a/playbooks/roles/registrar/templates/edx/app/registrar/worker.sh.j2
+++ b/playbooks/roles/registrar/templates/edx/app/registrar/worker.sh.j2
@@ -20,5 +20,4 @@ fi
 {% endif %}
 
 # We exec so that celery is the child of supervisor and can be managed properly
-
 exec {{ executable }} $@

--- a/playbooks/roles/registrar/templates/edx/app/supervisor/conf.d.available/registrar-workers.conf.j2
+++ b/playbooks/roles/registrar/templates/edx/app/supervisor/conf.d.available/registrar-workers.conf.j2
@@ -1,13 +1,13 @@
 {% for w in registrar_workers %}
-[program:{{ w.service_variant }}_{{ w.queue }}_{{ w.concurrency }}]
+[program:{{ w.queue }}_{{ w.concurrency }}]
 
-environment={% if COMMON_ENABLE_NEWRELIC_APP %}NEW_RELIC_APP_NAME={{ REGISTRAR_NEWRELIC_WORKERS_APPNAME }},NEW_RELIC_DISTRIBUTED_TRACING_ENABLED={{ REGISTRAR_WORKERS_ENABLE_NEWRELIC_DISTRIBUTED_TRACING }},NEW_RELIC_LICENSE_KEY={{ NEWRELIC_LICENSE_KEY }},{% endif -%}CONCURRENCY={{ w.concurrency }},LOGLEVEL=info,DJANGO_SETTINGS_MODULE={{ worker_django_settings_module }},LANG={{ REGISTRAR_LANG }},PYTHONPATH={{ registrar_code_dir }},SERVICE_VARIANT={{ w.service_variant }},BOTO_CONFIG="{{ registrar_app_dir }}/.boto,EDX_REST_API_CLIENT_NAME=edx.{{ w.service_variant }}.core.{{ w.queue }},"
+environment={% if COMMON_ENABLE_NEWRELIC_APP %}NEW_RELIC_APP_NAME={{ REGISTRAR_NEWRELIC_WORKERS_APPNAME }},NEW_RELIC_DISTRIBUTED_TRACING_ENABLED={{ REGISTRAR_WORKERS_ENABLE_NEWRELIC_DISTRIBUTED_TRACING }},NEW_RELIC_LICENSE_KEY={{ NEWRELIC_LICENSE_KEY }},{% endif -%}CONCURRENCY={{ w.concurrency }},LOGLEVEL=info,DJANGO_SETTINGS_MODULE={{ worker_django_settings_module }},LANG={{ REGISTRAR_LANG }},PYTHONPATH={{ registrar_code_dir }},BOTO_CONFIG="{{ registrar_app_dir }}/.boto,EDX_REST_API_CLIENT_NAME={{ COMMON_ENVIRONMENT }}-{{ COMMON_DEPLOYMENT }}-registrar-worker-{{ w.queue }},"
 user={{ common_web_user }}
 directory={{ registrar_code_dir }}
 stdout_logfile={{ supervisor_log_dir }}/%(program_name)s-stdout.log
 stderr_logfile={{ supervisor_log_dir }}/%(program_name)s-stderr.log
 
-command={{ registrar_app_dir }}/worker.sh worker -A {{ w.service_variant }} --app registrar.celery:app --loglevel=info --queue={{ w.queue }} --hostname=registrar.{{ w.queue }}.%%h --concurrency={{ w.concurrency }} {{ '--maxtasksperchild ' + w.max_tasks_per_child|string if w.max_tasks_per_child is defined else '' }} {{ '--without-heartbeat' if not REGISTRAR_CELERY_HEARTBEAT_ENABLED|bool else '' }}
+command={{ registrar_app_dir }}/worker.sh worker -A registrar --app registrar.celery:app --loglevel=info --queue={{ w.queue }} --hostname=registrar.{{ w.queue }}.%%h --concurrency={{ w.concurrency }} {{ '--maxtasksperchild ' + w.max_tasks_per_child|string if w.max_tasks_per_child is defined else '' }} {{ '--without-heartbeat' if not REGISTRAR_CELERY_HEARTBEAT_ENABLED|bool else '' }}
 killasgroup=true
 stopwaitsecs={{ w.stopwaitsecs | default(REGISTRAR_WORKER_DEFAULT_STOPWAITSECS) }}
 ; Set autorestart to `true`. The default value for autorestart is `unexpected`, but celery < 4.x will exit
@@ -19,4 +19,4 @@ autorestart=true
 {% endfor %}
 
 [group:registrar_worker]
-programs={%- for w in registrar_workers %}{{ w.service_variant }}_{{ w.queue }}_{{ w.concurrency }}{%- if not loop.last %},{%- endif %}{%- endfor %}
+programs={%- for w in registrar_workers %}{{ w.queue }}_{{ w.concurrency }}{%- if not loop.last %},{%- endif %}{%- endfor %}


### PR DESCRIPTION
The only other place I see this service_variant variable used is for edxapp, because it has both LMS and CMS. This seems a bit redundant for any other IDA so I think it makes sense to remove it to simplify things.

The one change I'm not entirely sure about is the ```EDX_REST_API_CLIENT_NAME``` setting. Is there anything that will have an issue if this changes? I couldn't find the old one anywhere.

```
-EDX_REST_API_CLIENT_NAME=edx.{{ w.service_variant }}.core.{{ w.queue }}
+EDX_REST_API_CLIENT_NAME={{ COMMON_ENVIRONMENT }}-{{ COMMON_DEPLOYMENT }}-registrar-worker-{{ w.queue }}
```

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
