### PR TITLE
[BD-6] Remove duplicated dict key (when).

### DIFF
--- a/playbooks/roles/edx_django_service/tasks/main.yml
+++ b/playbooks/roles/edx_django_service/tasks/main.yml
@@ -125,7 +125,6 @@
 - name: upgrade npm
   command: "npm install -g npm@{{ edx_django_service_npm_version }}"
   become_user: "{{ edx_django_service_user }}"
-  when: not edx_django_service_enable_experimental_docker_shim
   environment: "{{ edx_django_service_environment }}"
   tags:
     - install


### PR DESCRIPTION
`when` is duplicated in this task, it is using the valie defined in the last line of the task.

 ```yaml
 when: edx_django_service_npm_version is defined and not edx_django_service_enable_experimental_docker_shim
```

So we can remove this line. 

This is the warning in the travis tests:
```
 [WARNING]: While constructing a mapping from /home/travis/build/edx/configurat
ion/playbooks/roles/edx_django_service/tasks/main.yml, line 125, column 3,
found a duplicate dict key (when). Using last defined value only.
```

## Reviewers
- [ ] @awais786 
- [ ] @ericfab179 