### PR TITLE
remove quotes from sudoers file

### DIFF
--- a/playbooks/roles/automated/templates/99-automated.j2
+++ b/playbooks/roles/automated/templates/99-automated.j2
@@ -1,3 +1,3 @@
 {% for command in item.value.sudo_commands %}
-{{ item.key }} ALL=({{ command.sudo_user }}) SETENV:NOPASSWD:{{ command.command }}
+{{ item.key }} ALL=({{ command.sudo_user }}) SETENV:NOPASSWD:{{ command.command | replace('\'', '') }}
 {% endfor %}


### PR DESCRIPTION
quotes are never passed into sudo because the shell intercepts them, which means the sudoers file should have commands without quotes.