### PR TITLE
Update labxchange-xblocks to 0.3.0.

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -530,7 +530,7 @@ EDXAPP_PRIVATE_REQUIREMENTS:
     - name: git+https://github.com/edx/edx-zoom.git@7feb9972c4c689acf00bf9f1a0b77d0f21b52d9a#egg=edx-zoom
       extra_args: -e
     # XBlocks associated with the LabXchange project
-    - name: git+https://github.com/open-craft/labxchange-xblocks.git@171aec6fd7608d1a5e0af119c15e808a7320f2a7#egg=labxchange-xblocks
+    - name: git+https://github.com/open-craft/labxchange-xblocks.git@8d10b40c8d1b7eb084861bdb05ca1616a38bd873#egg=labxchange-xblocks
       extra_args: -e
 
 # List of custom middlewares that should be used in edxapp to process


### PR DESCRIPTION
Updates labxchange-xblocks dependency to 0.3.0. The changes in the new version are: 

- https://github.com/open-craft/labxchange-xblocks/pull/4

---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
