### PR TITLE
Fix Open edX installation in a few ways

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+- Open edX
+  - native.sh needed to uninstall pyyaml to proceed
+
 - Role: enterprise_catalog
   - Create role
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 - Open edX
   - native.sh needed to uninstall pyyaml to proceed
+  - no longer install certs
 
 - Role: enterprise_catalog
   - Create role

--- a/playbooks/openedx_native.yml
+++ b/playbooks/openedx_native.yml
@@ -41,7 +41,6 @@
       when: COMMON_ENABLE_AWS_ROLE
     - role: nginx
       nginx_sites:
-      - certs
       - cms
       - lms
       - forum
@@ -92,7 +91,6 @@
       NOTIFIER_DIGEST_TASK_INTERVAL: 5
     - role: xqueue
       update_users: True
-    - certs
     - edx_ansible
     - role: datadog
       when: COMMON_ENABLE_DATADOG

--- a/util/install/native.sh
+++ b/util/install/native.sh
@@ -100,6 +100,8 @@ sudo apt-get upgrade -y
 ## Install system pre-requisites
 ##
 sudo apt-get install -y build-essential software-properties-common curl git-core libxml2-dev libxslt1-dev python-pip libmysqlclient-dev python-apt python-dev libxmlsec1-dev libfreetype6-dev swig gcc g++
+# ansible-bootstrap installs yaml that pip 19 can't uninstall.
+sudo apt-get remove python-yaml
 sudo pip install --upgrade pip==19.3.1
 sudo pip install --upgrade setuptools==39.0.1
 sudo -H pip install --upgrade virtualenv==15.2.0

--- a/util/install/native.sh
+++ b/util/install/native.sh
@@ -112,7 +112,6 @@ sudo -H pip install --upgrade virtualenv==15.2.0
 ##
 VERSION_VARS=(
     edx_platform_version
-    certs_version
     forum_version
     xqueue_version
     configuration_version


### PR DESCRIPTION
I don't know why, but ansible-bootstrap somehow installs python-yaml.
Pip 19 refuses to uninstall it so that we can upgrade from 3.11 to 3.12.
