### PR TITLE
PROD-440: Upgrading requests and paramiko dependency to fix security vulnerabilities

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -12,7 +12,7 @@ Jinja2==2.8
 MarkupSafe==1.0
 MySQL-python==1.2.5                 # Needed for the mysql_db module
 networkx==1.11
-paramiko==2.4.1
+paramiko<2.5
 pathlib2==2.3.0
 prettytable==0.7.2
 pycrypto==2.6.1

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -19,5 +19,5 @@ pycrypto==2.6.1
 pymongo==3.2.2                      # Needed for the mongo_* modules (playbooks/library/mongo_*)
 python-simple-hipchat==0.2
 PyYAML==3.12
-requests==2.18.4
+requests
 wsgiref==0.1.2


### PR DESCRIPTION
Sustaining and Escalation has received few tickets to fix security vulnerabilities in our system, we are slowly working though them. Here I've changed the pinning on requests and paramiko in requirements/base.in file. From what I could tell this shouldn't break everything, but please verify!


Large ticket explaining task: [here](https://openedx.atlassian.net/secure/RapidBoard.jspa?rapidView=537&modal=detail&selectedIssue=PROD-440)
Ticket with paramiko security issue: [here](https://openedx.atlassian.net/browse/PROD-330)
Ticket with requests security issue: [here](https://openedx.atlassian.net/browse/PROD-293)



Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
