### PR TITLE
SE-1463 Fix *_ENV_EXTRA configuration

### DIFF
--- a/playbooks/roles/edxapp/templates/lms.yml.j2
+++ b/playbooks/roles/edxapp/templates/lms.yml.j2
@@ -1,3 +1,4 @@
 {% if lms_combined_config %}
+{% do lms_combined_config.update(EDXAPP_LMS_ENV_EXTRA) %}
 {{ lms_combined_config | to_nice_yaml }}
 {% endif %}

--- a/playbooks/roles/edxapp/templates/studio.yml.j2
+++ b/playbooks/roles/edxapp/templates/studio.yml.j2
@@ -1,3 +1,4 @@
 {% if cms_combined_config %}
+{% do cms_combined_config.update(EDXAPP_CMS_ENV_EXTRA) %}
 {{ cms_combined_config | to_nice_yaml }}
 {% endif %}


### PR DESCRIPTION
This PR re-enables support for `EDXAPP_{CMS,LMS}_ENV_EXTRA` snippets.
Previously these extra variables were only merged here:

https://github.com/edx/configuration/blob/master/playbooks/roles/edxapp/templates/lms.env.json.j2#L1

Now that edx-platform doesn't read from the json config files, this behaviour
must be ported to work with the new yml config.

**JIRA tickets**: [OSPR-3838](https://openedx.atlassian.net/browse/OSPR-3838)

**Dependencies**: None

**Sandbox URL**:

- lms: https://se-1071.sandbox.opencraft.hosting/

(This sandbox is for another ticket, but was deployed from this
configuration branch with the settings as at the end of this PR description.)

**Merge deadline**: None

**Testing instructions**:

1. add custom config to EDXAPP_LMS_ENV_EXTRA and EDXAPP_CMS_ENV_EXTRA
2. deploy an instance of edx platform using this configuration branch
3. check that the config added under the above variables are visible as top level
   keys in lms.yml and studio.yml respectively.

For example, if you add to the extra configuration:

```
EDXAPP_CMS_ENV_EXTRA:
  DUMMY: true
```

You should see this line in studio.yml:

```
DUMMY: true
```

(Previously, this would not end up with studio.yml; would only be in
cms.env.json)



**Author notes and concerns**:


**Reviewers**
- [x] @viadanna
- [x] edX reviewer[s] TBD

**Settings**
```yaml
EDXAPP_LMS_ENV_EXTRA:
  ADDL_INSTALLED_APPS:
   - openedx.core.djangoapps.heartbeat
  HEARTBEAT_EXTENDED_CHECKS:
   - "openedx.core.djangoapps.django_comment_common.comment_client.utils.check_forum_heartbeat"
   - "openedx.core.djangoapps.heartbeat.default_checks.check_celery"
```


