### PR TITLE
[BD] Install python3 requirements in data api

### DIFF
--- a/playbooks/roles/analytics_api/defaults/main.yml
+++ b/playbooks/roles/analytics_api/defaults/main.yml
@@ -40,6 +40,9 @@ analytics_api_newrelic_appname: 'analytics-api'
 #
 analytics_api_debian_pkgs:
   - 'libmysqlclient-dev'
+  # TODO: Remove these dependencies once analytics_api is in python3
+  - 'python3-pip'
+  - 'python3-dev'
 
 ANALYTICS_API_VERSION: "master"
 ANALYTICS_API_NGINX_PORT: '1{{ analytics_api_gunicorn_port }}'


### PR DESCRIPTION
### Description

Install python3 requirements in analytics data api. Related to https://openedx.atlassian.net/browse/BOM-1359

Right now, analytics_api tests in python3 are failing due to the docker container does not have installed the python3-dev package. See https://github.com/edx/edx-analytics-data-api/pull/327

## Reviewers
 - [ ] @andrey-canon
 - [x] Is this ready for edX's review?
- [ ] @jmbowman 


### Note
Once this get merged, please generate a new analytics_api docker image.