### PR TITLE
Add discovery mysql replica settings to env config.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+- Role: discovery
+  - Add mysql replica settings to env config.
+
 - Role: common_vars
   - Default `COMMON_JWT_PUBLIC_SIGNING_JWK_SET` to `''`
     instead of `!!null`. Because of how this setting is handled,

--- a/playbooks/roles/discovery/defaults/main.yml
+++ b/playbooks/roles/discovery/defaults/main.yml
@@ -19,8 +19,19 @@ DISCOVERY_GIT_IDENTITY: !!null
 discovery_service_name: "discovery"
 discovery_gunicorn_port: 8381
 
+DISCOVERY_DEFAULT_DB_NAME: 'discovery'
+DISCOVERY_MYSQL: 'localhost'
+# MySQL usernames are limited to 16 characters
+DISCOVERY_MYSQL_USER: 'discov001'
+DISCOVERY_MYSQL_PASSWORD: 'password'
+DISCOVERY_MYSQL_REPLICA_HOST: 'localhost'
+
 discovery_environment:
   DISCOVERY_CFG: "{{ COMMON_CFG_DIR }}/{{ discovery_service_name }}.yml"
+  DISCOVERY_MYSQL_REPLICA_HOST: '{{ DISCOVERY_MYSQL_REPLICA_HOST }}'
+  DISCOVERY_MYSQL_REPLICA_USER: '{{ DISCOVERY_MYSQL_USER }}'
+  DISCOVERY_MYSQL_REPLICA_PASSWORD: '{{ DISCOVERY_MYSQL_PASSWORD }}'
+  DISCOVERY_MYSQL_REPLICA_NAME: '{{ DISCOVERY_DEFAULT_DB_NAME }}'
 
 discovery_user: "{{ discovery_service_name }}"
 discovery_home: "{{ COMMON_APP_DIR }}/{{ discovery_service_name }}"
@@ -38,12 +49,6 @@ discovery_debian_pkgs:
 
 DISCOVERY_NGINX_PORT: "1{{ discovery_gunicorn_port }}"
 DISCOVERY_SSL_NGINX_PORT: "4{{ discovery_gunicorn_port }}"
-
-DISCOVERY_DEFAULT_DB_NAME: 'discovery'
-DISCOVERY_MYSQL: 'localhost'
-# MySQL usernames are limited to 16 characters
-DISCOVERY_MYSQL_USER: 'discov001'
-DISCOVERY_MYSQL_PASSWORD: 'password'
 
 # Using SSL? See https://www.elastic.co/guide/en/shield/current/ssl-tls.html.
 # Using AWS? Use the AWS-provided host (e.g. https://search-test-abc123.us-east-1.es.amazonaws.com/).


### PR DESCRIPTION
Corresponding course-discovery PR: https://github.com/edx/course-discovery/pull/2000

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
