### PR TITLE
add devstack var to analytics api overrides

### DIFF
--- a/docker/build/analytics_api/ansible_overrides.yml
+++ b/docker/build/analytics_api/ansible_overrides.yml
@@ -1,5 +1,7 @@
 ---
 
+edx_django_service_is_devstack: True
+
 DOCKER_TLD: "edx"
 
 ANALYTICS_API_DATABASES:


### PR DESCRIPTION
I had [previously](https://github.com/edx/configuration/pull/5264) added a tag to the analytics api ansible command when building containers, but it wasn't enough. I also needed to add a variable. This fixes the errors seen in travis [builds](https://travis-ci.org/edx/edx-analytics-data-api/builds/556795467). I have tested locally.