### PR TITLE
[BB-1453] Add a 'pre' requirements file for the sandbox and install it before the other edx-sandbox requirements

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -1592,6 +1592,7 @@ base_requirements_file:   "{{ edxapp_code_dir }}/requirements/edx/base.txt"
 django_requirements_file:   "{{ edxapp_code_dir }}/requirements/edx/django.txt"
 openstack_requirements_file: "{{ edxapp_code_dir }}/requirements/edx/openstack.txt"
 
+sandbox_pre_requirements: "{{ edxapp_code_dir }}/requirements/edx-sandbox/pre.txt"
 sandbox_base_requirements:  "{{ edxapp_code_dir }}/requirements/edx-sandbox/base.txt"
 
 # The Python requirements files in the order they should be installed.  This order should

--- a/playbooks/roles/edxapp/tasks/deploy.yml
+++ b/playbooks/roles/edxapp/tasks/deploy.yml
@@ -269,12 +269,15 @@
 - name: code sandbox | Install base sandbox requirements and create sandbox virtualenv
   pip:
     chdir: "{{ edxapp_code_dir }}"
-    requirements: "{{ sandbox_base_requirements }}"
+    requirements: "{{ item }}"
     virtualenv: "{{ edxapp_sandbox_venv_dir }}"
     state: present
     extra_args: "-i {{ COMMON_PYPI_MIRROR_URL }} --exists-action w"
   become_user: "{{ edxapp_sandbox_user }}"
   when: EDXAPP_PYTHON_SANDBOX
+  with_items:
+    - "{{ sandbox_pre_requirements }}"
+    - "{{ sandbox_base_requirements }}"
   tags:
     - edxapp-sandbox
     - install


### PR DESCRIPTION
`matplotlib`, which is a requirement under the `requirements/edx-sandbox/` folder of the `edx-platform` repository, requires `numpy` to be already installed. Otherwise it tries to download the latest version which is incompatible with Python 2.7. So this adds changes to install the 'pre' requirements file
before installing the sandbox requirements.

This PR is related to https://github.com/edx/edx-platform/pull/20928 and the changes in both the PRs are required for the fix.

This also affects Ironwood and has to be backported.

**JIRA tickets**:  None

**Discussions**:  I have mentioned this issue on the Open edX Slack [here](https://openedx.slack.com/archives/C12M8M5AR/p1561975422019300). The conversation on https://github.com/edx/edx-platform/pull/15101 is also relevant as it was for a similar issue.

**Dependencies**: https://github.com/edx/edx-platform/pull/20928

**Sandbox URL**: TBD - sandbox is being provisioned.

**Merge deadline**: ASAP since this is breaking new installations/deployments.

**Testing instructions**:

1.  Try to deploy a new edx-platform instance based on the `master` or `open-release/ironwood.master` branch. Observe that the deployment fails at the "code sandbox | Install base sandbox requirements and create sandbox virtualenv" step. The command that fails in that step is `/edx/app/edxapp/venvs/edxapp-sandbox/bin/pip2 install -i https://pypi.python.org/simple --exists-action w -r /edx/app/edxapp/edx-platform/requirements/edx-sandbox/base.txt`.

2. Deploy again, this time use the source branch of this PR and deploy an instance using the related `edx-platform` PR https://github.com/edx/edx-platform/pull/20928. Installation should now succeed.

**Author notes and concerns**:

1. Since this affects Ironwood as well, the fix has to be backported.

**Reviewers**
- [ ] @pomegranited 
- [ ] edX reviewer[s] TBD

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?


