### PR TITLE
Upgrade to xblock-problem-builder 4.0.0

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -240,7 +240,7 @@ EDXAPP_EXTRA_REQUIREMENTS: []
 #   - name: git+https://git.myproject.org/MyProject#egg=MyProject
 EDXAPP_PRIVATE_REQUIREMENTS:
     # For Harvard courses:
-    - name: xblock-problem-builder==3.4.14
+    - name: xblock-problem-builder==4.0.0
     # Oppia XBlock
     # https://github.com/oppia/xblock/pull/4
     - name: git+https://github.com/edx/oppia-xblock.git@1030adb3590ad2d32c93443cc8690db0985d76b6#egg=oppia-xblock


### PR DESCRIPTION
Upgrade xblock-problem-builder to the new release featuring Django 2.2 compatibility.
