### PR TITLE
[BD-6] Add config to deploy discovery with python3.8

### DIFF
--- a/playbooks/roles/discovery/defaults/main.yml
+++ b/playbooks/roles/discovery/defaults/main.yml
@@ -35,6 +35,7 @@ discovery_home: "{{ COMMON_APP_DIR }}/{{ discovery_service_name }}"
 discovery_code_dir: "{{ discovery_home }}/{{ discovery_service_name }}"
 
 DISCOVERY_NODE_VERSION: '12.11.1'
+DISCOVERY_USE_PYTHON38: false
 
 #
 # OS packages

--- a/playbooks/roles/discovery/meta/main.yml
+++ b/playbooks/roles/discovery/meta/main.yml
@@ -20,6 +20,7 @@
 # }
 dependencies:
   - role: edx_django_service
+    edx_django_service_use_python38: '{{ DISCOVERY_USE_PYTHON38 }}'
     edx_django_service_repos: '{{ DISCOVERY_REPOS }}'
     edx_django_service_name: '{{ discovery_service_name }}'
     edx_django_service_user: '{{ discovery_user }}'


### PR DESCRIPTION
Add ansible configuration to deploy course-discovery with python3.8

Right now, the default of edx_django_service_use_python38 is false. So, this change is not affecting the current behavior but add the possibility of install discovery with python3.8 if the value of DISCOVERY_USE_PYTHON38 is overrided.

Based in the changes of https://github.com/edx/configuration/pull/5833


## Reviewers
- [ ] @awais786 
