### PR TITLE
[BD] Install python3 requirements in Insights

### DIFF
--- a/playbooks/roles/insights/defaults/main.yml
+++ b/playbooks/roles/insights/defaults/main.yml
@@ -120,6 +120,9 @@ insights_debian_pkgs:
   - libssl-dev # needed for mysqlclient python library
   - build-essential
   - gettext
+  # TODO: Remove these dependencies once analytics_api is in python3
+  - python3-pip
+  - python3-dev
 
 insights_release_specific_debian_pkgs:
   xenial:


### PR DESCRIPTION
### Description

Install python3 requirements in insights. Related to https://openedx.atlassian.net/browse/BOM-1359

Install python3 in order to start to be able to run python3 tests for insights

## Reviewers
 - [ ] @andrey-canon
 - [x] Is this ready for edX's review?
- [ ] @jmbowman 

