### PR TITLE
Dockerfile fix 404, debian mirror removed

### DIFF
--- a/docker/build/analytics_pipeline_hadoop_datanode/Dockerfile
+++ b/docker/build/analytics_pipeline_hadoop_datanode/Dockerfile
@@ -1,15 +1,20 @@
 FROM uhopper/hadoop:2.7.2
 LABEL maintainer="edxops"
 
+RUN echo "deb http://deb.debian.org/debian buster-backports main" > /etc/apt/sources.list.d/backports.list
+
+RUN \
+echo "deb http://mirrors.linode.com/debian/ stretch main" > /etc/apt/sources.list && \
+echo "deb-src http://mirrors.linode.com/debian/ stretch main" >> /etc/apt/sources.list && \
+echo "deb http://mirrors.linode.com/debian-security/ stretch/updates main" >> /etc/apt/sources.list && \
+echo "deb-src http://mirrors.linode.com/debian-security/ stretch/updates main" >> /etc/apt/sources.list && \
+echo "deb http://mirrors.linode.com/debian/ stretch-updates main" >> /etc/apt/sources.list && \
+echo "deb-src http://mirrors.linode.com/debian/ stretch-updates main" >> /etc/apt/sources.list
+
 ENV HDFS_CONF_dfs_datanode_data_dir=file:///hadoop/dfs/data \
     MYSQL_VERSION=5.6 \
     DEBIAN_FRONTEND=noninteractive
 WORKDIR /tmp
-RUN \
-  echo "deb http://ftp.de.debian.org/debian/ stretch main non-free contrib\n" > /etc/apt/sources.list && \
-  echo "deb-src http://ftp.de.debian.org/debian/ stretch main non-free contrib\n" >> /etc/apt/sources.list && \
-  echo "deb http://security.debian.org/ stretch/updates main contrib non-free\n" >> /etc/apt/sources.list && \
-  echo "deb-src http://security.debian.org/ stretch/updates main contrib non-free" >> /etc/apt/sources.list
 
 RUN apt-get -y update
 RUN apt-get -yqq install apt-transport-https lsb-release ca-certificates gnupg2

--- a/docker/build/analytics_pipeline_hadoop_namenode/Dockerfile
+++ b/docker/build/analytics_pipeline_hadoop_namenode/Dockerfile
@@ -1,16 +1,20 @@
 FROM uhopper/hadoop:2.7.2
 LABEL maintainer="edxops"
 
+RUN echo "deb http://deb.debian.org/debian buster-backports main" > /etc/apt/sources.list.d/backports.list
+
+RUN \
+echo "deb http://mirrors.linode.com/debian/ stretch main" > /etc/apt/sources.list && \
+echo "deb-src http://mirrors.linode.com/debian/ stretch main" >> /etc/apt/sources.list && \
+echo "deb http://mirrors.linode.com/debian-security/ stretch/updates main" >> /etc/apt/sources.list && \
+echo "deb-src http://mirrors.linode.com/debian-security/ stretch/updates main" >> /etc/apt/sources.list && \
+echo "deb http://mirrors.linode.com/debian/ stretch-updates main" >> /etc/apt/sources.list && \
+echo "deb-src http://mirrors.linode.com/debian/ stretch-updates main" >> /etc/apt/sources.list
+
 ENV HDFS_CONF_dfs_namenode_name_dir=file:///hadoop/dfs/name \
     MYSQL_VERSION=5.6 \
     DEBIAN_FRONTEND=noninteractive
 WORKDIR /tmp
-RUN \
-  echo "deb http://ftp.de.debian.org/debian/ stretch main non-free contrib\n" > /etc/apt/sources.list && \
-  echo "deb-src http://ftp.de.debian.org/debian/ stretch main non-free contrib\n" >> /etc/apt/sources.list && \
-  echo "deb http://security.debian.org/ stretch/updates main contrib non-free\n" >> /etc/apt/sources.list && \
-  echo "deb-src http://security.debian.org/ stretch/updates main contrib non-free" >> /etc/apt/sources.list
-
 RUN apt-get -y update
 RUN apt-get -yqq install apt-transport-https lsb-release ca-certificates gnupg2
 RUN ( apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys A4A9406876FCBD3C456770C88C718D3B5072E1F5 \

--- a/docker/build/analytics_pipeline_hadoop_nodemanager/Dockerfile
+++ b/docker/build/analytics_pipeline_hadoop_nodemanager/Dockerfile
@@ -1,13 +1,18 @@
 FROM uhopper/hadoop:2.7.2
 LABEL maintainer="edxops"
 
+RUN echo "deb http://deb.debian.org/debian buster-backports main" > /etc/apt/sources.list.d/backports.list
+
+RUN \
+echo "deb http://mirrors.linode.com/debian/ stretch main" > /etc/apt/sources.list && \
+echo "deb-src http://mirrors.linode.com/debian/ stretch main" >> /etc/apt/sources.list && \
+echo "deb http://mirrors.linode.com/debian-security/ stretch/updates main" >> /etc/apt/sources.list && \
+echo "deb-src http://mirrors.linode.com/debian-security/ stretch/updates main" >> /etc/apt/sources.list && \
+echo "deb http://mirrors.linode.com/debian/ stretch-updates main" >> /etc/apt/sources.list && \
+echo "deb-src http://mirrors.linode.com/debian/ stretch-updates main" >> /etc/apt/sources.list
+
 ENV MYSQL_VERSION=5.6 DEBIAN_FRONTEND=noninteractive
 WORKDIR /tmp
-RUN \
-  echo "deb http://ftp.de.debian.org/debian/ stretch main non-free contrib\n" > /etc/apt/sources.list && \
-  echo "deb-src http://ftp.de.debian.org/debian/ stretch main non-free contrib\n" >> /etc/apt/sources.list && \
-  echo "deb http://security.debian.org/ stretch/updates main contrib non-free\n" >> /etc/apt/sources.list && \
-  echo "deb-src http://security.debian.org/ stretch/updates main contrib non-free" >> /etc/apt/sources.list
 
 RUN apt-get -y update
 RUN apt-get -yqq install apt-transport-https lsb-release ca-certificates gnupg2

--- a/docker/build/analytics_pipeline_hadoop_resourcemanager/Dockerfile
+++ b/docker/build/analytics_pipeline_hadoop_resourcemanager/Dockerfile
@@ -1,13 +1,18 @@
 FROM uhopper/hadoop:2.7.2
 LABEL maintainer="edxops"
 
+RUN echo "deb http://deb.debian.org/debian buster-backports main" > /etc/apt/sources.list.d/backports.list
+
+RUN \
+echo "deb http://mirrors.linode.com/debian/ stretch main" > /etc/apt/sources.list && \
+echo "deb-src http://mirrors.linode.com/debian/ stretch main" >> /etc/apt/sources.list && \
+echo "deb http://mirrors.linode.com/debian-security/ stretch/updates main" >> /etc/apt/sources.list && \
+echo "deb-src http://mirrors.linode.com/debian-security/ stretch/updates main" >> /etc/apt/sources.list && \
+echo "deb http://mirrors.linode.com/debian/ stretch-updates main" >> /etc/apt/sources.list && \
+echo "deb-src http://mirrors.linode.com/debian/ stretch-updates main" >> /etc/apt/sources.list
+
 ENV MYSQL_VERSION=5.6 DEBIAN_FRONTEND=noninteractive
 WORKDIR /tmp
-RUN \
-  echo "deb http://ftp.de.debian.org/debian/ stretch main non-free contrib\n" > /etc/apt/sources.list && \
-  echo "deb-src http://ftp.de.debian.org/debian/ stretch main non-free contrib\n" >> /etc/apt/sources.list && \
-  echo "deb http://security.debian.org/ stretch/updates main contrib non-free\n" >> /etc/apt/sources.list && \
-  echo "deb-src http://security.debian.org/ stretch/updates main contrib non-free" >> /etc/apt/sources.list
 
 RUN apt-get -y update
 RUN apt-get -yqq install apt-transport-https lsb-release ca-certificates gnupg2

--- a/docker/build/analytics_pipeline_spark_master/Dockerfile
+++ b/docker/build/analytics_pipeline_spark_master/Dockerfile
@@ -1,6 +1,9 @@
 FROM bde2020/spark-base:2.1.0-hadoop2.7
 LABEL maintainer="edxops"
 
+RUN echo "deb [check-valid-until=no] http://archive.debian.org/debian jessie-backports main" > /etc/apt/sources.list.d/jessie-backports.list
+RUN sed -i '/deb http:\/\/deb.debian.org\/debian jessie-updates main/d' /etc/apt/sources.list
+
 ADD docker/build/analytics_pipeline_spark_master/master.sh /
 ENV SPARK_MASTER_PORT=7077 \
     SPARK_MASTER_WEBUI_PORT=8080 \
@@ -29,7 +32,7 @@ ENV SPARK_MASTER_PORT=7077 \
     YARN_CONF_yarn_resourcemanager_scheduler_address=resourcemanager:8030 \
     YARN_CONF_yarn_resourcemanager_resource__tracker_address=resourcemanager:8031
 
-RUN apt-get -y update && apt-get -y install --reinstall python-pkg-resources \
+RUN apt-get -o Acquire::Check-Valid-Until=false update && apt-get -y install --reinstall python-pkg-resources \
     && echo 'spark.master  spark://sparkmaster:7077\nspark.eventLog.enabled  true\nspark.eventLog.dir  hdfs://namenode:8020/tmp/spark-events\nspark.history.fs.logDirectory  hdfs://namenode:8020/tmp/spark-events' > /spark/conf/spark-defaults.conf
 
 CMD ["/bin/bash", "/master.sh"]

--- a/docker/build/analytics_pipeline_spark_worker/Dockerfile
+++ b/docker/build/analytics_pipeline_spark_worker/Dockerfile
@@ -1,6 +1,9 @@
 FROM bde2020/spark-base:2.1.0-hadoop2.7
 LABEL maintainer="edxops"
 
+RUN echo "deb [check-valid-until=no] http://archive.debian.org/debian jessie-backports main" > /etc/apt/sources.list.d/jessie-backports.list
+RUN sed -i '/deb http:\/\/deb.debian.org\/debian jessie-updates main/d' /etc/apt/sources.list
+
 ADD docker/build/analytics_pipeline_spark_worker/worker.sh /
 ENV SPARK_WORKER_WEBUI_PORT=8081 \
     SPARK_WORKER_LOG=/spark/logs \
@@ -27,6 +30,9 @@ ENV SPARK_WORKER_WEBUI_PORT=8081 \
     YARN_CONF_yarn_resourcemanager_scheduler_address=resourcemanager:8030 \
     YARN_CONF_yarn_resourcemanager_resource__tracker_address=resourcemanager:8031
 
-RUN apt-get -y update && apt-get -y install --reinstall python-pkg-resources
+RUN ( apt-key adv --keyserver keyserver.ubuntu.com --recv-key 04EE7237B7D453EC \
+      || apt-key adv --keyserver keyserver.ubuntu.com --recv-key 648ACFD622F3D138)
+
+RUN apt-get -o Acquire::Check-Valid-Until=false update && apt-get -y install --reinstall python-pkg-resources
 CMD ["/bin/bash", "/worker.sh"]
 EXPOSE 8081


### PR DESCRIPTION
Configuration Pull Request
Related Ticket: https://openedx.atlassian.net/browse/DE-1603
All images related to hadoop / spark have been failing due to one of the mirrors ("jessie") removed from debian. ( https://lists.debian.org/debian-devel-announce/2019/03/msg00006.html )

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
