### PR TITLE
Version bump for LabXchange XBlocks on edx.org

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -536,7 +536,7 @@ EDXAPP_PRIVATE_REQUIREMENTS:
     - name: git+https://github.com/edx/edx-zoom.git@37c323ae93265937bf60abb92657318efeec96c5#egg=edx-zoom
       extra_args: -e
     # XBlocks associated with the LabXchange project
-    - name: git+https://github.com/open-craft/labxchange-xblocks.git@8d10b40c8d1b7eb084861bdb05ca1616a38bd873#egg=labxchange-xblocks
+    - name: git+https://github.com/open-craft/labxchange-xblocks.git@29c6d829b8d54f5683a41626616024c8643b7b0f#egg=labxchange-xblocks
       extra_args: -e
 
 # List of custom middlewares that should be used in edxapp to process


### PR DESCRIPTION
Version bump for LabXchange XBlocks.

Pulls in https://github.com/open-craft/labxchange-xblocks/pull/5 ("Fix static URLs, allow anonymous access")
