### PR TITLE
[BD-6]Ansible 2.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,3 @@ script:
   - docker --version
   - make --version
   - travis_wait 90 make --keep-going $MAKE_TARGET SHARD=$SHARD SHARDS=$SHARDS
-
-matrix:
-  allow_failures:
-    - python: 3.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-ansible==2.7.18           # via -r requirements/base.in
+ansible==2.8.13           # via -r requirements/base.in
 awscli==1.16.309          # via -r requirements/base.in
 bcrypt==3.1.7             # via paramiko
 boto3==1.10.45            # via -r requirements/base.in
@@ -26,7 +26,7 @@ jmespath==0.10.0          # via boto3, botocore
 markupsafe==1.1.1         # via jinja2
 mysqlclient==1.3.0        # via -r requirements/base.in
 networkx==1.11            # via -r requirements/base.in
-paramiko==2.4.2           # via -r requirements/base.in, ansible
+paramiko==2.4.2           # via -r requirements/base.in
 pathlib2==2.3.0           # via -r requirements/base.in
 prettytable==0.7.2        # via -r requirements/base.in
 pyasn1==0.4.8             # via paramiko, rsa
@@ -41,6 +41,3 @@ rsa==3.4.2                # via awscli
 s3transfer==0.2.1         # via awscli, boto3
 six==1.15.0               # via bcrypt, cryptography, pathlib2, pynacl, python-dateutil
 urllib3==1.24.3           # via botocore, requests
-
-# The following packages are considered to be unsafe in a requirements file:
-# setuptools

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -1,6 +1,6 @@
 # Standard dependencies for Ansible runs
 
-ansible<2.8.0
+ansible<2.9.0
 awscli==1.16.309
 boto==2.48.0
 boto3==1.10.45


### PR DESCRIPTION
Upgrade ansible to 2.8.

I checked the [porting guide](https://docs.ansible.com/ansible/latest/porting_guides/porting_guide_2.8.html) for ansible 2.8.  And it seems to me that there is not issues with this upgrade.

After this change the python3.8 tests are passing, though I think that we should use at least ansible 2.9.5 since that is the first ansible release with python3.8 in its PyPi classifiers.

## Reviewers
- [ ] @awais786 
- [ ] @ericfab179 