### PR TITLE
Refactor devstack_sqlite_fix role and use it in jenkins_worker

### DIFF
--- a/playbooks/edxapp.yml
+++ b/playbooks/edxapp.yml
@@ -20,7 +20,7 @@
      nginx_extra_configs: "{{ NGINX_EDXAPP_EXTRA_CONFIGS }}"
      nginx_skip_enable_sites: "{{ EDXAPP_NGINX_SKIP_ENABLE_SITES }}"
    - edxapp
-   - role: devstack_sqlite_fix
+   - role: sqlite_fix
      when: devstack is defined and devstack
    - role: datadog
      when: COMMON_ENABLE_DATADOG

--- a/playbooks/jenkins_worker.yml
+++ b/playbooks/jenkins_worker.yml
@@ -13,6 +13,9 @@
     COMMON_SECURITY_UPDATES: yes
     SECURITY_UPGRADE_ON_ANSIBLE: true
     MONGO_AUTH: false
+    SQLITE_AUTOCONF_URL: "https://www.sqlite.org/2019/sqlite-autoconf-3280000.tar.gz"
+    SQLITE_AUTOCONF_CREATED_PATH: "sqlite-autoconf-3280000"
+    SQLITE_FIX_PYTHON_PATH: "/home/jenkins/edx-venv/bin/python"
   serial: "{{ serial_count }}"
   vars_files:
     - roles/edxapp/defaults/main.yml
@@ -28,4 +31,5 @@
     - mongo_3_2
     - browsers
     - jenkins_worker
+    - sqlite_fix
     - newrelic_infrastructure

--- a/playbooks/roles/sqlite_fix/defaults/main.yml
+++ b/playbooks/roles/sqlite_fix/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-
+SQLITE_FIX_PYTHON_PATH: "python"
 SQLITE_FIX_TMP_DIR: "/var/tmp/sqlite_fix"
 
 PYSQLITE_URL: "https://codeload.github.com/ghaering/pysqlite/tar.gz/2.8.3"

--- a/playbooks/roles/sqlite_fix/tasks/main.yml
+++ b/playbooks/roles/sqlite_fix/tasks/main.yml
@@ -4,10 +4,10 @@
     path: "{{ SQLITE_FIX_TMP_DIR }}"
     state: directory
     mode: 0775
-  when: devstack is defined and devstack
   tags:
     - devstack
     - devstack:install
+    - install
 
 
 # Tasks to download and upgrade pysqlite to prevent segfaults when testing in devstack
@@ -16,45 +16,45 @@
     src: "{{ SQLITE_AUTOCONF_URL }}"
     dest: "{{ SQLITE_FIX_TMP_DIR }}"
     remote_src: yes
-  when: devstack is defined and devstack
   tags:
     - devstack
     - devstack:install
+    - install
 
 - name: Download and unzip pysqlite update
   unarchive:
     src: "{{ PYSQLITE_URL }}"
     dest: "{{ SQLITE_FIX_TMP_DIR }}"
     remote_src: yes
-  when: devstack is defined and devstack
   tags:
     - devstack
     - devstack:install
+    - install
 
 # Copy module doesn't support recursive dir copies for remote_src: yes
 - name: Copy pysqlite autoconf into pyslite update dir
   command: "cp -av . {{ PYSQLITE_TMP_PATH }}/"
   args:
     chdir: "{{ SQLITE_TMP_PATH }}"
-  when: devstack is defined and devstack
   tags:
     - devstack
     - devstack:install
+    - install
 
 - name: Build and install pysqlite update
-  command: "python setup.py build_static install"
+  command: "{{ SQLITE_FIX_PYTHON_PATH }} setup.py build_static install"
   args:
     chdir: "{{ PYSQLITE_TMP_PATH }}"
-  when: devstack is defined and devstack
   tags:
     - devstack
     - devstack:install
+    - install
 
 - name: Clean up pysqlite install artifacts
   file:
     state: absent
     path: "{{ SQLITE_FIX_TMP_DIR }}/"
-  when: devstack is defined and devstack
   tags:
     - devstack
     - devstack:install
+    - install


### PR DESCRIPTION
Upgrade sqlite in jenkins workers to avoid segfaults. This role existed to solve this problem in devstack, so I made it slightly more general and added it to the jenkins_worker playbook.