### PR TITLE
add cron job to ansible script to update lms program cache

### DIFF
--- a/playbooks/masters_sandbox.yml
+++ b/playbooks/masters_sandbox.yml
@@ -52,3 +52,10 @@
         --groups {{organization_key}}_{{registrar_role}}
       args:
         chdir: "{{ registrar_code_dir }}"
+
+    - name: set up cron job to refresh lms cache
+      cron:
+        name: "refresh masters sandbox cache"
+        job: ". {{ edxapp_env_path }} && {{ edxapp_venv_dir }}/bin/python {{ edxapp_code_dir }}/manage.py lms cache_programs"
+        hour: "0"
+        minute: "0"


### PR DESCRIPTION
EDUCATOR-4463: add entry to masters_sandbox.yml to create cron job to refresh program cache daily at midnight

/var/spool/cron/crontabs/root after sandbox was built:
```
# DO NOT EDIT THIS FILE - edit the master and reinstall.
# (/tmp/crontabVOiI9L installed on Thu Jul 11 15:42:26 2019)
# (Cron version -- $Id: crontab.c,v 2.13 1994/01/17 03:20:37 vixie Exp $)
#Ansible: log-ntp-alerts
* * * * * /edx/bin/log-ntp-alerts.sh >/dev/null 2>&1
#Ansible: mongostat logging job
*/3 * * * * /edx/bin/log-mongo-serverStatus.sh >> /edx/var/log/mongo/serverStatus.log 2>&1
#Ansible: refresh masters sandbox cache
0 0 * * * . /edx/app/edxapp/edxapp_env && /edx/app/edxapp/venvs/edxapp/bin/python /edx/app/edxapp/edx-platform/manage.py lms cache_programs
```
command runs successfully when I run it on the command line in my sandbox


Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
