### PR TITLE
Fix JWK decode error on sandboxes, attempt #1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+- Role: common_vars
+  - Default `COMMON_JWT_PUBLIC_SIGNING_JWK_SET` to `''`
+    instead of `!!null`. Because of how this setting is handled,
+    `!!null` ends up rendering as the literal string `None` instead
+    of the value `null`, which causes JSON decoding to fail
+    wherever the default value is used (as `'None'` is not valid JSON).
+    By setting the default to a Falsy value like the
+    empty string, edx-drf-extensions does not attempt to JSON-
+    decode it.
+
 - Role: registrar
   - Changed `REGISTRAR_CELERY_ALWAYS_EAGER` default to `false`.
 

--- a/playbooks/roles/common_vars/defaults/main.yml
+++ b/playbooks/roles/common_vars/defaults/main.yml
@@ -236,7 +236,7 @@ COMMON_JWT_ISSUER: '{{ COMMON_OIDC_ISSUER }}'
 # The following should be the string representation of a JSON Web Key Set (JWK set)
 # containing active public keys for signing JWTs.
 # See https://github.com/edx/edx-platform/blob/master/openedx/core/djangoapps/oauth_dispatch/docs/decisions/0008-use-asymmetric-jwts.rst
-COMMON_JWT_PUBLIC_SIGNING_JWK_SET: !!null
+COMMON_JWT_PUBLIC_SIGNING_JWK_SET: ''
 
 COMMON_JWT_AUTH_COOKIE_HEADER_PAYLOAD: 'edx-jwt-cookie-header-payload'
 COMMON_JWT_AUTH_COOKIE_SIGNATURE: 'edx-jwt-cookie-signature'


### PR DESCRIPTION
Update 2: Setting the default value to the empty string also works and seems more elegant.

Update: This PR sets `COMMON_JWT_PUBLIC_SIGNING_JWK_SET` to `'{"keys": []}'` as default instead of `!!null`. Currently it renders as `None` in the case that the setting is not overridden, which is not valid JSON. The optimal scenario would be making it equal `null`, but that doesn't seem like an option given how the setting is currently handled with the Ansible `|string` filter.

-------------------------------------------------

This is to fix an error I was getting on my sandbox:
```
Jun 21 20:14:48 kdmccormick [service_variant=registrar][django.request][env:no_env] ERROR [kdmccorm
Traceback (most recent call last):
File "/edx/app/registrar/venvs/registrar/lib/python3.5/site-packages/django/core/handlers/excepti
  response = get_response(request)
File "/edx/app/registrar/venvs/registrar/lib/python3.5/site-packages/django/core/handlers/base.py
  response = self.process_exception_by_middleware(e, request)
File "/edx/app/registrar/venvs/registrar/lib/python3.5/site-packages/django/core/handlers/base.py
  response = wrapped_callback(request, *callback_args, **callback_kwargs)
File "/edx/app/registrar/venvs/registrar/lib/python3.5/site-packages/django/views/decorators/csrf
  return view_func(*args, **kwargs)
File "/edx/app/registrar/venvs/registrar/lib/python3.5/site-packages/django/views/generic/base.py
  return self.dispatch(request, *args, **kwargs)
File "/edx/app/registrar/registrar/registrar/apps/api/mixins.py", line 66, in dispatch
  response = super().dispatch(*args, **kwargs)
File "/edx/app/registrar/venvs/registrar/lib/python3.5/site-packages/rest_framework/views.py", li
  response = self.handle_exception(exc)
File "/edx/app/registrar/venvs/registrar/lib/python3.5/site-packages/rest_framework/views.py", li
  self.raise_uncaught_exception(exc)
File "/edx/app/registrar/venvs/registrar/lib/python3.5/site-packages/rest_framework/views.py", li
  self.initial(request, *args, **kwargs)
File "/edx/app/registrar/venvs/registrar/lib/python3.5/site-packages/rest_framework/views.py", li
  self.perform_authentication(request)
File "/edx/app/registrar/venvs/registrar/lib/python3.5/site-packages/rest_framework/views.py", li
  request.user
File "/edx/app/registrar/venvs/registrar/lib/python3.5/site-packages/rest_framework/request.py",
  self._authenticate()
File "/edx/app/registrar/venvs/registrar/lib/python3.5/site-packages/rest_framework/request.py",
  user_auth_tuple = authenticator.authenticate(self)
File "/edx/app/registrar/venvs/registrar/lib/python3.5/site-packages/edx_rest_framework_extension
  return super(JwtAuthentication, self).authenticate(request)
File "/edx/app/registrar/venvs/registrar/lib/python3.5/site-packages/rest_framework_jwt/authentic
  payload = jwt_decode_handler(jwt_value)
File "/edx/app/registrar/venvs/registrar/lib/python3.5/site-packages/edx_rest_framework_extension
  _verify_jwt_signature(token, jwt_issuer)
File "/edx/app/registrar/venvs/registrar/lib/python3.5/site-packages/edx_rest_framework_extension
  key_set = _get_signing_jwk_key_set(jwt_issuer)
File "/edx/app/registrar/venvs/registrar/lib/python3.5/site-packages/edx_rest_framework_extension
  key_set.load_jwks(signing_jwk_set)
File "/edx/app/registrar/venvs/registrar/lib/python3.5/site-packages/jwkest/jwk.py", line 776, in
  self.load_dict(json.loads(jwks))
File "/usr/lib/python3.5/json/__init__.py", line 319, in loads
  return _default_decoder.decode(s)
File "/usr/lib/python3.5/json/decoder.py", line 339, in decode
  obj, end = self.raw_decode(s, idx=_w(s, 0).end())
File "/usr/lib/python3.5/json/decoder.py", line 357, in raw_decode
  raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

In `registrar.yml` I saw that `JWT_PUBLIC_SIGNING_JWK_SET` was set to `None`, which I'm guess caused the error. @doctoryes saw a similar experience when working with the ecommerce IDA, and worked around the problem by changing the setting in `lms.yml`/`studio.yml` from `None` to `null`.

This is my proposed fix; I don't know if it will break anything else. @feanil Please let me know if this looks good.