### PR TITLE
Revert "Make edx-platform app build on python 3 again."

### DIFF
--- a/playbooks/roles/edxapp/tasks/deploy.yml
+++ b/playbooks/roles/edxapp/tasks/deploy.yml
@@ -107,7 +107,7 @@
     - install:app-requirements
 
 - name: Create the virtualenv to install the Python requirements
-  command: "virtualenv {{ edxapp_venv_dir }} -p python3.5"
+  command: "virtualenv {{ edxapp_venv_dir }}"
   args:
     chdir: "{{ edxapp_code_dir }}"
     creates: "{{ edxapp_venv_dir }}/bin/pip"


### PR DESCRIPTION
Reverts edx/configuration#5548

Reverting so that we can get out other changes and not break blockstore.  We'll get a fix for blockstore in and go out to production after that.