### PR TITLE
BB-987: Fix typo on oauth client configuration

### DIFF
--- a/playbooks/roles/oauth_client_setup/defaults/main.yml
+++ b/playbooks/roles/oauth_client_setup/defaults/main.yml
@@ -93,8 +93,8 @@ oauth_client_setup_oauth2_clients:
       }
     - {
         name: "{{ retirement_service_name if COMMON_RETIREMENT_SERVICE_SETUP|default(false)|bool else 'None' }}",
-        backend_service_id: "{{ RETIREMENT_SERVICE_OAUTH_CLIENT_ID | default('None') }}",
-        backend_service_secret: "{{ RETIREMENT_SERVICE_OAUTH_CLIENT_SECRET | default('None') }}",
+        backend_service_id: "{{ RETIREMENT_SERVICE_EDX_OAUTH2_KEY | default('None') }}",
+        backend_service_secret: "{{ RETIREMENT_SERVICE_EDX_OAUTH2_SECRET | default('None') }}",
         username: "{{ EDXAPP_RETIREMENT_SERVICE_WORKER_USERNAME | default('None') }}",
       }
 #


### PR DESCRIPTION
This PR fixes a typo introduced when addressing comments on https://github.com/edx/configuration/pull/5040.

The following variables were renamed, but one of the instances was left behind:

- `RETIREMENT_SERVICE_OAUTH_CLIENT_ID` -> `RETIREMENT_SERVICE_EDX_OAUTH2_KEY`
- `RETIREMENT_SERVICE_OAUTH_CLIENT_SECRET` -> `RETIREMENT_SERVICE_EDX_OAUTH2_SECRET`

**Reviewers:**
- [ ] @Agrendalath or @viadanna

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
