### PR TITLE
update registrar_defaults to include home

### DIFF
--- a/playbooks/roles/registrar/defaults/main.yml
+++ b/playbooks/roles/registrar/defaults/main.yml
@@ -20,6 +20,7 @@ REGISTRAR_SANDBOX_BUILD: False
 registrar_service_name: 'registrar'
 
 registrar_user: "{{ registrar_service_name }}"
+registrar_home: "{{ COMMON_APP_DIR }}/{{ registrar_service_name }}"
 registrar_app_dir: "{{ COMMON_APP_DIR }}/{{ registrar_service_name }}"
 registrar_code_dir: "{{ registrar_app_dir }}/{{ registrar_service_name }}"
 registrar_venvs_dir: "{{ registrar_app_dir }}/venvs"


### PR DESCRIPTION
registrar_home is used in the dictionary [here](https://github.com/edx/configuration/blob/4292dbad88d1f1a84be055fc8733d9cdc1cd3d44/playbooks/roles/supervisor/defaults/main.yml#L81) but not defined. 