### PR TITLE
Add create_api_access_request call back to masters sandbox.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+- Playbook: masters_sandbox
+  - Include call to create_api_access_request
+
 - Role: discovery
   - Add mysql replica settings to env config.
 

--- a/playbooks/masters_sandbox.yml
+++ b/playbooks/masters_sandbox.yml
@@ -25,6 +25,13 @@
       args:
         chdir: "{{ edxapp_code_dir }}"
 
+    - name: create api access request
+      shell: >
+        . {{ edxapp_env_path }} && {{ edxapp_venv_dir }}/bin/python manage.py lms create_api_access_request {{username}}
+        --create-config --disconnect-signals
+      args:
+        chdir: "{{ edxapp_code_dir }}"
+
     - name: create discovery site configuration
       shell: >
         . {{ edxapp_env_path }} && {{ edxapp_venv_dir }}/bin/python manage.py lms create_site_configuration {{dns_name}}.sandbox.edx.org


### PR DESCRIPTION
Configuration Pull Request
---
Tested this and got a working api access request page after the build succeeded: https://iloveagent57.sandbox.edx.org/api-admin/status/
Successful sandbox build: https://tools-edx-jenkins.edx.org/job/Sandboxes/job/CreateSandbox/21868/parameters/

  - [x] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [x] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [x] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [x] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
