### PR TITLE
Add devstack.sh forum notes

### DIFF
--- a/docker/build/analytics_pipeline/devstack.sh
+++ b/docker/build/analytics_pipeline/devstack.sh
@@ -3,10 +3,24 @@
 COMMAND=$1
 
 case $COMMAND in
+    start)
+        /edx/app/supervisor/venvs/supervisor/bin/supervisord -n --configuration /edx/app/supervisor/supervisord.conf
+        ;;
     open)
         . /edx/app/analytics_pipeline/venvs/analytics_pipeline/bin/activate
         cd /edx/app/analytics_pipeline/analytics_pipeline
 
         /bin/bash
+        ;;
+    exec)
+        shift
+
+        . /edx/app/analytics_pipeline/venvs/analytics_pipeline/bin/activate
+        cd /edx/app/analytics_pipeline/analytics_pipeline
+
+        /bin/bash -c "$*"
+        ;;
+    *)
+        /bin/bash -c "$*"
         ;;
 esac

--- a/docker/build/notes/Dockerfile
+++ b/docker/build/notes/Dockerfile
@@ -29,5 +29,5 @@ RUN sudo /edx/app/edx_ansible/venvs/edx_ansible/bin/ansible-playbook notes.yml \
     --extra-vars="COMMON_GIT_PATH=$REPO_OWNER"
 
 USER root
-ENTRYPOINT ["/edx/app/notes/devstack.sh"]
+ENTRYPOINT ["/edx/app/edx_notes_api/devstack.sh"]
 CMD ["start"]

--- a/playbooks/roles/edx_django_service/templates/edx/app/app/devstack.sh.j2
+++ b/playbooks/roles/edx_django_service/templates/edx/app/app/devstack.sh.j2
@@ -25,4 +25,7 @@ case $COMMAND in
 
         /bin/bash -c "$*"
         ;;
+    *)
+        /bin/bash -c "$*"
+        ;;
 esac

--- a/playbooks/roles/edx_notes_api/tasks/main.yml
+++ b/playbooks/roles/edx_notes_api/tasks/main.yml
@@ -9,7 +9,7 @@
 #
 #
 # Tasks for role edx-notes-api
-# 
+#
 # Overview:
 #
 # Role for installing the edx-notes-api Django application, https://github.com/edx/edx-notes-api.
@@ -36,7 +36,7 @@
 #     nginx_sites:
 #       - edx-notes-api
 #   - aws
-#   - edx-notes-api 
+#   - edx-notes-api
 #   - role: datadog
 #     when: COMMON_ENABLE_DATADOG
 #   - role: splunkforwarder
@@ -53,6 +53,18 @@
   tags:
     - install
     - install:system-requirements
+
+- name: write devstack script
+  template:
+    src: "devstack.sh.j2"
+    dest: "{{ edx_notes_api_home }}/devstack.sh"
+    owner: "{{ supervisor_user }}"
+    group: "{{ common_web_user }}"
+    mode: 0744
+  when: devstack is defined and devstack
+  tags:
+    - devstack
+    - devstack:install
 
 - name: Migrate
   shell: >

--- a/playbooks/roles/edx_notes_api/templates/edx/app/edx_notes_api/devstack.sh.j2
+++ b/playbooks/roles/edx_notes_api/templates/edx/app/edx_notes_api/devstack.sh.j2
@@ -24,4 +24,8 @@ case $COMMAND in
         cd {{ edxapp_code_dir }}
 
         /bin/bash -c "$*"
+        ;;
+    *)
+        /bin/bash -c "$*"
+        ;;
 esac

--- a/playbooks/roles/edx_notes_api/templates/edx/app/edx_notes_api/devstack.sh.j2
+++ b/playbooks/roles/edx_notes_api/templates/edx/app/edx_notes_api/devstack.sh.j2
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+# {{ ansible_managed }}
+
+source {{ edxapp_app_dir }}/edxapp_env
+COMMAND=$1
+
+case $COMMAND in
+    start)
+        /edx/app/supervisor/venvs/supervisor/bin/supervisord -n --configuration /edx/app/supervisor/supervisord.conf
+        ;;
+    open)
+        . {{ edxapp_nodeenv_bin }}/activate
+        . {{ edxapp_venv_bin }}/activate
+        cd {{ edxapp_code_dir }}
+
+        /bin/bash
+        ;;
+    exec)
+        shift
+
+        . {{ edxapp_nodeenv_bin }}/activate
+        . {{ edxapp_venv_bin }}/activate
+        cd {{ edxapp_code_dir }}
+
+        /bin/bash -c "$*"
+esac

--- a/playbooks/roles/edxapp/templates/devstack.sh.j2
+++ b/playbooks/roles/edxapp/templates/devstack.sh.j2
@@ -24,4 +24,8 @@ case $COMMAND in
         cd {{ edxapp_code_dir }}
 
         /bin/bash -c "$*"
+        ;;
+    *)
+        /bin/bash -c "$*"
+        ;;
 esac

--- a/playbooks/roles/forum/tasks/main.yml
+++ b/playbooks/roles/forum/tasks/main.yml
@@ -44,6 +44,20 @@
     - install
     - install:base
 
+
+- name: write devstack script
+  template:
+    src: "devstack.sh.j2"
+    dest: "{{ forum_app_dir }}/devstack.sh"
+    owner: "{{ supervisor_user }}"
+    group: "{{ common_web_user }}"
+    mode: 0744
+  when: devstack is defined and devstack
+  tags:
+    - devstack
+    - devstack:install
+
+
 - name: setup the forum env for stage/prod
   template:
     src: forum_env.j2

--- a/playbooks/roles/forum/templates/devstack.sh.j2
+++ b/playbooks/roles/forum/templates/devstack.sh.j2
@@ -24,4 +24,8 @@ case $COMMAND in
         cd {{ edxapp_code_dir }}
 
         /bin/bash -c "$*"
+        ;;
+    *)
+        /bin/bash -c "$*"
+        ;;
 esac

--- a/playbooks/roles/forum/templates/devstack.sh.j2
+++ b/playbooks/roles/forum/templates/devstack.sh.j2
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+# {{ ansible_managed }}
+
+source {{ edxapp_app_dir }}/edxapp_env
+COMMAND=$1
+
+case $COMMAND in
+    start)
+        /edx/app/supervisor/venvs/supervisor/bin/supervisord -n --configuration /edx/app/supervisor/supervisord.conf
+        ;;
+    open)
+        . {{ edxapp_nodeenv_bin }}/activate
+        . {{ edxapp_venv_bin }}/activate
+        cd {{ edxapp_code_dir }}
+
+        /bin/bash
+        ;;
+    exec)
+        shift
+
+        . {{ edxapp_nodeenv_bin }}/activate
+        . {{ edxapp_venv_bin }}/activate
+        cd {{ edxapp_code_dir }}
+
+        /bin/bash -c "$*"
+esac

--- a/playbooks/roles/xqueue/templates/devstack.sh.j2
+++ b/playbooks/roles/xqueue/templates/devstack.sh.j2
@@ -21,4 +21,8 @@ case $COMMAND in
         cd {{ xqueue_code_dir }}
 
         /bin/bash -c "$*"
+        ;;
+    *)
+        /bin/bash -c "$*"
+        ;;
 esac


### PR DESCRIPTION
Add devstack.sh files for edx_notes_api and forum. Also make it so that `docker exec` with no `devstack.sh` command just forwards to `/bin/bash`.

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
