### PR TITLE
Add kube config for Atlantis

### DIFF
--- a/playbooks/roles/atlantis/defaults/main.yml
+++ b/playbooks/roles/atlantis/defaults/main.yml
@@ -20,6 +20,7 @@ atlantis_install_file: "atlantis_linux_amd64.zip"
 ATLANTIS_VERSION: 0.8.2
 ATLANTIS_INSTALL_URL: "https://github.com/runatlantis/atlantis/releases/download/v{{ ATLANTIS_VERSION }}/{{ atlantis_install_file }}"
 ATLANTIS_REPO_CONFIG: {}
+ATLANTIS_KUBE_CONFIG: {}
 ATLANTIS_ENVIRONMENT: {}
 #  ATLANTIS_GH_USER:
 #  ATLANTIS_GH_TOKEN:

--- a/playbooks/roles/atlantis/tasks/main.yml
+++ b/playbooks/roles/atlantis/tasks/main.yml
@@ -46,6 +46,27 @@
     - install:configuration
     - install:app-configuration
 
+- name: Create atlantis .kube dir
+  file:
+    path: "{{ atlantis_app_dir }}/.kube"
+    state: directory
+    owner: "{{ atlantis_user }}"
+    group: "{{ common_web_group }}"
+  tags:
+    - install
+    - install:base
+
+- name: Write out atlantis .kube/config file
+  template:
+    src: "templates/kube_config.yml.j2"
+    dest: "{{ atlantis_app_dir }}/.kube/config"
+    mode: "0644"
+  no_log: "{{ COMMON_CONFIG_NO_LOGGING }}"
+  tags:
+    - install
+    - install:configuration
+    - install:app-configuration
+
 - name: setup the atlantis env file
   template:
     src: "templates/atlantis_env.j2"

--- a/playbooks/roles/atlantis/tasks/main.yml
+++ b/playbooks/roles/atlantis/tasks/main.yml
@@ -37,7 +37,7 @@
 
 - name: Write out atlantis repo-config.yml file
   template:
-    src: "repo-config.yml.j2"
+    src: "templates/repo-config.yml.j2"
     dest: "{{ atlantis_repo_config_path }}"
     mode: "0644"
   no_log: "{{ COMMON_CONFIG_NO_LOGGING }}"

--- a/playbooks/roles/atlantis/templates/kube_config.yml.j2
+++ b/playbooks/roles/atlantis/templates/kube_config.yml.j2
@@ -1,0 +1,4 @@
+---
+# {{ ansible_managed }}
+
+{{ ATLANTIS_KUBE_CONFIG | to_nice_yaml }}


### PR DESCRIPTION
This kube config is a bit of a hack that will only work for a single EKS cluster in tools. We'll have to fix it for real when we want an EKS cluster in another account. For now this unblocks Atlantis running against the tools account.

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
