### PR TITLE
SE-1071 increase NLTK download timeout

### DIFF
--- a/playbooks/roles/nltk/defaults/main.yml
+++ b/playbooks/roles/nltk/defaults/main.yml
@@ -11,3 +11,5 @@ NLTK_DATA:
       url: "http://nltk.github.io/nltk_data/packages/corpora/stopwords.zip" }
   - { path: "corpora/wordnet",
       url: "http://nltk.github.io/nltk_data/packages/corpora/wordnet.zip" }
+
+NLTK_DOWNLOAD_TIMEOUT: 100

--- a/playbooks/roles/nltk/tasks/main.yml
+++ b/playbooks/roles/nltk/tasks/main.yml
@@ -13,6 +13,7 @@
   get_url:
     dest: "{{ NLTK_DATA_DIR }}/{{ item.url|basename }}"
     url: "{{ item.url }}"
+    timeout: "{{ NLTK_DOWNLOAD_TIMEOUT }}"
   with_items: "{{ NLTK_DATA }}"
   register: nltk_download
   tags:


### PR DESCRIPTION
Default timeout for get_url is 10s, and NLTK usually takes longer than
this to download.

**JIRA tickets**: [OSPR-3825](https://openedx.atlassian.net/browse/OSPR-3825)

**Dependencies**: None

**Merge deadline**: None

**Testing instructions**:

1. run configuration and confirm that nltk data is downloaded successfully

**Reviewers**
- [x] @pomegranited 
- [ ] edX reviewer[s] TBD

**Settings**
```yaml
```