### PR TITLE
Add a test for config files to nginx role

### DIFF
--- a/playbooks/roles/nginx/tasks/main.yml
+++ b/playbooks/roles/nginx/tasks/main.yml
@@ -366,6 +366,14 @@
     - install
     - install:configuration
 
+# Test the nginx configs before restarting nginx so that any errors are visible and not hidden in
+# the service logs.
+- name: Test nginx configs
+  command: nginx -t
+  tags:
+    - install
+    - install:configuration
+
 # nginx is started during package installation, before any of the configuration files are in place.
 # The handler that reloads the configuration would be run only at the very end of the playbook, so
 # none of the local services would be available in the meantime, e.g. causing certs to error out


### PR DESCRIPTION
This will made bad configs get displayed instead of hidden in a log file

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
