### PR TITLE
Version bump for LabXchange pathways plugin on edx.org

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -282,7 +282,7 @@ EDXAPP_PRIVATE_REQUIREMENTS:
     - name: git+https://github.com/open-craft/labxchange-xblocks.git@29c6d829b8d54f5683a41626616024c8643b7b0f#egg=labxchange-xblocks
       extra_args: -e
     # "Pathways" learning context plugin for the LabXchange project
-    - name: git+https://github.com/open-craft/lx-pathway-plugin.git@b69f6b27108fa033c9a402f65cbf3a34a7b5ad93#egg=lx-pathway-plugin
+    - name: git+https://github.com/open-craft/lx-pathway-plugin.git@ba1fc294738a7662fc901616fb68e6b91f46e80a#egg=lx-pathway-plugin
       extra_args: -e
 
 # Whether to run reindex_course on deploy


### PR DESCRIPTION
This is a small bugfix version bump for the `lx-pathway-plugin` on edx.org.

This change pulls in two minor bugfixes - one involving reading data from blockstore drafts and one for the pathway code's opaque key code that would result in strange behavior when the `lx_assignment` XBlock was used in a pathway.

The fixes that this pulls in are in: https://github.com/open-craft/lx-pathway-plugin/pull/5
