### PR TITLE
Update the edx-notes-api docker image to python3.

### DIFF
--- a/docker/build/notes/Dockerfile
+++ b/docker/build/notes/Dockerfile
@@ -21,6 +21,9 @@ ADD . /edx/app/edx_ansible/edx_ansible
 WORKDIR /edx/app/edx_ansible/edx_ansible/docker/plays
 
 COPY docker/build/notes/ansible_overrides.yml /
+
+RUN sudo apt-get update && sudo apt-get -y install python3-dev libmysqlclient-dev
+
 RUN sudo /edx/app/edx_ansible/venvs/edx_ansible/bin/ansible-playbook notes.yml \
     -c local -i '127.0.0.1,' \
     -t 'install,assets,devstack:install' \

--- a/playbooks/roles/edx_notes_api/tasks/main.yml
+++ b/playbooks/roles/edx_notes_api/tasks/main.yml
@@ -48,6 +48,7 @@
     virtualenv: "{{ edx_notes_api_home }}/venvs/{{ edx_notes_api_service_name }}"
     state: present
     extra_args: "--exists-action w"
+    virtualenv_python: 'python3.5'
   become_user: "{{ edx_notes_api_user }}"
   with_items: "{{ edx_notes_api_requirements }}"
   tags:


### PR DESCRIPTION
This PR updates the docker image used by devstack and by travis tests to run on python3.  Code in the edx-notes-api repo has already been updated to be python3 compatible.  

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
