### PR TITLE
point to schoolyourself py3 fix

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -512,7 +512,7 @@ EDXAPP_PRIVATE_REQUIREMENTS:
       extra_args: -e
     # This repository contains schoolyourself-xblock, which is used in
     # edX's "AlgebraX" and "GeometryX" courses.
-    - name: git+https://github.com/edx/schoolyourself-xblock.git@027b58a79ab28ee3bb0293985313eee1bf0a7535#egg=schoolyourself-xblock
+    - name: git+https://github.com/edx/schoolyourself-xblock.git@2093048720cfb36cc05b3143cd6f2585c7c64d85#egg=schoolyourself-xblock
       extra_args: -e
     # Prototype XBlocks from edX learning sciences limited roll-outs and user testing.
     # Concept XBlock, in particular, is nowhere near finished and an early prototype.


### PR DESCRIPTION
Configuration Pull Request
---

### [PROD-1108](https://openedx.atlassian.net/browse/PROD-1108)

### Description
This PR is changing the version of schoolyourself being used in the platform. There have been some py3 changes in the original repo that are necessary for the xblock to work fine. The changes were introduced in https://github.com/schoolyourself/schoolyourself-xblock/commit/2093048720cfb36cc05b3143cd6f2585c7c64d85 but are being included from edX fork https://github.com/edx/schoolyourself-xblock/commit/2093048720cfb36cc05b3143cd6f2585c7c64d85

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
