### PR TITLE
[BD-6] Use insights.yml config file defined in this repo instead of the insi…

### DIFF
--- a/docker/build/insights/Dockerfile
+++ b/docker/build/insights/Dockerfile
@@ -13,7 +13,6 @@ LABEL maintainer="edxops"
 
 ADD . /edx/app/edx_ansible/edx_ansible
 COPY docker/build/insights/ansible_overrides.yml /
-COPY docker/build/insights/insights.yml /edx/etc/insights.yml
 
 WORKDIR /edx/app/edx_ansible/edx_ansible/docker/plays
 
@@ -24,6 +23,7 @@ RUN /edx/app/edx_ansible/venvs/edx_ansible/bin/ansible-playbook insights.yml \
     -t "install:base,install:system-requirements,install:configuration,install:app-requirements,install:code" \
     --extra-vars="INSIGHTS_VERSION=${OPENEDX_RELEASE}" \
     --extra-vars="@/ansible_overrides.yml"
+COPY docker/build/insights/insights.yml /edx/etc/insights.yml
 ADD docker/build/insights/devstack.sh /edx/app/insights/devstack.sh
 RUN chown insights:insights /edx/app/insights/devstack.sh && chmod a+x /edx/app/insights/devstack.sh
 ENTRYPOINT ["/edx/app/insights/devstack.sh"]


### PR DESCRIPTION
…ghts.yml file rendered by the playbook

This would unblock this PR https://github.com/edx/devstack/pull/480

Which is currently failing due to this error:

```
edx.devstack.insights     | django.db.utils.OperationalError: (2005, "Unknown MySQL server host 'db.edx' (0)")
```
https://travis-ci.org/github/edx/devstack/jobs/696543178

## Reviewers
- [ ] @ericfab179
- [ ] @awais786 
