### PR TITLE
[BD-6] Use latest version of ansible 2.7.*

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-ansible==2.7.12           # via -r requirements/base.in
+ansible==2.7.18           # via -r requirements/base.in
 awscli==1.16.309          # via -r requirements/base.in
 bcrypt==3.1.7             # via paramiko
 boto3==1.10.45            # via -r requirements/base.in

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -1,6 +1,6 @@
 # Standard dependencies for Ansible runs
 
-ansible==2.7.12
+ansible<2.8.0
 awscli==1.16.309
 boto==2.48.0
 boto3==1.10.45


### PR DESCRIPTION
Use latest verision of ansible 2.7.*

The last time we upgraded ansible was due to a dependabot PR: https://github.com/edx/configuration/commit/4c2d444c79d3d36937af2ba362c6241d52904eb2

These upgrades have mostly bugfixes and security fixes: https://github.com/ansible/ansible/blob/stable-2.7/changelogs/CHANGELOG-v2.7.rst#v2-7-18


## Reviewers
- [ ] @awais786 
- [ ] @ericfab179 