### PR TITLE
add devstack script to insights container

### DIFF
--- a/docker/build/insights/Dockerfile
+++ b/docker/build/insights/Dockerfile
@@ -22,6 +22,8 @@ RUN /edx/app/edx_ansible/venvs/edx_ansible/bin/ansible-playbook insights.yml \
     -t "install:base,install:system-requirements,install:configuration,install:app-requirements,install:code" \
     --extra-vars="INSIGHTS_VERSION=${OPENEDX_RELEASE}" \
     --extra-vars="@/ansible_overrides.yml"
+ADD docker/build/insights/devstack.sh /edx/app/insights/devstack.sh
+RUN chown insights:insights /edx/app/insights/devstack.sh && chmod a+x /edx/app/insights/devstack.sh
 ENTRYPOINT ["/edx/app/insights/devstack.sh"]
 CMD ["start"]
 EXPOSE 8110 18110

--- a/docker/build/insights/devstack.sh
+++ b/docker/build/insights/devstack.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+COMMAND=$1
+
+case $COMMAND in
+    start)
+        /edx/app/supervisor/venvs/supervisor/bin/supervisord -n --configuration /edx/app/supervisor/supervisord.conf
+        ;;
+    open)
+        . /edx/app/insights/venvs/insights/bin/activate
+        cd /edx/app/insights/insights
+
+        /bin/bash
+        ;;
+    exec)
+        shift
+
+        . /edx/app/insights/venvs/insights/bin/activate
+        cd /edx/app/insights/insights
+
+        "$@"
+        ;;
+    *)
+        "$@"
+        ;;
+esac


### PR DESCRIPTION
This [change](https://github.com/edx/configuration/commit/473d73669fba687c6e291d694eb4448c4d81f456) requires a devstack script be present in the insights container. I was able to get it [templated in for edx-analytics-data-api](https://github.com/edx/configuration/pull/5282), but since insights doesn't already include the edx-django-service role, I didn't know enough about how to get that merged in. This follows the pattern already used by the edx-analytics-pipeline container https://github.com/edx/configuration/blob/master/docker/build/analytics_pipeline/Dockerfile#L137