### PR TITLE
Dockerfile entrypoints

### DIFF
--- a/docker.mk
+++ b/docker.mk
@@ -79,8 +79,13 @@ $(docker_push)%: $(docker_pkg)%
 
 .build/%/Dockerfile.d: docker/build/%/Dockerfile Makefile
 	@mkdir -p .build/$*
-	$(eval FROM=$(shell grep "^\s*FROM" $< | sed -E "s/FROM //" | sed -E "s/:/@/g"))
+	$(eval BASE_IMAGE_TAG=$(shell grep "^\s*ARG BASE_IMAGE_TAG" $< | sed -E "s/ARG BASE_IMAGE_TAG=//"))
+	@# I have no idea why the final sed is eating the first character of the substitution...
+	$(eval FROM=$(shell grep "^\s*FROM" docker/build/ecommerce/Dockerfile  | sed -E "s/FROM //" | sed -E "s/:/@/g" | sed -E 's/\$\{BASE_IMAGE_TAG\}/ $(BASE_IMAGE_TAG)/'))
 	$(eval EDXOPS_FROM=$(shell echo "$(FROM)" | sed -E "s#edxops/([^@]+)(@.*)?#\1#"))
+	@echo "Base Image Tag: $(BASE_IMAGE_TAG)"
+	@echo $(FROM)
+	@echo $(EDXOPS_FROM)
 	@echo "$(docker_build)$*: $(docker_pull)$(FROM)" > $@
 	@if [ "$(EDXOPS_FROM)" != "$(FROM)" ]; then \
 	echo "$(docker_test)$*: $(docker_test)$(EDXOPS_FROM:@%=)" >> $@; \

--- a/docker/build/analytics_api/Dockerfile
+++ b/docker/build/analytics_api/Dockerfile
@@ -28,5 +28,6 @@ RUN /edx/app/edx_ansible/venvs/edx_ansible/bin/ansible-playbook analytics_api.ym
     --extra-vars="ANALYTICS_API_VERSION=${OPENEDX_RELEASE}" \
     --extra-vars="@/ansible_overrides.yml"
 WORKDIR /edx/app/
-CMD ["/edx/app/supervisor/venvs/supervisor/bin/supervisord", "-n", "--configuration", "/edx/app/supervisor/supervisord.conf"]
+ENTRYPOINT ["/edx/app/analytics_api/devstack.sh"]
+CMD ["start"]
 EXPOSE 443 80

--- a/docker/build/analytics_pipeline/devstack.sh
+++ b/docker/build/analytics_pipeline/devstack.sh
@@ -18,9 +18,9 @@ case $COMMAND in
         . /edx/app/analytics_pipeline/venvs/analytics_pipeline/bin/activate
         cd /edx/app/analytics_pipeline/analytics_pipeline
 
-        /bin/bash -c "$*"
+        "$@"
         ;;
     *)
-        /bin/bash -c "$*"
+        "$@"
         ;;
 esac

--- a/docker/build/credentials/Dockerfile
+++ b/docker/build/credentials/Dockerfile
@@ -11,7 +11,8 @@ ARG BASE_IMAGE_TAG=latest
 FROM edxops/xenial-common:${BASE_IMAGE_TAG}
 LABEL maintainer="edxops"
 USER root
-CMD ["/edx/app/supervisor/venvs/supervisor/bin/supervisord", "-n", "--configuration", "/edx/app/supervisor/supervisord.conf"]
+ENTRYPOINT ["/edx/app/credentials/devstack.sh"]
+CMD ["start"]
 
 ADD . /edx/app/edx_ansible/edx_ansible
 WORKDIR /edx/app/edx_ansible/edx_ansible/docker/plays

--- a/docker/build/designer/Dockerfile
+++ b/docker/build/designer/Dockerfile
@@ -11,7 +11,8 @@ ARG BASE_IMAGE_TAG=latest
 FROM edxops/xenial-common:${BASE_IMAGE_TAG}
 MAINTAINER edxops
 USER root
-CMD ["/edx/app/supervisor/venvs/supervisor/bin/supervisord", "-n", "--configuration", "/edx/app/supervisor/supervisord.conf"]
+ENTRYPOINT ["/edx/app/designer/devstack.sh"]
+CMD ["start"]
 
 ADD . /edx/app/edx_ansible/edx_ansible
 WORKDIR /edx/app/edx_ansible/edx_ansible/docker/plays

--- a/docker/build/discovery/Dockerfile
+++ b/docker/build/discovery/Dockerfile
@@ -11,7 +11,8 @@ ARG BASE_IMAGE_TAG=latest
 FROM edxops/xenial-common:${BASE_IMAGE_TAG}
 LABEL maintainer="edxops"
 USER root
-CMD ["/edx/app/supervisor/venvs/supervisor/bin/supervisord", "-n", "--configuration", "/edx/app/supervisor/supervisord.conf"]
+ENTRYPOINT ["/edx/app/discovery/devstack.sh"]
+CMD ["start"]
 
 ADD . /edx/app/edx_ansible/edx_ansible
 WORKDIR /edx/app/edx_ansible/edx_ansible/docker/plays

--- a/docker/build/ecommerce/Dockerfile
+++ b/docker/build/ecommerce/Dockerfile
@@ -11,7 +11,8 @@ ARG BASE_IMAGE_TAG=latest
 FROM edxops/xenial-common:${BASE_IMAGE_TAG}
 LABEL maintainer="edxops"
 USER root
-CMD ["/edx/app/supervisor/venvs/supervisor/bin/supervisord", "-n", "--configuration", "/edx/app/supervisor/supervisord.conf"]
+ENTRYPOINT ["/edx/app/ecommerce/devstack.sh"]
+CMD ["start"]
 
 ADD . /edx/app/edx_ansible/edx_ansible
 WORKDIR /edx/app/edx_ansible/edx_ansible/docker/plays

--- a/docker/build/ecomworker/Dockerfile
+++ b/docker/build/ecomworker/Dockerfile
@@ -21,4 +21,5 @@ RUN sudo /edx/app/edx_ansible/venvs/edx_ansible/bin/ansible-playbook ecomworker.
     --extra-vars="@/ansible_overrides.yml"
 
 USER root
-CMD ["/edx/app/supervisor/venvs/supervisor/bin/supervisord", "-n", "--configuration", "/edx/app/supervisor/supervisord.conf"]
+ENTRYPOINT ["/edx/app/ecomworker/devstack.sh"]
+CMD ["start"]

--- a/docker/build/edxapp/Dockerfile
+++ b/docker/build/edxapp/Dockerfile
@@ -11,7 +11,8 @@ ARG BASE_IMAGE_TAG=latest
 FROM edxops/xenial-common:${BASE_IMAGE_TAG}
 LABEL maintainer="edxops"
 USER root
-CMD ["/edx/app/supervisor/venvs/supervisor/bin/supervisord", "-n", "--configuration", "/edx/app/supervisor/supervisord.conf"]
+ENTRYPOINT ["/edx/app/edxapp/devstack.sh"]
+CMD ["start"]
 
 ADD . /edx/app/edx_ansible/edx_ansible
 WORKDIR /edx/app/edx_ansible/edx_ansible/docker/plays

--- a/docker/build/forum/Dockerfile
+++ b/docker/build/forum/Dockerfile
@@ -23,5 +23,6 @@ RUN /edx/app/edx_ansible/venvs/edx_ansible/bin/ansible-playbook forum.yml \
     --extra-vars="forum_version=${OPENEDX_RELEASE}" \
     --extra-vars="@/ansible_overrides.yml"
 WORKDIR /edx/app
-CMD ["/edx/app/supervisor/venvs/supervisor/bin/supervisord", "-n", "--configuration", "/edx/app/supervisor/supervisord.conf"]
+ENTRYPOINT ["/edx/app/forum/devstack.sh"]
+CMD ["start"]
 EXPOSE 4567

--- a/docker/build/insights/Dockerfile
+++ b/docker/build/insights/Dockerfile
@@ -22,5 +22,6 @@ RUN /edx/app/edx_ansible/venvs/edx_ansible/bin/ansible-playbook insights.yml \
     -t "install:base,install:system-requirements,install:configuration,install:app-requirements,install:code" \
     --extra-vars="INSIGHTS_VERSION=${OPENEDX_RELEASE}" \
     --extra-vars="@/ansible_overrides.yml"
-CMD ["/edx/app/supervisor/venvs/supervisor/bin/supervisord", "-n", "--configuration", "/edx/app/supervisor/supervisord.conf"]
+ENTRYPOINT ["/edx/app/insights/devstack.sh"]
+CMD ["start"]
 EXPOSE 8110 18110

--- a/docker/build/notes/Dockerfile
+++ b/docker/build/notes/Dockerfile
@@ -29,4 +29,5 @@ RUN sudo /edx/app/edx_ansible/venvs/edx_ansible/bin/ansible-playbook notes.yml \
     --extra-vars="COMMON_GIT_PATH=$REPO_OWNER"
 
 USER root
-CMD ["/edx/app/supervisor/venvs/supervisor/bin/supervisord", "-n", "--configuration", "/edx/app/supervisor/supervisord.conf"]
+ENTRYPOINT ["/edx/app/edx_notes_api/devstack.sh"]
+CMD ["start"]

--- a/docker/build/notifier/Dockerfile
+++ b/docker/build/notifier/Dockerfile
@@ -9,4 +9,5 @@ RUN /edx/app/edx_ansible/venvs/edx_ansible/bin/ansible-playbook notifier.yml \
     -t 'install' \
     -e@/ansible_overrides.yml
 WORKDIR /edx/app
-CMD ["/edx/app/supervisor/venvs/supervisor/bin/supervisord", "-n", "--configuration", "/edx/app/supervisor/supervisord.conf"]
+ENTRYPOINT ["/edx/app/notifier/devstack.sh"]
+CMD ["start"]

--- a/docker/build/registrar/Dockerfile
+++ b/docker/build/registrar/Dockerfile
@@ -11,7 +11,8 @@ ARG BASE_IMAGE_TAG=latest
 FROM edxops/xenial-common:${BASE_IMAGE_TAG}
 LABEL maintainer="edxops"
 USER root
-CMD ["/edx/app/supervisor/venvs/supervisor/bin/supervisord", "-n", "--configuration", "/edx/app/supervisor/supervisord.conf"]
+ENTRYPOINT ["/edx/app/registrar/devstack.sh"]
+CMD ["start"]
 
 ADD . /edx/app/edx_ansible/edx_ansible
 WORKDIR /edx/app/edx_ansible/edx_ansible/docker/plays

--- a/docker/build/xqueue/Dockerfile
+++ b/docker/build/xqueue/Dockerfile
@@ -10,7 +10,8 @@
 ARG BASE_IMAGE_TAG=latest
 FROM edxops/xenial-common:${BASE_IMAGE_TAG}
 LABEL maintainer="edxops"
-CMD ["/edx/app/supervisor/venvs/supervisor/bin/supervisord", "-n", "--configuration", "/edx/app/supervisor/supervisord.conf"]
+ENTRYPOINT ["/edx/app/xqueue/devstack.sh"]
+CMD ["start"]
 
 USER root
 RUN apt-get update

--- a/docker/build/xqwatcher/Dockerfile
+++ b/docker/build/xqwatcher/Dockerfile
@@ -23,4 +23,5 @@ RUN /edx/app/edx_ansible/venvs/edx_ansible/bin/ansible-playbook xqwatcher.yml \
     --extra-vars="XQWATCHER_VERSION=${OPENEDX_RELEASE}" \
     --extra-vars="@/ansible_overrides.yml"
 WORKDIR /edx/app
-CMD ["/edx/app/supervisor/venvs/supervisor/bin/supervisord", "-n", "--configuration", "/edx/app/supervisor/supervisord.conf"]
+ENTRYPOINT ["/edx/app/edxapp/devstack.sh"]
+CMD ["start"]

--- a/playbooks/roles/ansible-role-django-ida/templates/docker/build/ROLE_NAME/Dockerfile.j2
+++ b/playbooks/roles/ansible-role-django-ida/templates/docker/build/ROLE_NAME/Dockerfile.j2
@@ -25,5 +25,6 @@ RUN sudo /edx/app/edx_ansible/venvs/edx_ansible/bin/ansible-playbook {{ role_nam
     --extra-vars="{{ role_name|upper }}_VERSION=${{ role_name|upper }}_VERSION" \
     --extra-vars="COMMON_GIT_PATH=$REPO_OWNER"
 
-USER root 
-CMD ["/edx/app/supervisor/venvs/supervisor/bin/supervisord", "-n", "--configuration", "/edx/app/supervisor/supervisord.conf"]
+USER root
+ENTRYPOINT ["/edx/app/edxapp/devstack.sh"]
+CMD ["start"]

--- a/playbooks/roles/edx_django_service/templates/edx/app/app/devstack.sh.j2
+++ b/playbooks/roles/edx_django_service/templates/edx/app/app/devstack.sh.j2
@@ -23,9 +23,9 @@ case $COMMAND in
         . {{ edx_django_service_venv_bin_dir }}/activate
         cd {{ edx_django_service_code_dir }}
 
-        /bin/bash -c "$*"
+        "$@"
         ;;
     *)
-        /bin/bash -c "$*"
+        "$@"
         ;;
 esac

--- a/playbooks/roles/edx_notes_api/templates/edx/app/edx_notes_api/devstack.sh.j2
+++ b/playbooks/roles/edx_notes_api/templates/edx/app/edx_notes_api/devstack.sh.j2
@@ -21,9 +21,9 @@ case $COMMAND in
         . {{ edx_notes_api_venv_bin }}/activate
         cd {{ edx_notes_api_code_dir }}
 
-        /bin/bash -c "$*"
+        "$@"
         ;;
     *)
-        /bin/bash -c "$*"
+        "$@"
         ;;
 esac

--- a/playbooks/roles/edxapp/templates/devstack.sh.j2
+++ b/playbooks/roles/edxapp/templates/devstack.sh.j2
@@ -23,9 +23,9 @@ case $COMMAND in
         . {{ edxapp_venv_bin }}/activate
         cd {{ edxapp_code_dir }}
 
-        /bin/bash -c "$*"
+        "$@"
         ;;
     *)
-        /bin/bash -c "$*"
+        "$@"
         ;;
 esac

--- a/playbooks/roles/forum/templates/devstack.sh.j2
+++ b/playbooks/roles/forum/templates/devstack.sh.j2
@@ -19,9 +19,9 @@ case $COMMAND in
 
         cd {{ forum_code_dir }}
 
-        /bin/bash -c "$*"
+        "$@"
         ;;
     *)
-        /bin/bash -c "$*"
+        "$@"
         ;;
 esac

--- a/playbooks/roles/xqueue/templates/devstack.sh.j2
+++ b/playbooks/roles/xqueue/templates/devstack.sh.j2
@@ -20,9 +20,9 @@ case $COMMAND in
         . {{ xqueue_venv_bin }}/activate
         cd {{ xqueue_code_dir }}
 
-        /bin/bash -c "$*"
+        "$@"
         ;;
     *)
-        /bin/bash -c "$*"
+        "$@"
         ;;
 esac


### PR DESCRIPTION
I've validated locally that the images built in this work to start devstack.

I think there's an argument for moving the commands that are currently part of the devstack docker-compose files and moving them into these scripts.

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
