### PR TITLE
CAM2-206 Campus.il Makes the instance types used by asgard configurable

### DIFF
--- a/playbooks/roles/hotg/defaults/main.yml
+++ b/playbooks/roles/hotg/defaults/main.yml
@@ -51,6 +51,9 @@ HOTG_CALLBACK_URI: "{{ HOTG_URL }}/auth/signIn"
 HOTG_SUCCESS_URI: "{{ HOTG_URL }}"
 HOTG_AUTHENTICATION_PROVIDER: "githubOauthAuthenticationProvider"
 
+# Instance types configuration
+HOTG_ADDITIONAL_INSTANCE_TYPES: []
+
 # Email configuration
 HOTG_EMAIL_FROM_ADDRESS: "asgard@example.com"
 HOTG_EMAIL_SYSTEM_FROM_ADDRESS: "asgard@example.com"

--- a/playbooks/roles/hotg/defaults/main.yml
+++ b/playbooks/roles/hotg/defaults/main.yml
@@ -51,7 +51,16 @@ HOTG_CALLBACK_URI: "{{ HOTG_URL }}/auth/signIn"
 HOTG_SUCCESS_URI: "{{ HOTG_URL }}"
 HOTG_AUTHENTICATION_PROVIDER: "githubOauthAuthenticationProvider"
 
-# Instance types configuration
+# Instance types configuration, e.g.
+#
+# HOTG_ADDITIONAL_INSTANCE_TYPES:
+#  t3.xlarge:      # Required, AWS instance type
+#    price: 0.052  # Required, must be a number
+#    # Remaining fields are optional strings, e.g.
+#    family: 'Burstable'
+#    group: 't3'
+#    vCpu: '4'
+#    mem: '16.00'
 HOTG_ADDITIONAL_INSTANCE_TYPES: []
 
 # Email configuration

--- a/playbooks/roles/hotg/defaults/main.yml
+++ b/playbooks/roles/hotg/defaults/main.yml
@@ -61,7 +61,7 @@ HOTG_AUTHENTICATION_PROVIDER: "githubOauthAuthenticationProvider"
 #    group: 't3'
 #    vCpu: '4'
 #    mem: '16.00'
-HOTG_ADDITIONAL_INSTANCE_TYPES: []
+HOTG_ADDITIONAL_INSTANCE_TYPES: {}
 
 # Email configuration
 HOTG_EMAIL_FROM_ADDRESS: "asgard@example.com"

--- a/playbooks/roles/hotg/meta/main.yml
+++ b/playbooks/roles/hotg/meta/main.yml
@@ -21,3 +21,4 @@
 
 dependencies:
   - role: oraclejdk
+  - supervisor

--- a/playbooks/roles/hotg/templates/edx/app/hotg/Config.groovy.j2
+++ b/playbooks/roles/hotg/templates/edx/app/hotg/Config.groovy.j2
@@ -328,6 +328,23 @@ cloud {
                                 size: 'm5ad.24xlarge', arch: '64-bit', vCpu: '96', ecu: 'n/a',
                                 mem: '384.00', storage: 'EBS only', ebsOptim: 'Y',
                                 netPerf: 'Up to 5 Gigabit')),
+                {% for instance_type, profile in HOTG_ADDITIONAL_INSTANCE_TYPES.iteritems() %}
+
+                new InstanceTypeData(linuxOnDemandPrice: {{ profile.price }}, hardwareProfile:
+                        new HardwareProfile(
+                                instanceType: '{{ instance_type }}',
+                                family: '{{ profile.family | default("?") }}',
+                                group: '{{ profile.group | default("?") }}',
+                                size: '{{ instance_type }}',
+                                arch: '{{ profile.arch | default("64-bit") }}',
+                                vCpu: '{{ profile.vCpu | default("?") }}',
+                                ecu: '{{ profile.ecu | default("?") }}',
+                                mem: '{{ profile.mem | default("?") }}',
+                                storage: '{{ profile.storage | default("EBS only") }}',
+                                ebsOptim: '{{ profile.ebsOptim | default("?") }}',
+                                netPerf: '{{ profile.netPerf | default("?") }}'
+                 )),
+                {% endfor %}
         ]
 }
 


### PR DESCRIPTION
Adds `HOTG_ADDITIONAL_INSTANCE_TYPES`, which can be used to expand the list of instance types allowed when creating clusters on Asgard.

Also adds the `supervisor` role as a meta requirement, as this is required to run the `hotg` role.

**Merge deadline**: None

**Testing instructions**:

This is the deployment process we used for the updated Campus admin server, so this change can be verified by checking the [olive admin instance type list](http://admin.edx-flatu.org/eu-west-1/instanceType/list).

1. Add an ansible variable like:
   ```
   HOTG_ADDITIONAL_INSTANCE_TYPES:
     t3.xlarge:
       price: 0.052
       family: 'Burstable'
       group: 't3'
       size: 'Extra Large'
       vCpu: '4'
       ecu: '6'
       mem: '16.00'
   ```
1. Deploy asgard using the [vpc_admin.yml](https://github.com/edx/configuration/blob/master/playbooks/vpc_admin.yml) playbook.
1. Check the Asgard EC2 > Instance Types list to ensure the additional types are added.

**Author notes and concerns**:

1. Simply installing Asgard on a fresh instance added some new instance types (e.g. `c5.xlarge`), but the `t3.xlarge` type was not added.  So this change ensures that it is always added, since we rely on it for olive's `edxapp` cluster.

**Reviewers**
- [ ] @swalladge
- [ ] edX reviewer[s] TBD

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
