### PR TITLE
Bump labxchange-xblocks version on edx.org

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -530,7 +530,7 @@ EDXAPP_PRIVATE_REQUIREMENTS:
     - name: git+https://github.com/edx/edx-zoom.git@7feb9972c4c689acf00bf9f1a0b77d0f21b52d9a#egg=edx-zoom
       extra_args: -e
     # XBlocks associated with the LabXchange project
-    - name: git+https://github.com/open-craft/labxchange-xblocks.git@7dd52d797ed5e7683030739d1f0b052947b0866e#egg=labxchange-xblocks
+    - name: git+https://github.com/open-craft/labxchange-xblocks.git@171aec6fd7608d1a5e0af119c15e808a7320f2a7#egg=labxchange-xblocks
       extra_args: -e
 
 # List of custom middlewares that should be used in edxapp to process


### PR DESCRIPTION
Pulls in a minor change to the LabXchange Image XBlock: https://github.com/open-craft/labxchange-xblocks/pull/3

Only used on edx prod/stage.