### PR TITLE
SE-1069 Add setting to disable deployment of the demo course

### DIFF
--- a/playbooks/openedx_native.yml
+++ b/playbooks/openedx_native.yml
@@ -34,6 +34,7 @@
     SANDBOX_ENABLE_RABBITMQ: true
     JOURNALS_ENABLED: false
     SANDBOX_ENABLE_NOTES: false
+    DEMO_ROLE_ENABLED: true
   roles:
     - role: swapfile
       SWAPFILE_SIZE: 4GB
@@ -79,7 +80,8 @@
       nginx_sites:
       - edx_notes_api
       when: SANDBOX_ENABLE_NOTES
-    - demo
+    - role: demo
+      when: DEMO_ROLE_ENABLED
     - oauth_client_setup
     - oraclejdk
     - role: elasticsearch


### PR DESCRIPTION
This PR adds an option to disable deployment of the demo course.

**JIRA tickets**: [OSPR-3783](https://openedx.atlassian.net/browse/OSPR-3783)

**Dependencies**: None

**Sandbox URL**: TBD - sandbox is being provisioned.

**Merge deadline**: None

**Testing instructions**:

1. set `DEMO_ROLE_ENABLED: false`
2. run the deployment
3. verify that the demo course is not present

**Author notes and concerns**:


**Reviewers**
- [x] @pomegranited 
- [ ] edX reviewer[s] TBD

**Settings**
```yaml
DEMO_ROLE_ENABLED: false
```