### PR TITLE
Consolidate retirement service user defintions to a common prefix.

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -346,8 +346,8 @@ EDXAPP_PROFILE_IMAGE_MAX_AGE: 31536000
 EDXAPP_PROFILE_IMAGE_MAX_BYTES: 1048576
 
 # Configuration needed for the retirement service
-EDXAPP_RETIREMENT_SERVICE_USER_EMAIL: "retirement_worker@example.com"
-EDXAPP_RETIREMENT_SERVICE_USER_NAME: "retirement_worker"
+EDXAPP_RETIREMENT_SERVICE_WORKER_EMAIL: "retirement_worker@example.com"
+EDXAPP_RETIREMENT_SERVICE_WORKER_USERNAME: "retirement_worker"
 
 EDXAPP_ENABLE_COMPREHENSIVE_THEMING: false
 
@@ -683,8 +683,8 @@ SERVICE_WORKER_USERS:
     username: "{{ REGISTRAR_SERVICE_USER_NAME }}"
     is_staff: true
     is_superuser: false
-  - email: "{{ EDXAPP_RETIREMENT_SERVICE_USER_EMAIL }}"
-    username: "{{ EDXAPP_RETIREMENT_SERVICE_USER_NAME }}"
+  - email: "{{ EDXAPP_RETIREMENT_SERVICE_WORKER_EMAIL }}"
+    username: "{{ EDXAPP_RETIREMENT_SERVICE_WORKER_USERNAME }}"
     is_staff: true
     is_superuser: false
     enabled: "{{ COMMON_RETIREMENT_SERVICE_SETUP | default(false) }}"

--- a/playbooks/roles/oauth_client_setup/defaults/main.yml
+++ b/playbooks/roles/oauth_client_setup/defaults/main.yml
@@ -90,7 +90,7 @@ oauth_client_setup_oauth2_clients:
         name: "{{ retirement_service_name if COMMON_RETIREMENT_SERVICE_SETUP|default(false)|bool else 'None' }}",
         backend_service_id: "{{ RETIREMENT_SERVICE_EDX_OAUTH2_KEY | default('None') }}",
         backend_service_secret: "{{ RETIREMENT_SERVICE_EDX_OAUTH2_SECRET | default('None') }}",
-        username: "{{ EDXAPP_RETIREMENT_SERVICE_USER_NAME | default('None') }}",
+        username: "{{ EDXAPP_RETIREMENT_SERVICE_WORKER_USERNAME | default('None') }}",
       }
 #
 # OS packages


### PR DESCRIPTION
https://openedx.atlassian.net/browse/DENG-75

Pairs with: https://github.com/edx/edx-platform/pull/23278

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
