### PR TITLE
Switch ecommerce back to python 2 for devstack (and tests)

### DIFF
--- a/docker/build/ecommerce/ansible_overrides.yml
+++ b/docker/build/ecommerce/ansible_overrides.yml
@@ -22,7 +22,7 @@ ECOMMERCE_MEMCACHE: ['edx.devstack.memcached:11211']
 ECOMMERCE_ECOMMERCE_URL_ROOT: 'http://localhost:18130'
 ECOMMERCE_LMS_URL_ROOT: 'http://edx.devstack.lms:18000'
 ECOMMERCE_DISCOVERY_SERVICE_URL: 'http://edx.devstack.discovery:18381'
-ECOMMERCE_USE_PYTHON3: true
+ECOMMERCE_USE_PYTHON3: false
 
 edx_django_service_is_devstack: true
 


### PR DESCRIPTION
Rationale
---

Switching devstack over to python3 didn't work because it caused tests on master to fail. The python2 tests need to be switched over to use tox, and both 2 and 3 need to pass under tox on both devstack and travis. Once that happens, then we can switch devstack over to python3.


Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
