### PR TITLE
Use a default sub-application name when running the django shell in e…

### DIFF
--- a/playbooks/continuous_delivery/upload_assets.yml
+++ b/playbooks/continuous_delivery/upload_assets.yml
@@ -23,11 +23,14 @@
 - hosts: all
   vars:
     EDX_PLATFORM_SETTINGS: "production"
+    # Both LMS and Studio gather their assets to the same directory,
+    # so most of the time leaving the default sub-application will be fine.
+    SUB_APPLICATION_NAME: "lms"
     COMMAND_PREFIX: " . {{ APPLICATION_PATH }}/{{ APPLICATION_NAME }}_env; /edx/bin/python.{{ APPLICATION_NAME }} /edx/bin/manage.{{ APPLICATION_NAME }}"
     STATIC_ROOT: >
       $({{ COMMAND_PREFIX }} shell --command "from django.conf import settings; print(getattr(settings, 'STATIC_ROOT', ''))")
     STATIC_ROOT_EDXAPP: >
-      $({{ COMMAND_PREFIX }} shell --settings "{{ EDX_PLATFORM_SETTINGS }}" --command "from django.conf import settings; print(getattr(settings, 'STATIC_ROOT', ''))")
+      $({{ COMMAND_PREFIX }} {{ SUB_APPLICATION_NAME }} shell --settings "{{ EDX_PLATFORM_SETTINGS }}" --command "from django.conf import settings; print(getattr(settings, 'STATIC_ROOT', ''))")
   gather_facts: False
   become: True
   tasks:


### PR DESCRIPTION
…dxapp during asset uploads

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
