### PR TITLE
[BD-6] Add config to deploy analytics api with python3.8

### DIFF
--- a/playbooks/roles/analytics_api/defaults/main.yml
+++ b/playbooks/roles/analytics_api/defaults/main.yml
@@ -41,6 +41,8 @@ analytics_api_newrelic_appname: 'analytics-api'
 analytics_api_debian_pkgs:
   - 'libmysqlclient-dev'
 
+ANALYTICS_API_USE_PYTHON38: false
+
 ANALYTICS_API_VERSION: "master"
 ANALYTICS_API_NGINX_PORT: '1{{ analytics_api_gunicorn_port }}'
 ANALYTICS_API_SSL_NGINX_PORT: '4{{ analytics_api_gunicorn_port }}'

--- a/playbooks/roles/analytics_api/meta/main.yml
+++ b/playbooks/roles/analytics_api/meta/main.yml
@@ -21,6 +21,7 @@
 
 dependencies:
   - role: edx_django_service
+    edx_django_service_use_python38: '{{ ANALYTICS_API_USE_PYTHON38 }}'
     edx_django_service_repos: '{{ ANALYTICS_API_REPOS }}'
     edx_django_service_name: '{{ analytics_api_service_name }}'
     edx_django_service_user: '{{ analytics_api_user }}'


### PR DESCRIPTION
Add ansible configuration to deploy analytics_api with python3.8

Right now, the default of edx_django_service_use_python38 is false. So, this change is not affecting the current behavior but add the possibility of install analyticsapi with python3.8 if the value of ANALYTICS_API_USE_PYTHON38 is overrided.

Based in the changes of https://github.com/edx/configuration/pull/5833
## Reviewers
- [ ] @awais786 
