### PR TITLE
add missing DigiCert intermediate certificate to installations (DOS-883)

### DIFF
--- a/playbooks/roles/common/tasks/main.yml
+++ b/playbooks/roles/common/tasks/main.yml
@@ -10,12 +10,21 @@
 
 # ubuntu
 - stat:
-    path: "/usr/sbin/update-ca-certificates"
+    path: "{{ item }}"
+  with_items:
+      - "/usr/local/share/ca-certificates"
+      - "/usr/sbin/update-ca-certificates"
   register: update_ca_certificates
+
+- name: Download digicert intermediate Certificate
+  get_url:
+    url: "{{ common_digicert_base_url }}/{{ common_digicert_name }}.pem"
+    dest: "/usr/local/share/ca-certificates/{{ common_digicert_name }}"
+  when: update_ca_certificates is defined and update_ca_certificates.results[0].stat.exists == True
 
 - name: Update CA Certificates
   shell: /usr/sbin/update-ca-certificates
-  when: update_ca_certificates is defined and update_ca_certificates.stat.exists == True
+  when: update_ca_certificates is defined and update_ca_certificates.results[1].stat.exists == True
 
 # ec2-linux
 - stat:

--- a/playbooks/roles/common_vars/defaults/main.yml
+++ b/playbooks/roles/common_vars/defaults/main.yml
@@ -54,6 +54,9 @@ COMMON_PYPI_MIRROR_URL: 'https://pypi.python.org/simple'
 COMMON_NPM_MIRROR_URL: 'https://registry.npmjs.org'
 COMMON_UBUNTU_APT_KEYSERVER: "http://keyserver.ubuntu.com/pks/lookup?op=get&fingerprint=on&search="
 
+common_digicert_name: "DigiCertSHA2SecureServerCA.crt"
+common_digicert_base_url: "https://dl.cacerts.digicert.com/"
+
 COMMON_EDX_PPA: "deb http://ppa.edx.org {{ ansible_distribution_release }} main"
 COMMON_EDX_PPA_KEY_SERVER: "keyserver.ubuntu.com"
 COMMON_EDX_PPA_KEY_ID: "69464050"


### PR DESCRIPTION
Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
