### PR TITLE
[BD-6] Fix duplicate dict key (owner) warning

### DIFF
--- a/playbooks/roles/gitreload/tasks/course_pull.yml
+++ b/playbooks/roles/gitreload/tasks/course_pull.yml
@@ -18,7 +18,7 @@
     path: "{{ GITRELOAD_REPODIR }}"
     state: directory
     owner: "{{ common_web_user }}"
-    owner: "{{ common_web_group }}"
+    group: "{{ common_web_group }}"
     recurse: yes
 
 - name: change group on repos if using devstack


### PR DESCRIPTION
Fix typo. It should be group instead of owner.

## Reviewers
- [ ] @awais786 
- [ ] @ericfab179 