### PR TITLE
Change Mongo auth_source setting to authsource

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -1069,7 +1069,7 @@ edxapp_generic_contentstore_config: &edxapp_generic_default_contentstore
     port: "{{ EDXAPP_MONGO_PORT }}"
     user: "{{ EDXAPP_MONGO_USER }}"
     ssl: "{{ EDXAPP_MONGO_USE_SSL }}"
-    auth_source: "{{ EDXAPP_MONGO_AUTH_DB }}"
+    authsource: "{{ EDXAPP_MONGO_AUTH_DB }}"
 
 edxapp_generic_doc_store_config: &edxapp_generic_default_docstore
   db: "{{ EDXAPP_MONGO_DB_NAME }}"
@@ -1084,7 +1084,7 @@ edxapp_generic_doc_store_config: &edxapp_generic_default_docstore
   socketTimeoutMS: 3000 # default is never timeout while the connection is open, this means it needs to explicitly close raising pymongo.errors.NetworkTimeout
   connectTimeoutMS: 2000 # default is 20000, I believe raises pymongo.errors.ConnectionFailure
   # Not setting waitQueueTimeoutMS and waitQueueMultiple since pymongo defaults to nobody being allowed to wait
-  auth_source: "{{ EDXAPP_MONGO_AUTH_DB }}"
+  authsource: "{{ EDXAPP_MONGO_AUTH_DB }}"
 
 EDXAPP_LMS_DRAFT_DOC_STORE_CONFIG:
   <<: *edxapp_generic_default_docstore


### PR DESCRIPTION
Configuration Pull Request
---

[MongoDB uses the `authSource` parameter to determine which database to use for authentication](https://docs.mongodb.com/manual/reference/connection-string/#urioption.authSource). The current configuration generates the module and content store settings with the name `auth_source`. 
Defined [here](https://github.com/edx/configuration/blob/62f022f55910410fc6c4a3ceaaaa854167b671fe/playbooks/roles/edxapp/defaults/main.yml#L1072) and [here](https://github.com/edx/configuration/blob/62f022f55910410fc6c4a3ceaaaa854167b671fe/playbooks/roles/edxapp/defaults/main.yml#L1087)


[PyMongo expects the value to be `authsource`](https://github.com/mongodb/mongo-python-driver/blob/2.9.1/pymongo/common.py#L417) and throws a ConfigurationError when attempting to access the module or content store:

```
ConfigurationError: Unknown option auth_source
```

[View full error Traceback](https://pastebin.com/Y94jSzAb)

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
