### PR TITLE
switched to python 3 for selected files

### DIFF
--- a/playbooks/roles/ecommerce/defaults/main.yml
+++ b/playbooks/roles/ecommerce/defaults/main.yml
@@ -307,7 +307,7 @@ ecommerce_debian_pkgs:
   - libffi-dev
   - libsqlite3-dev
   - python-dev
-  - python3-dev
+  - python3.8-dev
 
 ecommerce_redhat_pkgs: []
 

--- a/playbooks/roles/ecomworker/tasks/main.yml
+++ b/playbooks/roles/ecomworker/tasks/main.yml
@@ -8,7 +8,7 @@
 # license:    https://github.com/edx/configuration/blob/master/LICENSE.TXT
 #
 # Tasks for role ecommerce_worker.
-# 
+#
 
 - name: install application requirements
   pip:

--- a/playbooks/roles/gitreload/tasks/main.yml
+++ b/playbooks/roles/gitreload/tasks/main.yml
@@ -10,13 +10,13 @@
 #
 #
 # Tasks for role gitreload
-# 
+#
 # Overview: Install gitreload for doing course reload via github Web hooks
-# 
+#
 #
 # Dependencies: supervisor, common
 #
-# 
+#
 # Example playbook:
 #
 # - hosts: all

--- a/util/install/ansible-bootstrap.sh
+++ b/util/install/ansible-bootstrap.sh
@@ -123,20 +123,20 @@ if [[ "${SHORT_DIST}" != bionic ]] ;then
 fi
 
 
-# Install python 2.7 latest, git and other common requirements
-# NOTE: This will install the latest version of python 2.7 and
+# Install python 3.5, git and other common requirements
+# NOTE: This will install python 3.5
 # which may differ from what is pinned in virtualenvironments
 apt-get update -y
 
-apt-get install -y python2.7 python2.7-dev python-pip python-apt python-jinja2 build-essential sudo git-core libmysqlclient-dev libffi-dev libssl-dev
+apt-get install -y python3.5 python3.5-dev python3-pip python3-apt python3-jinja2 build-essential sudo git-core libmysqlclient-dev libffi-dev libssl-dev
 
 
-pip install --upgrade pip=="${PIP_VERSION}"
+pip3 install --upgrade pip=="${PIP_VERSION}"
 
 # pip moves to /usr/local/bin when upgraded
 PATH=/usr/local/bin:${PATH}
-pip install setuptools=="${SETUPTOOLS_VERSION}"
-pip install virtualenv=="${VIRTUAL_ENV_VERSION}"
+pip3 install setuptools=="${SETUPTOOLS_VERSION}"
+pip3 install virtualenv=="${VIRTUAL_ENV_VERSION}"
 
 
 if [[ "true" == "${RUN_ANSIBLE}" ]]; then
@@ -154,6 +154,7 @@ if [[ "true" == "${RUN_ANSIBLE}" ]]; then
 
     cd "${CONFIGURATION_DIR}"/playbooks
     "${PYTHON_BIN}"/ansible-playbook edx_ansible.yml -i '127.0.0.1,' -c local -e "configuration_version=${CONFIGURATION_VERSION}"
+    "${PYTHON_BIN}"/ansible-playbook edx_ansible.yml -i '127.0.0.1,' -c local -e "ansible_python_interpreter=/usr/bin/python3"
 
     # cleanup
     rm -rf "${ANSIBLE_DIR}"

--- a/util/install/native.sh
+++ b/util/install/native.sh
@@ -99,12 +99,12 @@ sudo apt-get upgrade -y
 ##
 ## Install system pre-requisites
 ##
-sudo apt-get install -y build-essential software-properties-common curl git-core libxml2-dev libxslt1-dev python-pip libmysqlclient-dev python-apt python-dev libxmlsec1-dev libfreetype6-dev swig gcc g++
+sudo apt-get install -y build-essential software-properties-common curl git-core libxml2-dev libxslt1-dev python3.8-pip libmysqlclient-dev python3.8-apt libxmlsec1-dev libfreetype6-dev swig gcc g++
 # ansible-bootstrap installs yaml that pip 19 can't uninstall.
 sudo apt-get remove -y python-yaml
-sudo pip install --upgrade pip==20.0.2
-sudo pip install --upgrade setuptools==44.1.0
-sudo -H pip install --upgrade virtualenv==16.7.10
+sudo pip3 install --upgrade pip==20.0.2
+sudo pip3 install --upgrade setuptools==44.1.0
+sudo -H pip3 install --upgrade virtualenv==16.7.10
 
 ##
 ## Overridable version variables in the playbooks. Each can be overridden
@@ -158,12 +158,12 @@ git pull
 ## Install the ansible requirements
 ##
 cd /var/tmp/configuration
-sudo -H pip install -r requirements.txt
+sudo -H pip3 install -r requirements.txt
 
 ##
 ## Run the openedx_native.yml playbook in the configuration/playbooks directory
 ##
-cd /var/tmp/configuration/playbooks && sudo -E ansible-playbook -c local ./openedx_native.yml -i "localhost," $EXTRA_VARS "$@"
+cd /var/tmp/configuration/playbooks && sudo -E ansible-playbook -c local ./openedx_native.yml -i "localhost," $EXTRA_VARS "$@" -e 'ansible_python_interpreter=/usr/bin/python3'
 ansible_status=$?
 
 if [[ $ansible_status -ne 0 ]]; then


### PR DESCRIPTION
### Description

- Updated the `native.sh` and `ansible-bootstrap` scripts to use python 3 available by the operating system and install several python 3 dev tools and pip 3. 

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
