### PR TITLE
Fix JWK decode error on sandboxes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+- Role: common_vars
+  - Default `COMMON_JWT_PUBLIC_SIGNING_JWK_SET` to `''`
+    instead of `!!null`. Because of how this setting is handled,
+    `!!null` ends up rendering as the literal string `None` instead
+    of the value `null`, which causes JSON decoding to fail
+    wherever the default value is used (as `'None'` is not valid JSON).
+    By setting the default to a Falsy value like the
+    empty string, edx-drf-extensions does not attempt to JSON-
+    decode it.
+
 - Playbook: masters_sandbox
   - Added playbook to setup user and api access
 

--- a/playbooks/roles/common_vars/defaults/main.yml
+++ b/playbooks/roles/common_vars/defaults/main.yml
@@ -236,7 +236,7 @@ COMMON_JWT_ISSUER: '{{ COMMON_OIDC_ISSUER }}'
 # The following should be the string representation of a JSON Web Key Set (JWK set)
 # containing active public keys for signing JWTs.
 # See https://github.com/edx/edx-platform/blob/master/openedx/core/djangoapps/oauth_dispatch/docs/decisions/0008-use-asymmetric-jwts.rst
-COMMON_JWT_PUBLIC_SIGNING_JWK_SET: !!null
+COMMON_JWT_PUBLIC_SIGNING_JWK_SET: ''
 
 COMMON_JWT_AUTH_COOKIE_HEADER_PAYLOAD: 'edx-jwt-cookie-header-payload'
 COMMON_JWT_AUTH_COOKIE_SIGNATURE: 'edx-jwt-cookie-signature'

--- a/playbooks/roles/mysql/tasks/mysql.yml
+++ b/playbooks/roles/mysql/tasks/mysql.yml
@@ -49,9 +49,7 @@
     mode: 0644
 
 - name: restart mysql
-  service:
-    name: mysql
-    state: restarted
+  command: service mysql restart
 
 - name: Ensure Anonymous user(s) does not exist
   mysql_user:


### PR DESCRIPTION
@edx/masters-neem 

### First commit: JWK decode error
Original PR: #5218 . See that for context.

### Second commit: Ansible workaround
See ansible/ansible#42620. This was stopping configuration from building correctly, as MySQL was not starting. The change in this commit works around the issue.