### PR TITLE
Revert "Change Mongo auth_source setting to authsource"

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -1069,7 +1069,7 @@ edxapp_generic_contentstore_config: &edxapp_generic_default_contentstore
     port: "{{ EDXAPP_MONGO_PORT }}"
     user: "{{ EDXAPP_MONGO_USER }}"
     ssl: "{{ EDXAPP_MONGO_USE_SSL }}"
-    authsource: "{{ EDXAPP_MONGO_AUTH_DB }}"
+    auth_source: "{{ EDXAPP_MONGO_AUTH_DB }}"
 
 edxapp_generic_doc_store_config: &edxapp_generic_default_docstore
   db: "{{ EDXAPP_MONGO_DB_NAME }}"
@@ -1084,7 +1084,7 @@ edxapp_generic_doc_store_config: &edxapp_generic_default_docstore
   socketTimeoutMS: 3000 # default is never timeout while the connection is open, this means it needs to explicitly close raising pymongo.errors.NetworkTimeout
   connectTimeoutMS: 2000 # default is 20000, I believe raises pymongo.errors.ConnectionFailure
   # Not setting waitQueueTimeoutMS and waitQueueMultiple since pymongo defaults to nobody being allowed to wait
-  authsource: "{{ EDXAPP_MONGO_AUTH_DB }}"
+  auth_source: "{{ EDXAPP_MONGO_AUTH_DB }}"
 
 EDXAPP_LMS_DRAFT_DOC_STORE_CONFIG:
   <<: *edxapp_generic_default_docstore


### PR DESCRIPTION
Reverts edx/configuration#5413

This PR on it's own caused a failure in pymongo:

```
Exception Value: Wrong type for authsource, value must be an instance of basestring
```

I'm going to revert this PR until the associated platform/comments service PRs have merged.