### PR TITLE
Certificate validation for intermediate certificate download

### DIFF
--- a/playbooks/roles/common/tasks/main.yml
+++ b/playbooks/roles/common/tasks/main.yml
@@ -20,7 +20,7 @@
   get_url:
     url: "{{ common_digicert_base_url }}/{{ common_digicert_name }}.pem"
     dest: "/usr/local/share/ca-certificates/{{ common_digicert_name }}"
-    validate_certs: no
+    validate_certs: yes
   when: update_ca_certificates is defined and update_ca_certificates.results[0].stat.exists == True
 
 - name: Update CA Certificates

--- a/playbooks/roles/common_vars/defaults/main.yml
+++ b/playbooks/roles/common_vars/defaults/main.yml
@@ -55,7 +55,7 @@ COMMON_NPM_MIRROR_URL: 'https://registry.npmjs.org'
 COMMON_UBUNTU_APT_KEYSERVER: "http://keyserver.ubuntu.com/pks/lookup?op=get&fingerprint=on&search="
 
 common_digicert_name: "DigiCertSHA2SecureServerCA.crt"
-common_digicert_base_url: "https://dl.cacerts.digicert.com/"
+common_digicert_base_url: "https://cacerts.digicert.com/"
 
 COMMON_EDX_PPA: "deb http://ppa.edx.org {{ ansible_distribution_release }} main"
 COMMON_EDX_PPA_KEY_SERVER: "keyserver.ubuntu.com"


### PR DESCRIPTION
Ansible "validate_certs" for ´get_url´ function needs to be turned on for any servers reached via the public Internet. This was likely turned off due to using a faulty certificate delivery server which itself had her trust chain broken. Changed the url to a properly configured certificate distribution server.

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
