### PR TITLE
grafana role: fetch from packages.grafana.com

### DIFF
--- a/playbooks/roles/grafana/tasks/main.yml
+++ b/playbooks/roles/grafana/tasks/main.yml
@@ -25,20 +25,18 @@
     msg: "this playbook can only be run on an Ubuntu host"
   when: ansible_distribution != "Ubuntu"
 
-- name: install PackageCloud GPG key
+- name: install packages.grafana.com GPG key
   apt_key:
-    id: "418A7F2FB0E1E6E7EABF6FE8C2E73424D59097AB"
-    url: "https://packagecloud.io/gpg.key"
+    url: "https://packages.grafana.com/gpg.key"
     state: present
   tags:
     - install
     - install:system-requirements
 
-- name: install PackageCloud PPA
+- name: install packages.grafana.com PPA
   apt_repository:
-    # This is  Debian Jessie repository, when we use Ubuntu Xenial, yes.  It's the latest Debian repository they
-    # populate for their official packages.  It does work, so, *shrug*.
-    repo: "deb https://packagecloud.io/grafana/stable/debian/ jessie main"
+    # PackageCloud isn't enabled anymore, so using packages.grafana.com(official) instead
+    repo: "deb https://packages.grafana.com/oss/deb stable main"
     update_cache: yes
     state: present
   tags:


### PR DESCRIPTION
reason: original PackageCloud apt sources are disabled, using packages.grafana.com from official instead
