### PR TITLE
Page_size=20 on CatalogIntegration for Masters Sandboxes

### DIFF
--- a/playbooks/masters_sandbox.yml
+++ b/playbooks/masters_sandbox.yml
@@ -45,7 +45,7 @@
     - name: create LMS catalog integration
       shell: >
         . {{ edxapp_env_path }} && {{ edxapp_venv_dir }}/bin/python manage.py lms create_catalog_integrations --enabled --internal_api_url
-        https://discovery-{{dns_name}}.sandbox.edx.org --service_username discovery_worker
+        https://discovery-{{dns_name}}.sandbox.edx.org --service_username discovery_worker --page_size 20
       args:
         chdir: "{{ edxapp_code_dir }}"
 


### PR DESCRIPTION
Update the page_size parameter of the catalog_integration on the Masters sandboxes to be 20 instead of default of 100.
The reason we want to limit the page size to be 20 is because If found an issue where when we make the course_runs api call, the page size 100 would cause 404 on second or third page call to discovery service. Discovery service have default page size of 20 on that endpoint.

@edx/masters-devs Please help review.

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.