### PR TITLE
Use relative path to role

### DIFF
--- a/playbooks/roles/automated/defaults/main.yml
+++ b/playbooks/roles/automated/defaults/main.yml
@@ -13,7 +13,7 @@
 
 automated_role_name: automated
 AUTOMATED_USER: "changeme"
-automated_sudoers_template: "roles/automated/templates/99-automated.j2"
+automated_sudoers_template: "99-automated.j2"
 
 #
 # OS packages


### PR DESCRIPTION
When the playbook is not placed in playbooks/, (An external repo), this template is not rendered because that path does not exist.