### PR TITLE
[BB-1336] Update the name of the management command to create site configuration

### DIFF
--- a/playbooks/masters_sandbox.yml
+++ b/playbooks/masters_sandbox.yml
@@ -37,7 +37,7 @@
 
     - name: create discovery site configuration
       shell: >
-        . {{ edxapp_env_path }} && {{ edxapp_venv_dir }}/bin/python manage.py lms create_site_configuration {{dns_name}}.sandbox.edx.org
+        . {{ edxapp_env_path }} && {{ edxapp_venv_dir }}/bin/python manage.py lms create_or_update_site_configuration {{dns_name}}.sandbox.edx.org
         --configuration '{"COURSE_CATALOG_API_URL":"https://discovery-{{dns_name}}.sandbox.edx.org/api/v1","email_from_address":"edX <no-reply@registration.{{dns_name}}.sandbox.edx.org>"}'
       args:
         chdir: "{{ edxapp_code_dir }}"


### PR DESCRIPTION
This PR updates the usages of the `create_site_configuration` management to `create_or_update_site_configuration`. This is required once the changes in
https://github.com/edx/edx-platform/pull/20804 are merged.

**JIRA tickets**: [OSPR-3650](https://openedx.atlassian.net/browse/OSPR-3650).
**Discussions**:  See https://github.com/edx/edx-platform/pull/20804
**Dependencies**: https://github.com/edx/edx-platform/pull/20804
**Sandbox URL**: TBD - sandbox is being provisioned.

**Merge deadline**: None

**Testing instructions**:

1. https://github.com/edx/edx-platform/pull/20804 updates the name of the management command. So once that is merged, verify that the task updated in this PR works okay.

**Author notes and concerns**:
None

**Reviewers**
- [ ] @giovannicimolin 
- [ ] edX reviewer[s] TBD

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
