### PR TITLE
Install Python 3.8 in Jenkins workers and xenial-common

### DIFF
--- a/docker/build/xenial-common/Dockerfile
+++ b/docker/build/xenial-common/Dockerfile
@@ -23,7 +23,7 @@ ENV CONFIGURATION_VERSION="${OPENEDX_RELEASE}"
 # Add the deadsnakes PPA to install Python 3.8
 RUN apt-add-repository -y ppa:deadsnakes/ppa
 RUN apt-get update &&\
-    apt-get install -y python3.8-dev
+    apt-get install -y python3.8-dev python3.8-distutils
 
 ADD util/install/ansible-bootstrap.sh /tmp/ansible-bootstrap.sh
 RUN chmod +x /tmp/ansible-bootstrap.sh

--- a/docker/build/xenial-common/Dockerfile
+++ b/docker/build/xenial-common/Dockerfile
@@ -7,8 +7,9 @@ LABEL maintainer="edxops"
 # http://jaredmarkell.com/docker-and-locales/
 # https://github.com/docker-library/python/issues/13
 # https://github.com/docker-library/python/pull/14/files
+# Also install software-properties-common to get apt-add-repository
 RUN apt-get update &&\
-    apt-get install -y locales &&\
+    apt-get install -y locales software-properties-common &&\
     locale-gen en_US.UTF-8
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
@@ -18,6 +19,11 @@ ENV ANSIBLE_REPO="https://github.com/edx/ansible"
 ENV CONFIGURATION_REPO="https://github.com/edx/configuration.git"
 ARG OPENEDX_RELEASE=master
 ENV CONFIGURATION_VERSION="${OPENEDX_RELEASE}"
+
+# Add the deadsnakes PPA to install Python 3.8
+RUN apt-add-repository -y ppa:deadsnakes/ppa
+RUN apt-get update &&\
+    apt-get install -y python3.8-dev
 
 ADD util/install/ansible-bootstrap.sh /tmp/ansible-bootstrap.sh
 RUN chmod +x /tmp/ansible-bootstrap.sh

--- a/playbooks/roles/jenkins_worker/defaults/main.yml
+++ b/playbooks/roles/jenkins_worker/defaults/main.yml
@@ -29,6 +29,8 @@ jenkins_worker_python_versions:
   - 2.7
   - 3.5
   - 3.6
+  - 3.8
 
 edx_platform_python_versions:
   - 3.5
+  - 3.8

--- a/playbooks/roles/jenkins_worker/defaults/main.yml
+++ b/playbooks/roles/jenkins_worker/defaults/main.yml
@@ -31,6 +31,11 @@ jenkins_worker_python_versions:
   - 3.6
   - 3.8
 
+# The packaging for Python 3.7 and above split distutils out into a separate package;
+# needed for virtualenv creation
+jenkins_worker_distutils_versions:
+  - 3.8
+
 edx_platform_python_versions:
   - 3.5
   - 3.8

--- a/playbooks/roles/jenkins_worker/tasks/python.yml
+++ b/playbooks/roles/jenkins_worker/tasks/python.yml
@@ -4,7 +4,7 @@
 # newer
 - name: add deadsnakes PPA for newer Python versions
   apt_repository:
-    repo: "ppa:fkrull/deadsnakes"
+    repo: "ppa:deadsnakes/ppa"
     update_cache: yes
   when: ansible_distribution_release == 'xenial'
 
@@ -24,6 +24,14 @@
     state: present
     update_cache: yes
   with_items: '{{ jenkins_worker_python_versions }}'
+
+# Install 'distutils' packages for each installed version of python which has one
+- name: Install python distutils packages
+  apt:
+    name: 'python{{ item }}-distutils'
+    state: present
+    update_cache: yes
+  with_items: '{{ jenkins_worker_distutils_versions }}'
 
 # Requests library is required for the github status script.
 - name: Install requests Python library

--- a/playbooks/roles/test_build_server/files/test-development-environment.sh
+++ b/playbooks/roles/test_build_server/files/test-development-environment.sh
@@ -18,6 +18,7 @@ cd edx-platform-clone
 
 # This will run all of the setup it usually runs, but none of the
 # tests because TEST_SUITE isn't defined.
+export PYTHON_VERSION=3.5
 source scripts/jenkins-common.sh
 
 case "$1" in


### PR DESCRIPTION
Make some changes to facilitate testing our services under Python 3.8:

* Add the deadsnakes PPA to the xenial-common images and install python3.8-dev and python3.8-distutils from it.  This increases the image size from 1.04 GB to 1.06 GB, which I think we can live with.
* Switch jenkins-worker from the legacy deadsnakes PPA that only has up to Python 3.6 to the current one that has through 3.9
* Install Python 3.8 on jenkins_worker, including distutils which is now a separate package (and needed for virtualenv creation to succeed)
* Create an edx-platform virtualenv for Python 3.8 also, we already have Jenkins test jobs that need it
* Try to fix packer AMI builds by specifying the correct Python version to use when testing the image.  Without this, it doesn't use a virtualenv and blows up on a pip/pip-tools version incompatibility ([example](https://build.testeng.edx.org/job/build-packer-ami/14752/consoleFull))

Make sure that the following steps are done before merging:

  - [x] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
