### PR TITLE
Remove misleading comment about profile image storage from edxapp role defaults

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -752,8 +752,6 @@ EDXAPP_SOCIAL_SHARING_SETTINGS:
 #     headers:
 #       Cache-Control: max-age-{{ EDXAPP_PROFILE_IMAGE_MAX_AGE }}
 #NB: access_key and secret_key are unneccessary if you use IAM roles
-#NB2: custom_domain is REQUIRED. Otherwise, boto will generate a
-# temporary URL whenever asked for the URL of a specific file.
 EDXAPP_PROFILE_IMAGE_BACKEND:
   class: openedx.core.storage.OverwriteStorage
   options:


### PR DESCRIPTION
Since https://github.com/edx/edx-platform/pull/24395 has landed, there is nothing that's keeping operators from using temporary signed URLs when serving profile images from S3. They may indeed prefer to do this, for compliance with privacy laws or other reasons, rather than store profile images in a bucket with a non-private ACL.

Thus, using a custom domain is no longer required, and the comment saying
otherwise can be removed.

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
