### PR TITLE
Add the ability to deploy credentials on python 3.8

### DIFF
--- a/playbooks/roles/credentials/meta/main.yml
+++ b/playbooks/roles/credentials/meta/main.yml
@@ -12,6 +12,7 @@
 #
 dependencies:
   - role: edx_django_service
+    edx_django_service_use_python38: true
     edx_django_service_version: '{{ CREDENTIALS_VERSION }}'
     edx_django_service_name: '{{ credentials_service_name }}'
     edx_django_service_config_overrides: '{{ credentials_service_config_overrides }}'

--- a/playbooks/roles/edx_django_service/defaults/main.yml
+++ b/playbooks/roles/edx_django_service/defaults/main.yml
@@ -4,6 +4,7 @@ edx_django_service_repo: '{{ edx_django_service_name }}'
 edx_django_service_home: '{{ COMMON_APP_DIR }}/{{ edx_django_service_name }}'
 edx_django_service_user: '{{ edx_django_service_name }}'
 edx_django_service_use_python3: true
+edx_django_service_use_python38: false
 
 # This should be overwritten at the time Ansible is run.
 edx_django_service_is_devstack: false

--- a/playbooks/roles/edx_django_service/tasks/main.yml
+++ b/playbooks/roles/edx_django_service/tasks/main.yml
@@ -61,6 +61,21 @@
     - install
     - install:configuration
 
+- name: add deadsnakes repo
+  apt_repository:
+      repo: ppa:deadsnakes/ppa
+  when: edx_django_service_use_python38 and not edx_django_service_enable_experimental_docker_shim
+
+- name: install python3.8
+  apt:
+    pkg:
+      - python3.8-dev
+      - python3.8-distutils
+  when: edx_django_service_use_python38 and not edx_django_service_enable_experimental_docker_shim
+  tags:
+    - install
+    - install:system-requirements
+
 - name: install python3
   apt:
     name: "{{ item }}"
@@ -72,12 +87,22 @@
     - install
     - install:system-requirements
 
+- name: build virtualenv with python3.8
+  command: "virtualenv --python=python3.8 {{ edx_django_service_venv_dir }}"
+  args:
+    creates: "{{ edx_django_service_venv_dir }}/bin/pip"
+  become_user: "{{ edx_django_service_user }}"
+  when: edx_django_service_use_python38 and not edx_django_service_enable_experimental_docker_shim
+  tags:
+    - install
+    - install:system-requirements
+
 - name: build virtualenv with python3
   command: "virtualenv --python=python3 {{ edx_django_service_venv_dir }}"
   args:
     creates: "{{ edx_django_service_venv_dir }}/bin/pip"
   become_user: "{{ edx_django_service_user }}"
-  when: edx_django_service_use_python3 and not edx_django_service_enable_experimental_docker_shim
+  when: edx_django_service_use_python3 and not edx_django_service_use_python38 and not edx_django_service_enable_experimental_docker_shim
   tags:
     - install
     - install:system-requirements
@@ -87,7 +112,7 @@
   args:
     creates: "{{ edx_django_service_venv_dir }}/bin/pip"
   become_user: "{{ edx_django_service_user }}"
-  when: not edx_django_service_use_python3 and not edx_django_service_enable_experimental_docker_shim
+  when: not edx_django_service_use_python3 and not edx_django_service_use_python38 and not edx_django_service_enable_experimental_docker_shim
   tags:
     - install
     - install:system-requirements


### PR DESCRIPTION
`credentials` is already running tests against python 3.8 in CI, this PR intends to get the pipeline ready for credentials deployment on python 3.8.

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
