### PR TITLE
Adds a small plugin used by LabXchange.org to implement "pathways"

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -538,6 +538,9 @@ EDXAPP_PRIVATE_REQUIREMENTS:
     # XBlocks associated with the LabXchange project
     - name: git+https://github.com/open-craft/labxchange-xblocks.git@29c6d829b8d54f5683a41626616024c8643b7b0f#egg=labxchange-xblocks
       extra_args: -e
+    # "Pathways" learning context plugin for the LabXchange project
+    - name: git+https://github.com/open-craft/lx-pathway-plugin.git@19993043686f727533319d70d257c7f32e83b877#egg=lx-pathway-plugin
+      extra_args: -e
 
 # List of custom middlewares that should be used in edxapp to process
 # incoming HTTP resquests. Should be a list of plain strings that fully


### PR DESCRIPTION
This change installs https://github.com/open-craft/lx-pathway-plugin onto edx.org for use by the LabXchange project. It does not affect other instances or Open edX in general.

----------------

"Pathways" use the new Blockstore-based XBlock runtime to create small playlist-style learning experiences that consist of a few XBlocks in a short linear sequence. This plugin allows each "pathway" to freeze the version of each XBlock at the time that it gets added to the pathway, and to allow users to have different grades/state/completion status for an XBlock in a pathway vs. accessed directly from a content library.

The plugin only provides a Studio REST API which is consumed by the LabXchange backend and used for pathway CRUD operations. Otherwise, learners use the new runtime's existing XBlock REST API, which fully supports pathways (because pathways are implemented as a standard "learning context" plugin, just like a library or a course).

This is the first real-world use case for the new pluggable "learning context" framework.

The plugin uses a simple security model where only an authorized service user (i.e. the LabXchange backend) can use the Studio REST API. Before it can be used, it's necessary to set `LX_PATHWAY_PLUGIN_AUTHORIZED_USERNAMES` via `EDXAPP_CMS_ENV_EXTRA`.
