### PR TITLE
Upgrade Jenkins LTS version to 2.176.2

### DIFF
--- a/playbooks/roles/jenkins_build/defaults/main.yml
+++ b/playbooks/roles/jenkins_build/defaults/main.yml
@@ -1,6 +1,6 @@
 build_jenkins_user_uid: 1002
 build_jenkins_group_gid: 1004
-build_jenkins_version: jenkins_2.164.3
+build_jenkins_version: jenkins_2.176.2
 build_jenkins_jvm_args: '-Djava.awt.headless=true -Xmx16384m -DsessionTimeout=60'
 
 build_jenkins_python_versions:
@@ -14,7 +14,6 @@ build_jenkins_configuration_scripts:
   - 3installPython.groovy
   - 3mainConfiguration.groovy
   - 3setGlobalProperties.groovy
-  - 3shutdownCLI.groovy
   - 4configureEc2Plugin.groovy
   - 4configureGHOAuth.groovy
   - 4configureGHPRB.groovy
@@ -85,7 +84,7 @@ build_jenkins_plugins_list:
     version: '1.8'
     group: 'org.jenkins-ci.plugins'
   - name: 'ec2'
-    version: '1.43'
+    version: '1.44.1'
     group: 'org.jenkins-ci.plugins'
   - name: 'email-ext'
     version: '2.66'
@@ -163,7 +162,7 @@ build_jenkins_plugins_list:
     version: '1.14'
     group: 'org.jenkins-ci.plugins'
   - name: 'maven-plugin'
-    version: '3.1.2'
+    version: '3.4'
     group: 'org.jenkins-ci.main'
   - name: 'monitoring'
     version: '1.76.0'
@@ -202,7 +201,7 @@ build_jenkins_plugins_list:
     version: '1.0'
     group: 'org.jenkins-ci.plugins'
   - name: 'script-security'
-    version: '1.58'
+    version: '1.62'
     group: 'org.jenkins-ci.plugins'
   - name: 'shiningpanda'
     version: '0.23'
@@ -259,7 +258,10 @@ build_jenkins_plugins_list:
     version: '1.3.1'
     group: 'org.jenkins-ci.plugins'
   - name: 'workflow-cps'
-    version: '2.66'
+    version: '2.71'
+    group: 'org.jenkins-ci.plugins.workflow'
+  - name: 'workflow-cps-global-lib'
+    version: '2.15'
     group: 'org.jenkins-ci.plugins.workflow'
   - name: 'workflow-job'
     version: '2.33'


### PR DESCRIPTION
- Upgrade our Jenkins version
- Stop running the shutdown CLI script, as it's no longer relevant
- Plugin bumps