### PR TITLE
[BD-6] Remove duplicated config in designer role

### DIFF
--- a/playbooks/roles/designer/defaults/main.yml
+++ b/playbooks/roles/designer/defaults/main.yml
@@ -107,7 +107,6 @@ DESIGNER_SOCIAL_AUTH_REDIRECT_IS_HTTPS: false
 
 DESIGNER_GIT_IDENTITY: !!null
 
-designer_service_name: "designer"
 designer_home: "{{ COMMON_APP_DIR }}/{{ designer_service_name }}"
 designer_code_dir: "{{ designer_home }}/{{ designer_service_name }}"
 


### PR DESCRIPTION
This fixes this warning:
```
 [WARNING]: While constructing a mapping from /home/travis/build/edx/configurat
ion/playbooks/roles/designer/defaults/main.yml, line 18, column 1, found a
duplicate dict key (designer_service_name). Using last defined value only.
```

You can see that `designer_service_name` is also fedined in line 18.	

## Reviewers
- [ ] @awais786 
- [ ] @ericfab179 