### PR TITLE
Never gather AWS facts for Open edX install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 - Open edX
+  - Don't use AWS_GATHER_FACTS, it was only for tagging which we don't need.
+
+- Open edX
   - The wrong version of xqueue was being installed, fixed.
 
 - Role: enterprise_catalog

--- a/playbooks/openedx_native.yml
+++ b/playbooks/openedx_native.yml
@@ -23,6 +23,7 @@
     # Set to false if deployed behind another proxy/load balancer.
     NGINX_SET_X_FORWARDED_HEADERS: True
     DISCOVERY_URL_ROOT: 'http://localhost:{{ DISCOVERY_NGINX_PORT }}'
+    AWS_GATHER_FACTS: false
     COMMON_ENABLE_AWS_ROLE: false
     ecommerce_create_demo_data: true
     credentials_create_demo_data: true


### PR DESCRIPTION
Configuration Pull Request
---
AWS_GATHER_FACTS prevented using this installation anywhere but AWS.  The information gathered was only used for tagging instances, which we don't need for Open edX installation anyway.

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
