### PR TITLE
SE-1213 Fix InCommon cert issues

### DIFF
--- a/playbooks/roles/notifier/tasks/main.yml
+++ b/playbooks/roles/notifier/tasks/main.yml
@@ -46,9 +46,17 @@
 
 - name: Retrieve incommon server CA
   get_url:
-    url: "https://www.incommon.org/cert/repository/InCommonServerCA.txt"
+    url: "http://crt.incommon-rsa.org/InCommonRSAServerCA_2.crt"
     dest: "/usr/share/ca-certificates/incommon/InCommonServerCA.crt"
   when: incommon_present|failed
+  register: incommon_retrieved
+  tags:
+    - "install"
+    - "install:base"
+
+- name: Convert incommon server CA to usable format
+  command: "openssl x509 -inform DER -in /usr/share/ca-certificates/incommon/InCommonServerCA.crt -out /usr/share/ca-certificates/incommon/InCommonServerCA.crt"
+  when: incommon_retrieved|success
   tags:
     - "install"
     - "install:base"


### PR DESCRIPTION
Recently, Incommon have made some changes with certificates which affect
the provisioning process for notifier. Namely:

The ssl certificate on www.incommon.org has changed, causing the
certificate verification during deployment to fail. The certificate is
valid, but is based on a different (newer) chain of trust.

The second issue (which is hidden by the first), is that the server CA
url that is retrieved in this step is non-existent (404).

We have been investigating the issue and have discovered that Incommon
previously documented the InCommon Server CA on their wiki at
https://spaces.at.internet2.edu/display/ICCS/InCommon+Cert+Types . On
June 11, info about this CA was removed. The last revision to have these
docs is: https://spaces.at.internet2.edu/pages/viewpage.action?pageId=152176663&navigatingVersions=true

This server CA was SHA-1, and Incommon have a SHA-2 server CA documented on the
same page. I'm not sure if they are used for similar purposes and this newer
one directly replaces the older one or not. It does appear that the SHA-1 cert
could have been removed since SHA-1 has been deprecated for a long time (see
https://spaces.at.internet2.edu/display/InCFederation/2014/05/07/Phasing+Out+SHA-1#PhasingOutSHA-1-SHA-1andX.509Certificates
).

This PR includes a potential fix: it installs the newer Incommon server
CA that appears to have replaced the previous one. It downloads it from
the url as documented on [InCommon's wiki](https://spaces.at.internet2.edu/display/ICCS/InCommon+Cert+Types).

The remaining question though is whether this particular CA was
installed and kept in the notifier deployment for a certain reason that
may only be apparent at runtime in the notifier. It may be helpful if
someone knew what the original purpose was. For reference, it was added
in PR #194, commit https://github.com/edx/configuration/pull/194/commits/7029a28d38694cf8366b3a3fd8a3a0794e98228b


**JIRA tickets**: [OSPR-3667](https://openedx.atlassian.net/browse/OSPR-3667)

**Dependencies**: None

**Merge deadline**: ASAP

**Discussion**: [openedx-ops ML](https://groups.google.com/forum/#!msg/openedx-ops/Z1wORIrSMhc/huIBXilqAwAJ)

**Testing instructions**:

1. Run an openedx deployment using this configuration and notifier
   deployment enabled.
2. unknown: TBD when the purpose of the certificate is determined

**Reviewers**
- [ ] @lgp171188
- [ ] edX reviewer[s] TBD

