### PR TITLE
add missing packages for ansible upgrade to 2.7

### DIFF
--- a/playbooks/roles/common_vars/defaults/main.yml
+++ b/playbooks/roles/common_vars/defaults/main.yml
@@ -136,6 +136,7 @@ common_pip_pkgs:
   - setuptools==39.0.1
   - virtualenv==15.2.0
   - virtualenvwrapper==4.8.2
+  - boto3
 
 common_web_user: www-data
 common_web_group: www-data


### PR DESCRIPTION
Context

Adding some context about the Ansible upgrade here

I had merged the PR and ran discovery and ecommerce pipelines which ran fine without any issues. Then I checked edxapp pipelines which were failing at run_play step. 

When I looked into it I found out that the required packages were missing and it was throwing the following error in the mentioned task

 
```

[edxapp : tag instance with edx_platform version]
Python modules \"botocore\" or \"boto3\" are missing, please install both
 
```

I then made a sample test play to check and install the required packages on the system which resulted in the error vanishing away. The following link also shows that for versions of ansible < 2.7 these packages were not pre-req’s.

 

For the time being, I have reverted the PR.

We can also give the link of the venv in config play from where to run the python if the packages are installed in the Venv on the desired host.


Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
