### PR TITLE
Stop alerting noise by not monitoring too early

### DIFF
--- a/playbooks/roles/mongo_3_2/tasks/main.yml
+++ b/playbooks/roles/mongo_3_2/tasks/main.yml
@@ -79,29 +79,6 @@
     - "install"
     - "install:app-configuration"
 
-- name: add serverStatus logging script
-  template:
-    src: "log-mongo-serverStatus.sh.j2"
-    dest: "{{ COMMON_BIN_DIR }}/log-mongo-serverStatus.sh"
-    owner: "{{ mongo_user }}"
-    group: "{{ mongo_user }}"
-    mode: 0700
-  when: MONGO_LOG_SERVERSTATUS
-  tags:
-    - "install"
-    - "install:app-configuration"
-
-- name: add serverStatus logging script to cron
-  cron:
-    name: mongostat logging job
-    minute: "*/3"
-    job: /edx/bin/log-mongo-serverStatus.sh >> {{ mongo_log_dir }}/serverStatus.log 2>&1
-  become: yes
-  when: MONGO_LOG_SERVERSTATUS
-  tags:
-    - "install"
-    - "install:app-configuration"
-
 # This will error when run on a new replica set, so we ignore_errors
 # and connect anonymously next.
 - name: determine if there is a replica set already
@@ -401,3 +378,26 @@
   tags:
     - "manage"
     - "manage:start"
+
+- name: add serverStatus logging script
+  template:
+    src: "log-mongo-serverStatus.sh.j2"
+    dest: "{{ COMMON_BIN_DIR }}/log-mongo-serverStatus.sh"
+    owner: "{{ mongo_user }}"
+    group: "{{ mongo_user }}"
+    mode: 0700
+  when: MONGO_LOG_SERVERSTATUS
+  tags:
+    - "install"
+    - "install:app-configuration"
+
+- name: add serverStatus logging script to cron
+  cron:
+    name: mongostat logging job
+    minute: "*/3"
+    job: /edx/bin/log-mongo-serverStatus.sh >> {{ mongo_log_dir }}/serverStatus.log 2>&1
+  become: yes
+  when: MONGO_LOG_SERVERSTATUS
+  tags:
+    - "install"
+    - "install:app-configuration"

--- a/playbooks/roles/mongo_3_4/tasks/main.yml
+++ b/playbooks/roles/mongo_3_4/tasks/main.yml
@@ -79,29 +79,6 @@
     - "install"
     - "install:app-configuration"
 
-- name: add serverStatus logging script
-  template:
-    src: "log-mongo-serverStatus.sh.j2"
-    dest: "{{ COMMON_BIN_DIR }}/log-mongo-serverStatus.sh"
-    owner: "{{ mongo_user }}"
-    group: "{{ mongo_user }}"
-    mode: 0700
-  when: MONGO_LOG_SERVERSTATUS
-  tags:
-    - "install"
-    - "install:app-configuration"
-
-- name: add serverStatus logging script to cron
-  cron:
-    name: mongostat logging job
-    minute: "*/3"
-    job: /edx/bin/log-mongo-serverStatus.sh >> {{ mongo_log_dir }}/serverStatus.log 2>&1
-  become: yes
-  when: MONGO_LOG_SERVERSTATUS
-  tags:
-    - "install"
-    - "install:app-configuration"
-
 # This will error when run on a new replica set, so we ignore_errors
 # and connect anonymously next.
 - name: determine if there is a replica set already
@@ -401,3 +378,26 @@
   tags:
     - "manage"
     - "manage:start"
+
+- name: add serverStatus logging script
+  template:
+    src: "log-mongo-serverStatus.sh.j2"
+    dest: "{{ COMMON_BIN_DIR }}/log-mongo-serverStatus.sh"
+    owner: "{{ mongo_user }}"
+    group: "{{ mongo_user }}"
+    mode: 0700
+  when: MONGO_LOG_SERVERSTATUS
+  tags:
+    - "install"
+    - "install:app-configuration"
+
+- name: add serverStatus logging script to cron
+  cron:
+    name: mongostat logging job
+    minute: "*/3"
+    job: /edx/bin/log-mongo-serverStatus.sh >> {{ mongo_log_dir }}/serverStatus.log 2>&1
+  become: yes
+  when: MONGO_LOG_SERVERSTATUS
+  tags:
+    - "install"
+    - "install:app-configuration"


### PR DESCRIPTION
Move setting up the server status script to after the mongo server
has started. This is to prevent unable to connect errors in the logs
alerting us via Splunk.

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
