### PR TITLE
Bump version of LabXchange XBlocks plugin for edx.org (Django 2.2 fix)

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -284,7 +284,7 @@ EDXAPP_PRIVATE_REQUIREMENTS:
     - name: git+https://github.com/edx/xblock-image-modal@9c19e426ea6118c1433e29cfccc1a88a2346510d#egg=xblock-image-modal
       extra_args: -e
     # XBlocks associated with the LabXchange project
-    - name: git+https://github.com/open-craft/labxchange-xblocks.git@997ab077bedcbdcc12bdc2375b131ea5e87329bf#egg=labxchange-xblocks
+    - name: git+https://github.com/open-craft/labxchange-xblocks.git@3830256088845c23eedaf6bc8c5b29c0ebc46fbb#egg=labxchange-xblocks
       extra_args: -e
     # "Pathways" learning context plugin for the LabXchange project
     - name: git+https://github.com/open-craft/lx-pathway-plugin.git@337abf249b7c5ecc1e78a44d2e639e1ab65f2085#egg=lx-pathway-plugin


### PR DESCRIPTION
This is a minor version bump to `labxchange-xblocks` used on edx.org.

It pulls in https://github.com/open-craft/labxchange-xblocks/pull/7 which removes all references to Django, and in particular removes the pinned requirement of Django 1.11.
