### PR TITLE
create multiple virtualenvs for jenkins workers

### DIFF
--- a/playbooks/roles/jenkins_worker/defaults/main.yml
+++ b/playbooks/roles/jenkins_worker/defaults/main.yml
@@ -23,9 +23,6 @@ nodejs_version: "8"
 ansible_distribution_release: "xenial"
 
 jenkins_worker_python_versions:
-  - python2.7
-  - python2.7-dev
-  - python3.5
-  - python3.5-dev
-  - python3.6
-  - python3.6-dev
+  - 2.7
+  - 3.5
+  - 3.6

--- a/playbooks/roles/jenkins_worker/tasks/python.yml
+++ b/playbooks/roles/jenkins_worker/tasks/python.yml
@@ -12,7 +12,15 @@
 # as the default version
 - name: Install python versions
   apt:
-    name: '{{ item }}'
+    name: 'python{{ item }}'
+    state: present
+    update_cache: yes
+  with_items: '{{ jenkins_worker_python_versions }}'
+
+# Install 'dev' packages for each version of python that is installed
+- name: Install python dev packages
+  apt:
+    name: 'python{{ item }}-dev'
     state: present
     update_cache: yes
   with_items: '{{ jenkins_worker_python_versions }}'

--- a/playbooks/roles/jenkins_worker/tasks/python_platform_worker.yml
+++ b/playbooks/roles/jenkins_worker/tasks/python_platform_worker.yml
@@ -23,9 +23,8 @@
   become_user: "{{ jenkins_user }}"
 
 # Combine testing and django requirements files for single virtualenv invocation
-- name: cat
-  command: "cat shallow-clone/requirements/edx/testing.txt shallow-clone/requirements/edx/django.txt shallow-clone/requirements/edx/jenkins.txt"
-  args:
+- name: Combine requirements files
+  command: "cat {{ jenkins_home }}/shallow-clone/requirements/edx/testing.txt {{ jenkins_home }}/shallow-clone/requirements/edx/django.txt > {{ jenkins_home }}/shallow-clone/requirements/edx/jenkins.txt"
     chdir: "{{ jenkins_home }}"
   become_user: "{{ jenkins_user }}"
 

--- a/playbooks/roles/jenkins_worker/tasks/python_platform_worker.yml
+++ b/playbooks/roles/jenkins_worker/tasks/python_platform_worker.yml
@@ -55,7 +55,6 @@
   command: "cp edx-venv_clean-2.7.tar.gz edx-venv_clean.tar.gz"
   args:
     chdir: "{{ jenkins_home }}"
-  with_items: "{{ jenkins_worker_python_versions }}"
   become_user: "{{ jenkins_user }}"
 
 - name: Add script to set install node packages

--- a/playbooks/roles/jenkins_worker/tasks/python_platform_worker.yml
+++ b/playbooks/roles/jenkins_worker/tasks/python_platform_worker.yml
@@ -25,7 +25,6 @@
 # Combine testing and django requirements files for single virtualenv invocation
 - name: Combine requirements files
   command: "cat {{ jenkins_home }}/shallow-clone/requirements/edx/testing.txt {{ jenkins_home }}/shallow-clone/requirements/edx/django.txt > {{ jenkins_home }}/shallow-clone/requirements/edx/jenkins.txt"
-    chdir: "{{ jenkins_home }}"
   become_user: "{{ jenkins_user }}"
 
 # Install the platform requirements using pip.

--- a/playbooks/roles/jenkins_worker/tasks/python_platform_worker.yml
+++ b/playbooks/roles/jenkins_worker/tasks/python_platform_worker.yml
@@ -48,6 +48,8 @@
 # generic name to avoid breaking older PRs
 - name: Make copy of py2.7 virtualenv tarball
   command: "cp edx-venv_clean-2.7.tar.gz edx-venv_clean.tar.gz"
+  args:
+    chdir: "{{ jenkins_home }}"
   with_items: "{{ jenkins_worker_python_versions }}"
   become_user: "{{ jenkins_user }}"
 

--- a/playbooks/roles/jenkins_worker/tasks/python_platform_worker.yml
+++ b/playbooks/roles/jenkins_worker/tasks/python_platform_worker.yml
@@ -24,7 +24,7 @@
 
 # Combine testing and django requirements files for single virtualenv invocation
 - name: Combine requirements files
-  command: "cat {{ jenkins_home }}/shallow-clone/requirements/edx/testing.txt {{ jenkins_home }}/shallow-clone/requirements/edx/django.txt > {{ jenkins_home }}/shallow-clone/requirements/edx/jenkins.txt"
+  shell: "cat {{ jenkins_home }}/shallow-clone/requirements/edx/testing.txt {{ jenkins_home }}/shallow-clone/requirements/edx/django.txt > {{ jenkins_home }}/shallow-clone/requirements/edx/jenkins.txt"
   become_user: "{{ jenkins_user }}"
 
 # Install the platform requirements using pip.

--- a/playbooks/roles/jenkins_worker/tasks/python_platform_worker.yml
+++ b/playbooks/roles/jenkins_worker/tasks/python_platform_worker.yml
@@ -22,6 +22,13 @@
   with_items: "{{ jenkins_worker_python_versions }}"
   become_user: "{{ jenkins_user }}"
 
+# Combine testing and django requirements files for single virtualenv invocation
+- name: cat
+  command: "cat shallow-clone/requirements/edx/testing.txt shallow-clone/requirements/edx/django.txt shallow-clone/requirements/edx/jenkins.txt"
+  args:
+    chdir: "{{ jenkins_home }}"
+  become_user: "{{ jenkins_user }}"
+
 # Install the platform requirements using pip.
 - name: Install edx-platform requirements using pip
   pip:
@@ -38,7 +45,7 @@
 # The edx-venv-x directory is deleted and then recreated
 # cleanly from the archive by the jenkins build scripts.
 - name: Create a clean virtualenv archive
-  command: "tar -cpzf edx-venv_clean-{{ item }}.tar.gz edx-venv-{{ item }}/edx-venv"
+  command: "tar -C edx-venv-{{ item }} -cpzf edx-venv_clean-{{ item }}.tar.gz edx-venv"
   args:
     chdir: "{{ jenkins_home }}"
   with_items: "{{ jenkins_worker_python_versions }}"

--- a/playbooks/roles/jenkins_worker/tasks/python_platform_worker.yml
+++ b/playbooks/roles/jenkins_worker/tasks/python_platform_worker.yml
@@ -13,27 +13,42 @@
     depth: 1
   become_user: "{{ jenkins_user }}"
 
+# In order to create multiple virtualenvs with the same name,
+# put them into separate directories
+- name: Create directories for virtualenvs to avoid naming collisions
+  file:
+    path: "{{ jenkins_home }}/edx-venv-{{ item }}"
+    state: directory
+  with_items: "{{ jenkins_worker_python_versions }}"
+  become_user: "{{ jenkins_user }}"
+
 # Install the platform requirements using pip.
 - name: Install edx-platform requirements using pip
   pip:
     chdir: "{{ jenkins_home }}/shallow-clone"
-    requirements: "{{ jenkins_home }}/shallow-clone/requirements/edx/{{ item }}"
+    requirements: "{{ jenkins_home }}/shallow-clone/requirements/edx/jenkins.txt"
     extra_args: "--exists-action=w"
-    virtualenv: "{{ jenkins_home }}/edx-venv"
+    virtualenv: "{{ jenkins_home }}/edx-venv-{{ item }}/edx-venv"
     virtualenv_command: virtualenv
-  with_items:
-    - django.txt
-    - testing.txt
+  with_items: "{{ jenkins_worker_python_versions }}"
   become_user: "{{ jenkins_user }}"
 
-# Archive the current state of the virtualenv
+# Archive the current state of each of the virtualenvs
 # as a starting point for new builds.
-# The edx-venv directory is deleted and then recreated
+# The edx-venv-x directory is deleted and then recreated
 # cleanly from the archive by the jenkins build scripts.
 - name: Create a clean virtualenv archive
-  command: "tar -cpzf edx-venv_clean.tar.gz edx-venv"
+  command: "tar -cpzf edx-venv_clean-{{ item }}.tar.gz edx-venv-{{ item }}/edx-venv"
   args:
     chdir: "{{ jenkins_home }}"
+  with_items: "{{ jenkins_worker_python_versions }}"
+  become_user: "{{ jenkins_user }}"
+
+# Temporary fix: make a copy of the python 2.7 virtualenv with a
+# generic name to avoid breaking older PRs
+- name: Make copy of py2.7 virtualenv tarball
+  command: "cp edx-venv_clean-2.7.tar.gz edx-venv_clean.tar.gz"
+  with_items: "{{ jenkins_worker_python_versions }}"
   become_user: "{{ jenkins_user }}"
 
 - name: Add script to set install node packages


### PR DESCRIPTION
Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?

-----
We already install multiple versions of Python onto Jenkins workers to be used by tox, but we only create a python 2.7 virtualenv. This is used by the scripts prior to tox invocation (i.e. worker spin up, node-env creation, etc). This PR will create a virtualenv (and tar it) for each installed version of python.

Requires that https://github.com/edx/edx-platform/pull/21353 be merged.
