### PR TITLE
SE-2585 Add systemd override to auto restart mongod

### DIFF
--- a/playbooks/roles/mongo_3_2/files/etc/systemd/system/mongod.service.d/restart.conf
+++ b/playbooks/roles/mongo_3_2/files/etc/systemd/system/mongod.service.d/restart.conf
@@ -1,0 +1,3 @@
+[Service]
+Restart=always
+RestartSec=5

--- a/playbooks/roles/mongo_3_2/tasks/main.yml
+++ b/playbooks/roles/mongo_3_2/tasks/main.yml
@@ -370,6 +370,37 @@
     - "manage:db-users"
     - "manage:db-replication"
 
+- name: systemd mongod service override dir exists
+  file:
+    path: "/etc/systemd/system/mongod.service.d/"
+    state: directory
+    owner: root
+    group: root
+    mode: 0755
+  tags:
+    - "install"
+    - "install:configuration"
+
+- name: copy mongod service override file
+  copy:
+    src: "etc/systemd/system/mongod.service.d/restart.conf"
+    dest: "/etc/systemd/system/mongod.service.d/restart.conf"
+    owner: root
+    group: root
+    mode: 0644
+  register: mongod_service_override
+  tags:
+    - "install"
+    - "install:configuration"
+
+- name: reload systemd if override files changed
+  command:
+    cmd: "systemctl daemon-reload"
+  when: mongod_service_override.changed
+  tags:
+    - "install"
+    - "install:configuration"
+
 - name: ensure mongo starts at boot time
   service:
     name: mongod


### PR DESCRIPTION
Add systemd override to auto restart mongod

This ensures mongod is always auto restarted by systemd if it crashes or exits for some
reason. The 5 second wait is to reduce issues if mongod crashes quickly after startup.

(cherry picked from commit 16ec1a6f503e0bfcfee96b6b8a87914cdae45996) This is the master port from https://github.com/edx-olive/configuration/pull/20

**Jira tickets**: [OSPR-4493](https://openedx.atlassian.net/browse/OSPR-4493)

**Dependencies**: None

**Merge deadline**: None

**Test instructions**:

- see https://github.com/edx-olive/configuration/pull/20 (basically, run against a mongod node with the `install:configuration` tag. Run again to check idempotency.

**Reviewers**:

- [x] @itsjeyd 
- [ ] edX reviewers TBD
