### PR TITLE
Fix exception/crash when queue empty

### DIFF
--- a/util/jenkins/check_celery_progress/check_celery_progress.py
+++ b/util/jenkins/check_celery_progress/check_celery_progress.py
@@ -424,7 +424,7 @@ def check_queues(host, port, environment, deploy, default_threshold, queue_thres
 
     # Temp debugging
     print("DEBUG: new_state from new_state() function\n{}\n".format(pretty_state(new_state)))
-    for queue_name in queue_names:
+    for queue_name, first_item in queue_first_items.items():
         redacted_body = ""
         threshold = default_threshold
         if queue_name in thresholds:
@@ -434,7 +434,7 @@ def check_queues(host, port, environment, deploy, default_threshold, queue_thres
         first_occurance_time = new_state[queue_name]['first_occurance_time']
         body = {}
         try:
-            body = extract_body(queue_first_items[queue_name])
+            body = extract_body(first_item)
         except Exception as error:
             print("ERROR: Unable to extract task body in queue {}, exception {}".format(queue_name, error))
             ret_val = 1


### PR DESCRIPTION
Fixes bug where there's an exception if the queue gets emptied before we look at the first item. There's a little bit of a race condition between when we look at the queue names and when we look at the top item of the queue. The exception occurs when because we don't add the queue name as a key to the queue_first_items dict if the queue is empty. The loop was trying to look for a queue that doesn't exist.

Example of exception
---
```
00:00:05.860 DEBUG: new_state from new_state() function
00:00:05.860 {
00:00:05.860     "edx.lms.core.default": {
00:00:05.860         "alert_created": false,
00:00:05.860         "correlation_id": "ad2d8028-2d8b-45d2-b3d2-e72c62bce2c7",
00:00:05.860         "first_occurance_time": "2019-06-25 13:27:06.036226"
00:00:05.860     },
00:00:05.860     "edx.lms.core.grades_policy_change": {
00:00:05.860         "alert_created": false,
00:00:05.860         "correlation_id": "58288c0d-fe71-4c1c-969d-f83bf479ebc4",
00:00:05.860         "first_occurance_time": "2019-06-25 13:27:06.036226"
00:00:05.860     },
00:00:05.860     "notifier.default": {
00:00:05.860         "alert_created": false,
00:00:05.860         "correlation_id": "b99f026d-9c94-480f-a265-fa329e987125",
00:00:05.860         "first_occurance_time": "2019-06-25 01:04:07.678525"
00:00:05.860     }
00:00:05.860 }
00:00:05.860 
00:00:05.861 Traceback (most recent call last):
00:00:05.861   File "./check_celery_progress.py", line 524, in <module>
00:00:05.861     check_queues()
00:00:05.861   File "/edx/var/jenkins/shiningpanda/jobs/a18cf8fb/virtualenvs/d41d8cd9/lib/python3.5/site-packages/click/core.py", line 722, in __call__
00:00:05.861     return self.main(*args, **kwargs)
00:00:05.861   File "/edx/var/jenkins/shiningpanda/jobs/a18cf8fb/virtualenvs/d41d8cd9/lib/python3.5/site-packages/click/core.py", line 697, in main
00:00:05.861     rv = self.invoke(ctx)
00:00:05.861   File "/edx/var/jenkins/shiningpanda/jobs/a18cf8fb/virtualenvs/d41d8cd9/lib/python3.5/site-packages/click/core.py", line 895, in invoke
00:00:05.861     return ctx.invoke(self.callback, **ctx.params)
00:00:05.862   File "/edx/var/jenkins/shiningpanda/jobs/a18cf8fb/virtualenvs/d41d8cd9/lib/python3.5/site-packages/click/core.py", line 535, in invoke
00:00:05.862     return callback(*args, **kwargs)
00:00:05.862   File "./check_celery_progress.py", line 433, in check_queues
00:00:05.862     correlation_id = new_state[queue_name]['correlation_id']
00:00:05.862 KeyError: 'edx.lms.core.grades'
00:00:05.912 Build step 'Virtualenv Builder' marked build as failure
00:00:05.940 Finished: FAILURE
```

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
