### PR TITLE
Add zoom xblock

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -520,6 +520,8 @@ EDXAPP_PRIVATE_REQUIREMENTS:
       extra_args: -e
     - name: git+https://github.com/open-craft/xblock-activetable.git@e933d41bb86a8d50fb878787ca680165a092a6d5#egg=xblock-activetable
       extra_args: -e
+    - name: git+https://github.com/edx/edx-zoom.git@ffd44b69735a670e889d14eaf4cd19fefb582e92#egg=edx-zoom
+      extra_args: -e
 
 # List of custom middlewares that should be used in edxapp to process
 # incoming HTTP resquests. Should be a list of plain strings that fully


### PR DESCRIPTION
This installs the Zoom XBlock. It's not in edx-platform's requirements because it's not ready to be made available to the OpenEdx community.