### PR TITLE
Fix learner portal build

### DIFF
--- a/playbooks/roles/launch_ec2/tasks/main.yml
+++ b/playbooks/roles/launch_ec2/tasks/main.yml
@@ -89,7 +89,7 @@
   delay: 30
   with_nested:
     - "{{ ec2.instances }}"
-    - ['studio', 'ecommerce', 'preview', 'discovery', 'journals', 'credentials', 'veda', 'analytics-api', 'registrar', 'program-manager', learner-portal']
+    - ['studio', 'ecommerce', 'preview', 'discovery', 'journals', 'credentials', 'veda', 'analytics-api', 'registrar', 'program-manager', 'learner-portal']
 
 - name: Add DNS name for whitelabel sites
   local_action:

--- a/playbooks/roles/learner_portal/defaults/main.yml
+++ b/playbooks/roles/learner_portal/defaults/main.yml
@@ -39,3 +39,4 @@ learner_portal_env_vars:
   DESIGNER_BASE_URL: ''
   HOST_NAME: ''
   SEGMENT_KEY: ''
+  MOCK_DATA: true

--- a/playbooks/roles/learner_portal/tasks/main.yml
+++ b/playbooks/roles/learner_portal/tasks/main.yml
@@ -55,6 +55,15 @@
     - install
     - install:app-requirements
 
+# we need to do this so that npm can find a node install to use to build node-sass
+- name: prepend node path
+  shell: "{{ learner_portal_nodeenv_bin }}/npm config set scripts-prepend-node-path true"
+  environment: "{{ learner_portal_env_vars }}"
+  become_user: "{{ learner_portal_user }}"
+  tags:
+    - install
+    - install:app-requirements
+
 # install with the shell command instead of the ansible npm module so we don't accidentally re-write package.json
 # The version of ansible we are using also does not make use of "--unsafe-perm", which we need for node-sass
 - name: Install node dependencies

--- a/playbooks/roles/prospectus/tasks/main.yml
+++ b/playbooks/roles/prospectus/tasks/main.yml
@@ -123,15 +123,6 @@
     - install
     - install:app-requirements
 
-# we need to do this so that npm can find a node install to use to build node-sass
-- name: prepend node path
-  shell: "{{ learner_portal_nodeenv_bin }}/npm config set scripts-prepend-node-path true"
-  environment: "{{ learner_portal_env_vars }}"
-  become_user: "{{ learner_portal_user }}"
-  tags:
-    - install
-    - install:app-requirements
-
 #install with the shell command instead of the ansible npm module so we don't accidentally re-write package.json
 - name: install node dependencies
   shell: "{{ prospectus_nodeenv_bin }}/npm install --unsafe-perm=true --allow-root"

--- a/playbooks/roles/prospectus/tasks/main.yml
+++ b/playbooks/roles/prospectus/tasks/main.yml
@@ -123,6 +123,15 @@
     - install
     - install:app-requirements
 
+# we need to do this so that npm can find a node install to use to build node-sass
+- name: prepend node path
+  shell: "{{ learner_portal_nodeenv_bin }}/npm config set scripts-prepend-node-path true"
+  environment: "{{ learner_portal_env_vars }}"
+  become_user: "{{ learner_portal_user }}"
+  tags:
+    - install
+    - install:app-requirements
+
 #install with the shell command instead of the ansible npm module so we don't accidentally re-write package.json
 - name: install node dependencies
   shell: "{{ prospectus_nodeenv_bin }}/npm install --unsafe-perm=true --allow-root"

--- a/util/jenkins/ansible-provision.sh
+++ b/util/jenkins/ansible-provision.sh
@@ -387,7 +387,7 @@ REGISTRAR_DISCOVERY_BASE_URL: "https://discovery-${deploy_host}"
 REGISTRAR_LMS_BASE_URL: "https://${deploy_host}"
 REGISTRAR_SOCIAL_AUTH_REDIRECT_IS_HTTPS: true
 
-LEARNER_PORTAL_URL_ROOT: "https://learner_portal-${deploy_host}"
+LEARNER_PORTAL_URL_ROOT: "https://learner-portal-${deploy_host}"
 LEARNER_PORTAL_DISCOVERY_BASE_URL: "https://discovery-${deploy_host}"
 LEARNER_PORTAL_LMS_BASE_URL: "https://${deploy_host}"
 


### PR DESCRIPTION
This fixes the `learner-portal` project build for the sandbox. Somehow, two typos got by without throwing a single error, and I've added the extra task to make sure `npm` properly links to node and builds the right binaries.