### PR TITLE
[PROD-1189] -  Update to ubcpi-xblock package.

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -526,7 +526,7 @@ EDXAPP_PRIVATE_REQUIREMENTS:
       extra_args: -e
     # Peer instruction XBlock
     # Need it from github until we can land https://github.com/ubc/ubcpi/pull/167 upstream.
-    - name: git+https://github.com/edx/ubcpi.git@3c4b2cdc9f595ab8cdb436f559b56f36638313b6#egg=ubcpi-xblock
+    - name: git+https://github.com/edx/ubcpi.git@0964302acb29a7bbdd145a1bcb6c8a45b0080343#egg=ubcpi-xblock
       extra_args: -e
     # Vector Drawing and ActiveTable XBlocks (Davidson)
     - name: git+https://github.com/open-craft/xblock-vectordraw.git@76976425356dfc7f13570f354c0c438db84c2840#egg=xblock-vectordraw==0.3.0


### PR DESCRIPTION
Configuration Pull Request
---
Update UBCPI version after package change.

## [PROD-1189](https://openedx.atlassian.net/browse/PROD-1189)

### Description
UBCPI (UBC Peer Instruction Tool for edX) is third-party package used by EDX for Peer instruction block. A recent ticket https://openedx.atlassian.net/browse/PROD-1173 was reported in which the display name was not being updated while editing this block. 
Upon investigation, it was noted that this third-party package expected a value (i.e. corrent_rationale)  at all times when updating/editing this block. In the reported case, the field Explanation which is OPTIONAL (responsible for correct_rationale value) was empty. As a result, whenever any field was updated on the block with this empty value, the block was not updated. 
This scenario occurs when we have a peer instruction block with the optional field (because n/a correct answer selected) and the course is exported and then imported back in.

### Sandbox
https://studio-saadyousafarbi.sandbox.edx.org/course/course-v1:edX+DemoX+Demo_Course


### Reviewers
If you've been tagged for review, please check your corresponding box once you've given the :+1:.
- [ ] @awaisdar001 
- [ ] @DawoudSheraz 

#### UBCPI Repository: https://github.com/edx/ubcpi
#### UBCPI Pull Request: https://github.com/edx/ubcpi/pull/1