### PR TITLE
[PROD-1440] - Update versions for packages handling fragment DeprecationWarning.

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -247,7 +247,7 @@ EDXAPP_PRIVATE_REQUIREMENTS:
       extra_args: -e
     # This repository contains schoolyourself-xblock, which is used in
     # edX's "AlgebraX" and "GeometryX" courses.
-    - name: git+https://github.com/edx/schoolyourself-xblock.git@2093048720cfb36cc05b3143cd6f2585c7c64d85#egg=schoolyourself-xblock
+    - name: git+https://github.com/edx/schoolyourself-xblock.git@c0c980be0a0fd00a653afc80d2cfd147f8f8987d#egg=schoolyourself-xblock
       extra_args: -e
     # Prototype XBlocks from edX learning sciences limited roll-outs and user testing.
     # Concept XBlock, in particular, is nowhere near finished and an early prototype.
@@ -261,7 +261,7 @@ EDXAPP_PRIVATE_REQUIREMENTS:
       extra_args: -e
     # Peer instruction XBlock
     # Need it from github until we can land https://github.com/ubc/ubcpi/pull/167 upstream.
-    - name: git+https://github.com/edx/ubcpi.git@0964302acb29a7bbdd145a1bcb6c8a45b0080343#egg=ubcpi-xblock
+    - name: git+https://github.com/edx/ubcpi.git@7b7a54ef4b99614f749128d3a1f47d31c143e25b#egg=ubcpi-xblock
       extra_args: -e
     # Vector Drawing and ActiveTable XBlocks (Davidson)
     - name: git+https://github.com/open-craft/xblock-vectordraw.git@76976425356dfc7f13570f354c0c438db84c2840#egg=xblock-vectordraw==0.3.0
@@ -275,7 +275,7 @@ EDXAPP_PRIVATE_REQUIREMENTS:
       extra_args: -e
     - name: git+https://github.com/edx/xblock-in-video-quiz.git@c1cc11f87285cd885d76604145433dae87434a6d#egg=invideoquiz-xblock
       extra_args: -e
-    - name: git+https://github.com/edx/xblock-submit-and-compare@84f09c9bef89bdb6371ee65e859364fca377ae00#egg=xblock-submit-and-compare
+    - name: git+https://github.com/edx/xblock-submit-and-compare@338cb3dd3c4ff5c50d509f34baaaf451255fdbc3#egg=xblock-submit-and-compare
       extra_args: -e
     - name: git+https://github.com/edx/xblock-free-text-response@cc85ca0d4aaab26c0362667c207d99dd0622878a#egg=xblock-free-text-response
       extra_args: -e


### PR DESCRIPTION
### [PROD-1440](https://openedx.atlassian.net/browse/PROD-1440)

#### Description
Updating packages that have been updated to handle fragment `DeprecationWarning`. This work is concerned with removing unnecessary logs to have more history on Splunk.

**ubcpi PR**: https://github.com/edx/ubcpi/pull/2
**xblock-submit-and-compare PR**: https://github.com/edx/xblock-submit-and-compare/pull/3
**school-yourself PR**: https://github.com/edx/schoolyourself-xblock/pull/5
