### PR TITLE
Update the COMMON_JWT_PUBLIC_SIGNING_JWK_SET to be empty string 

### DIFF
--- a/playbooks/roles/common_vars/defaults/main.yml
+++ b/playbooks/roles/common_vars/defaults/main.yml
@@ -236,7 +236,7 @@ COMMON_JWT_ISSUER: '{{ COMMON_OIDC_ISSUER }}'
 # The following should be the string representation of a JSON Web Key Set (JWK set)
 # containing active public keys for signing JWTs.
 # See https://github.com/edx/edx-platform/blob/master/openedx/core/djangoapps/oauth_dispatch/docs/decisions/0008-use-asymmetric-jwts.rst
-COMMON_JWT_PUBLIC_SIGNING_JWK_SET: !!null
+COMMON_JWT_PUBLIC_SIGNING_JWK_SET: ''
 
 COMMON_JWT_AUTH_COOKIE_HEADER_PAYLOAD: 'edx-jwt-cookie-header-payload'
 COMMON_JWT_AUTH_COOKIE_SIGNATURE: 'edx-jwt-cookie-signature'

--- a/playbooks/roles/common_vars/defaults/main.yml
+++ b/playbooks/roles/common_vars/defaults/main.yml
@@ -236,7 +236,7 @@ COMMON_JWT_ISSUER: '{{ COMMON_OIDC_ISSUER }}'
 # The following should be the string representation of a JSON Web Key Set (JWK set)
 # containing active public keys for signing JWTs.
 # See https://github.com/edx/edx-platform/blob/master/openedx/core/djangoapps/oauth_dispatch/docs/decisions/0008-use-asymmetric-jwts.rst
-COMMON_JWT_PUBLIC_SIGNING_JWK_SET: ""
+COMMON_JWT_PUBLIC_SIGNING_JWK_SET: 'None'
 
 COMMON_JWT_AUTH_COOKIE_HEADER_PAYLOAD: 'edx-jwt-cookie-header-payload'
 COMMON_JWT_AUTH_COOKIE_SIGNATURE: 'edx-jwt-cookie-signature'

--- a/playbooks/roles/common_vars/defaults/main.yml
+++ b/playbooks/roles/common_vars/defaults/main.yml
@@ -236,7 +236,7 @@ COMMON_JWT_ISSUER: '{{ COMMON_OIDC_ISSUER }}'
 # The following should be the string representation of a JSON Web Key Set (JWK set)
 # containing active public keys for signing JWTs.
 # See https://github.com/edx/edx-platform/blob/master/openedx/core/djangoapps/oauth_dispatch/docs/decisions/0008-use-asymmetric-jwts.rst
-COMMON_JWT_PUBLIC_SIGNING_JWK_SET: ''
+COMMON_JWT_PUBLIC_SIGNING_JWK_SET: ""
 
 COMMON_JWT_AUTH_COOKIE_HEADER_PAYLOAD: 'edx-jwt-cookie-header-payload'
 COMMON_JWT_AUTH_COOKIE_SIGNATURE: 'edx-jwt-cookie-signature'


### PR DESCRIPTION
The value COMMON_JWT_PUBLIC_SIGNING_JWK_SET needs to be changed to empty by fault rather than null

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist]
