### PR TITLE
Add back registrar configs which trigger Oauth backend setup

### DIFF
--- a/playbooks/roles/registrar/defaults/main.yml
+++ b/playbooks/roles/registrar/defaults/main.yml
@@ -72,6 +72,10 @@ REGISTRAR_VERSION: 'master'
 REGISTRAR_GUNICORN_EXTRA: ''
 
 # Used to automatically configure OAuth2 Client
+REGISTRAR_SOCIAL_AUTH_EDX_OAUTH2_KEY: 'registrar-sso-key'
+REGISTRAR_SOCIAL_AUTH_EDX_OAUTH2_SECRET: 'registrar-sso-secret'
+REGISTRAR_BACKEND_SERVICE_EDX_OAUTH2_KEY: 'registrar-backend-service-key'
+REGISTRAR_BACKEND_SERVICE_EDX_OAUTH2_SECRET: 'registrar-backend-service-secret'
 REGISTRAR_SOCIAL_AUTH_REDIRECT_IS_HTTPS: false
 
 # See edx_django_service_automated_users for an example of what this should be


### PR DESCRIPTION
This partially reverts some changes in 00e2d127df81837ad1bd2e7d0de09d114be3a8e1 to ensure that the `oauth_client_setup` role sets up configurations which would enable registrar to request auth tokens from the LMS. (See https://github.com/edx/configuration/blob/master/playbooks/roles/oauth_client_setup/defaults/main.yml and https://github.com/edx/configuration/blob/master/playbooks/roles/oauth_client_setup/tasks/main.yml to understand why these variables are necessary to trigger this setup.)

We should discuss whether a more thorough revert is necessary/how to avoid this issue without blocking @syedimranhassan's current work. But I'm putting up this PR because I'd like to be unblocked building master's integration sandboxes in the interim.

JIRA:EDUCATOR-4865

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
