### PR TITLE
rolling back the warnings ng plugin for build jenkins

### DIFF
--- a/playbooks/roles/jenkins_build/defaults/main.yml
+++ b/playbooks/roles/jenkins_build/defaults/main.yml
@@ -250,7 +250,7 @@ build_jenkins_plugins_list:
     version: '5.0.1'
     group: 'org.jvnet.hudson.plugins'
   - name: 'warnings-ng'
-    version: '5.1.0'
+    version: '2.2.1'
     group: 'io.jenkins.plugins'
   - name: 'workflow-aggregator'
     version: '2.6'


### PR DESCRIPTION
Rolling back one of the plugins in a recent PR (https://github.com/edx/configuration/pull/5233). I was noticing strange behavior w/ pipeline jobs not generating output and began checking if any of the recent plugin upgrades caused this. I am not sure why this is the culprit, but I rolled it back on test jenkins and the problem has gone away. Will put in a ticket to investigate in the future.