### PR TITLE
Enable JWT settings for Open edX installs CRI-173

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file.
 Add any new changes to the top(right below this line).
 
+- Role: all
+  - Split the COMMON_SANDBOX_BUILD variable with its two components: SANDBOX_CONFIG and CONFIGURE_JWTS.
+
 - Role: edxapp
   - enable paver autocomplete in docker devstack
 
@@ -12,7 +15,7 @@ Add any new changes to the top(right below this line).
     Use `":mongodb_cr"` for mongo 2.6.
 
 - Docker: edxapp
-  - Disable install of private requirements for docker devstack. 
+  - Disable install of private requirements for docker devstack.
 
 - Roles: edx_django_service, registrar, enterprise_catalog
   - Moved celery worker supervisor config files/scripts into edx_django_service

--- a/playbooks/openedx_native.yml
+++ b/playbooks/openedx_native.yml
@@ -27,6 +27,7 @@
     COMMON_ENABLE_AWS_ROLE: false
     ecommerce_create_demo_data: true
     credentials_create_demo_data: true
+    CONFIGURE_JWTS: true
     SANDBOX_ENABLE_BLOCKSTORE: false
     SANDBOX_ENABLE_DISCOVERY: true
     SANDBOX_ENABLE_ECOMMERCE: true

--- a/playbooks/roles/common_vars/defaults/main.yml
+++ b/playbooks/roles/common_vars/defaults/main.yml
@@ -269,7 +269,10 @@ COMMON_COPY_CONFIG_ENABLED: false
 COMMON_CONFIG_NO_LOGGING: True
 
 # Default sandbox build flag to false
-COMMON_SANDBOX_BUILD: False
+SANDBOX_CONFIG: False
+
+# Should we create the JWT settings?
+CONFIGURE_JWTS: false
 
 # Variable to control setting up the retirement services
 COMMON_RETIREMENT_SERVICE_SETUP: false

--- a/playbooks/roles/edx_django_service/tasks/main.yml
+++ b/playbooks/roles/edx_django_service/tasks/main.yml
@@ -400,7 +400,7 @@
 - name: Include JWT signature setting in the app config file
   include_role:
     name: jwt_signature
-  when: COMMON_SANDBOX_BUILD
+  when: CONFIGURE_JWTS
   vars:
      app_name: '{{ edx_django_service_name }}'
      app_config_file: "{{ edx_django_service_app_config_file }}"

--- a/playbooks/roles/edx_service/tasks/main.yml
+++ b/playbooks/roles/edx_service/tasks/main.yml
@@ -120,7 +120,7 @@
     path: "{{ UNENCRYPTED_CFG_DIR }}/{{ edx_service_name }}.yml"
     regexp: 'deploy_host'
     replace: "{{ COMMON_DEPLOY_HOSTNAME }}"
-  when: edx_service_decrypt_config_enabled and COMMON_SANDBOX_BUILD
+  when: edx_service_decrypt_config_enabled and SANDBOX_CONFIG
   no_log: "{{ COMMON_CONFIG_NO_LOGGING }}"
   become: false
   delegate_to: localhost

--- a/playbooks/roles/edxapp/tasks/main.yml
+++ b/playbooks/roles/edxapp/tasks/main.yml
@@ -176,7 +176,7 @@
 - name: Include JWT signature setting in the app config file
   include_role:
     name: jwt_signature
-  when: COMMON_SANDBOX_BUILD and celery_worker is not defined
+  when: CONFIGURE_JWTS and celery_worker is not defined
   vars:
      app_name: 'lms'
      app_config_file: "{{ COMMON_CFG_DIR }}/lms.yml"

--- a/playbooks/roles/edxapp/tasks/service_variant_config.yml
+++ b/playbooks/roles/edxapp/tasks/service_variant_config.yml
@@ -107,7 +107,7 @@
     regexp: 'deploy_host'
     replace: "{{ COMMON_DEPLOY_HOSTNAME }}"
   with_items: ['lms','studio']
-  when: EDXAPP_DECRYPT_CONFIG_ENABLED and COMMON_SANDBOX_BUILD
+  when: EDXAPP_DECRYPT_CONFIG_ENABLED and SANDBOX_CONFIG
   no_log: "{{ COMMON_CONFIG_NO_LOGGING }}"
   become: false
   delegate_to: localhost

--- a/playbooks/sample_vars/passwords.yml
+++ b/playbooks/sample_vars/passwords.yml
@@ -91,3 +91,8 @@ RABBIT_USERS:
     password: "{{ XQUEUE_RABBITMQ_PASS }}"
   - name: 'celery'
     password: "{{ EDXAPP_CELERY_PASSWORD }}"
+
+# JWT-related settings
+COMMON_JWT_AUDIENCE: !!null
+COMMON_JWT_SECRET_KEY: !!null #SECRET_KEY
+ECOMMERCE_WORKER_JWT_SECRET_KEY: !!null #SECRET_KEY

--- a/playbooks/worker.yml
+++ b/playbooks/worker.yml
@@ -16,7 +16,7 @@
     - role: datadog-uninstall
       when: not COMMON_ENABLE_DATADOG
     - role: jwt_signature
-      when: COMMON_SANDBOX_BUILD
+      when: CONFIGURE_JWTS
       app_name: lms
       app_config_file: "{{ COMMON_CFG_DIR }}/lms.yml"
       app_config_owner: "{{ edxapp_user }}"

--- a/util/jenkins/ansible-provision.sh
+++ b/util/jenkins/ansible-provision.sh
@@ -222,7 +222,8 @@ edx_ansible_source_repo: ${configuration_source_repo}
 edx_platform_repo: ${edx_platform_repo}
 
 EDXAPP_PLATFORM_NAME: $sandbox_platform_name
-COMMON_SANDBOX_BUILD: True
+SANDBOX_CONFIG: True
+CONFIGURE_JWTS: True
 
 EDXAPP_STATIC_URL_BASE: $static_url_base
 EDXAPP_LMS_NGINX_PORT: 80


### PR DESCRIPTION
This also splits COMMON_SANDBOX_BUILD into its two components: SANDBOX_CONFIG and CONFIGURE_JWTS.

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
