### PR TITLE
SE-1983 Campus.il Add newrelic mongo monitoring playbook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to this project will be documented in this file.
 Add any new changes to the top(right below this line).
 
+ - 2020-07-24
+    - Role: newrelic_mongo_monitor
+      - Added the new newrelic_mongo_monitor role and playbook for configuring newrelic infrastructure agent mongodb
+        integration.
+
  - 2020-06-30
     - Role: edxapp
       - Added COURSE_CATALOG_URL_ROOT that contains root url of course catalog service (discovery service).

--- a/playbooks/newrelic_mongo_monitor.yml
+++ b/playbooks/newrelic_mongo_monitor.yml
@@ -1,0 +1,7 @@
+
+- name: Configure newrelic mongo monitoring
+  hosts: all
+  become: True
+  gather_facts: True
+  roles:
+    - mongo_newrelic_monitor

--- a/playbooks/roles/mongo_newrelic_monitor/defaults/main.yml
+++ b/playbooks/roles/mongo_newrelic_monitor/defaults/main.yml
@@ -1,0 +1,5 @@
+MONGO_NEWRELIC_MONITOR_USER: 'newrelic-monitor'
+MONGO_NEWRELIC_MONITOR_PASSWORD: 'SET-ME-PLEASE'
+MONGO_NEWRELIC_USER_AUTH_SOURCE: 'admin'
+MONGO_NEWRELIC_CLUSTER_NAME: 'mongo-cluster'
+MONGO_NEWRELIC_LABELS: '{}' # eg '{ "env": "prod", "label": "my-label" }'

--- a/playbooks/roles/mongo_newrelic_monitor/meta/main.yml
+++ b/playbooks/roles/mongo_newrelic_monitor/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - newrelic_infrastructure

--- a/playbooks/roles/mongo_newrelic_monitor/tasks/main.yml
+++ b/playbooks/roles/mongo_newrelic_monitor/tasks/main.yml
@@ -1,0 +1,45 @@
+---
+
+- name: Install newrelic mongo integration
+  apt:
+    pkg: "{{ item }}"
+    state: present
+    update_cache: yes
+  with_items:
+    - "nri-mongodb"
+
+- name: Create newrelic monitoring role
+  shell:
+    cmd: 'mongo --authenticationDatabase admin -u "{{ MONGO_ADMIN_USER }}" -p "{{ MONGO_ADMIN_PASSWORD }}" --host "{{ MONGO_REPL_SET }}/{{ EDXAPP_MONGO_HOSTS }}" --eval ''db.createRole({ role: "listCollections", privileges: [{ resource: {db:"",collection:""}, actions: ["listCollections"] }], roles: [] });'' admin'
+  register: create_newrelic_role_result
+  ignore_errors: true
+
+- name: Fail if create newrelic monitoring role actually failed
+  fail:
+    msg: create newrelic monitoring role failed
+  when: 'create_newrelic_role_result.rc != 0 and "already exists" not in create_newrelic_role_result.stdout'
+
+- name: Create newrelic mongo user
+  mongodb_user:
+    login_database: "admin"
+    login_user: "{{ MONGO_ADMIN_USER }}"
+    login_password: "{{ MONGO_ADMIN_PASSWORD }}"
+    replica_set: "{{ MONGO_REPL_SET }}"
+    database: "admin"
+    name: "{{ MONGO_NEWRELIC_MONITOR_USER }}"
+    password: "{{ MONGO_NEWRELIC_MONITOR_PASSWORD }}"
+    roles:
+      - "clusterMonitor"
+      - "listCollections"
+    state: present
+
+- name: Copy newrelic mongo integration config
+  template:
+    src: "mongodb-config.yml.j2"
+    dest: "/etc/newrelic-infra/integrations.d/mongodb-config.yml"
+    backup: yes
+
+- name: Restart the infrastructure agent to apply changes
+  service:
+    name: newrelic-infra
+    state: restarted

--- a/playbooks/roles/mongo_newrelic_monitor/templates/mongodb-config.yml.j2
+++ b/playbooks/roles/mongo_newrelic_monitor/templates/mongodb-config.yml.j2
@@ -1,0 +1,44 @@
+# {{ ansible_managed }}
+#
+# Configuration docs:
+# https://docs.newrelic.com/docs/integrations/host-integrations/host-integrations-list/mongodb-monitoring-integration#users-privileges
+#
+# This is designed to be installed on the same instance as a mongo node.
+
+integration_name: com.newrelic.mongodb
+
+instances:
+  - name: all
+    # Available commands are "all", "metrics", and "inventory"
+    command: all
+    arguments:
+      cluster_name: '{{ MONGO_NEWRELIC_CLUSTER_NAME }}'
+      # The mongos to connect to
+      host: localhost
+      # The port the mongos is running on
+      port: 27017
+      # The username of the user created to monitor the cluster.
+      # This user should exist on the cluster as a whole as well
+      # as on each of the individual mongods.
+      username: '{{ MONGO_NEWRELIC_MONITOR_USER }}'
+      # The password for the monitoring user
+      password: '{{ MONGO_NEWRELIC_MONITOR_PASSWORD }}'
+      # The database on which the monitoring user is stored
+      auth_source: '{{ MONGO_NEWRELIC_USER_AUTH_SOURCE }}'
+      # Connect using SSL
+      ssl: false
+      # Skip verification of the certificate sent by the host.
+      # This can make the connection susceptible to man-in-the-middle attacks,
+      # and should only be used for testing
+      #ssl_insecure_skip_verify: true
+      # Path to the CA certs file
+      #ssl_ca_certs: /sample/path/to/ca_certs
+      # Client Certificate to present to the server (optional)
+      #pem_key_file: /sample/file.pem
+      # Passphrase to decrypt PEMKeyFile file (optional)
+      #passphrase: secret
+      # A JSON map of database names to an array of collection names. If empty,
+      # defaults to all databases and collections. If the list of collections is null,
+      # collects all collections for the database.
+      filters: ''
+    labels: {{ MONGO_NEWRELIC_LABELS }}


### PR DESCRIPTION
This adds a playbook to deploy newrelic monitoring of a mongodb installation.

**JIRA tickets**: [OSPR-4262](https://openedx.atlassian.net/browse/OSPR-4262)

**Dependencies**: None

**Sandbox URL**: TBD

**Merge deadline**: "None"

**Testing instructions**:

1. deploy a multi-node mongodb installation
1. configure valid newrelic vars overriding the new defaults here
1. run this playbook against the mongo node instances
1. verify that newrelic mongodb monitoring agent is set up and reporting data
   to newrelic for the nodes.

See also https://github.com/edx-olive/configuration/pull/15 where this new
playbook was used for a client's gingko Open edX instance.

**Author notes and concerns**:


**Reviewers**
- [x] @itsyejd
- [ ] edX reviewer[s] TBD

**Settings**
```yaml
```

