### PR TITLE
Supervisorctl stop all before killing supervisor

### DIFF
--- a/playbooks/roles/stop_all_edx_services/handlers/main.yml
+++ b/playbooks/roles/stop_all_edx_services/handlers/main.yml
@@ -18,6 +18,13 @@
 #   an AMI.
 #
 #
+- name: stop supervisor children
+  shell: /edx/bin/supervisorctl stop all
+  service:
+    name: supervisor
+    state: stopped
+    arguments: "{{ STOP_ALL_EDX_SERVICES_EXTRA_ARGS }}"
+
 - name: stop supervisor
   service:
     name: supervisor

--- a/playbooks/roles/stop_all_edx_services/tasks/main.yml
+++ b/playbooks/roles/stop_all_edx_services/tasks/main.yml
@@ -33,11 +33,23 @@
     state: stopped
   ignore_errors: yes
 
-- name: Stop supervisor
+- name: Stop supervisor children
   stat:
     path: /etc/init/supervisor.conf
   register: stat_out
   changed_when: stat_out is defined and stat_out.stat.exists
+  notify:
+    - stop supervisor children
+
+- name: Get supervisorctl output
+  shell: "/edx/bin/supervisorctl status"
+  register: supervisorctl_command_result
+
+- name: Stop supervisor
+  stat:
+    path: /etc/init/supervisor.conf
+  register: stat_out
+  changed_when: stat_out is defined and stat_out.stat.exists and 'RUNNING' not in supervisorctl_command_result.stdout
   notify:
     - stop supervisor
 
@@ -77,7 +89,7 @@
   stat:
     path: /etc/systemd/system/supervisor.service
   register: stat_out
-  changed_when: stat_out is defined and stat_out.stat.exists
+  changed_when: stat_out is defined and stat_out.stat.exists and 'RUNNING' not in supervisorctl_command_result.stdout
   notify:
     - stop supervisor
 


### PR DESCRIPTION
Sometimes worker nodes get into a bad state where supervisor is in a
shutdown state and it's children have not responded to sigterm. This
change will call supervisorctl stop everytime it's run and won't kill
supervisor until all it's children have stopped running. I hope this
results in sending more sigterms to it's children which might make them
more likely to shutdown.

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
