### PR TITLE
[BD-6] Use sandbox py35 requirements  when not EDXAPP_PYTHON_SANDBOX

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -1649,7 +1649,8 @@ base_requirements_file:   "{{ edxapp_code_dir }}/requirements/edx/base.txt"
 django_requirements_file:   "{{ edxapp_code_dir }}/requirements/edx/django.txt"
 openstack_requirements_file: "{{ edxapp_code_dir }}/requirements/edx/openstack.txt"
 
-sandbox_base_requirements:  "{{ edxapp_code_dir }}/requirements/edx-sandbox/base.txt"
+sandbox_base_requirements: "{{ edxapp_code_dir }}/requirements/edx-sandbox/base.txt"
+sandbox_py35_requirements: "{{ edxapp_code_dir }}/requirements/edx-sandbox/py35.txt"
 
 # The Python requirements files in the order they should be installed.  This order should
 # match the order of PYTHON_REQ_FILES in edx-platform/pavelib/prereqs.py.

--- a/playbooks/roles/edxapp/tasks/deploy.yml
+++ b/playbooks/roles/edxapp/tasks/deploy.yml
@@ -208,7 +208,7 @@
   args:
     chdir: "{{ edxapp_code_dir }}"
   with_items:
-  - "{{ sandbox_base_requirements }}"
+  - "{{ sandbox_py35_requirements }}"
   become_user: "{{ edxapp_user }}"
   when: not EDXAPP_PYTHON_SANDBOX
   tags:


### PR DESCRIPTION
## Description

Use py35 requirements when installing the sandbox python modules into the edx-platform venv.

See issue in https://openedx.atlassian.net/browse/BOM-1642

## Reviewers
- [ ] @ericfab179
- [ ] @awais786