### PR TITLE
SE-1787 Add mongo backups

### DIFF
--- a/playbooks/roles/mongo_3_2/defaults/main.yml
+++ b/playbooks/roles/mongo_3_2/defaults/main.yml
@@ -107,4 +107,3 @@ mongo_backup_cron:
   day: '*'
   month: '*'
   weekday: '*'
-is_backup_node: false

--- a/playbooks/roles/mongo_3_2/defaults/main.yml
+++ b/playbooks/roles/mongo_3_2/defaults/main.yml
@@ -107,3 +107,4 @@ mongo_backup_cron:
   day: '*'
   month: '*'
   weekday: '*'
+is_backup_node: false

--- a/playbooks/roles/mongo_3_2/defaults/main.yml
+++ b/playbooks/roles/mongo_3_2/defaults/main.yml
@@ -86,3 +86,20 @@ mongo_dbpath: "{{ mongo_data_dir }}/mongodb"
 mongo_enable_journal: true
 
 MONGO_LOG_SERVERSTATUS: true
+
+# backups vars. These must all be set according to your mongo instance setup
+MONGO_BACKUP_EBS_VOLUME_DEVICE: ""
+MONGO_BACKUP_EBS_VOLUME_ID: ""
+MONGO_BACKUP_VOLUME_MOUNT_PATH: "/mnt/mongo-backup"
+MONGO_BACKUP_NODE: "" # note: most likely the ip address of the instance on which to perform the backups
+MONGO_BACKUP_AUTH_DATABASE: ""
+MONGO_BACKUP_SNAPSHOT_DESC: "mongo-backup"
+MONGO_BACKUP_PRUNE_OLDER_THAN_DATE: ""  # passed to `date -d`; should be a relative date like "-30days"
+MONGO_BACKUP_SNITCH_URL: "" # Optional URL that will be used to ping a monitoring service (such as Dead Man's Snitch) upon successful completion of a backup.
+mongo_backup_script_path: "/usr/local/sbin/backup-mongo.sh"
+mongo_backup_cron:
+  minute: '12'
+  hour: '*/12'
+  day: '*'
+  month: '*'
+  weekday: '*'

--- a/playbooks/roles/mongo_3_2/defaults/main.yml
+++ b/playbooks/roles/mongo_3_2/defaults/main.yml
@@ -107,3 +107,7 @@ mongo_backup_cron:
   day: '*'
   month: '*'
   weekday: '*'
+
+# Internal variable set to true dynamically if backups enabled and playbook running on MONGO_BACKUP_NODE. Do not
+# manually override.
+is_backup_node: false

--- a/playbooks/roles/mongo_3_2/defaults/main.yml
+++ b/playbooks/roles/mongo_3_2/defaults/main.yml
@@ -87,15 +87,19 @@ mongo_enable_journal: true
 
 MONGO_LOG_SERVERSTATUS: true
 
-# backups vars. These must all be set according to your mongo instance setup
+# Vars for configuring a mongo backup node. If enabled, this node will be provisioned with a script that uses mongodump
+# to backup the database to an ebs volume at a period set by mongo_backup_cron.
+# Set MONGO_BACKUP_ENABLED to true to enable. If enabled, all the other MONGO_BACKUP_ vars must be set according to your
+# setup.
+MONGO_BACKUP_ENABLED: false
+MONGO_BACKUP_NODE: "" # note: most likely the ip address of the instance on which to perform the backups
 MONGO_BACKUP_EBS_VOLUME_DEVICE: ""
 MONGO_BACKUP_EBS_VOLUME_ID: ""
-MONGO_BACKUP_VOLUME_MOUNT_PATH: "/mnt/mongo-backup"
-MONGO_BACKUP_NODE: "" # note: most likely the ip address of the instance on which to perform the backups
 MONGO_BACKUP_AUTH_DATABASE: ""
-MONGO_BACKUP_SNAPSHOT_DESC: "mongo-backup"
 MONGO_BACKUP_PRUNE_OLDER_THAN_DATE: ""  # passed to `date -d`; should be a relative date like "-30days"
 MONGO_BACKUP_SNITCH_URL: "" # Optional URL that will be used to ping a monitoring service (such as Dead Man's Snitch) upon successful completion of a backup.
+MONGO_BACKUP_VOLUME_MOUNT_PATH: "/mnt/mongo-backup"
+MONGO_BACKUP_SNAPSHOT_DESC: "mongo-backup"
 mongo_backup_script_path: "/usr/local/sbin/backup-mongo.sh"
 mongo_backup_cron:
   minute: '12'

--- a/playbooks/roles/mongo_3_2/tasks/main.yml
+++ b/playbooks/roles/mongo_3_2/tasks/main.yml
@@ -172,19 +172,6 @@
     - "manage:db-replication"
     - "mongodb_key"
 
-- name: install prereqs for backup script
-  apt:
-    pkg: "{{ item }}"
-    state: present
-    update_cache: yes
-  with_items:
-    - jq
-  tags:
-    - "backup:mongo"
-    - "install"
-    - "install:app-requirements"
-    - "mongo_packages"
-
 # If skip_replica_set is true, this template will not contain a replica set stanza
 # because of the fact above.
 - name: copy configuration template
@@ -200,21 +187,44 @@
     - "manage:db-replication"
     - "update_mongod_conf"
 
+- name: check mongo backups enabled
+  set_fact:
+    enable_mongo_backups: MONGO_BACKUP_ENABLED and '{{ ansible_default_ipv4.address|default(ansible_all_ipv4_addresses[0]) }}' == '{{ MONGO_BACKUP_NODE }}'
+
 - name: install logrotate configuration
   template:
     src: mongo_logrotate.j2
     dest: /etc/logrotate.d/hourly/mongo
+  vars:
+    include_backup_log: enable_mongo_backups
   tags:
     - "backup:mongo"
     - "install"
     - "install:app-configuration"
     - "logrotate"
 
+- name: install prereqs for backup script
+  apt:
+    pkg: "{{ item }}"
+    state: present
+    update_cache: yes
+  with_items:
+    - jq
+  when:
+    - enable_mongo_backups
+  tags:
+    - "backup:mongo"
+    - "install"
+    - "install:app-requirements"
+    - "mongo_packages"
+
 - name: install backup script
   template:
     src: backup-mongo.sh.j2
     dest: "{{ mongo_backup_script_path }}"
     mode: 0700
+  when:
+    - enable_mongo_backups
   tags:
     - "backup:mongo"
     - "install"
@@ -229,6 +239,8 @@
     weekday: "{{ mongo_backup_cron.weekday | default('*') }}"
     job: "{{ mongo_backup_script_path }} >> {{ mongo_log_dir }}/mongo-backup.log 2>&1"
   become: yes
+  when:
+    - enable_mongo_backups
   tags:
     - "backup:mongo"
     - "install"
@@ -239,7 +251,8 @@
     fstype: ext4
     force: true
   ignore_errors: true
-  when: "'{{ ansible_default_ipv4.address|default(ansible_all_ipv4_addresses[0]) }}' == '{{ MONGO_BACKUP_NODE }}'"
+  when:
+    - enable_mongo_backups
   tags:
     - "backup:mongo"
     - "install"

--- a/playbooks/roles/mongo_3_2/tasks/main.yml
+++ b/playbooks/roles/mongo_3_2/tasks/main.yml
@@ -187,11 +187,12 @@
     - "manage:db-replication"
     - "update_mongod_conf"
 
-# this sets the enable_mongo_backups var if mongo backups are enabled AND we're currently running against the designated
-# mongo backup node.
+# This sets the is_backup_node var by checking whether
+# mongo backups are enabled AND we're currently running against the designated mongo backup node.
+# This allows backup-related tasks below to determine whether or not they should run on the current mongo node.
 - name: check mongo backups enabled
   set_fact:
-    enable_mongo_backups: MONGO_BACKUP_ENABLED and '{{ ansible_default_ipv4.address|default(ansible_all_ipv4_addresses[0]) }}' == '{{ MONGO_BACKUP_NODE }}'
+    is_backup_node: MONGO_BACKUP_ENABLED and '{{ ansible_default_ipv4.address|default(ansible_all_ipv4_addresses[0]) }}' == '{{ MONGO_BACKUP_NODE }}'
   tags:
     - "backup:mongo"
 
@@ -213,7 +214,7 @@
   with_items:
     - jq
   when:
-    - enable_mongo_backups
+    - is_backup_node
   tags:
     - "backup:mongo"
     - "install"
@@ -226,7 +227,7 @@
     dest: "{{ mongo_backup_script_path }}"
     mode: 0700
   when:
-    - enable_mongo_backups
+    - is_backup_node
   tags:
     - "backup:mongo"
     - "install"
@@ -242,7 +243,7 @@
     job: "{{ mongo_backup_script_path }} >> {{ mongo_log_dir }}/mongo-backup.log 2>&1"
   become: yes
   when:
-    - enable_mongo_backups
+    - is_backup_node
   tags:
     - "backup:mongo"
     - "install"
@@ -254,7 +255,7 @@
     force: true
   ignore_errors: true
   when:
-    - enable_mongo_backups
+    - is_backup_node
   tags:
     - "backup:mongo"
     - "install"

--- a/playbooks/roles/mongo_3_2/tasks/main.yml
+++ b/playbooks/roles/mongo_3_2/tasks/main.yml
@@ -192,7 +192,8 @@
 # This allows backup-related tasks below to determine whether or not they should run on the current mongo node.
 - name: check mongo backups enabled
   set_fact:
-    is_backup_node: MONGO_BACKUP_ENABLED and '{{ ansible_default_ipv4.address|default(ansible_all_ipv4_addresses[0]) }}' == '{{ MONGO_BACKUP_NODE }}'
+    is_backup_node: true
+  when: MONGO_BACKUP_ENABLED and '{{ ansible_default_ipv4.address|default(ansible_all_ipv4_addresses[0]) }}' == '{{ MONGO_BACKUP_NODE }}'
   tags:
     - "backup:mongo"
 

--- a/playbooks/roles/mongo_3_2/tasks/main.yml
+++ b/playbooks/roles/mongo_3_2/tasks/main.yml
@@ -172,6 +172,19 @@
     - "manage:db-replication"
     - "mongodb_key"
 
+- name: install prereqs for backup script
+  apt:
+    pkg: "{{ item }}"
+    state: present
+    update_cache: yes
+  with_items:
+    - jq
+  tags:
+    - "backup:mongo"
+    - "install"
+    - "install:app-requirements"
+    - "mongo_packages"
+
 # If skip_replica_set is true, this template will not contain a replica set stanza
 # because of the fact above.
 - name: copy configuration template
@@ -192,9 +205,44 @@
     src: mongo_logrotate.j2
     dest: /etc/logrotate.d/hourly/mongo
   tags:
+    - "backup:mongo"
     - "install"
     - "install:app-configuration"
     - "logrotate"
+
+- name: install backup script
+  template:
+    src: backup-mongo.sh.j2
+    dest: "{{ mongo_backup_script_path }}"
+    mode: 0700
+  tags:
+    - "backup:mongo"
+    - "install"
+
+- name: add mongo backup script to cron
+  cron:
+    name: mongo backup job
+    minute: "{{ mongo_backup_cron.minute | default('12') }}"
+    hour: "{{ mongo_backup_cron.hour | default('*/12') }}"
+    day: "{{ mongo_backup_cron.day | default('*') }}"
+    month: "{{ mongo_backup_cron.month | default('*') }}"
+    weekday: "{{ mongo_backup_cron.weekday | default('*') }}"
+    job: "{{ mongo_backup_script_path }} >> {{ mongo_log_dir }}/mongo-backup.log 2>&1"
+  become: yes
+  tags:
+    - "backup:mongo"
+    - "install"
+
+- name: format mongo backup volume
+  filesystem:
+    dev: "{{ MONGO_BACKUP_EBS_VOLUME_DEVICE }}"
+    fstype: ext4
+    force: true
+  ignore_errors: true
+  when: "'{{ ansible_default_ipv4.address|default(ansible_all_ipv4_addresses[0]) }}' == '{{ MONGO_BACKUP_NODE }}'"
+  tags:
+    - "backup:mongo"
+    - "install"
 
 - name: restart mongo service if we changed our configuration
   service:

--- a/playbooks/roles/mongo_3_2/tasks/main.yml
+++ b/playbooks/roles/mongo_3_2/tasks/main.yml
@@ -190,6 +190,8 @@
 - name: check mongo backups enabled
   set_fact:
     enable_mongo_backups: MONGO_BACKUP_ENABLED and '{{ ansible_default_ipv4.address|default(ansible_all_ipv4_addresses[0]) }}' == '{{ MONGO_BACKUP_NODE }}'
+  tags:
+    - "backup:mongo"
 
 - name: install logrotate configuration
   template:

--- a/playbooks/roles/mongo_3_2/tasks/main.yml
+++ b/playbooks/roles/mongo_3_2/tasks/main.yml
@@ -187,6 +187,8 @@
     - "manage:db-replication"
     - "update_mongod_conf"
 
+# this sets the enable_mongo_backups var if mongo backups are enabled AND we're currently running against the designated
+# mongo backup node.
 - name: check mongo backups enabled
   set_fact:
     enable_mongo_backups: MONGO_BACKUP_ENABLED and '{{ ansible_default_ipv4.address|default(ansible_all_ipv4_addresses[0]) }}' == '{{ MONGO_BACKUP_NODE }}'
@@ -197,8 +199,6 @@
   template:
     src: mongo_logrotate.j2
     dest: /etc/logrotate.d/hourly/mongo
-  vars:
-    include_backup_log: enable_mongo_backups
   tags:
     - "backup:mongo"
     - "install"

--- a/playbooks/roles/mongo_3_2/tasks/main.yml
+++ b/playbooks/roles/mongo_3_2/tasks/main.yml
@@ -190,7 +190,7 @@
 # This sets the is_backup_node var by checking whether
 # mongo backups are enabled AND we're currently running against the designated mongo backup node.
 # This allows backup-related tasks below to determine whether or not they should run on the current mongo node.
-- name: check mongo backups enabled
+- name: determine if backup tasks should run
   set_fact:
     is_backup_node: true
   when: MONGO_BACKUP_ENABLED and '{{ ansible_default_ipv4.address|default(ansible_all_ipv4_addresses[0]) }}' == '{{ MONGO_BACKUP_NODE }}'

--- a/playbooks/roles/mongo_3_2/templates/backup-mongo.sh.j2
+++ b/playbooks/roles/mongo_3_2/templates/backup-mongo.sh.j2
@@ -1,0 +1,133 @@
+#!/bin/bash
+# ref https://tasks.opencraft.com/browse/SE-1669
+# Script to perform a point-in-time dump of the local mongodb database using
+# mongodump.
+# includes locking (prevent this script from running multiple times in
+# parallel), creating a snapshot of the volume used to backup to
+
+# exit by default on failure
+set -e
+# verbose for help with debugging
+set -x
+
+# make sure local/bin is in the path so we can use aws cli
+PATH="$PATH:/usr/local/bin"
+
+# vars set by ansible
+MONGO_BACKUP_EBS_VOLUME_DEVICE="{{ MONGO_BACKUP_EBS_VOLUME_DEVICE }}" # eg. /dev/svdk or /dev/disk/by-label/mylabel
+MONGO_BACKUP_EBS_VOLUME_ID="{{ MONGO_BACKUP_EBS_VOLUME_ID }}" # eg. vol-123456
+MONGO_BACKUP_VOLUME_MOUNT_PATH="{{ MONGO_BACKUP_VOLUME_MOUNT_PATH }}" # eg. /mnt/mongobackup/
+MONGO_BACKUP_NODE="{{ MONGO_BACKUP_NODE }}"
+EDXAPP_MONGO_DB_NAME="{{ EDXAPP_MONGO_DB_NAME }}"
+MONGO_BACKUP_AUTH_DATABASE="{{ MONGO_BACKUP_AUTH_DATABASE }}"
+MONGO_ADMIN_USER="{{ MONGO_ADMIN_USER }}"
+MONGO_ADMIN_PASSWORD="{{ MONGO_ADMIN_PASSWORD }}"
+AWS_ACCESS_KEY_ID="{{ MONGO_BACKUP_AWS_ACCESS_KEY_ID }}"
+AWS_SECRET_ACCESS_KEY="{{ MONGO_BACKUP_AWS_SECRET_ACCESS_KEY }}"
+MONGO_BACKUP_SNAPSHOT_DESC="{{ MONGO_BACKUP_SNAPSHOT_DESC }}"
+MONGO_BACKUP_PRUNE_OLDER_THAN_DATE="{{ MONGO_BACKUP_PRUNE_OLDER_THAN_DATE }}"
+MONGO_BACKUP_SNITCH_URL="{{ MONGO_BACKUP_SNITCH_URL }}"
+aws_region="{{ aws_region }}"
+
+# export to make available to aws cli
+export AWS_ACCESS_KEY_ID
+export AWS_SECRET_ACCESS_KEY
+
+# other vars
+archive_path="mongo-backup-$(date --iso-8601=minutes --utc)"
+
+# verify required variables are set
+required() {
+    if [ -z "$1" ]; then
+        echo "$2"
+        required_var_missing="yes"
+    fi
+}
+required "$MONGO_BACKUP_EBS_VOLUME_DEVICE" "MONGO_BACKUP_EBS_VOLUME_DEVICE missing; EBS volume device path is required"
+required "$MONGO_BACKUP_EBS_VOLUME_ID" "MONGO_BACKUP_EBS_VOLUME_ID missing; EBS volume id is required"
+required "$MONGO_BACKUP_VOLUME_MOUNT_PATH" "MONGO_BACKUP_VOLUME_MOUNT_PATH missing; path on which to mount ebs backup volume is required"
+required "$MONGO_BACKUP_NODE" "MONGO_BACKUP_NODE missing; this must be set to determine if this is the correct node to run backup on"
+required "$MONGO_BACKUP_AUTH_DATABASE" "MONGO_BACKUP_AUTH_DATABASE missing; this must be set to use the correct authenticationDatabase to auth against"
+required "$MONGO_ADMIN_USER" "MONGO_ADMIN_USER missing; this must be set to auth against the database"
+required "$MONGO_ADMIN_PASSWORD" "MONGO_ADMIN_PASSWORD missing; this must be set to auth against the database"
+required "$AWS_ACCESS_KEY_ID" "MONGO_BACKUP_AWS_ACCESS_KEY_ID missing; this must be set to auth against the database"
+required "$AWS_SECRET_ACCESS_KEY" "MONGO_BACKUP_AWS_SECRET_ACCESS_KEY missing; this must be set to auth against the database"
+required "$aws_region" "aws_region missing; this must be set to use awscli"
+[ -n "$required_var_missing" ] && exit 1
+
+
+# only run on specified node - this pulls the node name (ip address) of the mongo db on this instance
+mynodename=$(echo "db.isMaster()" | mongo -u "$MONGO_ADMIN_USER" -p"$MONGO_ADMIN_PASSWORD" --authenticationDatabase "$MONGO_BACKUP_AUTH_DATABASE" "$EDXAPP_MONGO_DB_NAME" | grep \"me\" | cut -f 2 -d ':' | sed -e 's/ //' -e 's/,//' -e 's/"//');
+if [ "$mynodename" != "$MONGO_BACKUP_NODE" ]; then
+    echo "This is not the backup host. Run on a different instance."
+    exit 1
+fi
+
+# Acquire backup lock using this script itself as the lockfile. If another
+# backup task is already running, then exit immediately.
+exec 200<$0
+flock -n 200 || { echo "Another backup task is already running."; exit 1; }
+
+echo "Starting at $(date)"
+
+# ensure volume is mounted
+mkdir -p "$MONGO_BACKUP_VOLUME_MOUNT_PATH"
+if ! mountpoint -q "$MONGO_BACKUP_VOLUME_MOUNT_PATH"; then
+  mount -o discard,defaults,noatime "$MONGO_BACKUP_EBS_VOLUME_DEVICE" "$MONGO_BACKUP_VOLUME_MOUNT_PATH"
+fi
+
+# Clean old backup files to save space and so we start afresh.
+rm -rf "$MONGO_BACKUP_VOLUME_MOUNT_PATH/mongo/"
+mkdir -p "$MONGO_BACKUP_VOLUME_MOUNT_PATH/mongo/"
+
+
+# create the dump
+# XXX: we may want to check how this lays out of disk and how it will play against ebs volume snapshots. The idea was
+# that snapshots would be cheap because you only pay for data blocks that have changed between one snapshot and the
+# next. however, if the mongodump -> gzip process ends up not being consistent in layout,
+# this may end up with a lot of the disk content changing between snapshots.
+mongodump --host="localhost" --oplog --gzip -u "$MONGO_ADMIN_USER" --password "$MONGO_ADMIN_PASSWORD" --authenticationDatabase "$MONGO_BACKUP_AUTH_DATABASE" --out="$MONGO_BACKUP_VOLUME_MOUNT_PATH/mongo/$archive_path"
+
+
+# flush everything to disk, and unmount the volume ready to snapshot
+sync
+umount "$MONGO_BACKUP_VOLUME_MOUNT_PATH"
+
+# create a snapshot of the volume
+snapshot_data=$(aws --region "$aws_region" ec2 create-snapshot --volume-id "$MONGO_BACKUP_EBS_VOLUME_ID" --description "$MONGO_BACKUP_SNAPSHOT_DESC")
+echo "$snapshot_data"
+snapshot_id="$(echo "$snapshot_data" | jq -r .SnapshotId)"
+
+# Poll until the snapshot has been created. We want to block here to avoid the chance of this script being run (and the
+# current backup deleted / a new backup created) while the snapshot is taking place. The snapshot must also be done
+# while the volume is unmounted to ensure data integrity.
+while true; do
+    sleep 60
+    snapshot_data=$(aws --region "$aws_region" ec2 describe-snapshots --snapshot-ids "$snapshot_id" || true)
+    if [ "$(echo "$snapshot_data" | jq -r '.Snapshots[0].State')" = "completed" ]; then
+        break
+    fi
+done
+
+if [ -n "$MONGO_BACKUP_PRUNE_OLDER_THAN_DATE" ]; then
+    # Prune old snapshots
+    old_snapshot_data="$(aws --region "$aws_region" ec2 describe-snapshots --filters "Name=description,Values=$MONGO_BACKUP_SNAPSHOT_DESC")"
+    lines_="$(echo "$old_snapshot_data" | jq -r ".Snapshots | map(\"\(.SnapshotId) \(.StartTime)\") | .[]")"
+    earliest_date="$(date -d "$MONGO_BACKUP_PRUNE_OLDER_THAN_DATE" "+%s")"
+    while read -r line; do
+        # each $line looks like: "snap-0123456789DEADBEEF 2019-11-01T00:15:12.492Z"
+        snapshot_id=$(echo "$line" | cut -f1 -d' ')
+        timestamp="$(date -d "$(echo "$line" | cut -f2 -d' ')" "+%s")"
+        if [ "$timestamp" -lt "$earliest_date" ]; then
+            # this snapshot_id is older than we want to keep around, so delete it
+            aws --region "$aws_region" ec2 delete-snapshot --snapshot-id "$snapshot_id"
+        fi
+    done <<< "$lines_"
+fi
+
+# ping the snitch url if available
+if [ -n "$MONGO_BACKUP_SNITCH_URL" ]; then
+    curl "$MONGO_BACKUP_SNITCH_URL"
+fi
+
+echo "End at $(date)"

--- a/playbooks/roles/mongo_3_2/templates/mongo_logrotate.j2
+++ b/playbooks/roles/mongo_3_2/templates/mongo_logrotate.j2
@@ -12,7 +12,6 @@
   size 1M
 }
 
-{% if include_backup_log %}
 {{ mongo_log_dir }}/mongo-backup.log {
   create
   compress
@@ -26,7 +25,6 @@
   rotate 90
   size 1M
 }
-{% endif %}
 
 {{ mongo_log_dir }}/mongodb.log {
   create

--- a/playbooks/roles/mongo_3_2/templates/mongo_logrotate.j2
+++ b/playbooks/roles/mongo_3_2/templates/mongo_logrotate.j2
@@ -12,6 +12,7 @@
   size 1M
 }
 
+{% if include_backup_log %}
 {{ mongo_log_dir }}/mongo-backup.log {
   create
   compress
@@ -25,6 +26,7 @@
   rotate 90
   size 1M
 }
+{% endif %}
 
 {{ mongo_log_dir }}/mongodb.log {
   create

--- a/playbooks/roles/mongo_3_2/templates/mongo_logrotate.j2
+++ b/playbooks/roles/mongo_3_2/templates/mongo_logrotate.j2
@@ -12,6 +12,7 @@
   size 1M
 }
 
+{% if is_backup_node %}
 {{ mongo_log_dir }}/mongo-backup.log {
   create
   compress
@@ -25,6 +26,7 @@
   rotate 90
   size 1M
 }
+{% endif %}
 
 {{ mongo_log_dir }}/mongodb.log {
   create

--- a/playbooks/roles/mongo_3_2/templates/mongo_logrotate.j2
+++ b/playbooks/roles/mongo_3_2/templates/mongo_logrotate.j2
@@ -12,6 +12,20 @@
   size 1M
 }
 
+{{ mongo_log_dir }}/mongo-backup.log {
+  create
+  compress
+  copytruncate
+  delaycompress
+  dateext
+  dateformat -%Y%m%d-%s
+  missingok
+  notifempty
+  daily
+  rotate 90
+  size 1M
+}
+
 {{ mongo_log_dir }}/mongodb.log {
   create
   compress


### PR DESCRIPTION
This adds support for automated backups on a mongo db node to an EBS volume.

This has been used successfully on a client's mongo cluster. See https://github.com/edx-olive/configuration/pull/14 The way it works is to have a mongo node designated as the `MONGO_BACKUP_NODE`. On this node is a cron job that periodically launches the backup script. This backup script does roughly the following:

- mounts an ebs volume
- deletes all the files
- dumps the mongo database with mongodump
- unmounts the ebs volume
- creates a snapshot of the volume
- prunes old snapshots of the volume

This allows for flexible, consistent backups, versioned with ebs snapshots on aws.

This PR differs from the revision used on the client in that it is disabled by default, and backup related tasks will only run if `MONGO_BACKUP_ENABLED` is true *and* the current host is the `MONGO_BACKUP_NODE`.

**JIRA tickets**: [OSPR-3954](https://openedx.atlassian.net/browse/OSPR-3954)

**Dependencies**: None

**Merge deadline**: None

**Testing instructions**:

- Note that steps 1 to 3 were thoroughly tested in the context of  https://github.com/edx-olive/configuration/pull/14. This PR only differs in terms of extra variables and conditionals to disable this functionality.

1. set appropriate vars for the `MONGO_BACKUP_*` vars found in
   `playbooks/roles/mongo_3_2/defaults/main.yml`
2. deploy a mongo node on aws
3. verify that the backup script runs on the `MONGO_BACKUP_NODE` instance.
4. set `MONGO_BACKUP_ENABLED` to false
5. deploy a mongo node
6. verify that none of the backup tasks from `playbooks/roles/mongo_3_2/tasks/main.yml` were run, and that the deployed mongo_logrotate.j2 template does not include the block for the mongo-backup.log.

See https://github.com/edx-olive/configuration/pull/17, where we show the results of live tests. Note that this was against a different branch than master since it was required by the client.

**Author notes**:

**Reviewers**
- [x] @itsjeyd
- [ ] edX reviewer[s] TBD

