### PR TITLE
[BD-6] Change supported python versions in codejail.

### DIFF
--- a/playbooks/roles/codejail/defaults/main.yml
+++ b/playbooks/roles/codejail/defaults/main.yml
@@ -2,9 +2,8 @@
 codejail_debian_packages:
   - apparmor-utils
 CODEJAIL_PYTHON_VERSIONS:
-  - python2.7
   - python3.5
-  - python3.6
+  - python3.8
 codejail_python_versions: "{{ CODEJAIL_PYTHON_VERSIONS }}"
 codejail_sandbox_user: 'sandbox'
 codejail_sandbox_group: 'sandbox'


### PR DESCRIPTION
Add python3.8 to the codejail supported versions and remove python2.7 and python3.6

## Reviewers
- [x] @feanil 