### PR TITLE
[BD-6] Add configuration to allow the installation of insights with python3.8

### DIFF
--- a/playbooks/roles/insights/defaults/main.yml
+++ b/playbooks/roles/insights/defaults/main.yml
@@ -207,6 +207,7 @@ insights_python_path: "{{ insights_code_dir }}/analytics_dashboard"
 insights_static_path: "{{ insights_code_dir }}/analytics_dashboard/static"
 insights_conf_dir: "{{ insights_home }}"
 insights_log_dir: "{{ COMMON_LOG_DIR }}/{{ insights_service_name }}"
+INSIGHTS_PYTHON_VERSION: "3.5"
 
 insights_nodeenv_dir: "{{ insights_home }}/nodeenvs/{{ insights_service_name }}"
 insights_nodeenv_bin: "{{ insights_nodeenv_dir }}/bin"

--- a/playbooks/roles/insights/tasks/main.yml
+++ b/playbooks/roles/insights/tasks/main.yml
@@ -32,13 +32,31 @@
     - install
     - install:configuration
 
+- name: add deadsnakes repo
+  apt_repository:
+      repo: ppa:deadsnakes/ppa
+  when: INSIGHTS_PYTHON_VERSION == "3.8" and ansible_distribution_release != 'focal'
+  tags:
+    - install
+    - install:system-requirements
+
+- name: install python3.8
+  apt:
+    pkg:
+      - python3.8-dev
+      - python3.8-distutils
+  when: INSIGHTS_PYTHON_VERSION == "3.8" ansible_distribution_release != 'focal'
+  tags:
+    - install
+    - install:system-requirements
+
 - name: install application requirements
   pip:
     requirements: "{{ insights_requirements_base }}/{{ item }}"
     virtualenv: "{{ insights_venv_dir }}"
     state: present
     extra_args: "--exists-action w"
-    virtualenv_python: python3.5
+    virtualenv_python: "python{{ INSIGHTS_PYTHON_VERSION }}"
   become_user: "{{ insights_user }}"
   with_items: "{{ insights_requirements }}"
   tags:


### PR DESCRIPTION
Add INSIGHTS_PYTHON_VERSION ansible configuration in order to allow the installation of insights with python3.8.


Based in the changes of https://github.com/edx/configuration/pull/5833
## Reviewers
- [ ] @awais786 
