### PR TITLE
Version bump for LabXchange pathways plugin on edx.org

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -539,7 +539,7 @@ EDXAPP_PRIVATE_REQUIREMENTS:
     - name: git+https://github.com/open-craft/labxchange-xblocks.git@29c6d829b8d54f5683a41626616024c8643b7b0f#egg=labxchange-xblocks
       extra_args: -e
     # "Pathways" learning context plugin for the LabXchange project
-    - name: git+https://github.com/open-craft/lx-pathway-plugin.git@19993043686f727533319d70d257c7f32e83b877#egg=lx-pathway-plugin
+    - name: git+https://github.com/open-craft/lx-pathway-plugin.git@b69f6b27108fa033c9a402f65cbf3a34a7b5ad93#egg=lx-pathway-plugin
       extra_args: -e
 
 # List of custom middlewares that should be used in edxapp to process


### PR DESCRIPTION
This is a small bugfix version bump for the `lx-pathway-plugin` on edx.org.

This change pulls in a bugfix for the pathway code's opaque key parsing that would result in strange behavior if there was (for example) a problem block inside a unit inside a pathway.

The fix that this pulls in is: https://github.com/open-craft/lx-pathway-plugin/pull/4
