### PR TITLE
[BB-2438] Override additional partials and the discussion bootstrap styles to fix styling issues

### DIFF
--- a/playbooks/roles/simple_theme/files/default_skeleton/lms/static/sass/discussion/lms-discussion-bootstrap.scss
+++ b/playbooks/roles/simple_theme/files/default_skeleton/lms/static/sass/discussion/lms-discussion-bootstrap.scss
@@ -1,0 +1,2 @@
+@import 'lms/static/sass/discussion/lms-discussion-bootstrap';
+@import '../lms-overrides';

--- a/playbooks/roles/simple_theme/files/default_skeleton/lms/static/sass/discussion/lms-discussion-main.scss
+++ b/playbooks/roles/simple_theme/files/default_skeleton/lms/static/sass/discussion/lms-discussion-main.scss
@@ -1,2 +1,0 @@
-@import 'lms/static/sass/discussion/lms-discussion-main';
-@import '../lms-overrides';

--- a/playbooks/roles/simple_theme/files/default_skeleton/lms/static/sass/lms-main-v2.scss
+++ b/playbooks/roles/simple_theme/files/default_skeleton/lms/static/sass/lms-main-v2.scss
@@ -1,3 +1,0 @@
-@import 'lms/static/sass/lms-main-v2';
-
-@import 'lms-overrides';

--- a/playbooks/roles/simple_theme/files/default_skeleton/lms/static/sass/partials/lms/theme/_variables-v1.scss
+++ b/playbooks/roles/simple_theme/files/default_skeleton/lms/static/sass/partials/lms/theme/_variables-v1.scss
@@ -1,0 +1,2 @@
+@import '../common-variables';
+@import 'lms/static/sass/partials/lms/theme/variables-v1';

--- a/playbooks/roles/simple_theme/files/default_skeleton/lms/static/sass/partials/lms/theme/_variables.scss
+++ b/playbooks/roles/simple_theme/files/default_skeleton/lms/static/sass/partials/lms/theme/_variables.scss
@@ -1,0 +1,2 @@
+@import '../common-variables';
+@import 'lms/static/sass/partials/lms/theme/variables';

--- a/playbooks/roles/simple_theme/tasks/deploy.yml
+++ b/playbooks/roles/simple_theme/tasks/deploy.yml
@@ -91,7 +91,6 @@
   with_items:
     # List of files from ./templates to be processed
     - "lms/static/sass/common-variables.scss"
-    - "lms/static/sass/partials/lms/theme/_variables-v1.scss"
     - "lms/static/sass/_lms-overrides.scss"
 
 # Copying static files is done in two steps: create directories + copy files


### PR DESCRIPTION
This PR adds additional partials to the default skeleton so that the styles get applied uniformly on bootstrap and non-bootstrap pages and also the discussion pages.

**Dependencies**: None

**Sandbox URL**: https://confpr5837.sandbox.opencraft.hosting

**Merge deadline**: None

**Testing instructions**:
1. Deploy an instance with the `simple_theme` role (from the source branch of this PR) enabled. Verify that there are no theme compilation errors and overriding the existing SASS variables (via `SIMPLETHEME_SASS_OVERRIDES`) in the platform and adding custom SASS (via `SIMPLETHEME_EXTRA_SASS) using Ansible variables works.
For example, set `$link-color` to some color and verify that the color is applied in pages using different theming systems (bootstrap, non-bootstrap) like LMS home page, dashboard (non-bootstrap), course outline, discussion (bootstrap).

Note that the `$link-color` variable doesn't set the colors of all links everywhere in the platform due to the inherent issues in the platform theming and the SASS variables.

To add some custom SASS, it is advisable to use the same selectors used in the platform's default theme and override the style to avoid any issues with specificity.

**Reviewers**
- [ ] @giovannicimolin 
- [ ] @pomegranited as the community core committer

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
