### PR TITLE
ARCHBOM-1326 - Update oppia xblock to point back upstream.

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -507,8 +507,7 @@ EDXAPP_PRIVATE_REQUIREMENTS:
     # For Harvard courses:
     - name: xblock-problem-builder==4.0.0
     # Oppia XBlock
-    # https://github.com/oppia/xblock/pull/4
-    - name: git+https://github.com/edx/oppia-xblock.git@1030adb3590ad2d32c93443cc8690db0985d76b6#egg=oppia-xblock
+    - name: git+https://github.com/oppia/xblock.git@3b5c17c5832b4f8ef132c6bbf48da8a86df43b3d#egg=oppia-xblock
       extra_args: -e
     # This repository contains schoolyourself-xblock, which is used in
     # edX's "AlgebraX" and "GeometryX" courses.


### PR DESCRIPTION
Oppia has merged our PR to allow them to run on python 3 so we're updating
the pointer to the merge commit upstream.