### PR TITLE
ENT-2317 - Add new properties to support sending sales data to HubSpot for Bulk Purchases

### DIFF
--- a/playbooks/roles/ecommerce/defaults/main.yml
+++ b/playbooks/roles/ecommerce/defaults/main.yml
@@ -315,3 +315,7 @@ ecommerce_post_migrate_commands:
     when: '{{ ecommerce_create_demo_data }}'
   - command: './manage.py create_demo_data --partner=edX'
     when: '{{ ecommerce_create_demo_data }}'
+
+# For sending course bulk purchase sales information to HubSpot
+ECOMMERCE_HUBSPOT_PORTAL_ID: "HubSpot Portal Id"
+ECOMMERCE_HUBSPOT_FORM_GUID: "HubSpot Form GUID"


### PR DESCRIPTION
For a purchase that is on behalf of a company/organization, we want to start sending that data to HubSpot as a Sales lead. Adding new parameters for edX's internal HubSpot portal Id and the GUID of the form we are going to submit against to create a sales lead at the time of purchase. 

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
