### PR TITLE
Reduce hermes build box noise with sleep OPS-4107

### DIFF
--- a/playbooks/roles/hermes/files/pre_hermes_checks.sh
+++ b/playbooks/roles/hermes/files/pre_hermes_checks.sh
@@ -8,6 +8,14 @@
 # on build boxes. 
 # This script is run before hermes is started, preventing it from booting during builds.
 
+# Default startup timeout in systemd is 60 seconds, sleep 50 means we should return before the timeout
+sleep_time=50
 
-# This is a hack to return 1 if build box, 0 otherwise
-aws sts get-caller-identity --output=text --query 'Arn' | grep -iv 'gocd' > /dev/null
+# This is a hack to sleep and then return 1 if on a build box
+# The sleep slows down the looping caused by systemd trying to start the service again if it failed.
+# Just returning 1 causes tons of "Unit entered failed state" messages. This will reduce them to 1 a minute or so.
+if aws sts get-caller-identity --output=text --query 'Arn' | grep -q 'gocd'; then
+    echo "Detected build server, sleeping ${sleep_time} seconds to reduce log noise"
+    sleep $sleep_time
+    exit 1
+fi


### PR DESCRIPTION
Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
