### PR TITLE
[BD-6] Fix s3 deprecation warning.

### DIFF
--- a/playbooks/roles/go-server/tasks/download_backup.yml
+++ b/playbooks/roles/go-server/tasks/download_backup.yml
@@ -52,7 +52,7 @@
     mode: 0755
 
 - name: get s3 one time url
-  s3:
+  aws_s3:
     bucket: "{{ GO_SERVER_BACKUP_S3_BUCKET }}"
     object: "{{ GO_SERVER_BACKUP_S3_OBJECT }}"
     mode: "geturl"

--- a/playbooks/roles/jenkins_admin/tasks/main.yml
+++ b/playbooks/roles/jenkins_admin/tasks/main.yml
@@ -136,7 +136,7 @@
     validate: "visudo -cf %s"
 
 - name: get s3 one time url
-  s3:
+  aws_s3:
     bucket: "{{ JENKINS_ADMIN_BACKUP_BUCKET }}"
     object: "{{ JENKINS_ADMIN_BACKUP_S3_KEY }}"
     mode: "geturl"


### PR DESCRIPTION
In Ansible 2.4, s3 module has been renamed to aws_s3.

**Reviewers**
- [ ] @awais786 
- [ ] @morenol

