### PR TITLE
Add new conductor (learner portal router) role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+- Role: conductor
+  - New role added to configure the conductor service
+
 - Role: jwt_signature
   - Added role to inject JWT signing keys into application config, used from edxapp, worker, and registrar.
 
@@ -14,7 +17,7 @@
   - Set CSRF_TRUSTED_ORIGINS.
 
 - Role: registrar
-  - Set CORS_ORIGIN_WHITELIST.	
+  - Set CORS_ORIGIN_WHITELIST.
 
 - Role: discovery
   - Override DISCOVERY_MYSQL_REPLICA_HOST to `edx.devstack.mysql` in docker.

--- a/playbooks/conductor.yml
+++ b/playbooks/conductor.yml
@@ -1,0 +1,25 @@
+- name: Deploy conductor (router for learner portal)
+  hosts: all
+  become: True
+  gather_facts: True
+  vars:
+    ENABLE_NEWRELIC: False
+    CLUSTER_NAME: 'conductor'
+    NGINX_OVERRIDE_DEFAULT_MAP_HASH_SIZE: True
+    NGINX_MAP_HASH_MAX_SIZE: 4096
+    NGINX_MAP_HASH_BUCKET_SIZE: 128
+  roles:
+    - role: aws
+      when: COMMON_ENABLE_AWS_ROLE
+    - role: nginx
+      nginx_app_dir: "/etc/nginx"
+      nginx_sites:
+      - conductor
+      nginx_default_sites:
+      - conductor
+      CONDUCTOR_NGINX_PORT: 8000
+    - role: conductor
+    - role: splunkforwarder
+      when: COMMON_ENABLE_SPLUNKFORWARDER
+    - role: newrelic_infrastructure
+      when: COMMON_ENABLE_NEWRELIC_INFRASTRUCTURE

--- a/playbooks/roles/conductor/defaults/main.yml
+++ b/playbooks/roles/conductor/defaults/main.yml
@@ -1,0 +1,19 @@
+---
+#
+# edX Configuration
+#
+# github:     https://github.com/edx/configuration
+# wiki:       https://openedx.atlassian.net/wiki/display/OpenOPS
+# code style: https://openedx.atlassian.net/wiki/display/OpenOPS/Ansible+Code+Conventions
+# license:    https://github.com/edx/configuration/blob/master/LICENSE.TXT
+#
+##
+# Defaults for role conductor
+#
+
+# .env vars
+
+# nginx vars
+NGINX_CONDUCTOR_PROXY_INTERCEPT_ERRORS: true
+CONDUCTOR_STATIC_SITES: []
+

--- a/playbooks/roles/conductor/meta/main.yml
+++ b/playbooks/roles/conductor/meta/main.yml
@@ -1,0 +1,4 @@
+---
+dependencies:
+  - common
+  - nginx

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/conductor.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/conductor.j2
@@ -1,0 +1,37 @@
+{%- if "conductor" in nginx_default_sites -%}
+  {%- set default_site = "default_server" -%}
+{%- else -%}
+  {%- set default_site = "" -%}
+{%- endif -%}
+
+server {
+  # Conductor configuration file for nginx, templated by ansible
+
+  {% if NGINX_CONDUCTOR_PROXY_INTERCEPT_ERRORS %}
+  proxy_intercept_errors on;
+  {% endif %}
+
+  listen {{ CONDUCTOR_NGINX_PORT }} {{ default_site }};
+
+  # CONDUCTOR_STATIC_SITES will be a list of dictionaries which have a:
+  #   - router_path: The path you will go to on the router to access the content
+  #   - proxied_path: The path to proxy the requests to
+  {% for static_site in CONDUCTOR_STATIC_SITES %}
+
+    # Matches: <router>/<organization>
+    location = /{{ static_site.router_path }}/ {
+        proxy_pass {{ static_site.proxied_path }}/index.html;
+    }
+
+    # Matches: <router>/<organization>/[.../]<file.ext>
+    location ~ ^/{{ static_site.router_path }}/((?:\w+\/+)*)([\w\-\.]+\.[\w\-\.]+) {
+        proxy_pass {{ static_site.proxied_path }}/$1$2;
+    }
+
+    # Matches: <router>/<organization>/<subpage>/[.../]
+    location ~ ^/{{ static_site.router }}/([a-z0-9-]+)[/]? {
+        proxy_pass {{ static_site.proxied_path }}/$1/index.html;
+    }
+
+  {% endfor %}
+}


### PR DESCRIPTION
New role will just run nginx with a custom config

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
