### PR TITLE
remove nodeenv references

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -990,8 +990,6 @@ edxapp_log_dir: "{{ COMMON_LOG_DIR }}/edx"
 edxapp_venvs_dir: "{{ edxapp_app_dir }}/venvs"
 edxapp_venv_dir: "{{ edxapp_venvs_dir }}/edxapp"
 edxapp_venv_bin: "{{ edxapp_venv_dir }}/bin"
-edxapp_nodeenv_dir: "{{ edxapp_app_dir }}/nodeenvs/edxapp"
-edxapp_nodeenv_bin: "{{ edxapp_nodeenv_dir }}/bin"
 edxapp_settings: '{{ EDXAPP_SETTINGS }}'
 edxapp_node_version: "12"
 # This is where node installs modules, not node itself
@@ -999,7 +997,7 @@ edxapp_node_bin: "{{ edxapp_code_dir }}/node_modules/.bin"
 edxapp_user: edxapp
 edxapp_user_createhome: 'no'
 edxapp_user_shell: '/bin/false'
-edxapp_deploy_path: "{{ edxapp_venv_bin }}:{{ edxapp_code_dir }}/bin:{{ edxapp_node_bin }}:{{ edxapp_nodeenv_bin }}:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+edxapp_deploy_path: "{{ edxapp_venv_bin }}:{{ edxapp_code_dir }}/bin:{{ edxapp_node_bin }}:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 edxapp_staticfile_dir: "{{ edxapp_data_dir }}/staticfiles"
 edxapp_media_dir: "{{ edxapp_data_dir }}/media"
 edxapp_course_static_dir: "{{ edxapp_data_dir }}/course_static"

--- a/playbooks/roles/edxapp/templates/devstack.sh.j2
+++ b/playbooks/roles/edxapp/templates/devstack.sh.j2
@@ -10,7 +10,6 @@ case $COMMAND in
         /edx/app/supervisor/venvs/supervisor/bin/supervisord -n --configuration /edx/app/supervisor/supervisord.conf
         ;;
     open)
-        . {{ edxapp_nodeenv_bin }}/activate
         . {{ edxapp_venv_bin }}/activate
         cd {{ edxapp_code_dir }}
 
@@ -19,7 +18,6 @@ case $COMMAND in
     exec)
         shift
 
-        . {{ edxapp_nodeenv_bin }}/activate
         . {{ edxapp_venv_bin }}/activate
         cd {{ edxapp_code_dir }}
 


### PR DESCRIPTION
remove references to `edxapp_nodeenv_dir` and `edxapp_nodeenv_bin` to
complete the removal of nodeenv started in: https://github.com/edx/configuration/pull/5481

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
