### PR TITLE
CRI-171 Makes the forum mongo authentication mechanism configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 All notable changes to this project will be documented in this file.
 Add any new changes to the top(right below this line).
 
+- Role: forum
+  - Added `FORUM_MONGO_AUTH_MECH` to allow the authentication mechanism to be configurable.
+    Must be set if user credentials are in the connection string.
+    Defaults to `":scram"`, which is supported by Mongo>=3.0, because `":mongodb_cr"` is removed in Mongo>=4.0.
+    Use `":mongodb_cr"` for mongo 2.6.
+
 - Docker: edxapp
   - Disable install of private requirements for docker devstack. 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Add any new changes to the top(right below this line).
 
 - Role: forum
   - Added `FORUM_MONGO_AUTH_MECH` to allow the authentication mechanism to be configurable.
-    Must be set if user credentials are in the connection string.
+    Must be set if user credentials are in the connection string, or use `""` if no user credentials required.
     Defaults to `":scram"`, which is supported by Mongo>=3.0, because `":mongodb_cr"` is removed in Mongo>=4.0.
     Use `":mongodb_cr"` for mongo 2.6.
 

--- a/playbooks/roles/forum/defaults/main.yml
+++ b/playbooks/roles/forum/defaults/main.yml
@@ -20,6 +20,9 @@ FORUM_MONGO_TAGS: !!null
 FORUM_MONGO_PORT: "27017"
 FORUM_MONGO_DATABASE: "cs_comments_service"
 FORUM_MONGO_AUTH_DB: ""
+# Must be set if user credentials are provided.
+# Can be one of :scram, :mongodb_cr, :mongodb_x509, :plain, or empty/null if no credentials.
+FORUM_MONGO_AUTH_MECH: ":scram"
 FORUM_MONGO_USE_SSL: false
 FORUM_MONGO_URL: "mongodb://{{ FORUM_MONGO_USER }}:{{ FORUM_MONGO_PASSWORD }}@{%- for host in FORUM_MONGO_HOSTS -%}{{ host }}:{{ FORUM_MONGO_PORT }}{%- if not loop.last -%},{%- endif -%}{%- endfor -%}/{{ FORUM_MONGO_DATABASE }}{%- if FORUM_MONGO_TAGS -%}?tags={{ FORUM_MONGO_TAGS }}{%- endif -%}"
 FORUM_SINATRA_ENV: "development"
@@ -61,6 +64,7 @@ forum_base_env: &forum_base_env
   MONGOHQ_URL: "{{ FORUM_MONGO_URL }}"
   MONGOID_USE_SSL: "{{ FORUM_MONGO_USE_SSL }}"
   MONGOID_AUTH_SOURCE: "{{ FORUM_MONGO_AUTH_DB }}"
+  MONGOID_AUTH_MECH: "{{ FORUM_MONGO_AUTH_MECH }}"
   HOME: "{{ forum_app_dir }}"
   NEW_RELIC_ENABLE: "{{ FORUM_NEW_RELIC_ENABLE }}"
   NEW_RELIC_APP_NAME: "{{ FORUM_NEW_RELIC_APP_NAME }}"
@@ -79,6 +83,7 @@ devstack_forum_env:
   SINATRA_ENV: "development"
   SEARCH_SERVER: "http://edx.devstack.elasticsearch:9200/"
   MONGOHQ_URL: "mongodb://cs_comments_service:password@edx.devstack.mongo:27017/cs_comments_service"
+  MONGOID_AUTH_MECH: "{{ FORUM_MONGO_AUTH_MECH }}"
 
 forum_user: "forum"
 forum_ruby_version: "2.5.7"

--- a/playbooks/roles/forum/defaults/main.yml
+++ b/playbooks/roles/forum/defaults/main.yml
@@ -21,7 +21,7 @@ FORUM_MONGO_PORT: "27017"
 FORUM_MONGO_DATABASE: "cs_comments_service"
 FORUM_MONGO_AUTH_DB: ""
 # Must be set if user credentials are provided.
-# Can be one of :scram, :mongodb_cr, :mongodb_x509, :plain, or empty/null if no credentials.
+# Can be one of :scram, :mongodb_cr, :mongodb_x509, :plain, or empty string "" if no credentials.
 FORUM_MONGO_AUTH_MECH: ":scram"
 FORUM_MONGO_USE_SSL: false
 FORUM_MONGO_URL: "mongodb://{{ FORUM_MONGO_USER }}:{{ FORUM_MONGO_PASSWORD }}@{%- for host in FORUM_MONGO_HOSTS -%}{{ host }}:{{ FORUM_MONGO_PORT }}{%- if not loop.last -%},{%- endif -%}{%- endfor -%}/{{ FORUM_MONGO_DATABASE }}{%- if FORUM_MONGO_TAGS -%}?tags={{ FORUM_MONGO_TAGS }}{%- endif -%}"


### PR DESCRIPTION
Adds ansible variable to set the forum mongo authentication mechanism.

**JIRA tickets**: [CRI-186](https://openedx.atlassian.net/browse/CRI-186), [OSPR-4403](https://openedx.atlassian.net/browse/OSPR-4403), [SE-2321](https://tasks.opencraft.com/browse/SE-2321)

**Discussions**: [Discussion forum errors in latest master with mongo 3.2](https://discuss.openedx.org/t/discussion-forum-errors-in-latest-master-with-mongo-3-2/1843/5)

**Dependencies**: Relates to https://github.com/edx/cs_comments_service/pull/316

**Sandbox URL**: See https://github.com/edx/cs_comments_service/pull/316

**Merge deadline**: ASAP, fix needed in Juniper

**Testing instructions**:

See https://github.com/edx/cs_comments_service/pull/316 under "Sandbox".

**Reviewers**
- [ ] @toxinu
- [ ] edX reviewer[s] TBD

FYI @bderusha 

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [x] Are you adding any new default values that need to be overridden when this change goes live? No, default value leaves behaviour unchanged.
    If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [x] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Simple change.
        Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
         Will post info on [Juniper Confluence](https://openedx.atlassian.net/wiki/spaces/COMM/pages/940048716/Juniper).