### PR TITLE
SE-46 revert install resolvconf

### DIFF
--- a/playbooks/roles/common_vars/defaults/main.yml
+++ b/playbooks/roles/common_vars/defaults/main.yml
@@ -112,7 +112,6 @@ common_redhat_pkgs:
   - git
   - unzip
   - acl
-  - resolvconf
 common_debian_pkgs:
   - apt-transport-https
   - ntp
@@ -125,7 +124,6 @@ common_debian_pkgs:
   - unzip
   - python-pip
   - python2.7-dev
-  - resolvconf
 
 # Packages that should be installed from our custom PPA, i.e. COMMON_EDX_PPA
 old_python_debian_pkgs:


### PR DESCRIPTION
This reverts commit 8927bb07d53c0009b0dc61116ac6a2fe92719dd0 (PR #4116), reversing
changes made to 0db511bb17fb042ac7755c53937ef174e7986c68.

Installing resolvconf breaks in docker unless specific extra config is
applied. This specific extra config was not included with the commit that this reverts, and so everything was broken.

The original PR (https://github.com/edx/configuration/pull/4116) should never have been merged - the tests were failing and it was no longer clear why this change was necessary to be separate from https://github.com/edx/configuration/pull/3872 (the PR where this change was required).

If adding resolvconf is necessary for #3872, then it should be added there and appropriate config developed to fix installation in docker.

CC @fredsmith (merged the PR that this reverts) and @SSPJ (current task assignee)

**JIRA tickets**: [OSPR-3943](https://openedx.atlassian.net/browse/OSPR-3943)

**Discussions**: https://discuss.openedx.org/t/ironwood-master-devstack-installation-fails/924 (forum thread where others in community have this issue.

**Dependencies**: None

**Merge deadline**: ASAP - this breaks docker provisioning everywhere

**Reviewers**
- [x] @SSPJ 
- [x] edX reviewer[s] TBD
