### PR TITLE
If ansible fails, decode the error message to make it readable.

### DIFF
--- a/util/ansible_msg.py
+++ b/util/ansible_msg.py
@@ -1,8 +1,8 @@
-#!/usr/bin/env python3.6
+#!/usr/bin/env python
 """Simple utility for deciphering Ansible jsonized task output."""
 
-from __future__ import absolute_import
 from __future__ import print_function
+
 import json
 import sys
 
@@ -15,11 +15,12 @@ else:
     f = sys.stdin
 
 junk = f.read()
+if not junk:
+    print("No message to decode.")
+    sys.exit()
 
 # junk:
 # '==> default: failed: [localhost] (item=/edx/app/edx_ansible/edx_ansible/requirements.txt) => {"cmd": "/edx/app/edx...'
-
-print(("Stdin is {} chars: {!r}...{!r}".format(len(junk), junk[:40], junk[-40:])))
 
 junk = junk.replace('\n', '')
 junk = junk[junk.index('=> {')+3:]
@@ -27,16 +28,17 @@ junk = junk[:junk.rindex('}')+1]
 
 data = json.loads(junk)
 
-GOOD_KEYS = ['cmd', 'msg', 'stdout', 'stderr', 'module_stdout', 'module_stderr', 'warnings']
+# Order these so that the most likely useful messages are last.
+GOOD_KEYS = ['cmd', 'module_stdout', 'module_stderr', 'warnings', 'msg', 'censored', 'stderr', 'stdout']
 IGNORE_KEYS = ['stdout_lines', 'stderr_lines', 'start', 'end', 'delta', 'changed', 'failed', 'rc', 'item']
-
-for key in GOOD_KEYS:
-    if data.get(key):
-        print(f"== {key} ===========================")
-        print((data[key]))
 
 unknown_keys = set(data) - set(GOOD_KEYS) - set(IGNORE_KEYS)
 if unknown_keys:
     print("== Unknown keys ======================")
     for key in unknown_keys:
-        print(f"{key}: {data[key]!r:80}")
+        print("{key}: {val!r:80}".format(key=key, val=data[key]))
+
+for key in GOOD_KEYS:
+    if data.get(key):
+        print("== {key} ===========================".format(key=key))
+        print((data[key]))

--- a/util/install/native.sh
+++ b/util/install/native.sh
@@ -72,7 +72,7 @@ fi
 ##
 
 mkdir -p logs
-log_file=logs/install-$(date +%Y%m%d-%H%M%S).log
+log_file=$(realpath logs/install-$(date +%Y%m%d-%H%M%S).log)
 exec > >(tee $log_file) 2>&1
 echo "Capturing output to $log_file"
 echo "Installation started at $(date '+%Y-%m-%d %H:%M:%S')"
@@ -168,14 +168,22 @@ ansible_status=$?
 
 if [[ $ansible_status -ne 0 ]]; then
     echo " "
-    echo "========================================"
+    echo "============================================================"
     echo "Ansible failed!"
-    echo "----------------------------------------"
+    echo "------------------------------------------------------------"
+    echo " "
+    echo "Decoded error:"
+    # Find the FAILED line before the "to retry," line, and decode it.
+    awk '/to retry,/{if (bad) print bad} /FAILED/{bad=$0}' $log_file | python3 /var/tmp/configuration/util/ansible_msg.py
+    echo " "
+    echo "============================================================"
+    echo "Installation failed!"
+    echo "------------------------------------------------------------"
     echo "If you need help, see https://open.edx.org/getting-help ."
     echo "When asking for help, please provide as much information as you can."
     echo "These might be helpful:"
     echo "    Your log file is at $log_file"
     echo "    Your environment:"
     env | egrep -i 'version|release' | sed -e 's/^/        /'
-    echo "========================================"
+    echo "============================================================"
 fi


### PR DESCRIPTION
When installing Open edX, if ansible fails, use the ansible message decoder to include a readable version of the error in the output and logs.

I tested this with the recent ecommerce migration error.  Now the end of the installation looks like this (I've truncated the very long FAILED line here):
```
TASK [edx_django_service : migrate database] ***********************************
fatal: [localhost]: FAILED! => {"changed": true, "cmd": ["make", "migrate"], "delta": "0:00:52.729094", "end": "2020-04-29 19:46:44.086599", ....(much text deleted here)....

NO MORE HOSTS LEFT *************************************************************
	to retry, use: --limit @/var/tmp/configuration/playbooks/openedx_native.retry

PLAY RECAP *********************************************************************
localhost                  : ok=313  changed=120  unreachable=0    failed=1


============================================================
Ansible failed!
------------------------------------------------------------

Decoded error:
== cmd ===========================
['make', 'migrate']
== msg ===========================
non-zero return code
== stderr ===========================
WARNING: You are using pip version 19.3.1; however, version 20.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
make: *** [migrate] Error 1
== stdout ===========================
pip install -r requirements/tox.txt --exists-action w
Collecting filelock==3.0.12
  Downloading https://files.pythonhosted.org/packages/93/83/71a2ee6158bb9f39a90c0dea1637f81d5eef866e188e1971a1b1ab01a35a/filelock-3.0.12-py3-none-any.whl
Collecting importlib-metadata==1.6.0
  Downloading https://files.pythonhosted.org/packages/ad/e4/891bfcaf868ccabc619942f27940c77a8a4b45fd8367098955bb7e152fb1/importlib_metadata-1.6.0-py2.py3-none-any.whl
Collecting packaging==20.3
  Downloading https://files.pythonhosted.org/packages/62/0a/34641d2bf5c917c96db0ded85ae4da25b6cd922d6b794648d4e7e07c88e5/packaging-20.3-py2.py3-none-any.whl
Collecting pluggy==0.13.1
  Downloading https://files.pythonhosted.org/packages/a0/28/85c7aa31b80d150b772fbe4a229487bc6644da9ccb7e427dd8cc60cb8a62/pluggy-0.13.1-py2.py3-none-any.whl
Collecting py==1.8.1
  Downloading https://files.pythonhosted.org/packages/99/8d/21e1767c009211a62a8e3067280bfce76e89c9f876180308515942304d2d/py-1.8.1-py2.py3-none-any.whl (83kB)
Collecting pyparsing==2.4.7
  Downloading https://files.pythonhosted.org/packages/8a/bb/488841f56197b13700afd5658fc279a2025a39e22449b7cf29864669b15d/pyparsing-2.4.7-py2.py3-none-any.whl (67kB)
Requirement already satisfied: six==1.14.0 in /edx/app/ecommerce/venvs/ecommerce/lib/python3.5/site-packages (from -r requirements/tox.txt (line 13)) (1.14.0)
Collecting toml==0.10.0
  Downloading https://files.pythonhosted.org/packages/a2/12/ced7105d2de62fa7c8fb5fce92cc4ce66b57c95fb875e9318dba7f8c5db0/toml-0.10.0-py2.py3-none-any.whl
Collecting tox-battery==0.5.2
  Downloading https://files.pythonhosted.org/packages/f4/be/38ea85a689eff5fefa7385feb7e71a17a6cb8eb45f1ba2bd54a1d153d4ef/tox_battery-0.5.2-py2.py3-none-any.whl
Collecting tox==3.14.6
  Downloading https://files.pythonhosted.org/packages/7b/4b/a90a0a89db60fc39fc92e31e7da436177a12c06038973c8b7199f47b47c0/tox-3.14.6-py2.py3-none-any.whl (81kB)
Collecting virtualenv==16.7.9
  Downloading https://files.pythonhosted.org/packages/05/f1/2e07e8ca50e047b9cc9ad56cf4291f4e041fa73207d000a095fe478abf84/virtualenv-16.7.9-py2.py3-none-any.whl (3.4MB)
Collecting zipp==1.2.0
  Downloading https://files.pythonhosted.org/packages/96/0a/67556e9b7782df7118c1f49bdc494da5e5e429c93aa77965f33e81287c8c/zipp-1.2.0-py2.py3-none-any.whl
Installing collected packages: filelock, zipp, importlib-metadata, pyparsing, packaging, pluggy, py, toml, virtualenv, tox, tox-battery
Successfully installed filelock-3.0.12 importlib-metadata-1.6.0 packaging-20.3 pluggy-0.13.1 py-1.8.1 pyparsing-2.4.7 toml-0.10.0 tox-3.14.6 tox-battery-0.5.2 virtualenv-16.7.9 zipp-1.2.0
tox -e py35-migrate
py35-migrate create: /edx/app/ecommerce/ecommerce/.tox/py35
py35-migrate installdeps: -r/edx/app/ecommerce/ecommerce/requirements/test.txt
py35-migrate installed: amqp==1.4.9,analytics-python==1.2.9,anyjson==0.3.3,appdirs==1.4.3,astroid==2.3.3,attrs==19.3.0,Babel==2.8.0,beautifulsoup4==4.9.0,billiard==3.3.0.23,bleach==3.1.4,bok-choy==1.0.1,cached-property==1.5.1,celery==3.1.26.post2,certifi==2020.4.5.1,cffi==1.14.0,chardet==3.0.4,coreapi==2.3.3,coreschema==0.0.4,coverage==5.1,cryptography==2.9,cssselect==1.1.0,cssutils==1.0.2,ddt==1.3.1,defusedxml==0.6.0,diff-cover==2.6.1,Django==2.2.12,django-appconf==1.0.3,django-compressor==2.4,django-cors-headers==3.2.1,django-crispy-forms==1.8.1,django-crum==0.7.5,django-extensions==2.2.9,django-extra-views==0.11.0,django-filter==2.2.0,django-haystack==2.8.1,django-libsass==0.8,django-model-utils==3.2.0,django-oscar==2.0.4,django-phonenumber-field==2.0.1,django-rest-swagger==2.2.0,django-simple-history==2.8.0,django-solo==1.1.3,django-tables2==1.21.2,django-threadlocals==0.10,django-treebeard==4.3.1,django-waffle==0.20.0,django-webtest==1.9.7,django-widget-tweaks==1.4.8,djangorestframework==3.11.0,djangorestframework-csv==2.1.0,djangorestframework-datatables==0.5.2,drf-extensions==0.6.0,drf-jwt==1.14.0,edx-auth-backends==3.0.2,edx-django-release-util==0.4.2,edx-django-sites-extensions==2.4.3,edx-django-utils==3.2.1,edx-drf-extensions==5.0.2,edx-ecommerce-worker==0.7.2,edx-i18n-tools==0.5.0,edx-opaque-keys==2.0.2,edx-rbac==1.1.3,edx-rest-api-client==1.9.2,factory-boy==2.12.0,Faker==4.0.3,filelock==3.0.12,freezegun==0.3.15,future==0.18.2,httpretty==0.9.7,idna==2.9,importlib-metadata==1.6.0,inflect==3.0.2,isodate==0.6.0,isort==4.3.21,itypes==1.1.0,Jinja2==2.11.2,jinja2-pluralize==0.3.0,jsonfield2==3.0.3,kombu==3.0.37,lazy==1.4,lazy-object-proxy==1.4.3,libsass==0.9.2,lxml==4.5.0,Markdown==2.6.9,MarkupSafe==1.1.1,mccabe==0.6.1,mock==3.0.5,mock-django==0.6.10,more-itertools==8.2.0,mysqlclient==1.4.6,ndg-httpsclient==0.5.1,newrelic==5.12.0.140,oauthlib==3.1.0,openapi-codec==1.3.2,packaging==20.3,path.py==7.2,pathlib2==2.3.5,paypalrestsdk==1.13.1,pbr==5.4.5,phonenumbers==8.12.1,Pillow==7.1.1,pluggy==0.13.1,polib==1.1.0,premailer==2.9.2,psutil==1.2.1,purl==1.5,py==1.8.1,pyasn1==0.4.8,pycodestyle==2.5.0,pycountry==17.1.8,pycparser==2.20,pycryptodomex==3.9.7,Pygments==2.6.1,pyjwkest==1.4.2,PyJWT==1.7.1,pylint==2.4.4,pymongo==3.10.1,pyOpenSSL==19.1.0,pyparsing==2.4.7,pytest==5.3.5,pytest-base-url==1.4.1,pytest-cov==2.8.1,pytest-django==3.9.0,pytest-django-ordering==1.2.0,pytest-html==1.22.1,pytest-metadata==1.8.0,pytest-randomly==3.2.1,pytest-selenium==1.17.0,pytest-timeout==1.3.4,pytest-variables==1.9.0,python-dateutil==2.8.1,python-dotenv==0.12.0,python-memcached==1.58,python3-openid==3.1.0,pytz==2016.10,PyYAML==5.3.1,rcssmin==1.0.6,requests==2.23.0,requests-oauthlib==1.3.0,requests-toolbelt==0.9.1,responses==0.10.12,rest-condition==1.0.3,rjsmin==1.1.0,rules==2.2,sailthru-client==2.2.3,selenium==3.141.0,semantic-version==2.8.4,simplejson==3.17.0,six==1.14.0,slumber==0.7.1,social-auth-app-django==3.1.0,social-auth-core==3.3.3,sorl-thumbnail==12.6.3,soupsieve==2.0,sqlparse==0.3.1,stevedore==1.32.0,stripe==1.70.0,testfixtures==6.14.0,text-unidecode==1.3,toml==0.10.0,tox==3.14.6,tox-battery==0.5.2,typed-ast==1.4.1,unicodecsv==0.14.1,uritemplate==3.0.1,urllib3==1.25.8,virtualenv==16.7.9,waitress==1.4.3,wcwidth==0.1.9,webencodings==0.5.1,WebOb==1.8.6,WebTest==2.0.34,wrapt==1.11.2,xss-utils==0.1.2,zeep==3.4.0,zipp==1.2.0
py35-migrate run-test-pre: PYTHONHASHSEED='2712804318'
py35-migrate run-test: commands[0] | python manage.py migrate --noinput
/edx/app/ecommerce/ecommerce/ecommerce/settings/production.py:59: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
  config_from_yaml = yaml.load(f)
Traceback (most recent call last):
  File "manage.py", line 12, in <module>
    execute_from_command_line(sys.argv)
  File "/edx/app/ecommerce/ecommerce/.tox/py35/lib/python3.5/site-packages/django/core/management/__init__.py", line 381, in execute_from_command_line
    utility.execute()
  File "/edx/app/ecommerce/ecommerce/.tox/py35/lib/python3.5/site-packages/django/core/management/__init__.py", line 375, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/edx/app/ecommerce/ecommerce/.tox/py35/lib/python3.5/site-packages/django/core/management/base.py", line 323, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/edx/app/ecommerce/ecommerce/.tox/py35/lib/python3.5/site-packages/django/core/management/base.py", line 361, in execute
    self.check()
  File "/edx/app/ecommerce/ecommerce/.tox/py35/lib/python3.5/site-packages/django/core/management/base.py", line 390, in check
    include_deployment_checks=include_deployment_checks,
  File "/edx/app/ecommerce/ecommerce/.tox/py35/lib/python3.5/site-packages/django/core/management/commands/migrate.py", line 64, in _run_checks
    issues = run_checks(tags=[Tags.database])
  File "/edx/app/ecommerce/ecommerce/.tox/py35/lib/python3.5/site-packages/django/core/checks/registry.py", line 72, in run_checks
    new_errors = check(app_configs=app_configs)
  File "/edx/app/ecommerce/ecommerce/.tox/py35/lib/python3.5/site-packages/django/core/checks/database.py", line 10, in check_database_backends
    issues.extend(conn.validation.check(**kwargs))
  File "/edx/app/ecommerce/ecommerce/.tox/py35/lib/python3.5/site-packages/django/db/backends/mysql/validation.py", line 9, in check
    issues.extend(self._check_sql_mode(**kwargs))
  File "/edx/app/ecommerce/ecommerce/.tox/py35/lib/python3.5/site-packages/django/db/backends/mysql/validation.py", line 13, in _check_sql_mode
    with self.connection.cursor() as cursor:
  File "/edx/app/ecommerce/ecommerce/.tox/py35/lib/python3.5/site-packages/django/db/backends/base/base.py", line 256, in cursor
    return self._cursor()
  File "/edx/app/ecommerce/ecommerce/.tox/py35/lib/python3.5/site-packages/django/db/backends/base/base.py", line 233, in _cursor
    self.ensure_connection()
  File "/edx/app/ecommerce/ecommerce/.tox/py35/lib/python3.5/site-packages/django/db/backends/base/base.py", line 217, in ensure_connection
    self.connect()
  File "/edx/app/ecommerce/ecommerce/.tox/py35/lib/python3.5/site-packages/django/db/backends/base/base.py", line 190, in connect
    self.close_at = None if max_age is None else time.time() + max_age
TypeError: unsupported operand type(s) for +: 'float' and 'str'
ERROR: InvocationError for command /edx/app/ecommerce/ecommerce/.tox/py35/bin/python manage.py migrate --noinput (exited with code 1)
___________________________________ summary ____________________________________
ERROR:   py35-migrate: commands failed
Makefile:52: recipe for target 'migrate' failed

============================================================
Installation failed!
------------------------------------------------------------
If you need help, see https://open.edx.org/getting-help .
When asking for help, please provide as much information as you can.
These might be helpful:
    Your log file is at /home/ubuntu/logs/install-20200429-191952.log
    Your environment:
        CONFIGURATION_VERSION=nedbat/test-auto-decode
        TIG_LS_REMOTE=ls-remote-grep -v release-candidate
        OPENEDX_RELEASE=open-release/juniper.rc1
        LC_TERMINAL_VERSION=3.3.9
============================================================
Installation finished at 2020-04-29 19:46:44
```


Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
