### PR TITLE
TE-2847 Remove config for old Splunk servers

### DIFF
--- a/playbooks/roles/jenkins_common/defaults/main.yml
+++ b/playbooks/roles/jenkins_common/defaults/main.yml
@@ -284,10 +284,7 @@ jenkins_common_splunk_event_source: ''
 jenkins_common_splunk_script_type: 'path'
 jenkins_common_splunk_script_path: ''
 jenkins_common_splunk_file_path: '{{ role_path }}/files/splunk/*'
-jenkins_common_splunk_metadata:
-    - data_source: 'Default'
-      config_item: 'Source Type'
-      value: 'json:jenkins:old'
+jenkins_common_splunk_metadata: []
 JENKINS_SPLUNK_HOSTNAME: ''
 JENKINS_SPLUNK_PORT: 8088
 JENKINS_SPLUNK_APP_URL: ''


### PR DESCRIPTION
Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?

Remove a legacy configuration setting for Splunk servers prior to 6.5 (edX currently uses a version well beyond this).  More details on [this page](https://wiki.jenkins.io/display/JENKINS/Splunk+plugin+for+Jenkins) under "2.1. Metadata configuration for Splunk App for Jenkins".