### PR TITLE
Add Stanford XBlocks: Qualtrics, In-Video Quiz

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+- Role: edxapp
+  - Added Stanford-developed Qualtrics and In-Video Quiz XBlocks.
+
 - Open edX
   - The wrong version of xqueue was being installed, fixed.
 

--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -535,6 +535,11 @@ EDXAPP_PRIVATE_REQUIREMENTS:
       extra_args: -e
     - name: git+https://github.com/edx/edx-zoom.git@37c323ae93265937bf60abb92657318efeec96c5#egg=edx-zoom
       extra_args: -e
+    # Stanford-developed XBlocks (technically unsupported, but here to ease migration of courses from Lagunita)
+    - name: git+https://github.com/edx/xblock-qualtrics-survey.git@e35ea220af30ac6066588c9dd2a7518fac50222d#egg=xblock_qualtrics_survey
+      extra_args: -e
+    - name: git+https://github.com/edx/xblock-in-video-quiz.git@93624bd04a4b613ae53794fd97333192a606aaa8#egg=invideoquiz-xblock
+      extra_args: -e
     # XBlocks associated with the LabXchange project
     - name: git+https://github.com/open-craft/labxchange-xblocks.git@29c6d829b8d54f5683a41626616024c8643b7b0f#egg=labxchange-xblocks
       extra_args: -e


### PR DESCRIPTION
These XBlocks are not officially supported, but are being enabled to ease the migration of content from Lagunita.
