### PR TITLE
Fix paypal payment processor default configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+- Role: ecommerce
+  - Fixed paypal payment processor default configuration
+
 - Role: edxapp
   - Added `ENABLE_PUBLISHER` for indicating that the publisher frontend service is in use
 

--- a/playbooks/roles/ecommerce/defaults/main.yml
+++ b/playbooks/roles/ecommerce/defaults/main.yml
@@ -153,7 +153,7 @@ ECOMMERCE_PAYMENT_PROCESSOR_CONFIG:
       client_id: '{{ ECOMMERCE_PAYPAL_CLIENT_ID }}'
       client_secret: '{{ ECOMMERCE_PAYPAL_CLIENT_SECRET }}'
       receipt_url: '{{ ECOMMERCE_PAYPAL_RECEIPT_URL }}'
-      cancel_url: '{{ ECOMMERCE_PAYPAL_CANCEL_URL }}'
+      cancel_checkout_path: '{{ ECOMMERCE_PAYPAL_CANCEL_URL }}'
       error_url: '{{ ECOMMERCE_PAYPAL_ERROR_URL }}'
 
 # JWT payload user attribute mapping


### PR DESCRIPTION
This is the companion PR of the upstream ecommerce repo:
https://github.com/edx/ecommerce/pull/2684

The `cancel_url` configuration setting is not used by the paypal payment
processor in ecommerce. Instead, the payment processor uses the
`cancel_checkout_path` configuration parameter.

This error has been reported by two different users:
https://discuss.overhang.io/t/ecommerce-plugin-500-error-on-fresh-setup
https://openedx.slack.com/archives/C02SNA1U4/p1573488822105900?thread_ts=1573488555.104900&cid=C02SNA1U4

The proposed fix has worked in both cases.

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - ~~[ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.~~
  - ~~[ ] Are you adding any new default values that need to be overridden when this change goes live? If so:~~
    - [x] Update the appropriate internal repo (be sure to update for all our environments)
    - ~~[ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.~~
    - [x] Add an entry to the CHANGELOG.
  - ~~[ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).~~
  - ~~[ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?~~ Documentation is already up-to-date: https://edx-ecommerce.readthedocs.io/en/latest/additional_features/payment_processors.html
