### PR TITLE
Don't double wire config overrides.

### DIFF
--- a/playbooks/roles/blockstore/defaults/main.yml
+++ b/playbooks/roles/blockstore/defaults/main.yml
@@ -46,13 +46,14 @@ BLOCKSTORE_DATABASE_PORT: 3306
 BLOCKSTORE_DJANGO_SETTINGS_MODULE: 'blockstore.settings.production'
 BLOCKSTORE_SECRET_KEY: !!null
 
-BLOCKSTORE_URL_ROOT: 'http://localhost:{{ blockstore_gunicorn_port }}'
 
 # See edx_django_service_automated_users for an example of what this should be
 BLOCKSTORE_AUTOMATED_USERS: {}
 
-blockstore_service_config_overrides:
-  BLOCKSTORE_URL_ROOT: '{{ BLOCKSTORE_URL_ROOT }}'
+# Rather than adding extra wiring for each var under here.
+# Just override this whole config dictionary
+BLOCKSTORE_SERVICE_CONFIG_OVERRIDES:
+  BLOCKSTORE_URL_ROOT: 'http://localhost:{{ blockstore_gunicorn_port }}'
 
 blockstore_environment:
   BLOCKSTORE_CFG: '{{ COMMON_CFG_DIR }}/{{ blockstore_service_name }}.yml'


### PR DESCRIPTION
Make it clear that everyone should just fully override
`BLOCKSTORE_SERVICE_CONFIG_OVERRIDES` instead of the old way we've been
doing things where we have to add in extra wiring here before we
override everything.

Since we're eventually moving away from using ansible to manage this
config anyway, we don't need to have the wasted effort of wiring things
into here.

Defaults come from the code defaults and all overrides are provided by
the operator, no opinions about this in ansible.

If we want to add devstack specific overrides they can go into the
devstack overrides, and prod related ones can go into the operators
overrides files.

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
