### PR TITLE
Add more conditionals for applying 'aws' role

### DIFF
--- a/docker/plays/go-agent.yml
+++ b/docker/plays/go-agent.yml
@@ -5,6 +5,7 @@
   become: True
   gather_facts: True
   roles:
-  - aws
+  - role: aws
+    when: COMMON_ENABLE_AWS_ROLE
   - supervisor
   - go-agent

--- a/docker/plays/go-server.yml
+++ b/docker/plays/go-server.yml
@@ -5,6 +5,7 @@
   become: True
   gather_facts: True
   roles:
-  - aws
+  - role: aws
+    when: COMMON_ENABLE_AWS_ROLE
   - supervisor
   - go-server

--- a/playbooks/aide.yml
+++ b/playbooks/aide.yml
@@ -6,7 +6,8 @@
     serial_count: 1
   serial: "{{ serial_count }}"
   roles:
-    - aws
+    - role: aws
+      when: COMMON_ENABLE_AWS_ROLE
     - aide
     - role: datadog
       when: COMMON_ENABLE_DATADOG

--- a/playbooks/alton.yml
+++ b/playbooks/alton.yml
@@ -8,5 +8,6 @@
     serial_count: 1
   serial: "{{ serial_count }}"
   roles:
-    - aws
+    - role: aws
+      when: COMMON_ENABLE_AWS_ROLE
     - alton

--- a/playbooks/analytics_single.yml
+++ b/playbooks/analytics_single.yml
@@ -25,7 +25,8 @@
     EDXAPP_MEMCACHE: ''
     POSTFIX_QUEUE_EXTERNAL_SMTP_HOST: ''
   roles:
-    - aws
+    - role: aws
+      when: COMMON_ENABLE_AWS_ROLE
     - role: edxlocal
       when: EDXAPP_MYSQL_HOST == 'localhost'
     - role: memcache

--- a/playbooks/analyticsapi.yml
+++ b/playbooks/analyticsapi.yml
@@ -7,7 +7,8 @@
     ENABLE_NEWRELIC: False
     CLUSTER_NAME: 'analytics-api'
   roles:
-    - aws
+    - role: aws
+      when: COMMON_ENABLE_AWS_ROLE
     - role: nginx
       nginx_default_sites:
         - analytics_api

--- a/playbooks/antivirus.yml
+++ b/playbooks/antivirus.yml
@@ -3,7 +3,8 @@
   become: True
   gather_facts: True
   roles:
-    - aws
+    - role: aws
+      when: COMMON_ENABLE_AWS_ROLE
     - antivirus
     - role: datadog
       when: COMMON_ENABLE_DATADOG

--- a/playbooks/aws.yml
+++ b/playbooks/aws.yml
@@ -7,4 +7,5 @@
   serial: "{{ serial_count }}"
   roles:
     - common
-    - aws
+    - role: aws
+      when: COMMON_ENABLE_AWS_ROLE

--- a/playbooks/blockstore.yml
+++ b/playbooks/blockstore.yml
@@ -6,7 +6,8 @@
     ENABLE_NEWRELIC: True
     CLUSTER_NAME: 'blockstore'
   roles:
-    - aws
+    - role: aws
+      when: COMMON_ENABLE_AWS_ROLE
     - role: nginx
       nginx_default_sites:
         - blockstore 

--- a/playbooks/certs.yml
+++ b/playbooks/certs.yml
@@ -6,7 +6,8 @@
     serial_count: 1
   serial: "{{ serial_count }}"
   roles:
-    - aws
+    - role: aws
+      when: COMMON_ENABLE_AWS_ROLE
     - certs
     - role: datadog
       when: COMMON_ENABLE_DATADOG

--- a/playbooks/commoncluster.yml
+++ b/playbooks/commoncluster.yml
@@ -26,7 +26,8 @@
       become: False
       when: elb_pre_post
   roles:
-    - aws
+    - role: aws
+      when: COMMON_ENABLE_AWS_ROLE
     - role: datadog
       when: COMMON_ENABLE_DATADOG
     - role: splunkforwarder

--- a/playbooks/credentials.yml
+++ b/playbooks/credentials.yml
@@ -7,7 +7,8 @@
     ENABLE_NEWRELIC: False
     CLUSTER_NAME: 'credentials'
   roles:
-    - aws
+    - role: aws
+      when: COMMON_ENABLE_AWS_ROLE
     - role: nginx
       nginx_default_sites:
         - credentials

--- a/playbooks/deploy_nginx_all_roles.yml
+++ b/playbooks/deploy_nginx_all_roles.yml
@@ -8,7 +8,8 @@
     - roles/xserver/defaults/main.yml
   roles:
     - common
-    - aws
+    - role: aws
+      when: COMMON_ENABLE_AWS_ROLE
     - role: nginx
       nginx_sites:
       - cms

--- a/playbooks/designer.yml
+++ b/playbooks/designer.yml
@@ -6,7 +6,8 @@
     ENABLE_NEWRELIC: True
     CLUSTER_NAME: 'designer'
   roles:
-    - aws
+    - role: aws
+      when: COMMON_ENABLE_AWS_ROLE
     - role: nginx
       nginx_default_sites:
         - designer

--- a/playbooks/discovery.yml
+++ b/playbooks/discovery.yml
@@ -7,7 +7,8 @@
     ENABLE_NEWRELIC: False
     CLUSTER_NAME: 'discovery'
   roles:
-    - aws
+    - role: aws
+      when: COMMON_ENABLE_AWS_ROLE
     - role: nginx
       nginx_default_sites:
         - discovery

--- a/playbooks/ecommerce.yml
+++ b/playbooks/ecommerce.yml
@@ -7,7 +7,8 @@
     ENABLE_NEWRELIC: False
     CLUSTER_NAME: 'ecommerce'
   roles:
-    - aws
+    - role: aws
+      when: COMMON_ENABLE_AWS_ROLE
     - role: nginx
       nginx_default_sites:
         - ecommerce

--- a/playbooks/ecomworker.yml
+++ b/playbooks/ecomworker.yml
@@ -6,7 +6,8 @@
     ENABLE_DATADOG: False
     ENABLE_NEWRELIC: False
   roles:
-    - aws
+    - role: aws
+      when: COMMON_ENABLE_AWS_ROLE
     - ecomworker
     - role: datadog
       when: COMMON_ENABLE_DATADOG

--- a/playbooks/edx_continuous_integration.yml
+++ b/playbooks/edx_continuous_integration.yml
@@ -6,7 +6,8 @@
   vars:
     migrate_db: "yes"
   roles:
-    - aws
+    - role: aws
+      when: COMMON_ENABLE_AWS_ROLE
     - role: nginx
       nginx_sites:
       - cms

--- a/playbooks/edx_jenkins_tests.yml
+++ b/playbooks/edx_jenkins_tests.yml
@@ -13,7 +13,8 @@
     - "{{ secure_dir }}/vars/edx_jenkins_tests.yml"
   roles:
     - common
-    - aws
+    - role: aws
+      when: COMMON_ENABLE_AWS_ROLE
     - role: nginx
       nginx_sites:
       - lms

--- a/playbooks/edx_provision.yml
+++ b/playbooks/edx_provision.yml
@@ -72,7 +72,8 @@
   roles:
     # rerun common to set the hostname, nginx to set basic auth
     - common
-    - aws
+    - role: aws
+      when: COMMON_ENABLE_AWS_ROLE
     - edx-sandbox
     - role: nginx
       nginx_sites:

--- a/playbooks/elasticsearch.yml
+++ b/playbooks/elasticsearch.yml
@@ -26,7 +26,8 @@
       when: elb_pre_post
   roles:
     - common
-    - aws
+    - role: aws
+      when: COMMON_ENABLE_AWS_ROLE
     - elasticsearch
   post_tasks:
     - debug:

--- a/playbooks/enterprise-catalog.yml
+++ b/playbooks/enterprise-catalog.yml
@@ -6,7 +6,8 @@
     ENABLE_NEWRELIC: True
     CLUSTER_NAME: 'enterprise_catalog'
   roles:
-    - aws
+    - role: aws
+      when: COMMON_ENABLE_AWS_ROLE
     - role: nginx
       nginx_default_sites:
         - enterprise_catalog

--- a/playbooks/flower.yml
+++ b/playbooks/flower.yml
@@ -6,5 +6,6 @@
     serial_count: 1
   serial: "{{ serial_count }}"
   roles:
-    - aws
+    - role: aws
+      when: COMMON_ENABLE_AWS_ROLE
     - flower

--- a/playbooks/forum.yml
+++ b/playbooks/forum.yml
@@ -7,7 +7,8 @@
     CLUSTER_NAME: 'forum'
   serial: "{{ serial_count }}"
   roles:
-    - aws
+    - role: aws
+      when: COMMON_ENABLE_AWS_ROLE
     - role: nginx
       nginx_sites:
       - forum

--- a/playbooks/go-agent-docker.yml
+++ b/playbooks/go-agent-docker.yml
@@ -5,5 +5,6 @@
   become: True
   gather_facts: True
   roles:
-  - aws
+  - role: aws
+    when: COMMON_ENABLE_AWS_ROLE
   - go-agent-docker-server

--- a/playbooks/go-server.yml
+++ b/playbooks/go-server.yml
@@ -19,7 +19,8 @@
   become: True
   gather_facts: True
   roles:
-    - aws
+    - role: aws
+      when: COMMON_ENABLE_AWS_ROLE
     - go-server
     - role: splunkforwarder
       when: COMMON_ENABLE_SPLUNKFORWARDER

--- a/playbooks/insights.yml
+++ b/playbooks/insights.yml
@@ -7,7 +7,8 @@
     ENABLE_NEWRELIC: True
     CLUSTER_NAME: 'insights'
   roles:
-    - aws
+    - role: aws
+      when: COMMON_ENABLE_AWS_ROLE
     - role: nginx
       nginx_sites:
         - insights

--- a/playbooks/jenkins_admin.yml
+++ b/playbooks/jenkins_admin.yml
@@ -13,7 +13,8 @@
     COMMON_SECURITY_UPDATES: yes
     SECURITY_UPGRADE_ON_ANSIBLE: true
   roles:
-    - aws
+    - role: aws
+      when: COMMON_ENABLE_AWS_ROLE
     - jenkins_admin
     # This requires an override of the following form:
     # SPLUNKFORWARDER_LOG_ITEMS:

--- a/playbooks/jenkins_build.yml
+++ b/playbooks/jenkins_build.yml
@@ -17,7 +17,8 @@
     SECURITY_UPGRADE_ON_ANSIBLE: true
 
   roles:
-    - aws
+    - role: aws
+      when: COMMON_ENABLE_AWS_ROLE
     - role: datadog
       when: COMMON_ENABLE_DATADOG
     - role: datadog-uninstall

--- a/playbooks/jenkins_build_bastion.yml
+++ b/playbooks/jenkins_build_bastion.yml
@@ -17,7 +17,8 @@
     SECURITY_UPGRADE_ON_ANSIBLE: true
 
   roles:
-    - aws
+    - role: aws
+      when: COMMON_ENABLE_AWS_ROLE
     - role: newrelic_infrastructure
       when: COMMON_ENABLE_NEWRELIC_INFRASTRUCTURE
       tags:

--- a/playbooks/jenkins_data_engineering.yml
+++ b/playbooks/jenkins_data_engineering.yml
@@ -25,7 +25,8 @@
     SECURITY_UPGRADE_ON_ANSIBLE: true
 
   roles:
-    - aws
+    - role: aws
+      when: COMMON_ENABLE_AWS_ROLE
     - jenkins_data_engineering
     - role: newrelic_infrastructure
       when: COMMON_ENABLE_NEWRELIC_INFRASTRUCTURE

--- a/playbooks/jenkins_it.yml
+++ b/playbooks/jenkins_it.yml
@@ -16,6 +16,7 @@
     SECURITY_UPGRADE_ON_ANSIBLE: true
 
   roles:
-    - aws
+    - role: aws
+      when: COMMON_ENABLE_AWS_ROLE
     - docker-tools
     - jenkins_it

--- a/playbooks/jenkins_testeng_master.yml
+++ b/playbooks/jenkins_testeng_master.yml
@@ -49,7 +49,8 @@
         followSymlink: false
 
   roles:
-    - aws
+    - role: aws
+      when: COMMON_ENABLE_AWS_ROLE
     - role: datadog
       when: COMMON_ENABLE_DATADOG
     - role: datadog-uninstall

--- a/playbooks/jenkins_worker.yml
+++ b/playbooks/jenkins_worker.yml
@@ -23,7 +23,8 @@
     - roles/xserver/defaults/main.yml
     - roles/forum/defaults/main.yml
   roles:
-    - aws
+    - role: aws
+      when: COMMON_ENABLE_AWS_ROLE
     - docker-tools
     - mysql
     - edxlocal

--- a/playbooks/jenkins_worker_android.yml
+++ b/playbooks/jenkins_worker_android.yml
@@ -14,6 +14,7 @@
     SECURITY_UPGRADE_ON_ANSIBLE: true
   serial: "{{ serial_count }}"
   roles:
-    - aws
+    - role: aws
+      when: COMMON_ENABLE_AWS_ROLE
     - jenkins_worker
     - newrelic_infrastructure

--- a/playbooks/jenkins_worker_codejail.yml
+++ b/playbooks/jenkins_worker_codejail.yml
@@ -13,7 +13,8 @@
     SECURITY_UPGRADE_ON_ANSIBLE: true
   serial: "{{ serial_count }}"
   roles:
-    - aws
+    - role: aws
+      when: COMMON_ENABLE_AWS_ROLE
     - docker-tools
     - jenkins_worker
     - codejail

--- a/playbooks/learner_portal.yml
+++ b/playbooks/learner_portal.yml
@@ -8,7 +8,8 @@
     LEARNER_PORTAL_ENABLED: True
     LEARNER_PORTAL_SANDBOX_BUILD: False
   roles:
-    - aws
+    - role: aws
+      when: COMMON_ENABLE_AWS_ROLE
     - role: nginx
       nginx_sites:
       - learner_portal

--- a/playbooks/locust.yml
+++ b/playbooks/locust.yml
@@ -4,5 +4,6 @@
   become: True
   gather_facts: True
   roles:
-    - aws
+    - role: aws
+      when: COMMON_ENABLE_AWS_ROLE
     - locust

--- a/playbooks/minos.yml
+++ b/playbooks/minos.yml
@@ -6,5 +6,6 @@
     serial_count: 1
   serial: "{{ serial_count }}"
   roles:
-    - aws
+    - role: aws
+      when: COMMON_ENABLE_AWS_ROLE
     - minos

--- a/playbooks/mongo.yml
+++ b/playbooks/mongo.yml
@@ -3,7 +3,8 @@
   become: True
   gather_facts: True
   roles:
-    - aws
+    - role: aws
+      when: COMMON_ENABLE_AWS_ROLE
     - mongo
     - role: datadog
       when: COMMON_ENABLE_DATADOG

--- a/playbooks/mongo_3_0.yml
+++ b/playbooks/mongo_3_0.yml
@@ -15,7 +15,8 @@
   become: True
   gather_facts: True
   roles:
-    - aws
+    - role: aws
+      when: COMMON_ENABLE_AWS_ROLE
     - enhanced_networking
     - mongo_3_0
     - munin_node

--- a/playbooks/mongo_3_2.yml
+++ b/playbooks/mongo_3_2.yml
@@ -21,7 +21,8 @@
   become: True
   gather_facts: True
   roles:
-    - aws
+    - role: aws
+      when: COMMON_ENABLE_AWS_ROLE
     - mongo_3_2
     - munin_node
     - role: datadog

--- a/playbooks/mongo_3_4.yml
+++ b/playbooks/mongo_3_4.yml
@@ -21,7 +21,8 @@
   become: True
   gather_facts: True
   roles:
-    - aws
+    - role: aws
+      when: COMMON_ENABLE_AWS_ROLE
     - mongo_3_4
     - munin_node
     - role: datadog

--- a/playbooks/mongo_mms.yml
+++ b/playbooks/mongo_mms.yml
@@ -6,7 +6,8 @@
     serial_count: 1
   serial: "{{ serial_count }}"
   roles:
-    - aws
+    - role: aws
+      when: COMMON_ENABLE_AWS_ROLE
     - mongo_mms
     - role: datadog
       when: COMMON_ENABLE_DATADOG

--- a/playbooks/notes.yml
+++ b/playbooks/notes.yml
@@ -6,7 +6,8 @@
     ENABLE_DATADOG: False
     ENABLE_NEWRELIC: True
   roles:
-    - aws
+    - role: aws
+      when: COMMON_ENABLE_AWS_ROLE
     - role: nginx
       nginx_sites:
         - edx_notes_api

--- a/playbooks/notifier.yml
+++ b/playbooks/notifier.yml
@@ -6,7 +6,8 @@
     serial_count: 1
   serial: "{{ serial_count }}"
   roles:
-    - aws
+    - role: aws
+      when: COMMON_ENABLE_AWS_ROLE
     - notifier
     - role: splunkforwarder
       when: COMMON_ENABLE_SPLUNKFORWARDER

--- a/playbooks/program_manager.yml
+++ b/playbooks/program_manager.yml
@@ -8,7 +8,8 @@
     PROGRAM_MANAGER_ENABLED: True
     PROGRAM_MANAGER_SANDBOX_BUILD: False
   roles:
-    - aws
+    - role: aws
+      when: COMMON_ENABLE_AWS_ROLE
     - role: nginx
       nginx_sites:
       - program_manager

--- a/playbooks/rabbitmq.yml
+++ b/playbooks/rabbitmq.yml
@@ -30,7 +30,8 @@
       become: False
       when: elb_pre_post
   roles:
-    - aws
+    - role: aws
+      when: COMMON_ENABLE_AWS_ROLE
     - role: automated
       AUTOMATED_USERS: "{{ RABBIT_AUTOMATED_USERS | default({}) }}"
       tags: 

--- a/playbooks/redirector.yml
+++ b/playbooks/redirector.yml
@@ -7,7 +7,8 @@
     CLUSTER_NAME: 'redirector'
   serial: "{{ serial_count }}"
   roles:
-    - aws
+    - role: aws
+      when: COMMON_ENABLE_AWS_ROLE
     - role: nginx
       nginx_redirects: "{{ NGINX_REDIRECTOR_CUSTOM_REDIRECTS }}"
       REDIRECT_NGINX_PORT: "80"

--- a/playbooks/redis.yml
+++ b/playbooks/redis.yml
@@ -3,7 +3,8 @@
   become: True
   gather_facts: True
   roles:
-    - aws
+    - role: aws
+      when: COMMON_ENABLE_AWS_ROLE
     - redis
     - role: datadog
       when: COMMON_ENABLE_DATADOG

--- a/playbooks/registrar.yml
+++ b/playbooks/registrar.yml
@@ -8,7 +8,8 @@
     REGISTRAR_ENABLED: True
     REGISTRAR_SANDBOX_BUILD: False
   roles:
-    - aws
+    - role: aws
+      when: COMMON_ENABLE_AWS_ROLE
     - role: nginx
       nginx_default_sites:
         - registrar

--- a/playbooks/snort.yml
+++ b/playbooks/snort.yml
@@ -6,7 +6,8 @@
     serial_count: 1
   serial: "{{ serial_count }}"
   roles:
-    - aws
+    - role: aws
+      when: COMMON_ENABLE_AWS_ROLE
     - snort
     - role: datadog
       when: COMMON_ENABLE_DATADOG

--- a/playbooks/tanaguru.yml
+++ b/playbooks/tanaguru.yml
@@ -3,6 +3,7 @@
   become: True
   gather_facts: True
   roles:
-    - aws
+    - role: aws
+      when: COMMON_ENABLE_AWS_ROLE
     - mysql
     - tanaguru 

--- a/playbooks/tools-gp.yml
+++ b/playbooks/tools-gp.yml
@@ -10,7 +10,8 @@
     serial_count: 1
   serial: "{{ serial_count }}"
   roles:
-    - aws
+    - role: aws
+      when: COMMON_ENABLE_AWS_ROLE
     - ad_hoc_reporting 
     - gh-ost
     - role: splunkforwarder

--- a/playbooks/tools_jenkins.yml
+++ b/playbooks/tools_jenkins.yml
@@ -17,7 +17,8 @@
     SECURITY_UPGRADE_ON_ANSIBLE: true
   serial: "{{ serial_count }}"
   roles:
-    - aws
+    - role: aws
+      when: COMMON_ENABLE_AWS_ROLE
     # jenkins_master role does extra tweaks to datadog if COMMON_ENABLE_DATADOG is set
     # so this needs to run early.
     - role: datadog

--- a/playbooks/veda_delivery_worker.yml
+++ b/playbooks/veda_delivery_worker.yml
@@ -2,7 +2,8 @@
   hosts: all
   gather_facts: True
   roles:
-    - aws
+    - role: aws
+      when: COMMON_ENABLE_AWS_ROLE
     - veda_delivery_worker
     - role: splunkforwarder
       when: COMMON_ENABLE_SPLUNKFORWARDER

--- a/playbooks/veda_encode_worker.yml
+++ b/playbooks/veda_encode_worker.yml
@@ -3,7 +3,8 @@
   become: True
   gather_facts: True
   roles:
-    - aws
+    - role: aws
+      when: COMMON_ENABLE_AWS_ROLE
     - veda_encode_worker
     - role: splunkforwarder
       when: COMMON_ENABLE_SPLUNKFORWARDER

--- a/playbooks/veda_pipeline_worker.yml
+++ b/playbooks/veda_pipeline_worker.yml
@@ -3,7 +3,8 @@
   become: True
   gather_facts: True
   roles:
-    - aws
+    - role: aws
+      when: COMMON_ENABLE_AWS_ROLE
     - veda_pipeline_worker
     - role: splunkforwarder
       when: COMMON_ENABLE_SPLUNKFORWARDER

--- a/playbooks/veda_web_frontend.yml
+++ b/playbooks/veda_web_frontend.yml
@@ -3,7 +3,8 @@
   become: True
   gather_facts: True
   roles:
-    - aws
+    - role: aws
+      when: COMMON_ENABLE_AWS_ROLE
     - role: nginx
       nginx_default_sites:
         - veda_web_frontend

--- a/playbooks/vpc_admin.yml
+++ b/playbooks/vpc_admin.yml
@@ -5,7 +5,8 @@
   become: True
   gather_facts: True
   roles:
-    - aws
+    - role: aws
+      when: COMMON_ENABLE_AWS_ROLE
     - edx_ansible
     - user
     - jenkins_admin

--- a/playbooks/whitelabel.yml
+++ b/playbooks/whitelabel.yml
@@ -11,7 +11,8 @@
     - "roles/discovery/defaults/main.yml"
     - "roles/ecommerce/defaults/main.yml"
   roles:
-    - aws
+    - role: aws
+      when: COMMON_ENABLE_AWS_ROLE
     - edxlocal
     - role: nginx
       nginx_default_sites:

--- a/playbooks/worker.yml
+++ b/playbooks/worker.yml
@@ -3,7 +3,8 @@
   become: True
   gather_facts: True
   roles:
-    - aws
+    - role: aws
+      when: COMMON_ENABLE_AWS_ROLE
     - role: edxapp
       celery_worker: True
     - role: datadog

--- a/playbooks/xqueue.yml
+++ b/playbooks/xqueue.yml
@@ -2,7 +2,8 @@
   hosts: all
   become: True
   roles:
-    - aws
+    - role: aws
+      when: COMMON_ENABLE_AWS_ROLE
     - role: automated
       AUTOMATED_USERS: "{{ XQUEUE_AUTOMATED_USERS | default({}) }}"
     - role: nginx

--- a/playbooks/xqwatcher.yml
+++ b/playbooks/xqwatcher.yml
@@ -10,7 +10,8 @@
     serial_count: 1
   serial: "{{ serial_count }}"
   roles:
-    - aws
+    - role: aws
+      when: COMMON_ENABLE_AWS_ROLE
     - xqwatcher
     - role: datadog
       when: COMMON_ENABLE_DATADOG

--- a/playbooks/xserver.yml
+++ b/playbooks/xserver.yml
@@ -6,7 +6,8 @@
     serial_count: 1
   serial: "{{ serial_count }}"
   roles:
-    - aws
+    - role: aws
+      when: COMMON_ENABLE_AWS_ROLE
     - role: nginx
       nginx_sites:
       - xserver


### PR DESCRIPTION
**Background**: The task `aws : Install aws python packages` is applied even when we have `COMMON_ENABLE_AWS_ROLE: False` in our Ansible vars.

This PR will add more conditionals for applying the `aws` role, as is done already in
some files, like [playbooks/edxapp.yml](https://github.com/edx/configuration/blob/8afeda16e07f4ed2fd9b0283945a3f650243c616/playbooks/edxapp.yml#L11-L12).

The checkboxes below are from the PR template. I don't think that any of them apply.

I'm happy to redo this PR against the master branch, or another branch if that's more appropriate.

### PR template checkboxes

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
