### PR TITLE
Version bump for LabXchange XBlocks on edx.org

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -280,7 +280,7 @@ EDXAPP_PRIVATE_REQUIREMENTS:
     - name: git+https://github.com/edx/xblock-free-text-response@95bee343eaeb29ff012aa05a7043d6cefd08ce91#egg=xblock-free-text-response
       extra_args: -e
     # XBlocks associated with the LabXchange project
-    - name: git+https://github.com/open-craft/labxchange-xblocks.git@29c6d829b8d54f5683a41626616024c8643b7b0f#egg=labxchange-xblocks
+    - name: git+https://github.com/open-craft/labxchange-xblocks.git@997ab077bedcbdcc12bdc2375b131ea5e87329bf#egg=labxchange-xblocks
       extra_args: -e
     # "Pathways" learning context plugin for the LabXchange project
     - name: git+https://github.com/open-craft/lx-pathway-plugin.git@ba1fc294738a7662fc901616fb68e6b91f46e80a#egg=lx-pathway-plugin


### PR DESCRIPTION
This is a minor version bump to `labxchange-xblocks` used on edx.org.

It pulls in https://github.com/open-craft/labxchange-xblocks/pull/6 :
* updates the `student_view_data` of Assignment XBlocks to return more useful data that we need.
* Removes python 2.7 support.
