### PR TITLE
Increase upload limit for Blockstore to 10M

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+- Role: blockstore
+  - Increased upload limit to 10M
+
 - Role: ecommerce
   - Fixed paypal payment processor default configuration
 

--- a/playbooks/roles/blockstore/meta/main.yml
+++ b/playbooks/roles/blockstore/meta/main.yml
@@ -5,7 +5,7 @@
 #
 ##
 # Role includes for role blockstore
-# 
+#
 dependencies:
   - role: edx_django_service
     edx_django_service_use_python3: true
@@ -19,6 +19,7 @@ dependencies:
     edx_django_service_gunicorn_worker_class: '{{ BLOCKSTORE_GUNICORN_WORKER_CLASS }}'
     edx_django_service_gunicorn_max_requests: '{{ BLOCKSTORE_GUNICORN_MAX_REQUESTS }}'
     edx_django_service_hostname: '{{ BLOCKSTORE_NGINX_HOSTNAME }}'
+    edx_django_service_max_webserver_upload: 10
     edx_django_service_nginx_port: '{{ BLOCKSTORE_NGINX_PORT }}'
     edx_django_service_ssl_nginx_port: '{{ BLOCKSTORE_SSL_NGINX_PORT }}'
     edx_django_service_default_db_name: '{{ BLOCKSTORE_DEFAULT_DB_NAME }}'


### PR DESCRIPTION
@feanil: The Blockstore upload PR as discussed a week ago. Is that all I have to change?