### PR TITLE
Add fact regathering to fix missing uuid error

### DIFF
--- a/playbooks/roles/mount_ebs/tasks/main.yml
+++ b/playbooks/roles/mount_ebs/tasks/main.yml
@@ -55,6 +55,9 @@
     force: "{{ FORCE_REFORMAT_DISKS }}"
   with_items: "{{ volumes }}"
 
+- name: Regather facts to get UUIDs of freshly formatted disks
+  setup: ""
+
 # This can fail if one volume is mounted on a child directory as another volume
 # and it attempts to unmount the parent first.  This is generally fixable by rerunning.
 # Order is super dependent here, but we're iterating ansible_mounts (in order to identify


### PR DESCRIPTION
Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
