### PR TITLE
[BB-2447] Add `NGINX_ALLOW_PRIVATE_IP_ACCESS` variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 All notable changes to this project will be documented in this file.
 Add any new changes to the top(right below this line).
 
+ - 2020-08-17
+     - Role: nginx
+       - Added `NGINX_ALLOW_PRIVATE_IP_ACCESS` boolean, which allows to disable handling the IP disclosure within private subnetworks.
+         This is needed by ELB to run health checks while using encrypted connection between ELB and AppServer (`NGINX_ENABLE_SSL`).
+         Without this enabled, ELB will get `403` response when trying to reach the AppServer via its IP address (it is still impossible to specify the `Host` header for the health check).
+
  - 2020-08-01
      - Role: edxapp
        - Added `EDXAPP_SITE_CONFIGURATION` to allow creating/updating the `SiteConfiguration` values during provisioning.

--- a/playbooks/roles/edx_django_service/templates/edx/app/nginx/sites-available/concerns/handle-ip-disclosure.j2
+++ b/playbooks/roles/edx_django_service/templates/edx/app/nginx/sites-available/concerns/handle-ip-disclosure.j2
@@ -2,6 +2,11 @@
 # there is a TLS redirect to same box, and a TLS redirect to externally terminated TLS
 # version of this in nginx and in edx_django_service role.
 
+{% if NGINX_ALLOW_PRIVATE_IP_ACCESS %}
+# This regexp matches only public IP addresses.
+if ($host ~ "(\d+)(?<!10)\.(\d+)(?<!192\.168)(?<!172\.(1[6-9]|2\d|3[0-1]))\.(\d+)\.(\d+)") {
+{% else %}
 if ($host ~ "\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}") { 
+{% endif %}
   	return 403;
 } 

--- a/playbooks/roles/edx_django_service/templates/edx/app/nginx/sites-available/concerns/handle-tls-terminated-elsewhere-ip-disclosure.j2
+++ b/playbooks/roles/edx_django_service/templates/edx/app/nginx/sites-available/concerns/handle-tls-terminated-elsewhere-ip-disclosure.j2
@@ -3,7 +3,12 @@
 # there is a TLS redirect to same box, and a TLS redirect to externally terminated TLS
 # version of this in nginx and in edx_django_service role.
 
+{% if NGINX_ALLOW_PRIVATE_IP_ACCESS %}
+# This regexp matches only public IP addresses.
+if ($host ~ "(\d+)(?<!10)\.(\d+)(?<!192\.168)(?<!172\.(1[6-9]|2\d|3[0-1]))\.(\d+)\.(\d+)") {
+{% else %}
 if ($host ~ "\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}") { 
+{% endif %}
   set $test_ip_disclosure  A; 
 } 
 

--- a/playbooks/roles/edx_django_service_with_rendered_config/templates/edx/app/nginx/sites-available/concerns/handle-ip-disclosure.j2
+++ b/playbooks/roles/edx_django_service_with_rendered_config/templates/edx/app/nginx/sites-available/concerns/handle-ip-disclosure.j2
@@ -2,6 +2,11 @@
 # there is a TLS redirect to same box, and a TLS redirect to externally terminated TLS
 # version of this in nginx and in edx_django_service_with_rendered_config role.
 
+{% if NGINX_ALLOW_PRIVATE_IP_ACCESS %}
+# This regexp matches only public IP addresses.
+if ($host ~ "(\d+)(?<!10)\.(\d+)(?<!192\.168)(?<!172\.(1[6-9]|2\d|3[0-1]))\.(\d+)\.(\d+)") {
+{% else %}
 if ($host ~ "\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}") { 
+{% endif %}
   	return 403;
 } 

--- a/playbooks/roles/edx_django_service_with_rendered_config/templates/edx/app/nginx/sites-available/concerns/handle-tls-terminated-elsewhere-ip-disclosure.j2
+++ b/playbooks/roles/edx_django_service_with_rendered_config/templates/edx/app/nginx/sites-available/concerns/handle-tls-terminated-elsewhere-ip-disclosure.j2
@@ -3,7 +3,12 @@
 # there is a TLS redirect to same box, and a TLS redirect to externally terminated TLS
 # version of this in nginx and in edx_django_service_with_rendered_config role.
 
+{% if NGINX_ALLOW_PRIVATE_IP_ACCESS %}
+# This regexp matches only public IP addresses.
+if ($host ~ "(\d+)(?<!10)\.(\d+)(?<!192\.168)(?<!172\.(1[6-9]|2\d|3[0-1]))\.(\d+)\.(\d+)") {
+{% else %}
 if ($host ~ "\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}") { 
+{% endif %}
   set $test_ip_disclosure  A; 
 } 
 

--- a/playbooks/roles/nginx/defaults/main.yml
+++ b/playbooks/roles/nginx/defaults/main.yml
@@ -35,6 +35,8 @@ PROSPECTUS_PREVIEW_NGINX_USERS:
 
 NGINX_ENABLE_SSL: False
 NGINX_REDIRECT_TO_HTTPS: False
+# Disable handling IP disclosure for private IP addresses. This is needed by ELB to run the health checks while using `NGINX_ENABLE_SSL`.
+NGINX_ALLOW_PRIVATE_IP_ACCESS: False
 NGINX_HSTS_MAX_AGE: 31536000
 # Set these to real paths on your
 # filesystem, otherwise nginx will

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/handle-ip-disclosure.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/handle-ip-disclosure.j2
@@ -2,6 +2,11 @@
 # there is a TLS redirect to same box, and a TLS redirect to externally terminated TLS
 # version of this in nginx and in edx_django_service role.
 
+{% if NGINX_ALLOW_PRIVATE_IP_ACCESS %}
+# This regexp matches only public IP addresses.
+if ($host ~ "(\d+)(?<!10)\.(\d+)(?<!192\.168)(?<!172\.(1[6-9]|2\d|3[0-1]))\.(\d+)\.(\d+)") {
+{% else %}
 if ($host ~ "\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}") { 
+{% endif %}
   	return 403;
 } 

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/handle-tls-terminated-elsewhere-ip-disclosure.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/handle-tls-terminated-elsewhere-ip-disclosure.j2
@@ -2,7 +2,12 @@
 # there is a TLS redirect to same box, and a TLS redirect to externally terminated TLS
 # version of this in nginx and in edx_django_service role.
 
+{% if NGINX_ALLOW_PRIVATE_IP_ACCESS %}
+# This regexp matches only public IP addresses.
+if ($host ~ "(\d+)(?<!10)\.(\d+)(?<!192\.168)(?<!172\.(1[6-9]|2\d|3[0-1]))\.(\d+)\.(\d+)") {
+{% else %}
 if ($host ~ "\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}") { 
+{% endif %}
   set $test_ip_disclosure  A; 
 } 
 


### PR DESCRIPTION
Context: we are using `NGINX_ENABLE_SSL` variable to have the encrypted connection between ELB and AppServer, but this [adds](https://github.com/edx/configuration/blob/574cb0e396bcd8403b86a6000f8b573c81d4f5cd/playbooks/roles/edx_django_service/templates/edx/app/nginx/sites-available/app.j2#L13) IP disclosure handling, which returns `403` on attempt of reaching the server via its IP address. As it's [not possible](https://forums.aws.amazon.com/thread.jspa?messageID=423533) to specify the Host header for the health check, we should be able to set a variable that alters this behavior.

This adds a new variable called `NGINX_ALLOW_PRIVATE_IP_ACCESS`, which  allows to disable handling the IP disclosure within private subnetworks.

Breakdown of the used regexp ([source](https://stackoverflow.com/a/33453740)):
- `(\d+)(?<!10)` is used for the `10.0.0.0 – 10.255.255.255` range,
- `\.(\d+)(?<!192\.168)(?<!172\.(1[6-9]|2\d|3[0-1]))` handles `172.16.0.0  - 172.31.255.255 ` and `192.168.0.0 – 192.168.255.255` ranges.
- `\.(\d+)\.(\d+)` matches the remaining two octets.

**JIRA tickets**: [OSPR-4616](https://openedx.atlassian.net/browse/OSPR-4616)

**Dependencies**: None

**Merge deadline**: "None"

**Reviewers**
- [x] @lgp171188 (approved in open-craft/configuration/pull/126)
- [x] @pomegranited (Core Committer)
- [ ] edX reviewer[s] TBD


Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] <s>Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).</s>
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
