### PR TITLE
ARCHBOM-1239 - Be able to disable gunicorn instrumentation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file.
 Add any new changes to the top(right below this line).
 
+- Role: edxapp
+  - Added a new config variable `edxapp_newrelic_monitor_gunicorn` which will let you turn on/off monitoring of gunicorn via newrelic.  It defaults to true which will result in the same default behaviour we've historically had.
+
 - Role: all
   - Split the COMMON_SANDBOX_BUILD variable with its two components: SANDBOX_CONFIG and CONFIGURE_JWTS.
 

--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -1613,6 +1613,9 @@ edxapp_cms_gunicorn_host: 127.0.0.1
 edxapp_lms_gunicorn_port: 8000
 edxapp_lms_gunicorn_host: 127.0.0.1
 
+# used in newrelic.ini to enable/disable monitorig of gunicorn
+edxapp_newrelic_monitor_gunicorn: true
+
 # These vars are for creating the application json config
 # files.  There are two for each service that uses the
 # 'edx-platform' code.  Defining them will create the upstart

--- a/playbooks/roles/edxapp/templates/newrelic.ini.j2
+++ b/playbooks/roles/edxapp/templates/newrelic.ini.j2
@@ -27,3 +27,13 @@
 # `course_id`.
 #
 browser_monitoring.attributes.enabled=true
+
+
+# See https://docs.newrelic.com/docs/agents/python-agent/configuration/python-agent-configuration#builtin-instrumentation
+# for more details on this.
+
+# We want to optionally disable gunicorn monitoring so we can enable smart routing
+# of requests to specific APM applications.
+
+[import-hook:gunicorn.app.base]
+enabled={{ edxapp_newrelic_monitor_gunicorn }}


### PR DESCRIPTION
Make newrelic monitoring of gunicorn configurable.  We default it to
true which is what it is now by default.  This allows us to configure it
to be false in the future on a per environment basis as we roll it out.
