### PR TITLE
[BB-2217] Allow setting SiteConfiguration values when provisioning an instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 Add any new changes to the top(right below this line).
 
+ - 2020-08-01
+     - Role: edxapp
+       - Added `EDXAPP_SITE_CONFIGURATION` to allow creating/updating the `SiteConfiguration` values during provisioning.
+
  - 2020-07-27
      - Role: all
        - Convert ansible lowercase variables to upercase.

--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -1740,3 +1740,23 @@ EDXAPP_LMS_LOCAL_CONFIG_FILE: "{{ UNENCRYPTED_CFG_DIR }}/lms.yml"
 EDXAPP_CMS_LOCAL_CONFIG_FILE: "{{ UNENCRYPTED_CFG_DIR }}/studio.yml"
 
 edxapp_staticfiles_storage_overrides: !!null
+
+# Accepts a list of dictionaries of the following form.
+# EDXAPP_SITE_CONFIGURATION:
+#   - site_id: 1
+#     values:
+#       foo: true
+#       bar: false
+#   - domain: example.com
+#     values:
+#       abc: true
+#   - values:
+#       xyz: true
+#
+# In each dictionary, the 'site_id' and the 'domain' keys are optional and the 'values' key
+# is required. However, only one of 'site_id', 'domain' can be specified due to the behaviour
+# of the 'create_or_update_site_configuration' management command. The 'values' key accepts a
+# dictionary of keys and values corresponding to the SiteConfiguration paramters to be added to the
+# SiteConfiguration instance.
+
+EDXAPP_SITE_CONFIGURATION: {}

--- a/playbooks/roles/edxapp/tasks/service_variant_config.yml
+++ b/playbooks/roles/edxapp/tasks/service_variant_config.yml
@@ -302,3 +302,11 @@
   tags:
     - gather_static_assets
     - assets
+
+- name: Create or update SiteConfiguration
+  include: site_configuration.yml
+  when: celery_worker is not defined and EDXAPP_SITE_CONFIGURATION
+  with_items: "{{ EDXAPP_SITE_CONFIGURATION }}"
+  become_user: "{{ edxapp_user }}"
+  tags:
+    - create_or_update_site_configuration

--- a/playbooks/roles/edxapp/tasks/site_configuration.yml
+++ b/playbooks/roles/edxapp/tasks/site_configuration.yml
@@ -1,0 +1,42 @@
+---
+- name: Create or update SiteConfiguration
+  block:
+    - name: Create the SiteConfiguration JSON file
+      template:
+        src: "site_configuration.json.j2"
+        dest: "/tmp/site_configuration.json"
+
+    - name: Use the site_id if it is provided
+      set_fact:
+        site_identifier: "--site-id {{ item.site_id }}"
+      when: item.site_id is defined and item.domain is not defined
+
+    - name: Use the domain name if it is provided
+      set_fact:
+        site_identifier: "{{ item.domain }}"
+      when: item.domain is defined and item.site_id is not defined
+
+    - name: Fail if both site_id and domain are provided
+      fail:
+        msg: "Cannot specify the site_id and domain at the same time in {{ item }}"
+      when: item.domain is defined and item.site_id is defined
+
+    - name: Get the default SITE_ID
+      shell: ". {{ edxapp_app_dir }}/edxapp_env && {{ edxapp_venv_bin }}/python {{ edxapp_code_dir }}/manage.py lms print_setting SITE_ID 2>/dev/null"
+      register: default_site_id
+      when: item.site_id is not defined and item.domain is not defined
+
+    - name: Use the default SITE_ID as the site identifier
+      set_fact:
+        site_identifier: "--site-id {{ default_site_id.stdout }}"
+      when: item.site_id is not defined and item.domain is not defined
+
+    - name: Run create_or_update_site_configuration
+      shell: |
+        . {{ edxapp_app_dir }}/edxapp_env
+        {{ edxapp_venv_bin }}/python {{ edxapp_code_dir }}/manage.py lms create_or_update_site_configuration -f /tmp/site_configuration.json --enabled {{ site_identifier }}
+
+    - name: Remove the generated SiteConfiguration JSON file
+      file:
+        path: "/tmp/site_configuration.json"
+        state: absent

--- a/playbooks/roles/edxapp/templates/site_configuration.json.j2
+++ b/playbooks/roles/edxapp/templates/site_configuration.json.j2
@@ -1,0 +1,1 @@
+{{ item['values'] | to_nice_json }}


### PR DESCRIPTION
Allow setting `SiteConfiguration` values for the default site or a
specific site by id or domain when provisioning an instance.

**JIRA tickets**: [OSPR-4288](https://openedx.atlassian.net/browse/OSPR-4288).

**Dependencies**: None

**Sandbox URL**: TBD - sandbox is being provisioned.

**Merge deadline**: None

**Testing instructions**:
1. Provision an instance with this branch. Verify that there are no errors.
1. Provision a new appserver on the instance with `EDXAPP_SITE_CONFIGURATION` set (see the comment in the `playbooks/roles/edxapp/defaults/main.yml` file for the structure of values). Verify that the `SiteConfiguration` values are set and there are no errors.
  For example, this could be a good test configuration
    ```yaml
   EDXAPP_SITE_CONFIGURATION:
     - values:
        ENABLE_ACCOUNT_DELETION: false
        ENABLE_SOCIAL_MEDIA_LINKS: true
    - values:
        ENABLE_ACCOUNT_DELETION: true
        ENABLE_SOCIAL_MEDIA_LINKS: false
      site_id: 1
    - values:
        ENABLE_ACCOUNT_DELETION: false
        ENABLE_SOCIAL_MEDIA_LINKS: true
      domain: example.com
    ```
1. Repeat the previous step by adding another item to the list with both `site_id` and `domain` keys set and verify that the playbook fails with an error message stating that both cannot be specified at the same time.

Since each of the above steps involve provisioning new appservers and that can take a lot of time, there is a workaround to test the steps 2 and 3.
1. Log in to the appserver created for the step 1.
1. Navigate to the `/edx/app/edx_ansible/edx_ansible` directory as the `root` user. Create a virtualenv environment, activate it and install the requirements in `requirements.txt`.
1. Save the secure configuration variables used to provision the appserver on disk (say `/tmp/vars.yml`).
1.  Edit the `/edx/app/edx_ansible/edx_ansible/playbooks/openedx_native.yml` playbook to comment out the entire `Bootstrap instance(s)` play.
1. Under the `Configure instance(s)` play, add `connection: local` before the `hosts: all` line.
1. The edits done in the previous steps will reduce the running time of the playbook by commenting out the tasks/plays that were already run successfully and hence need not be run repeatedly during testing. They will also allow running the playbook locally without SSH.
1. Run the following command from the `/edx/app/edx_ansible/edx_ansible/playbooks` directory, replacing the name and path to the vars file with the correct ones you have used.

    ```
    ansible-playbook -i "127.0.0.1," -e @/tmp/vars.yml openedx_native.yml --tags create_or_update_configuration
    ```
1. For testing various scenarios, update the vars file, update/delete the existing `SiteConfiguration` values as required and re-run the command mentioned in the previous step to test various scenarios.

**Reviewers**
- [ ] @giovannicimolin / @viadanna
- [ ] edX reviewer[s] TBD


Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?

**Settings**
```yaml
EDXAPP_SITE_CONFIGURATION:
  - values:
      static_template_about_header: "About Page!"
      static_template_about_content: "Hello world!"
```