### PR TITLE
Fix ecomworker Docker image builds ARCHBOM-1270

### DIFF
--- a/docker/build/ecomworker/Dockerfile
+++ b/docker/build/ecomworker/Dockerfile
@@ -7,7 +7,8 @@
 # This allows the dockerfile to update /edx/app/edx_ansible/edx_ansible
 # with the currently checked-out configuration repo.
 
-FROM edxops/xenial-common:latest
+ARG BASE_IMAGE_TAG=latest
+FROM edxops/xenial-common:${BASE_IMAGE_TAG}
 LABEL maintainer="edxops"
 
 ADD . /edx/app/edx_ansible/edx_ansible
@@ -17,9 +18,12 @@ WORKDIR /edx/app/edx_ansible/edx_ansible/docker/plays
 COPY docker/build/ecomworker/ansible_overrides.yml /
 COPY docker/build/ecomworker/ecomworker.yml /edx/etc/ecomworker.yml
 
+ARG OPENEDX_RELEASE=master
+ENV OPENEDX_RELEASE=${OPENEDX_RELEASE}
 RUN sudo /edx/app/edx_ansible/venvs/edx_ansible/bin/ansible-playbook ecomworker.yml \
     -c local -i '127.0.0.1,' \
     -t "install:base,install:system-requirements,install:configuration,install:app-requirements,install:code" \
+    --extra-vars="ECOMMERCE_WORKER_VERSION=${OPENEDX_RELEASE}" \
     --extra-vars="@/ansible_overrides.yml"
 
 USER root


### PR DESCRIPTION
This Docker image hasn't been built in 3 years, but is still used in the ecommerce-worker reop's Travis tests.  Using this outdated image is now a blocker for merging Python 3.8 support, since it doesn't have Python 3.8 installed to test with (whereas the latest xenial-common images do).  Updated the Dockerfile to work with the current tooling for image builds.