### PR TITLE
[BD-6] Add config to deploy registrar with python3.8

### DIFF
--- a/playbooks/roles/registrar/defaults/main.yml
+++ b/playbooks/roles/registrar/defaults/main.yml
@@ -26,6 +26,8 @@ registrar_venvs_dir: "{{ registrar_app_dir }}/venvs"
 registrar_venv_dir: "{{ registrar_venvs_dir }}/registrar"
 registrar_celery_default_queue: 'registrar.default'
 
+REGISTRAR_USE_PYTHON38: false
+
 REGISTRAR_CELERY_ALWAYS_EAGER: false
 REGISTRAR_CELERY_BROKER_TRANSPORT: ''
 REGISTRAR_CELERY_BROKER_USER: ''

--- a/playbooks/roles/registrar/meta/main.yml
+++ b/playbooks/roles/registrar/meta/main.yml
@@ -12,6 +12,7 @@
 #
 dependencies:
   - role: edx_django_service
+    edx_django_service_use_python38: '{{ REGISTRAR_USE_PYTHON38 }}'
     edx_django_service_version: '{{ REGISTRAR_VERSION }}'
     edx_django_service_name: '{{ registrar_service_name }}'
     edx_django_service_home: '{{ COMMON_APP_DIR }}/{{ registrar_service_name }}'


### PR DESCRIPTION
Add ansible configuration to deploy registrar with python3.8

Right now, the default of edx_django_service_use_python38 is false. So, this change is not affecting the current behavior but add the possibility of install registrar with python3.8 if the value ofREGISTRAR_USE_PYTHON38 is overrided.

Based in the changes of https://github.com/edx/configuration/pull/5833
## Reviewers
- [x] @awais786 
