### PR TITLE
Refactor node versions for discovery and credentials.

### DIFF
--- a/playbooks/roles/credentials/defaults/main.yml
+++ b/playbooks/roles/credentials/defaults/main.yml
@@ -21,6 +21,7 @@ credentials_environment:
   CREDENTIALS_CFG: '{{ COMMON_CFG_DIR }}/{{ credentials_service_name }}.yml'
 
 credentials_gunicorn_port: 8150
+credentials_node_version: '8.9.3'
 
 #
 # OS packages
@@ -175,6 +176,8 @@ CREDENTIALS_ENABLE_NEWRELIC_DISTRIBUTED_TRACING: false
 credentials_post_migrate_commands:
   - command: './manage.py create_or_update_site --site-id=1 --site-domain={{ CREDENTIALS_DOMAIN }} --site-name="Open edX" --platform-name="Open edX" --company-name="Open edX" --lms-url-root={{ CREDENTIALS_LMS_URL_ROOT }} --catalog-api-url={{ CREDENTIALS_DISCOVERY_API_URL }} --tos-url={{ CREDENTIALS_LMS_URL_ROOT }}/tos --privacy-policy-url={{ CREDENTIALS_LMS_URL_ROOT }}/privacy --homepage-url={{ CREDENTIALS_LMS_URL_ROOT }} --certificate-help-url={{ CREDENTIALS_LMS_URL_ROOT }}/faq --records-help-url={{ CREDENTIALS_LMS_URL_ROOT }}/faq --theme-name=openedx'
     when: '{{ credentials_create_demo_data }}'
+
+
 
 # Remote config
 CREDENTIALS_HERMES_ENABLED: "{{ COMMON_HERMES_ENABLED }}"

--- a/playbooks/roles/credentials/meta/main.yml
+++ b/playbooks/roles/credentials/meta/main.yml
@@ -27,6 +27,7 @@ dependencies:
     edx_django_service_staticfiles_storage: '{{ CREDENTIALS_STATICFILES_STORAGE }}'
     edx_django_service_media_storage_backend: '{{ CREDENTIALS_MEDIA_STORAGE_BACKEND }}'
     edx_django_service_memcache: '{{ CREDENTIALS_MEMCACHE }}'
+    edx_django_service_node_version: '{{ credentials_node_version }}'
     edx_django_service_default_db_host: '{{ CREDENTIALS_MYSQL_HOST }}'
     edx_django_service_default_db_name: '{{ CREDENTIALS_DEFAULT_DB_NAME }}'
     edx_django_service_default_db_atomic_requests: false

--- a/playbooks/roles/discovery/defaults/main.yml
+++ b/playbooks/roles/discovery/defaults/main.yml
@@ -33,6 +33,8 @@ discovery_user: "{{ discovery_service_name }}"
 discovery_home: "{{ COMMON_APP_DIR }}/{{ discovery_service_name }}"
 discovery_code_dir: "{{ discovery_home }}/{{ discovery_service_name }}"
 
+discovery_node_version: '8.9.3'
+
 #
 # OS packages
 #

--- a/playbooks/roles/discovery/meta/main.yml
+++ b/playbooks/roles/discovery/meta/main.yml
@@ -38,6 +38,7 @@ dependencies:
     edx_django_service_staticfiles_storage: '{{ DISCOVERY_STATICFILES_STORAGE }}'
     edx_django_service_media_storage_backend: '{{ DISCOVERY_MEDIA_STORAGE_BACKEND }}'
     edx_django_service_memcache: '{{ DISCOVERY_MEMCACHE }}'
+    edx_django_service_node_version: '{{ discovery_node_version }}'
     edx_django_service_social_auth_edx_oidc_key: '{{ DISCOVERY_SOCIAL_AUTH_EDX_OIDC_KEY }}'
     edx_django_service_social_auth_edx_oidc_secret: '{{ DISCOVERY_SOCIAL_AUTH_EDX_OIDC_SECRET }}'
     edx_django_service_social_auth_edx_oauth2_key: '{{ DISCOVERY_SOCIAL_AUTH_EDX_OAUTH2_KEY }}'


### PR DESCRIPTION
Refactoring out the node versions for discovery and credentials so that they can be updated separately.

This is not a complete refactor, but it does separate out two of the individual IDAs so that https://github.com/edx/configuration/pull/5456 can be merged separately.