### PR TITLE
Revert "[BD-6] Use pip3 in the Makefile"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,13 +17,13 @@ main.help:
 	@echo ''
 
 requirements:
-	pip3 install -qr pre-requirements.txt --exists-action w
-	pip3 install -qr requirements.txt --exists-action w
+	pip install -qr pre-requirements.txt --exists-action w
+	pip install -qr requirements.txt --exists-action w
 
 upgrade: export CUSTOM_COMPILE_COMMAND=make upgrade
 upgrade: ## update the pip requirements files to use the latest releases satisfying our constraints
-	pip3 install -qr pre-requirements.txt --exists-action w
-	pip3 install -qr requirements/pip-tools.txt
+	pip install -qr pre-requirements.txt --exists-action w
+	pip install -qr requirements/pip-tools.txt
 	# Make sure to compile files after any other files they include!
 	pip-compile --upgrade -o requirements/pip-tools.txt requirements/pip-tools.in
 	pip-compile --upgrade -o requirements.txt requirements/base.in


### PR DESCRIPTION
Reverts edx/configuration#5867

This may be causing problems in native installations:

https://github.com/edx/configuration/commit/73010507ac5235dc49a433df39280fbf3b1356e6#commitcomment-40650194

## Reviewers
- [  ] @awais786 