### PR TITLE
Dockerfile to build Blockstore

### DIFF
--- a/docker/build/blockstore/Dockerfile
+++ b/docker/build/blockstore/Dockerfile
@@ -1,0 +1,32 @@
+# To build this Dockerfile:
+#
+# From the root of configuration:
+#
+# docker build -f docker/build/blockstore/Dockerfile .
+#
+# This allows the dockerfile to update /edx/app/edx_ansible/edx_ansible
+# with the currently checked-out configuration repo.
+
+ARG BASE_IMAGE_TAG=latest
+FROM edxops/xenial-common:${BASE_IMAGE_TAG}
+LABEL maintainer="edxops"
+USER root
+ENTRYPOINT ["/edx/app/blockstore/devstack.sh"]
+CMD ["start"]
+
+ADD . /edx/app/edx_ansible/edx_ansible
+WORKDIR /edx/app/edx_ansible/edx_ansible/docker/plays
+
+COPY docker/build/blockstore/ansible_overrides.yml /
+COPY docker/devstack_common_ansible_overrides.yml /devstack/ansible_overrides.yml
+
+ARG OPENEDX_RELEASE=master
+ENV OPENEDX_RELEASE=${OPENEDX_RELEASE}
+RUN sudo /edx/app/edx_ansible/venvs/edx_ansible/bin/ansible-playbook blockstore.yml \
+    -c local -i "127.0.0.1," \
+    -t "install,assets,devstack" \
+    --extra-vars="BLOCKSTORE_VERSION=${OPENEDX_RELEASE}" \
+    --extra-vars="@/ansible_overrides.yml" \
+    --extra-vars="@/devstack/ansible_overrides.yml"
+
+EXPOSE 18150

--- a/docker/build/blockstore/ansible_overrides.yml
+++ b/docker/build/blockstore/ansible_overrides.yml
@@ -1,0 +1,13 @@
+---
+COMMON_GIT_PATH: 'edx'
+
+COMMON_MYSQL_MIGRATE_USER: '{{ BLOCKSTORE_MYSQL_USER }}'
+COMMON_MYSQL_MIGRATE_PASS: '{{ BLOCKSTORE_MYSQL_PASSWORD }}'
+
+BLOCKSTORE_MYSQL_HOST: 'edx.devstack.mysql'
+BLOCKSTORE_DJANGO_SETTINGS_MODULE: 'blockstore.settings.local'
+BLOCKSTORE_GUNICORN_EXTRA: '--reload'
+BLOCKSTORE_MEMCACHE: ['edx.devstack.memcached:11211']
+BLOCKSTORE_URL_ROOT: 'http://localhost:18250'
+
+edx_django_service_is_devstack: true

--- a/docker/plays/blockstore.yml
+++ b/docker/plays/blockstore.yml
@@ -1,0 +1,12 @@
+- name: Deploy blockstore
+  hosts: all
+  become: True
+  gather_facts: True
+  vars:
+    serial_count: 1
+  serial: "{{ serial_count }}"
+  roles:
+    - role: nginx
+      nginx_default_sites:
+        - blockstore
+    - blockstore

--- a/util/parsefiles_config.yml
+++ b/util/parsefiles_config.yml
@@ -48,3 +48,4 @@ weights:
   - flower: 1
   - registrar: 3
   - designer: 3
+  - blockstore: 6


### PR DESCRIPTION
This is a Dockerfile to build blockstore for use with devstack.

It's working but not _quite_ ready to go because I need some input.

**Question (input needed)**: Currently some settings (like the static files dir) are wrong, so I need to create a working `devstack.py` settings file in Blockstore. Should the devstack settings be put into blockstore/settings/devstack.py (as e.g. [credentials does](https://github.com/edx/credentials/blob/master/credentials/settings/devstack.py), and just ignore everything that ansible put into `/edx/etc/blockstore.yml`? It seems to me that things like the static files path are defined by the `edx_django_service` role and so should be read out of `/edx/etc/blockstore.yml`, but that doesn't seem to be what credentials is doing, which I used as a starting point here.

**Other Notes and concerns**:  
- The resulting image based on the edX base images is 1.57GB, which seems excessive? Our [previous Dockerfile](https://github.com/open-craft/blockstore/blob/master/Dockerfile-dev) is ~300MB
- We are thinking that to facilitate tests in devstack, we'll run two instances of this, `edx.devstack.blockstore` and `edx.devstack.blockstore-test` with different databases and static media volumes. I did a quick test of running two instances with the second one using `-p 18251:18250` (different port) and it seems to work fine.
- Per [these instructions](https://github.com/edx/configuration/blob/master/util/README.rst), the build for commit 5628cbd925f44e87baf1a80b7aa46f13dd8c4b2a on Travis CI took 6 minutes. Those instructions don't say what unit time should be measured in, but I'm assuming it's minutes so I've added `blockstore: 6` to `parsefiles_config.yml`

**Test instructions**:
How to test it out (from root of the configuration repo, with this branch checked out):

```
$ make docker.build.blockstore
...
Successfully built fcef14de8cbc
$ docker image tag fcef14de8cbc blockstore-local-build
$ docker run -p 18250:18250 --tty --interactive --rm --name edx.devstack.blockstore-dev --env  blockstore-local-build
```
(change `fcef14de8cbc` to whatever the most recent image ID is - I'm not sure how to get `make docker.build.blockstore` to tag the image automatically)

Currently blockstore's `local.py` settings file sets the wrong location for static files, so this fix is needed:

```
docker exec -it edx.devstack.blockstore-dev /bin/bash -c 'mkdir /edx/var/blockstore/staticfiles && cp -r /edx/app/blockstore/blockstore/blockstore/assets/* /edx/var/blockstore/staticfiles'
```

Then it should be running, although it won't connect to MySQL unless you adjust the environment variables. I'm assuming the code that provisions the MySQL DB and sets the correct env vars will be in the `edx/devstack` repo's `docker-compose` and `provision` files.

---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
