### PR TITLE
[BD-6] Upgrade packages for python3.8

### DIFF
--- a/playbooks/roles/aws/templates/requirements.txt.j2
+++ b/playbooks/roles/aws/templates/requirements.txt.j2
@@ -4,19 +4,19 @@
 #
 #    make upgrade
 #
-awscli==1.18.50           # via -r requirements/aws.in
-boto3==1.13.0             # via -r requirements/aws.in
+awscli==1.18.91           # via -r requirements/aws.in
+boto3==1.14.14            # via -r requirements/aws.in
 boto==2.49.0              # via -r requirements/aws.in
-botocore==1.16.0          # via awscli, boto3, s3transfer
+botocore==1.17.14         # via awscli, boto3, s3transfer
 colorama==0.4.3           # via awscli
 docutils==0.15.2          # via awscli, botocore
-jmespath==0.9.5           # via boto3, botocore
+jmespath==0.10.0          # via boto3, botocore
 pyasn1==0.4.8             # via rsa
 python-dateutil==2.8.1    # via botocore, s3cmd
-python-magic==0.4.15      # via s3cmd
+python-magic==0.4.18      # via s3cmd
 pyyaml==3.11              # via -r requirements/aws.in, awscli
 rsa==3.4.2                # via awscli
 s3cmd==2.1.0              # via -r requirements/aws.in
 s3transfer==0.3.3         # via awscli, boto3
-six==1.14.0               # via python-dateutil
+six==1.15.0               # via python-dateutil
 urllib3==1.25.9           # via botocore

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,24 +5,24 @@
 #    make upgrade
 #
 ansible==2.7.12           # via -r requirements/base.in
-awscli==1.15.19           # via -r requirements/base.in
+awscli==1.16.309          # via -r requirements/base.in
 bcrypt==3.1.7             # via paramiko
-boto3==1.7.14             # via -r requirements/base.in
+boto3==1.10.45            # via -r requirements/base.in
 boto==2.48.0              # via -r requirements/base.in
-botocore==1.10.19         # via awscli, boto3, s3transfer
-certifi==2020.4.5.1       # via requests
+botocore==1.13.45         # via awscli, boto3, s3transfer
+certifi==2020.6.20        # via requests
 cffi==1.14.0              # via bcrypt, cryptography, pynacl
 chardet==3.0.4            # via requests
-colorama==0.3.7           # via awscli
+colorama==0.4.1           # via awscli
 cryptography==2.9.2       # via ansible, paramiko
 datadog==0.8.0            # via -r requirements/base.in
 decorator==4.4.2          # via datadog, networkx
 docopt==0.6.2             # via -r requirements/base.in
-docutils==0.16            # via awscli, botocore
+docutils==0.15.2          # via awscli, botocore
 ecdsa==0.13.3             # via -r requirements/base.in
 idna==2.7                 # via requests
 jinja2==2.8               # via -r requirements/base.in, ansible
-jmespath==0.9.5           # via boto3, botocore
+jmespath==0.10.0          # via boto3, botocore
 markupsafe==1.1.1         # via jinja2
 mysqlclient==1.3.0        # via -r requirements/base.in
 networkx==1.11            # via -r requirements/base.in
@@ -33,14 +33,14 @@ pyasn1==0.4.8             # via paramiko, rsa
 pycparser==2.20           # via cffi
 pycrypto==2.6.1           # via -r requirements/base.in
 pymongo==3.9.0            # via -r requirements/base.in
-pynacl==1.3.0             # via paramiko
+pynacl==1.4.0             # via paramiko
 python-dateutil==2.8.1    # via botocore
-pyyaml==3.12              # via -r requirements/base.in, ansible, awscli
+pyyaml==5.2               # via -r requirements/base.in, ansible, awscli
 requests==2.20.0          # via -r requirements/base.in, datadog
 rsa==3.4.2                # via awscli
-s3transfer==0.1.13        # via awscli, boto3
-six==1.14.0               # via bcrypt, cryptography, pathlib2, pynacl, python-dateutil
-urllib3==1.24.3           # via requests
+s3transfer==0.2.1         # via awscli, boto3
+six==1.15.0               # via bcrypt, cryptography, pathlib2, pynacl, python-dateutil
+urllib3==1.24.3           # via botocore, requests
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -1,9 +1,9 @@
 # Standard dependencies for Ansible runs
 
 ansible==2.7.12
-awscli==1.15.19
+awscli==1.16.309
 boto==2.48.0
-boto3==1.7.14
+boto3==1.10.45
 datadog==0.8.0
 docopt==0.6.2
 ecdsa==0.13.3
@@ -15,5 +15,5 @@ pathlib2==2.3.0
 prettytable==0.7.2
 pycrypto==2.6.1
 pymongo==3.9.0                      # Needed for the mongo_* modules (playbooks/library/mongo_*)
-PyYAML==3.12
+PyYAML
 requests==2.20.0

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -5,8 +5,8 @@
 #    make upgrade
 #
 click==7.1.2              # via pip-tools
-pip-tools==5.1.0          # via -r requirements/pip-tools.in
-six==1.14.0               # via pip-tools
+pip-tools==5.2.1          # via -r requirements/pip-tools.in
+six==1.15.0               # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/util/elasticsearch/requirements.txt
+++ b/util/elasticsearch/requirements.txt
@@ -6,7 +6,7 @@
 #
 deepdiff==3.1.0           # via -r requirements/elasticsearch.in
 elasticsearch==0.4.5      # via -r requirements/elasticsearch.in
-importlib-metadata==1.6.0  # via jsonpickle
+importlib-metadata==1.7.0  # via jsonpickle
 jsonpickle==1.4.1         # via deepdiff
 urllib3==1.25.9           # via elasticsearch
-zipp==3.1.0               # via importlib-metadata
+zipp==1.2.0               # via importlib-metadata

--- a/util/jenkins/check_celery_progress/requirements.txt
+++ b/util/jenkins/check_celery_progress/requirements.txt
@@ -12,13 +12,13 @@ billiard==3.3.0.23        # via celery
 boto3==1.5.4              # via -r requirements/celery_progress.in
 botocore==1.8.36          # via awscli, boto3, s3transfer
 celery==3.1.25            # via -r requirements/celery_progress.in
-certifi==2020.4.5.1       # via opsgenie-sdk, requests
+certifi==2020.6.20        # via opsgenie-sdk, requests
 chardet==3.0.4            # via requests
 click==6.7                # via -r requirements/celery_progress.in
 colorama==0.3.7           # via awscli
 docutils==0.16            # via awscli, botocore
-idna==2.9                 # via requests
-jmespath==0.9.5           # via boto3, botocore
+idna==2.10                # via requests
+jmespath==0.10.0          # via boto3, botocore
 kombu==3.0.37             # via celery
 opsgenie-sdk==0.3.1       # via -r requirements/celery_progress.in
 pyasn1==0.4.8             # via rsa
@@ -26,10 +26,10 @@ python-dateutil==2.8.1    # via botocore, opsgenie-sdk
 pytz==2020.1              # via celery, opsgenie-sdk
 pyyaml==3.12              # via awscli
 redis==2.10.6             # via -r requirements/celery_progress.in
-requests==2.23.0          # via opsgenie-sdk
+requests==2.24.0          # via opsgenie-sdk
 rsa==3.4.2                # via awscli
 s3transfer==0.1.13        # via awscli, boto3
-six==1.14.0               # via opsgenie-sdk, python-dateutil
+six==1.15.0               # via opsgenie-sdk, python-dateutil
 urllib3==1.25.9           # via opsgenie-sdk, requests
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/util/jenkins/requirements-cloudflare.txt
+++ b/util/jenkins/requirements-cloudflare.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-certifi==2020.4.5.1       # via requests
+certifi==2020.6.20        # via requests
 chardet==3.0.4            # via requests
 idna==2.7                 # via requests
 requests==2.20.0          # via -r requirements/cloudflare.in

--- a/util/jenkins/update_celery_monitoring/requirements.txt
+++ b/util/jenkins/update_celery_monitoring/requirements.txt
@@ -11,11 +11,11 @@ botocore==1.8.36          # via awscli, boto3, s3transfer
 click==6.7                # via -r requirements/celery.in
 colorama==0.3.7           # via awscli
 docutils==0.16            # via awscli, botocore
-jmespath==0.9.5           # via boto3, botocore
+jmespath==0.10.0          # via boto3, botocore
 pyasn1==0.4.8             # via rsa
 python-dateutil==2.8.1    # via botocore
 pyyaml==3.12              # via awscli
 redis==2.10.6             # via -r requirements/celery.in
 rsa==3.4.2                # via awscli
 s3transfer==0.1.13        # via awscli, boto3
-six==1.14.0               # via python-dateutil
+six==1.15.0               # via python-dateutil

--- a/util/pingdom/requirements.txt
+++ b/util/pingdom/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-certifi==2020.4.5.1       # via requests
+certifi==2020.6.20        # via requests
 chardet==3.0.4            # via requests
 click==6.7                # via -r requirements/pingdom.in
 idna==2.7                 # via requests

--- a/util/vpc-tools/requirements.txt
+++ b/util/vpc-tools/requirements.txt
@@ -5,9 +5,9 @@
 #    make upgrade
 #
 boto==2.49.0              # via -r requirements/vpc-tools.in
-certifi==2020.4.5.1       # via requests
+certifi==2020.6.20        # via requests
 chardet==3.0.4            # via requests
 docopt==0.6.2             # via -r requirements/vpc-tools.in
-idna==2.9                 # via requests
-requests==2.23.0          # via -r requirements/vpc-tools.in
+idna==2.10                # via requests
+requests==2.24.0          # via -r requirements/vpc-tools.in
 urllib3==1.25.9           # via requests


### PR DESCRIPTION
Upgrade awscli and boto3 in base.in in order to use a version of pyyaml compatible with python3.8

In order to pass the tests in python3.8 I think that we need to upgrade the version of ansible 

## Reviewers
- [ ] @awais786 
- [ ] @ericfab179