### PR TITLE
[BD-6] Fix deprecation warning: [sudo/sudo_user -> become/become_user]

### DIFF
--- a/docker/plays/notifier.yml
+++ b/docker/plays/notifier.yml
@@ -1,6 +1,6 @@
 - name: Deploy notifier
   hosts: all
-  sudo: True
+  become: True
   gather_facts: True
   vars:
     serial_count: 1

--- a/playbooks/automated.yml
+++ b/playbooks/automated.yml
@@ -1,6 +1,6 @@
 - name: Deploy automated role
   hosts: all
-  sudo: True
+  become: True
   gather_facts: True
   roles:
 #    - aws

--- a/playbooks/neo4j.yml
+++ b/playbooks/neo4j.yml
@@ -1,6 +1,6 @@
 - name: Deploy neo4j for coursegraph
   hosts: all
-  sudo: True
+  become: True
   gather_facts: True
   vars:
     CLUSTER_NAME: 'coursegraph'

--- a/playbooks/redirector.yml
+++ b/playbooks/redirector.yml
@@ -1,6 +1,6 @@
 - name: Deploy redirector host
   hosts: all
-  sudo: True
+  become: True
   gather_facts: True
   vars:
     serial_count: 1

--- a/playbooks/roles/ansible-role-django-ida/templates/docker/plays/ROLE_NAME.yml.j2
+++ b/playbooks/roles/ansible-role-django-ida/templates/docker/plays/ROLE_NAME.yml.j2
@@ -1,6 +1,6 @@
 - name: Deploy {{ role_name|replace('_', ' ')|title }}
   hosts: all
-  sudo: True
+  become: True
   gather_facts: True
   vars:
     serial_count: 1

--- a/playbooks/roles/ansible-role-django-ida/templates/tasks/main.yml.j2
+++ b/playbooks/roles/ansible-role-django-ida/templates/tasks/main.yml.j2
@@ -18,7 +18,7 @@
   template:
     src: edx/app/{{ role_name }}/{{ role_name }}_gunicorn.py.j2
     dest: "{{ '{{' }} {{ role_name }}_home }}/{{ role_name }}_gunicorn.py"
-  sudo_user: "{{ '{{' }} {{ role_name }}_user }}"
+  become_user: "{{ '{{' }} {{ role_name }}_user }}"
   tags:
     - install
     - install:configuration
@@ -27,7 +27,7 @@
   command: "virtualenv {{ '{{' }} {{ role_name }}_venv_dir }}"
   args:
     creates: "{{ '{{' }} {{ role_name }}_venv_dir }}/bin/pip"
-  sudo_user: "{{ '{{' }} {{ role_name }}_user }}"
+  become_user: "{{ '{{' }} {{ role_name }}_user }}"
   environment: "{{ '{{' }} {{ role_name }}_environment }}"
   tags:
     - install
@@ -37,7 +37,7 @@
   command: make requirements
   args:
     chdir: "{{ '{{' }} {{ role_name }}_code_dir }}"
-  sudo_user: "{{ '{{' }} {{ role_name }}_user }}"
+  become_user: "{{ '{{' }} {{ role_name }}_user }}"
   environment: "{{ '{{' }} {{ role_name }}_environment }}"
   tags:
     - install
@@ -47,7 +47,7 @@
   command: make local-requirements
   args:
     chdir: "{{ '{{' }} {{ role_name }}_code_dir }}"
-  sudo_user: "{{ '{{' }} {{ role_name }}_user }}"
+  become_user: "{{ '{{' }} {{ role_name }}_user }}"
   environment: "{{ '{{' }} {{ role_name }}_environment }}"
   tags:
     - devstack
@@ -57,7 +57,7 @@
   command: make migrate
   args:
     chdir: "{{ '{{' }} {{ role_name }}_code_dir }}"
-  sudo_user: "{{ '{{' }} {{ role_name }}_user }}"
+  become_user: "{{ '{{' }} {{ role_name }}_user }}"
   environment: "{{ '{{' }} {{ role_name }}_migration_environment }}"
   when: migrate_db is defined and migrate_db|lower == "yes"
   run_once: yes
@@ -155,7 +155,7 @@
   command: make static
   args:
     chdir: "{{ '{{' }} {{ role_name }}_code_dir }}"
-  sudo_user: "{{ '{{' }} {{ role_name }}_user }}"
+  become_user: "{{ '{{' }} {{ role_name }}_user }}"
   environment: "{{ '{{' }} {{ role_name }}_environment }}"
   tags:
     - assets
@@ -168,7 +168,7 @@
     config: "{{ '{{' }} supervisor_cfg }}"
     name: "{{ '{{' }} {{ role_name }}_service_name }}"
   when: not disable_edx_services
-  sudo_user: "{{ '{{' }} supervisor_service_user }}"
+  become_user: "{{ '{{' }} supervisor_service_user }}"
   tags:
     - manage
     - manage:start

--- a/playbooks/roles/flower/handlers/main.yml
+++ b/playbooks/roles/flower/handlers/main.yml
@@ -5,4 +5,4 @@
     supervisorctl_path: "{{ supervisor_ctl }}"
     config: "{{ supervisor_cfg }}"
     name: "{{ FLOWER_USER }}"
-  sudo_user: "{{ supervisor_service_user }}"
+  become_user: "{{ supervisor_service_user }}"

--- a/playbooks/roles/ghost/tasks/main.yml
+++ b/playbooks/roles/ghost/tasks/main.yml
@@ -17,7 +17,7 @@
 
 - name: Install ghost_package
   apt: deb="{{ ghost_download_target }}"
-  sudo: true
+  become: true
   when: ghost_correct.rc != 0
 
 - name: "Install percona packages for dropping large tables"

--- a/playbooks/roles/go-agent-docker-server/tasks/main.yml
+++ b/playbooks/roles/go-agent-docker-server/tasks/main.yml
@@ -22,7 +22,7 @@
 #
 # - name: Configure instance(s)
 #   hosts: go-server
-#   sudo: True
+#   become: True
 #   vars_files:
 #     - "{{ secure_dir }}/admin/sandbox.yml"
 #   gather_facts: True

--- a/playbooks/roles/go-agent/tasks/main.yml
+++ b/playbooks/roles/go-agent/tasks/main.yml
@@ -22,7 +22,7 @@
 #
 # - name: Configure instance(s)
 #   hosts: go-agent
-#   sudo: True
+#   become: True
 #   vars_files:
 #     - "{{ secure_dir }}/admin/sandbox.yml"
 #   gather_facts: True

--- a/playbooks/roles/hotg/tasks/deploy.yml
+++ b/playbooks/roles/hotg/tasks/deploy.yml
@@ -42,7 +42,7 @@
     supervisorctl_path={{ supervisor_ctl }}
     config={{ supervisor_cfg }}
     name="{{ HOTG_SERVICE_NAME }}"
-  sudo_user: "{{ supervisor_service_user }}"
+  become_user: "{{ supervisor_service_user }}"
   tags:
     - manage
     - manage:stop
@@ -52,7 +52,7 @@
     src=edx/app/hotg/Config.groovy.j2
     dest={{ hotg_app_dir }}/Config.groovy
     mode=0644
-  sudo_user: "{{ HOTG_USER }}"
+  become_user: "{{ HOTG_USER }}"
   tags:
     - install
     - install:configuration
@@ -92,7 +92,7 @@
     supervisorctl_path={{ supervisor_ctl }}
     config={{ supervisor_cfg }}
     name="{{ HOTG_SERVICE_NAME }}"
-  sudo_user: "{{ supervisor_service_user }}"
+  become_user: "{{ supervisor_service_user }}"
   tags:
     - manage
     - manage:start

--- a/playbooks/roles/hotg/tasks/main.yml
+++ b/playbooks/roles/hotg/tasks/main.yml
@@ -22,7 +22,7 @@
 #
 # - name: Configure instance(s)
 #   hosts: hotg
-#   sudo: True
+#   become: True
 #   vars_files:
 #     - "{{ secure_dir }}/vars/common/common.yml"
 #     - "{{ secure_dir }}/vars/users.yml"

--- a/playbooks/roles/minos/tasks/main.yml
+++ b/playbooks/roles/minos/tasks/main.yml
@@ -25,7 +25,7 @@
 #
 # - name: Deploy minos
 #   hosts: all
-#   sudo: True
+#   become: True
 #   gather_facts: True
 #   vars:
 #     COMMON_ENABLE_MINOS: True

--- a/playbooks/roles/openstack/tasks/main.yml
+++ b/playbooks/roles/openstack/tasks/main.yml
@@ -58,7 +58,7 @@
   command: "{{ edxapp_venv_dir }}/bin/pip install {{ COMMON_PIP_VERBOSITY }} -i {{ COMMON_PYPI_MIRROR_URL }} --exists-action w -r {{ openstack_requirements_file }}"
   args:
     chdir: "{{ edxapp_code_dir }}"
-  sudo_user: "{{ edxapp_user }}"
+  become_user: "{{ edxapp_user }}"
   environment: "{{ edxapp_environment }}"
   when: edxapp_code_dir is defined
   tags:

--- a/playbooks/roles/s3fs/tasks/main.yml
+++ b/playbooks/roles/s3fs/tasks/main.yml
@@ -43,7 +43,7 @@
 #
 # - name: Configure instance(s)
 #   hosts: s3fs_hosts
-#   sudo: True
+#   become: True
 #   vars_files:
 #     - "{{ secure_dir }}/vars/common/common.yml"
 #     - "{{ secure_dir }}/vars/users.yml"

--- a/playbooks/roles/xqwatcher/tasks/main.yml
+++ b/playbooks/roles/xqwatcher/tasks/main.yml
@@ -24,7 +24,7 @@
 #
 # - name: Deploy xqueue-watcher
 #   hosts: all
-#   sudo: True
+#   become: True
 #   gather_facts: True
 #   vars:
 #     COMMON_APP_DIR: "/edx/app"

--- a/playbooks/vagrant-cluster.yml
+++ b/playbooks/vagrant-cluster.yml
@@ -23,7 +23,7 @@
 # Rabbit needs to be built serially
 - name: Configure group cluster serial roles 
   hosts: all
-  sudo: True
+  become: True
   serial: 1
   gather_facts: True
   vars:
@@ -40,7 +40,7 @@
 # but will also show as failed
 - name: Configure group with tasks that will always fail
   hosts: all
-  sudo: True
+  become: True
   gather_facts: True
   vars:
     MARIADB_CLUSTERED: yes


### PR DESCRIPTION
This fixes a deprecation warning. You can see that in the results of the travis test related to the playbooks.

Make sure become_method is 'sudo' (default). This feature will be removed in
version 2.9. 

I did not change the places where it is used sudo_user for this template: playbooks/roles/automated/templates/99-automated.j2

## Reviewers
- [ ]  @awais786 