### PR TITLE
Increase xqueue upload limit to match LMS.

### DIFF
--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/xqueue.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/xqueue.j2
@@ -14,6 +14,9 @@ server {
 
   access_log {{ nginx_log_dir }}/access.log {{ NGINX_LOG_FORMAT_NAME }};
   error_log {{ nginx_log_dir }}/error.log error;
+
+  # set xqueue upload limit to 20MB to match the LMS upload limit.
+  client_max_body_size 20M;
   
   ssl_certificate /etc/ssl/certs/{{ NGINX_SSL_CERTIFICATE|basename }};
   ssl_certificate_key /etc/ssl/private/{{ NGINX_SSL_KEY|basename }};


### PR DESCRIPTION
Currently LMS is allowing to submit files upto 20MBs but xqueue is set the upload limit size to 1MB.

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
