### PR TITLE
Call create_dot_application with --update flag

### DIFF
--- a/playbooks/roles/oauth_client_setup/tasks/main.yml
+++ b/playbooks/roles/oauth_client_setup/tasks/main.yml
@@ -55,6 +55,7 @@
     --client-secret {{ item.sso_secret }}
     --scopes user_id
     --skip-authorization
+    --update
     {{ item.name }}-sso
     {{ item.username }}
   become_user: "{{ edxapp_user }}"
@@ -75,6 +76,7 @@
     --client-id {{ item.backend_service_id }}
     --client-secret {{ item.backend_service_secret }}
     --scopes user_id
+    --update
     {{ item.name }}-backend-service
     {{ item.username }}
   become_user: "{{ edxapp_user }}"


### PR DESCRIPTION
@edx/masters-neem 
https://openedx.atlassian.net/browse/EDUCATOR-4489

**Is blocked by https://github.com/edx/edx-platform/pull/21172**

One if the bugs causing the linked issue was that `./manage.py lms create_dot_access` will silently do nothing if the specified DOT Application already exists. Because the Registrar (and eCommerce, and Credentials) Applications existed on int-nightly already, provisioning a new sandbox fails to overwrite the `int-nightly` redirect URLs.

In order to avoid breaking any existing users of the command, I added an `--update` option, which causes the command to update the Application and ApplicationAccess with the values from the command. The linked edx-platform PR adds that option.

This PR changes the `oauth_client_setup` role to use the `--update` option.