### PR TITLE
Properly set the version of xqueue to install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+- Open edX
+  - The wrong version of xqueue was being installed, fixed.
+
 - Role: enterprise_catalog
   - Added infrstructure to start up and deploy celery workers
 
@@ -6,7 +9,7 @@
 
 - Role: insights
   - install libssl-dev, needed for mysqlclient
-  
+
 - Role: insights
   - add DOT config (deprecate DOP)
 

--- a/docker/build/xqueue/Dockerfile
+++ b/docker/build/xqueue/Dockerfile
@@ -25,7 +25,7 @@ RUN /edx/app/edx_ansible/venvs/edx_ansible/bin/ansible-playbook xqueue.yml \
     -i '127.0.0.1,' \
     -c local \
     -t "install:base,install:system-requirements,install:configuration,install:app-requirements,install:code,devstack" \
-    --extra-vars="xqueue_version=${OPENEDX_RELEASE}" \
+    --extra-vars="XQUEUE_VERSION=${OPENEDX_RELEASE}" \
     --extra-vars="@/ansible_overrides.yml"
 
 EXPOSE 18040

--- a/playbooks/roles/edx_ansible/templates/update.j2
+++ b/playbooks/roles/edx_ansible/templates/update.j2
@@ -60,7 +60,7 @@ edx_ansible_cmd="{{ edx_ansible_venv_bin }}/ansible-playbook -i localhost, -c lo
 
 repos_to_cmd["edx-platform"]="$edx_ansible_cmd edxapp.yml -e 'edx_platform_version=$2'"
 repos_to_cmd["edx-workers"]="$edx_ansible_cmd edxapp.yml -e 'edx_platform_version=$2' -e 'celery_worker=true'"
-repos_to_cmd["xqueue"]="$edx_ansible_cmd xqueue.yml -e 'xqueue_version=$2' -e 'elb_pre_post=false'"
+repos_to_cmd["xqueue"]="$edx_ansible_cmd xqueue.yml -e 'XQUEUE_VERSION=$2' -e 'elb_pre_post=false'"
 repos_to_cmd["credentials"]="$edx_ansible_cmd credentials.yml -e 'credentials_version=$2'"
 repos_to_cmd["cs_comments_service"]="$edx_ansible_cmd forum.yml -e 'forum_version=$2'"
 repos_to_cmd["xserver"]="$edx_ansible_cmd xserver.yml -e 'xserver_version=$2'"

--- a/util/install/native.sh
+++ b/util/install/native.sh
@@ -114,7 +114,7 @@ VERSION_VARS=(
     edx_platform_version
     certs_version
     forum_version
-    xqueue_version
+    XQUEUE_VERSION
     configuration_version
     demo_version
     NOTIFIER_VERSION

--- a/util/jenkins/ansible-provision.sh
+++ b/util/jenkins/ansible-provision.sh
@@ -209,7 +209,7 @@ cat << EOF > $extra_vars_file
 edx_platform_version: $edxapp_version
 forum_version: $forum_version
 notifier_version: $notifier_version
-XQUEUE_VERSION: $xqueue_version
+XQUEUE_VERSION: $XQUEUE_VERSION
 certs_version: $certs_version
 configuration_version: $configuration_version
 demo_version: $demo_version

--- a/vagrant/base/analyticstack/Vagrantfile
+++ b/vagrant/base/analyticstack/Vagrantfile
@@ -22,7 +22,7 @@ VERSION_VARS = [
   'configuration_version',
   'certs_version',
   'forum_version',
-  'xqueue_version',
+  'XQUEUE_VERSION',
   'demo_version',
   'NOTIFIER_VERSION',
   'ECOMMERCE_VERSION',

--- a/vagrant/release/analyticstack/Vagrantfile
+++ b/vagrant/release/analyticstack/Vagrantfile
@@ -17,7 +17,7 @@ VERSION_VARS = [
   'configuration_version',
   'certs_version',
   'forum_version',
-  'xqueue_version',
+  'XQUEUE_VERSION',
   'demo_version',
   'NOTIFIER_VERSION',
   'ECOMMERCE_VERSION',


### PR DESCRIPTION
We were using the wrong variable name for the version of xqueue to install.  Correct it everywhere.

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
