### PR TITLE
[BD-6] Use python 3.8 in hermes role

### DIFF
--- a/playbooks/roles/designer/defaults/main.yml
+++ b/playbooks/roles/designer/defaults/main.yml
@@ -24,6 +24,8 @@ designer_gunicorn_port: 8808
 
 designer_debian_pkgs: []
 
+DESIGNER_USE_PYTHON38: false
+
 DESIGNER_NGINX_PORT: '1{{ designer_gunicorn_port }}'
 DESIGNER_SSL_NGINX_PORT: '4{{ designer_gunicorn_port }}'
 

--- a/playbooks/roles/designer/meta/main.yml
+++ b/playbooks/roles/designer/meta/main.yml
@@ -12,6 +12,7 @@
 
 dependencies:
   - role: edx_django_service
+    edx_django_service_use_python38: '{{ DESIGNER_USE_PYTHON38 }}'
     edx_django_service_version: '{{ DESIGNER_VERSION }}'
     edx_django_service_name: '{{ designer_service_name }}'
     edx_django_service_config_overrides: '{{ designer_service_config_overrides }}'

--- a/playbooks/roles/hermes/tasks/main.yml
+++ b/playbooks/roles/hermes/tasks/main.yml
@@ -24,6 +24,7 @@
 - name: add deadsnakes repository
   apt_repository:
     repo: "ppa:deadsnakes/ppa"
+  when: ansible_distribution_release != 'focal'
   tags:
     - install
     - install:system-requirements

--- a/playbooks/roles/hermes/tasks/main.yml
+++ b/playbooks/roles/hermes/tasks/main.yml
@@ -20,29 +20,26 @@
 #
 #
 
-# The deadsnakes PPA is required to install python3.6 on Xenial.
-# Bionic comes with python3.6 installed.
+# The deadsnakes PPA is required to install python3.8 on Xenial and Bionic.
 - name: add deadsnakes repository
   apt_repository:
-    repo: "ppa:fkrull/deadsnakes"
-  when: ansible_distribution_release == 'xenial'
+    repo: "ppa:deadsnakes/ppa"
   tags:
     - install
     - install:system-requirements
 
-- name: install python3.6
+- name: install python3.8
   apt:
     name: "{{ item }}"
   with_items:
-    - python3.6
+    - python3.8
     - python3-pip
-  when: ansible_distribution_release == 'xenial'
   tags:
     - install
     - install:system-requirements
 
 - name: build virtualenv with python3
-  command: "virtualenv --python=/usr/bin/python3.6 {{ hermes_venv_dir }}"
+  command: "virtualenv --python=/usr/bin/python3.8 {{ hermes_venv_dir }}"
   args:
     creates: "{{ hermes_venv_dir }}/bin/pip"
   become_user: "{{ hermes_user }}"


### PR DESCRIPTION
Add deadsnakes PPA and install python 3.8 package in Xenial and Bionic.
Use Python 3.8 to create hermes virtualenv.

**Reviewers**
- [ ] @awais786 
- [ ] @morenol