### PR TITLE
Version bump for LabXchange pathways plugin on edx.org

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -285,7 +285,7 @@ EDXAPP_PRIVATE_REQUIREMENTS:
     - name: git+https://github.com/open-craft/labxchange-xblocks.git@997ab077bedcbdcc12bdc2375b131ea5e87329bf#egg=labxchange-xblocks
       extra_args: -e
     # "Pathways" learning context plugin for the LabXchange project
-    - name: git+https://github.com/open-craft/lx-pathway-plugin.git@ba1fc294738a7662fc901616fb68e6b91f46e80a#egg=lx-pathway-plugin
+    - name: git+https://github.com/open-craft/lx-pathway-plugin.git@337abf249b7c5ecc1e78a44d2e639e1ab65f2085#egg=lx-pathway-plugin
       extra_args: -e
 
 # Whether to run reindex_course on deploy


### PR DESCRIPTION
This is a version bump for the `lx-pathway-plugin` on edx.org.

This pulls in:
* https://github.com/open-craft/lx-pathway-plugin/pull/8 for Django 2.2 compatibility
* https://github.com/open-craft/lx-pathway-plugin/pull/6 which makes the main "read pathway" REST API view work from the LMS and not just Studio. This allows the LabXchange app to make its "GET pathway" operation use the LMS instead of Studio, so that normal read-only views of the content don't depend on the backend making Studio API calls. Pathway edits/deletes still use Studio as before.

Important: the edxapp django setting `LX_PATHWAY_PLUGIN_AUTHORIZED_USERNAMES` must be set to the same value on stage/prod for the LMS as was previously set for Studio. Studio is currently configured correctly, but I don't know if the way that setting is defined currently applies only to Studio or to both Studio and the LMS. If it's only set for Studio, it must be set for the LMS as well.