### PR TITLE
BOM-1241 - Add watchman to devstack.

### DIFF
--- a/docker/build/ecomworker/ansible_overrides.yml
+++ b/docker/build/ecomworker/ansible_overrides.yml
@@ -1,3 +1,4 @@
 ---
 
 DOCKER_TLD: "edx"
+devstack: true

--- a/docker/build/insights/ansible_overrides.yml
+++ b/docker/build/insights/ansible_overrides.yml
@@ -18,3 +18,5 @@ INSIGHTS_DATABASES:
     PASSWORD: 'secret'
     HOST: "db.{{ DOCKER_TLD  }}"
     PORT: '3306'
+
+edx_django_service_is_devstack: true

--- a/docker/build/notifier/ansible_overrides.yml
+++ b/docker/build/notifier/ansible_overrides.yml
@@ -1,3 +1,4 @@
 ---
 
 DOCKER_TLD: "notifier"
+devstack: true

--- a/docker/build/xenial-common/Dockerfile
+++ b/docker/build/xenial-common/Dockerfile
@@ -1,3 +1,4 @@
+ARG BASE_IMAGE_TAG=latest
 FROM ubuntu:xenial
 LABEL maintainer="edxops"
 

--- a/playbooks/roles/common/tasks/main.yml
+++ b/playbooks/roles/common/tasks/main.yml
@@ -51,6 +51,14 @@
     repo: "{{ common_git_ppa }}"
   when: ansible_distribution in common_debian_variants
 
+- name: Add ppa for watchman package
+  apt_repository:
+    repo: "ppa:linuxuprising/apps"
+  when: >
+      ansible_distribution in common_debian_variants and 
+      ({{ devstack | default(False) }} or {{ edx_django_service_is_devstack | default(False) }})
+  tags:
+    - "devstack"
 
 # Ensure that we can install old software if need be.
 - name: Add edX PPA apt key
@@ -87,6 +95,19 @@
     state: present
     update_cache: yes
   when: ansible_distribution in common_debian_variants
+
+- name: Install role-independent packages useful for devstack.
+  apt:
+    name: "{{ common_debian_devstack_pkgs }}"
+    install_recommends: yes
+    state: present
+    update_cache: yes
+  when: >
+      ansible_distribution in common_debian_variants and 
+      ({{ devstack | default(False) }} or {{ edx_django_service_is_devstack | default(False) }})
+  tags:
+    - "devstack"
+
 
 - name: Install role-independent useful system packages from custom PPA
   apt:

--- a/playbooks/roles/common_vars/defaults/main.yml
+++ b/playbooks/roles/common_vars/defaults/main.yml
@@ -125,6 +125,9 @@ common_debian_pkgs:
   - python-pip
   - python2.7-dev
 
+common_debian_devstack_pkgs:
+  - watchman
+
 # Packages that should be installed from our custom PPA, i.e. COMMON_EDX_PPA
 old_python_debian_pkgs:
   - "python2.7=2.7.10-0+{{ ansible_distribution_release }}1"

--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -619,8 +619,6 @@ edxapp_requirements_with_github_urls:
   - "{{ base_requirements_file }}"
   - "{{ sandbox_base_requirements }}"
 
-edxapp_chrislea_ppa: "ppa:chris-lea/node.js"
-
 edxapp_debian_pkgs_default:
   # for compiling the virtualenv
   # (only needed if wheel files aren't available)


### PR DESCRIPTION
Watchman is used by runserver in Django 2.2.  It will be installed by
default in newer versions of ubuntu but needs to be install manually for
ubuntu 16.04(xenial).

We choose to install it from a PPA instead of from source to not make
the build more complex.  The PPA is active and backed by a linux
news company.