### PR TITLE
EDUCATOR-4498 | Copy some JWT config to registrar's config file.

### DIFF
--- a/playbooks/masters_sandbox.yml
+++ b/playbooks/masters_sandbox.yml
@@ -12,6 +12,7 @@
     - registrar_venv_dir: /edx/app/registrar/venvs/registrar
     - registrar_code_dir: /edx/app/registrar/registrar
     - lms_config_file: /edx/etc/lms.yml
+    - registrar_config_file: /edx/etc/registrar.yml
     - jwt_signature_file: /tmp/lms_jwt_signature.yml
 
   tasks:
@@ -77,7 +78,7 @@
         minute: "0"
 
     - name: create JWT signature settings
-      shell: . {{ edxapp_env_path }} && {{ edxapp_venv_dir }}/bin/python manage.py lms generate_jwt_signing_key --output-file {{ jwt_signature_file }}
+      shell: . {{ edxapp_env_path }} && {{ edxapp_venv_dir }}/bin/python manage.py lms generate_jwt_signing_key --output-file {{ jwt_signature_file }} --strip-key-prefix
       args:
         chdir: "{{ edxapp_code_dir }}"
 
@@ -103,6 +104,17 @@
         file: "/tmp/{{ inventory_hostname }}/{{ lms_config_file }}"
         name: lms_config_vars
 
+    - name: fetch registrar settings from host
+      fetch:
+        src: "{{ registrar_config_file }}"
+        # this will save into /tmp/{{ inventory_hostname }}/{{ registrar_config_file }} on jenkins node
+        dest: /tmp
+
+    - name: read registrar config into variable
+      include_vars:
+        file: "/tmp/{{ inventory_hostname }}/{{ registrar_config_file }}"
+        name: registrar_config_vars
+
     - name: combine lms config with jwt_signature config
       set_fact:
         lms_combined_config: '{{ lms_config_vars|combine(lms_jwt_signature, recursive=True) }}'
@@ -116,6 +128,19 @@
         mode: 0640
       become: true
 
+    - name: combine registrar config with jwt_signature config
+      set_fact:
+        registrar_combined_config: '{{ registrar_config_vars|combine(lms_jwt_signature, recursive=True) }}'
+
+    - name: render registrar yml config with jwt signature
+      template:
+        src: "roles/registrar/templates/registrar.yml.j2"
+        dest: "{{ registrar_config_file }}"
+        owner: "root"
+        group: "root"
+        mode: 0644
+      become: true
+
     - name: delete JWT signature file on jenkins
       file:
         path: "/tmp/{{ inventory_hostname }}/{{ jwt_signature_file }}"
@@ -124,4 +149,9 @@
     - name: delete LMS config file on jenkins
       file:
         path: "/tmp/{{ inventory_hostname }}/{{ lms_config_file }}"
+        state: absent
+
+    - name: delete registrar config file on jenkins
+      file:
+        path: "/tmp/{{ inventory_hostname }}/{{ registrar_config_file }}"
         state: absent

--- a/playbooks/roles/registrar/templates/registrar.yml.j2
+++ b/playbooks/roles/registrar/templates/registrar.yml.j2
@@ -1,0 +1,3 @@
+{% if registrar_combined_config %}
+{{ registrar_combined_config | to_nice_yaml }}
+{% endif %}


### PR DESCRIPTION
Configuration Pull Request
---
https://openedx.atlassian.net/browse/EDUCATOR-4498?oldIssueView=true
We also need these settings to make it into registrar's config file.

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
