### PR TITLE
Make node build by default on jenkins workers.

### DIFF
--- a/playbooks/roles/jenkins_worker/defaults/main.yml
+++ b/playbooks/roles/jenkins_worker/defaults/main.yml
@@ -19,7 +19,7 @@ jenkins_debian_pkgs:
 # packer direct download URL
 packer_url: "https://releases.hashicorp.com/packer/0.8.6/packer_0.8.6_linux_amd64.zip"
 
-nodejs_version: "8"
+jenkins_node_version: "12"
 ansible_distribution_release: "xenial"
 
 jenkins_worker_python_versions:

--- a/playbooks/roles/jenkins_worker/defaults/main.yml
+++ b/playbooks/roles/jenkins_worker/defaults/main.yml
@@ -17,7 +17,7 @@ jenkins_debian_pkgs:
     - libfreetype6-dev
 
 # packer direct download URL
-packer_url: "https://releases.hashicorp.com/packer/0.8.6/packer_0.8.6_linux_amd64.zip"
+packer_url: "https://releases.hashicorp.com/packer/1.4.4/packer_1.4.4_linux_amd64.zip"
 
 jenkins_node_version: "12"
 ansible_distribution_release: "xenial"

--- a/playbooks/roles/jenkins_worker/tasks/main.yml
+++ b/playbooks/roles/jenkins_worker/tasks/main.yml
@@ -8,10 +8,7 @@
 - include: packer.yml
 - include: system.yml
 - include: python.yml
-
-# only android worker 
 - include: node.yml
-  when: android_worker is defined
 
 # only platform workers
 - include: python_platform_worker.yml

--- a/playbooks/roles/jenkins_worker/tasks/node.yml
+++ b/playbooks/roles/jenkins_worker/tasks/node.yml
@@ -5,15 +5,12 @@
   apt_key:
     url: "https://deb.nodesource.com/gpgkey/nodesource.gpg.key"
     state: present
-  when: android_worker is defined
 - name: Install the nodejs LTS repos
   apt_repository:
-    repo: "deb https://deb.nodesource.com/node_{{ nodejs_version }}.x {{ ansible_distribution_release }} main"
+    repo: "deb https://deb.nodesource.com/node_{{ jenkins_node_version }}.x {{ ansible_distribution_release }} main"
     state: present
     update_cache: yes
-  when: android_worker is defined  
 - name: Install the nodejs
   apt:
     name: nodejs
     state: present
-  when: android_worker is defined  


### PR DESCRIPTION
We've been seeing issues installing `node` via `nodeenv` in our jenkins builds. One of the proposed solutions is to build node on all of our jenkins workers by default using `apt` instead of `nodeenv`.

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
