### PR TITLE
Catch S3 404s in conductor

### DIFF
--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/conductor.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/conductor.j2
@@ -11,6 +11,13 @@ server {
   proxy_intercept_errors on;
   {% endif %}
 
+  # Catches 404s from S3 and returns the default nginx 404 page instead
+  error_page 404 @error404;
+
+  location @error404 {
+    return 404;
+  }
+
   {% include "handle-tls-redirect-and-ip-disclosure.j2" %}
 
   {% if NGINX_ENABLE_SSL or NGINX_REDIRECT_TO_HTTPS %}
@@ -19,9 +26,6 @@ server {
   {% endif %}
 
   listen {{ CONDUCTOR_NGINX_PORT }} {{ default_site }};
-
-  # Catches all responses > 300 from S3 and returns an nginx response page instead.
-  proxy_intercept_errors on;
 
   # CONDUCTOR_STATIC_SITES will be a list of dictionaries which have a:
   #   - router_path: The path you will go to on the router to access the content


### PR DESCRIPTION
Catches 404s and returns nginx's 404 page instead of S3's.

Also removes duplicate proxy_intercept_errors.

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
