### PR TITLE
Update blockstore git repo (it was moved to the edX GitHub org)

### DIFF
--- a/playbooks/roles/blockstore/defaults/main.yml
+++ b/playbooks/roles/blockstore/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # Role to deploy Blockstore, the next-generation Open edX Learning Object Repository
 #
-# github: https://github.com/open-craft/blockstore
+# github: https://github.com/edx/blockstore
 #
 
 blockstore_service_name: 'blockstore'
@@ -10,7 +10,7 @@ blockstore_home: '{{ COMMON_APP_DIR }}/{{ blockstore_service_name }}'
 blockstore_code_dir: '{{ blockstore_home }}/{{ blockstore_service_name }}'
 blockstore_venv_dir: '{{ blockstore_home }}/venvs/{{ blockstore_service_name }}'
 
-BLOCKSTORE_GIT_PATH: 'open-craft'
+BLOCKSTORE_GIT_PATH: 'edx'
 BLOCKSTORE_VERSION: 'master'
 BLOCKSTORE_GIT_IDENTITY: !!null
 

--- a/playbooks/roles/blockstore/meta/main.yml
+++ b/playbooks/roles/blockstore/meta/main.yml
@@ -1,7 +1,7 @@
 ---
 # Role to deploy Blockstore, the next-generation Open edX Learning Object Repository
 #
-# github: https://github.com/open-craft/blockstore
+# github: https://github.com/edx/blockstore
 #
 ##
 # Role includes for role blockstore

--- a/playbooks/roles/blockstore/tasks/main.yml
+++ b/playbooks/roles/blockstore/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 # Role to deploy Blockstore, the next-generation Open edX Learning Object Repository
 #
-# github: https://github.com/open-craft/blockstore
+# github: https://github.com/edx/blockstore
 #
 #
 # Tasks for role blockstore


### PR DESCRIPTION
The repo for blockstore is now https://github.com/edx/blockstore/ and https://github.com/open-craft/blockstore/ is our fork. This updates the deployment accordingly.