### PR TITLE
Add the ability to run `devstack.sh exec cmd --with args`

### DIFF
--- a/docker/build/analytics_api/Dockerfile
+++ b/docker/build/analytics_api/Dockerfile
@@ -28,5 +28,6 @@ RUN /edx/app/edx_ansible/venvs/edx_ansible/bin/ansible-playbook analytics_api.ym
     --extra-vars="ANALYTICS_API_VERSION=${OPENEDX_RELEASE}" \
     --extra-vars="@/ansible_overrides.yml"
 WORKDIR /edx/app/
-CMD ["/edx/app/supervisor/venvs/supervisor/bin/supervisord", "-n", "--configuration", "/edx/app/supervisor/supervisord.conf"]
+ENTRYPOINT ["/edx/app/edxapp/devstack.sh"]
+CMD ["start"]
 EXPOSE 443 80

--- a/docker/build/credentials/Dockerfile
+++ b/docker/build/credentials/Dockerfile
@@ -11,7 +11,8 @@ ARG BASE_IMAGE_TAG=latest
 FROM edxops/xenial-common:${BASE_IMAGE_TAG}
 LABEL maintainer="edxops"
 USER root
-CMD ["/edx/app/supervisor/venvs/supervisor/bin/supervisord", "-n", "--configuration", "/edx/app/supervisor/supervisord.conf"]
+ENTRYPOINT ["/edx/app/edxapp/devstack.sh"]
+CMD ["start"]
 
 ADD . /edx/app/edx_ansible/edx_ansible
 WORKDIR /edx/app/edx_ansible/edx_ansible/docker/plays

--- a/docker/build/designer/Dockerfile
+++ b/docker/build/designer/Dockerfile
@@ -11,7 +11,8 @@ ARG BASE_IMAGE_TAG=latest
 FROM edxops/xenial-common:${BASE_IMAGE_TAG}
 MAINTAINER edxops
 USER root
-CMD ["/edx/app/supervisor/venvs/supervisor/bin/supervisord", "-n", "--configuration", "/edx/app/supervisor/supervisord.conf"]
+ENTRYPOINT ["/edx/app/edxapp/devstack.sh"]
+CMD ["start"]
 
 ADD . /edx/app/edx_ansible/edx_ansible
 WORKDIR /edx/app/edx_ansible/edx_ansible/docker/plays

--- a/docker/build/discovery/Dockerfile
+++ b/docker/build/discovery/Dockerfile
@@ -11,7 +11,8 @@ ARG BASE_IMAGE_TAG=latest
 FROM edxops/xenial-common:${BASE_IMAGE_TAG}
 LABEL maintainer="edxops"
 USER root
-CMD ["/edx/app/supervisor/venvs/supervisor/bin/supervisord", "-n", "--configuration", "/edx/app/supervisor/supervisord.conf"]
+ENTRYPOINT ["/edx/app/edxapp/devstack.sh"]
+CMD ["start"]
 
 ADD . /edx/app/edx_ansible/edx_ansible
 WORKDIR /edx/app/edx_ansible/edx_ansible/docker/plays

--- a/docker/build/ecommerce/Dockerfile
+++ b/docker/build/ecommerce/Dockerfile
@@ -11,7 +11,8 @@ ARG BASE_IMAGE_TAG=latest
 FROM edxops/xenial-common:${BASE_IMAGE_TAG}
 LABEL maintainer="edxops"
 USER root
-CMD ["/edx/app/supervisor/venvs/supervisor/bin/supervisord", "-n", "--configuration", "/edx/app/supervisor/supervisord.conf"]
+ENTRYPOINT ["/edx/app/edxapp/devstack.sh"]
+CMD ["start"]
 
 ADD . /edx/app/edx_ansible/edx_ansible
 WORKDIR /edx/app/edx_ansible/edx_ansible/docker/plays

--- a/docker/build/ecomworker/Dockerfile
+++ b/docker/build/ecomworker/Dockerfile
@@ -20,5 +20,6 @@ RUN sudo /edx/app/edx_ansible/venvs/edx_ansible/bin/ansible-playbook ecomworker.
     -t "install:base,install:system-requirements,install:configuration,install:app-requirements,install:code" \
     --extra-vars="@/ansible_overrides.yml"
 
-USER root 
-CMD ["/edx/app/supervisor/venvs/supervisor/bin/supervisord", "-n", "--configuration", "/edx/app/supervisor/supervisord.conf"]
+USER root
+ENTRYPOINT ["/edx/app/edxapp/devstack.sh"]
+CMD ["start"]

--- a/docker/build/edxapp/Dockerfile
+++ b/docker/build/edxapp/Dockerfile
@@ -11,7 +11,8 @@ ARG BASE_IMAGE_TAG=latest
 FROM edxops/xenial-common:${BASE_IMAGE_TAG}
 LABEL maintainer="edxops"
 USER root
-CMD ["/edx/app/supervisor/venvs/supervisor/bin/supervisord", "-n", "--configuration", "/edx/app/supervisor/supervisord.conf"]
+ENTRYPOINT ["/edx/app/edxapp/devstack.sh"]
+CMD ["start"]
 
 ADD . /edx/app/edx_ansible/edx_ansible
 WORKDIR /edx/app/edx_ansible/edx_ansible/docker/plays

--- a/docker/build/forum/Dockerfile
+++ b/docker/build/forum/Dockerfile
@@ -23,5 +23,6 @@ RUN /edx/app/edx_ansible/venvs/edx_ansible/bin/ansible-playbook forum.yml \
     --extra-vars="forum_version=${OPENEDX_RELEASE}" \
     --extra-vars="@/ansible_overrides.yml"
 WORKDIR /edx/app
-CMD ["/edx/app/supervisor/venvs/supervisor/bin/supervisord", "-n", "--configuration", "/edx/app/supervisor/supervisord.conf"]
+ENTRYPOINT ["/edx/app/edxapp/devstack.sh"]
+CMD ["start"]
 EXPOSE 4567

--- a/docker/build/insights/Dockerfile
+++ b/docker/build/insights/Dockerfile
@@ -22,5 +22,6 @@ RUN /edx/app/edx_ansible/venvs/edx_ansible/bin/ansible-playbook insights.yml \
     -t "install:base,install:system-requirements,install:configuration,install:app-requirements,install:code" \
     --extra-vars="INSIGHTS_VERSION=${OPENEDX_RELEASE}" \
     --extra-vars="@/ansible_overrides.yml"
-CMD ["/edx/app/supervisor/venvs/supervisor/bin/supervisord", "-n", "--configuration", "/edx/app/supervisor/supervisord.conf"]
+ENTRYPOINT ["/edx/app/edxapp/devstack.sh"]
+CMD ["start"]
 EXPOSE 8110 18110

--- a/docker/build/notes/Dockerfile
+++ b/docker/build/notes/Dockerfile
@@ -29,4 +29,5 @@ RUN sudo /edx/app/edx_ansible/venvs/edx_ansible/bin/ansible-playbook notes.yml \
     --extra-vars="COMMON_GIT_PATH=$REPO_OWNER"
 
 USER root
-CMD ["/edx/app/supervisor/venvs/supervisor/bin/supervisord", "-n", "--configuration", "/edx/app/supervisor/supervisord.conf"]
+ENTRYPOINT ["/edx/app/edxapp/devstack.sh"]
+CMD ["start"]

--- a/docker/build/notifier/Dockerfile
+++ b/docker/build/notifier/Dockerfile
@@ -9,4 +9,5 @@ RUN /edx/app/edx_ansible/venvs/edx_ansible/bin/ansible-playbook notifier.yml \
     -t 'install' \
     -e@/ansible_overrides.yml
 WORKDIR /edx/app
-CMD ["/edx/app/supervisor/venvs/supervisor/bin/supervisord", "-n", "--configuration", "/edx/app/supervisor/supervisord.conf"]
+ENTRYPOINT ["/edx/app/edxapp/devstack.sh"]
+CMD ["start"]

--- a/docker/build/registrar/Dockerfile
+++ b/docker/build/registrar/Dockerfile
@@ -11,7 +11,8 @@ ARG BASE_IMAGE_TAG=latest
 FROM edxops/xenial-common:${BASE_IMAGE_TAG}
 LABEL maintainer="edxops"
 USER root
-CMD ["/edx/app/supervisor/venvs/supervisor/bin/supervisord", "-n", "--configuration", "/edx/app/supervisor/supervisord.conf"]
+ENTRYPOINT ["/edx/app/edxapp/devstack.sh"]
+CMD ["start"]
 
 ADD . /edx/app/edx_ansible/edx_ansible
 WORKDIR /edx/app/edx_ansible/edx_ansible/docker/plays

--- a/docker/build/xqueue/Dockerfile
+++ b/docker/build/xqueue/Dockerfile
@@ -10,7 +10,8 @@
 ARG BASE_IMAGE_TAG=latest
 FROM edxops/xenial-common:${BASE_IMAGE_TAG}
 LABEL maintainer="edxops"
-CMD ["/edx/app/supervisor/venvs/supervisor/bin/supervisord", "-n", "--configuration", "/edx/app/supervisor/supervisord.conf"]
+ENTRYPOINT ["/edx/app/edxapp/devstack.sh"]
+CMD ["start"]
 
 USER root
 RUN apt-get update

--- a/docker/build/xqwatcher/Dockerfile
+++ b/docker/build/xqwatcher/Dockerfile
@@ -23,4 +23,5 @@ RUN /edx/app/edx_ansible/venvs/edx_ansible/bin/ansible-playbook xqwatcher.yml \
     --extra-vars="XQWATCHER_VERSION=${OPENEDX_RELEASE}" \
     --extra-vars="@/ansible_overrides.yml"
 WORKDIR /edx/app
-CMD ["/edx/app/supervisor/venvs/supervisor/bin/supervisord", "-n", "--configuration", "/edx/app/supervisor/supervisord.conf"]
+ENTRYPOINT ["/edx/app/edxapp/devstack.sh"]
+CMD ["start"]

--- a/playbooks/roles/ansible-role-django-ida/templates/docker/build/ROLE_NAME/Dockerfile.j2
+++ b/playbooks/roles/ansible-role-django-ida/templates/docker/build/ROLE_NAME/Dockerfile.j2
@@ -25,5 +25,6 @@ RUN sudo /edx/app/edx_ansible/venvs/edx_ansible/bin/ansible-playbook {{ role_nam
     --extra-vars="{{ role_name|upper }}_VERSION=${{ role_name|upper }}_VERSION" \
     --extra-vars="COMMON_GIT_PATH=$REPO_OWNER"
 
-USER root 
-CMD ["/edx/app/supervisor/venvs/supervisor/bin/supervisord", "-n", "--configuration", "/edx/app/supervisor/supervisord.conf"]
+USER root
+ENTRYPOINT ["/edx/app/edxapp/devstack.sh"]
+CMD ["start"]

--- a/playbooks/roles/edx_django_service/templates/edx/app/app/devstack.sh.j2
+++ b/playbooks/roles/edx_django_service/templates/edx/app/app/devstack.sh.j2
@@ -13,4 +13,12 @@ case $COMMAND in
 
         /bin/bash
         ;;
+    exec)
+        shift
+
+        . {{ edx_django_service_nodeenv_bin }}/activate
+        . {{ edx_django_service_venv_bin_dir }}/activate
+        cd {{ edx_django_service_code_dir }}
+
+        /bin/bash -c "$*"
 esac

--- a/playbooks/roles/edx_django_service/templates/edx/app/app/devstack.sh.j2
+++ b/playbooks/roles/edx_django_service/templates/edx/app/app/devstack.sh.j2
@@ -6,6 +6,9 @@ source {{ edx_django_service_home }}/{{ edx_django_service_name }}_env
 COMMAND=$1
 
 case $COMMAND in
+    start)
+        /edx/app/supervisor/venvs/supervisor/bin/supervisord -n --configuration /edx/app/supervisor/supervisord.conf
+        ;;
     open)
         . {{ edx_django_service_nodeenv_bin }}/activate
         . {{ edx_django_service_venv_bin_dir }}/activate
@@ -21,4 +24,5 @@ case $COMMAND in
         cd {{ edx_django_service_code_dir }}
 
         /bin/bash -c "$*"
+        ;;
 esac

--- a/playbooks/roles/edxapp/templates/devstack.sh.j2
+++ b/playbooks/roles/edxapp/templates/devstack.sh.j2
@@ -13,4 +13,12 @@ case $COMMAND in
 
         /bin/bash
         ;;
+    exec)
+        shift
+
+        . {{ edxapp_nodeenv_bin }}/activate
+        . {{ edxapp_venv_bin }}/activate
+        cd {{ edxapp_code_dir }}
+
+        /bin/bash -c "$*"
 esac

--- a/playbooks/roles/edxapp/templates/devstack.sh.j2
+++ b/playbooks/roles/edxapp/templates/devstack.sh.j2
@@ -6,6 +6,9 @@ source {{ edxapp_app_dir }}/edxapp_env
 COMMAND=$1
 
 case $COMMAND in
+    start)
+        /edx/app/supervisor/venvs/supervisor/bin/supervisord -n --configuration /edx/app/supervisor/supervisord.conf
+        ;;
     open)
         . {{ edxapp_nodeenv_bin }}/activate
         . {{ edxapp_venv_bin }}/activate

--- a/playbooks/roles/xqueue/templates/devstack.sh.j2
+++ b/playbooks/roles/xqueue/templates/devstack.sh.j2
@@ -11,4 +11,11 @@ case $COMMAND in
 
         /bin/bash
         ;;
+    exec)
+        shift
+
+        . {{ xqueue_venv_bin }}/activate
+        cd {{ xqueue_code_dir }}
+
+        /bin/bash -c "$*"
 esac

--- a/playbooks/roles/xqueue/templates/devstack.sh.j2
+++ b/playbooks/roles/xqueue/templates/devstack.sh.j2
@@ -5,6 +5,9 @@
 COMMAND=$1
 
 case $COMMAND in
+    start)
+        /edx/app/supervisor/venvs/supervisor/bin/supervisord -n --configuration /edx/app/supervisor/supervisord.conf
+        ;;
     open)
         . {{ xqueue_venv_bin }}/activate
         cd {{ xqueue_code_dir }}


### PR DESCRIPTION
The goal of this PR is to make it easier to run single commands within devstacks (with the proper environment) so that command history stays in the local shell.

For instance, with this in place, one can run a test in the lms by using:

`docker-compose exec lms exec pytest openedx/features`

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
