### PR TITLE
Add python3-dev to the edxapp dependencies.

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -1633,6 +1633,7 @@ edxapp_debian_pkgs_default:
   # cffi needs libffi-dev
   - libffi-dev
   - python-dev
+  - python3-dev
   - libsqlite3-dev
 
 edxapp_debian_pkgs_extra: []


### PR DESCRIPTION
This is because some of the edxapp python libraries need to compile C
Extensions for python.  This will install headers needed for that
compilation to succeed in python 3.

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
