### PR TITLE
Allow ssh access to users (OPS-4232)

### DIFF
--- a/playbooks/roles/automated/tasks/main.yml
+++ b/playbooks/roles/automated/tasks/main.yml
@@ -89,3 +89,22 @@
     owner: "{{ item.key }}"
     group: "{{ item.key }}"
   with_dict: "{{ AUTOMATED_USERS }}"
+
+- name: Are we in a Docker container
+  shell: echo $(egrep -q 'docker' /proc/self/cgroup && echo 'yes' || echo 'no')
+  ignore_errors: yes
+  register: docker_container
+
+- name: Allow automated users to ssh
+  lineinfile:
+    dest: /etc/ssh/sshd_config
+    regexp: '#automated_users_allowed_to_ssh'
+    line: "AllowUsers {{ AUTOMATED_USERS.keys() | list | join(' ') }} #automated_users_allowed_to_ssh"
+  when: ( AUTOMATED_USERS|length > 0 ) and docker_container.stdout != 'yes'
+  register: users_ssh_access
+
+- name: restart ssh
+  service:
+    name: ssh
+    state: restarted
+  when: users_ssh_access.changed

--- a/playbooks/roles/user/tasks/main.yml
+++ b/playbooks/roles/user/tasks/main.yml
@@ -225,3 +225,17 @@
   with_nested:
     - "{{ user_info }}"
     - "{{ user_rbash_links }}"
+
+- name: Allow users to ssh
+  lineinfile:
+    dest: /etc/ssh/sshd_config
+    regexp: "#users_allowed_to_ssh {{ vars['user_info'] }}"
+    line: "AllowUsers {{ (( user_info | map(attribute='name') | list ) + [ ansible_ssh_user ]) | join(' ') }} #users_allowed_to_ssh {{ vars['user_info'] }}"
+  when: user_info|length > 0
+  register: users_ssh_access
+
+- name: restart ssh
+  service:
+    name: ssh
+    state: restarted
+  when: users_ssh_access.changed

--- a/playbooks/users.yml
+++ b/playbooks/users.yml
@@ -1,4 +1,5 @@
 # Simple playbook for creating/updating/removing users on a box
+# If you run it against a box with automated users and don't pass them in it will break them
 # ansible-playbook -i 'host.example.com,' ./tools-gp.yml -e@/var/path/users.yml -e@/vars/path/environnment-deployment.yml
 - name: Update users
   hosts: all


### PR DESCRIPTION
Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
