### PR TITLE
Don't create a py38 edx-platform virtualenv on Jenkins workers

### DIFF
--- a/playbooks/roles/jenkins_worker/defaults/main.yml
+++ b/playbooks/roles/jenkins_worker/defaults/main.yml
@@ -38,4 +38,3 @@ jenkins_worker_distutils_versions:
 
 edx_platform_python_versions:
   - 3.5
-  - 3.8


### PR DESCRIPTION
Configuration Pull Request
---

Nothing in Juniper uses Python 3.8, and edx-platform dependencies still don't install cleanly under it.  Stop trying to create an edx-platform virtualenv using it, as it causes the jenkins_worker Docker image build to fail.