### PR TITLE
this is fine

### DIFF
--- a/playbooks/roles/common/tasks/main.yml
+++ b/playbooks/roles/common/tasks/main.yml
@@ -20,6 +20,7 @@
   get_url:
     url: "{{ common_digicert_base_url }}/{{ common_digicert_name }}.pem"
     dest: "/usr/local/share/ca-certificates/{{ common_digicert_name }}"
+    validate_certs: no
   when: update_ca_certificates is defined and update_ca_certificates.results[0].stat.exists == True
 
 - name: Update CA Certificates


### PR DESCRIPTION
![](https://i2.wp.com/thenib.com/wp-content/uploads/2019/08/this-is-not-fine-001-dae9d5-1.png?w=800&ssl=1)

This is breaking builds because digicert is serving their intermediate certs off a server which is, itself, not serving a complete certificate chain.