### PR TITLE
Fix the job definition for the jobs which app-permissions kicks off

### DIFF
--- a/playbooks/manage_edxapp_users_and_groups.yml
+++ b/playbooks/manage_edxapp_users_and_groups.yml
@@ -104,6 +104,6 @@
         {% if item.get('initial_password_hash') %}--initial-password-hash {{ item.initial_password_hash | quote }}{% endif %}
       with_items: "{{ django_users }}"
       register: manage_users_result
-      failed_when: (manage_users_result is failed) and not (ignore_user_creation_errors is bool)
+      failed_when: (manage_users_result is failed) and not (ignore_user_creation_errors | bool)
       become: true
       become_user: "{{ common_web_user }}"


### PR DESCRIPTION
Issue has caused e.g. this failure https://tools-edx-jenkins.edx.org/job/App-Permissions/job/app-permissions-runner-prod-edx/307/console


Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
