### PR TITLE
no tty for jenkins codejail sudo

### DIFF
--- a/playbooks/roles/codejail/defaults/main.yml
+++ b/playbooks/roles/codejail/defaults/main.yml
@@ -2,9 +2,9 @@
 codejail_debian_packages:
   - apparmor-utils
 codejail_python_versions:
-  - python2-7
-  - python3-5
-  - python3-6
+  - python2.7
+  - python3.5
+  - python3.6
 codejail_sandbox_user: 'sandbox'
 codejail_sandbox_group: 'sandbox'
 codejail_sandbox_name_base: 'codejail_sandbox'

--- a/playbooks/roles/codejail/tasks/main.yml
+++ b/playbooks/roles/codejail/tasks/main.yml
@@ -16,9 +16,29 @@
     group: '{{ codejail_sandbox_group }}'
     state: present
 - name: Create sandboxed virtual environments for every Python installation
-  shell: "virtualenv -p {{ item | replace('-','.') }} --always-copy {{ codejail_sandbox_env }}-{{ item }}"
+  shell: "virtualenv -p {{ item  }} --always-copy {{ codejail_sandbox_env }}-{{ item }}"
   become: true
   with_items: "{{ codejail_python_versions }}"
+- name: Clone codejail repo
+  git:
+    repo: 'https://github.com/edx/codejail.git'
+    dest: '/tmp/codejail'
+    version: 'master'
+- name: Install codejail sandbox dependencies
+  pip:
+    requirements: '/tmp/codejail/requirements/sandbox.txt'
+    virtualenv: "{{ codejail_sandbox_env }}-{{ item }}"
+    state: present
+  become: true
+  with_items: "{{ codejail_python_versions }}"
+- name: Set permissions for sandboxed Python environments
+  file:
+    path: '{{ codejail_sandbox_env }}-{{ item }}'
+    recurse: yes
+    owner: '{{ codejail_sandbox_user }}'
+    group: '{{ codejail_sandbox_group }}'
+  with_items: "{{ codejail_python_versions }}"
+  become: true
 - name: Template sudoers file
   template:
     src:  "sudoers-template"
@@ -30,5 +50,9 @@
   with_items: "{{ codejail_python_versions }}"
 - name: Parse AppArmor profiles
   shell: 'apparmor_parser /etc/apparmor.d/home.{{ codejail_sandbox_user }}.{{ codejail_sandbox_name_base }}-{{ item }}.bin.python'
+  become: true
+  with_items: "{{ codejail_python_versions }}"
+- name: Enforce AppArmor profile
+  shell: 'aa-enforce /etc/apparmor.d/home.{{ codejail_sandbox_user }}.{{ codejail_sandbox_name_base }}-{{ item }}.bin.python'
   become: true
   with_items: "{{ codejail_python_versions }}"

--- a/playbooks/roles/codejail/templates/apparmor-template
+++ b/playbooks/roles/codejail/templates/apparmor-template
@@ -7,4 +7,21 @@
     {{ codejail_sandbox_env }}-{{ item }}/** mr,
     /tmp/codejail-*/ rix,
     /tmp/codejail-*/** wrix,
+
+    # Whitelist particiclar shared objects from the system
+    # python installation
+    #
+    /usr/lib/{{ item }}/lib-dynload/_json.so mr,
+    /usr/lib/{{ item }}/lib-dynload/_ctypes.so mr,
+    /usr/lib/{{ item }}/lib-dynload/_heapq.so mr,
+    /usr/lib/{{ item }}/lib-dynload/_io.so mr,
+    /usr/lib/{{ item }}/lib-dynload/_csv.so mr,
+    /usr/lib/{{ item }}/lib-dynload/datetime.so mr,
+    /usr/lib/{{ item }}/lib-dynload/_elementtree.so mr,
+    /usr/lib/{{ item }}/lib-dynload/pyexpat.so mr,
+    /usr/lib/{{ item }}/lib-dynload/future_builtins.so mr,
+    #
+    # Allow access to selections from /proc
+    #
+    /proc/*/mounts r,
 }

--- a/playbooks/roles/codejail/templates/sudoers-template
+++ b/playbooks/roles/codejail/templates/sudoers-template
@@ -3,3 +3,9 @@
 {% endfor %}
 {{ codejail_sandbox_caller }} ALL=({{ codejail_sandbox_user }}) SETENV:NOPASSWD:/usr/bin/find
 {{ codejail_sandbox_caller }} ALL=(ALL) NOPASSWD:/usr/bin/pkill
+
+{% for python_version in codejail_python_versions %}
+Defaults!{{ codejail_sandbox_env }}-{{ python_version }}/bin/python !requiretty
+{% endfor %}
+Defaults!/usr/bin/find !requiretty
+Defaults!/usr/bin/pkill !requiretty


### PR DESCRIPTION
Some fixes for the codejail role so that it works on Jenkins. Mainly, I needed to disable the `requirestty` default for the sudo commands that Jenkins will be using, as it is launched in a non-tty environment. I also added the libraries called out in xqwatcher role to this apparmor profile and adjusted the group ownership of the sandboxed environments.