### PR TITLE
Add "| default" filter on AWS_GATHER_FACTS conditional in edx_service

### DIFF
--- a/playbooks/roles/edx_service/tasks/main.yml
+++ b/playbooks/roles/edx_service/tasks/main.yml
@@ -163,7 +163,7 @@
 
 - name: Get instance information
   action: ec2_metadata_facts
-  when: AWS_GATHER_FACTS
+  when: AWS_GATHER_FACTS | default(false)
   tags:
     - to-remove
 


### PR DESCRIPTION
`edx_service` references `AWS_GATHER_FACTS`, which is a variable whose default is set in the `aws` role. `edx_service` does not list a dependency on `aws` in its `meta/main.yml` declaration, so it does not inherit that default.

As a result, operators writing their own playbook (which may not include the `aws` role) would have to set `AWS_GATHER_FACTS: false`, just to use any service that depends on `edx_service`.

`openedx_native.yml` does set `AWS_GATHER_FACTS: false`, so its users are not affected by this problem, but relying on that is really a kludge: the `edx_service` role should be able to function on its own (plus its declared dependencies), not rely on setting a variable whose default lives in another role that it does not depend on.

Add a `| default(false)` filter to the `AWS_GATHER_FACTS` conditional, so that operators not using AWS at all (and hence not enabling the `aws` role) are able to use the `edx_service` role without having to set that variable.

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
