### PR TITLE
update hermes to use multiple secret key files (OPS-4163)

### DIFF
--- a/playbooks/roles/hermes/defaults/main.yml
+++ b/playbooks/roles/hermes/defaults/main.yml
@@ -67,7 +67,7 @@ hermes_service_config:
   - url: '{{ HERMES_REMOTE_FILE_PATH }}'
     filename: '{{ HERMES_LOCAL_FILE_PATH }}'
     command:  'sudo {{ HERMES_COPY_COMMAND }} && sudo {{ HERMES_RELOAD_COMMAND }}'
-    secret_key_file: '{{ hermes_private_key_file_path if HERMES_PRIVATE_KEY is defined else None }}'
+    secret_key_files: "{{ HERMES_PRIVATE_KEYS_DICT | map('regex_replace','(.*)','/edx/app/hermes/hermes-\\1') | join(',') if HERMES_PRIVATE_KEYS_DICT is defined else None }}"
 
 # These are dropped into sudoers for the user that runs this program, care should be taken to ensure they are safe
 # to run. By default we assume the 1 service per box and restart supervisor model. If you did something custom with

--- a/playbooks/roles/hermes/tasks/main.yml
+++ b/playbooks/roles/hermes/tasks/main.yml
@@ -109,12 +109,13 @@
 
 - name: install private key
   copy:
-    content: "{{ HERMES_PRIVATE_KEY }}"
-    dest: "{{ hermes_private_key_file_path }}"
+    content: "{{ item.value }}"
+    dest: "{{ hermes_app_dir }}/{{ hermes_service_name }}-{{ item.key }}"
     force: yes
     owner: "{{ hermes_user }}"
     mode: "0600"
-  when: HERMES_PRIVATE_KEY is defined
+  with_dict: "{{ HERMES_PRIVATE_KEYS_DICT }}"
+  when: HERMES_PRIVATE_KEYS_DICT is defined
   tags:
     - install
     - install:base


### PR DESCRIPTION
Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
