### PR TITLE
Revert "Explicitly set CORS_ORIGIN_WHITELIST for registrar."

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,3 @@
-- Role: registrar
-  - Explicitly set CORS_ORIGIN_WHITELIST.
-
 - Role: discovery
   - Override DISCOVERY_MYSQL_REPLICA_HOST to `edx.devstack.mysql` in docker.
 

--- a/playbooks/roles/registrar/defaults/main.yml
+++ b/playbooks/roles/registrar/defaults/main.yml
@@ -128,7 +128,6 @@ registrar_service_config_overrides:
   SEGMENT_KEY: "{{ REGISTRAR_SEGMENT_KEY }}"
   DISCOVERY_BASE_URL: "{{ REGISTRAR_DISCOVERY_BASE_URL }}"
   LMS_BASE_URL: "{{ REGISTRAR_LMS_BASE_URL }}"
-  CORS_ORIGIN_WHITELIST: "{{ REGISTRAR_CORS_ORIGIN_WHITELIST }}"
 
 # See edx_django_service_automated_users for an example of what this should be
 REGISTRAR_AUTOMATED_USERS: {}


### PR DESCRIPTION
This reverts commit d0fa3dfecdfbb5ef1f1fe657f9bb133d85926129.

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
