### PR TITLE
add devstack tag to analytics api container

### DIFF
--- a/docker/build/analytics_api/Dockerfile
+++ b/docker/build/analytics_api/Dockerfile
@@ -24,7 +24,7 @@ ENV OPENEDX_RELEASE=${OPENEDX_RELEASE}
 RUN /edx/app/edx_ansible/venvs/edx_ansible/bin/ansible-playbook analytics_api.yml \
     -i '127.0.0.1,' \
     -c local \
-    -t "install:base,install:system-requirements,install:configuration,install:app-requirements,install:code" \
+    -t "install:base,install:system-requirements,install:configuration,install:app-requirements,install:code,devstack:install" \
     --extra-vars="ANALYTICS_API_VERSION=${OPENEDX_RELEASE}" \
     --extra-vars="@/ansible_overrides.yml"
 WORKDIR /edx/app/


### PR DESCRIPTION
The analytics api container was not being built with the `devstack:install` tag, so it was not picking up the templated `devstack.sh` file (https://github.com/edx/configuration/blob/master/playbooks/roles/edx_django_service/tasks/main.yml#L173-L183), which is now required since this (https://github.com/edx/configuration/commit/473d73669fba687c6e291d694eb4448c4d81f456) was merged.