### PR TITLE
Removing override for credentials node version

### DIFF
--- a/playbooks/roles/credentials/defaults/main.yml
+++ b/playbooks/roles/credentials/defaults/main.yml
@@ -21,7 +21,6 @@ credentials_environment:
   CREDENTIALS_CFG: '{{ COMMON_CFG_DIR }}/{{ credentials_service_name }}.yml'
 
 credentials_gunicorn_port: 8150
-CREDENTIALS_NODE_VERSION: '12.11.1'
 
 #
 # OS packages

--- a/playbooks/roles/credentials/meta/main.yml
+++ b/playbooks/roles/credentials/meta/main.yml
@@ -41,7 +41,6 @@ dependencies:
     edx_django_service_social_auth_redirect_is_https: '{{ CREDENTIALS_SOCIAL_AUTH_REDIRECT_IS_HTTPS }}'
     edx_django_service_extra_apps: '{{ CREDENTIALS_EXTRA_APPS }}'
     edx_django_service_session_expire_at_browser_close: '{{ CREDENTIALS_SESSION_EXPIRE_AT_BROWSER_CLOSE }}'
-    edx_django_service_node_version: '{{ CREDENTIALS_NODE_VERSION }}'
     edx_django_service_automated_users: '{{ CREDENTIALS_AUTOMATED_USERS }}'
     edx_django_service_cors_whitelist: '{{ CREDENTIALS_CORS_ORIGIN_WHITELIST }}'
     edx_django_service_post_migrate_commands: '{{ credentials_post_migrate_commands }}'


### PR DESCRIPTION
this is a bit of a "kick the bucket" change, but I anticipate we
should not override the node version without overriding the npm
version as well. Those versions not matching appears to cause
node-sass to be installed improperly, or for npm to not be installed
in an in-Docker usable way at all.

But either way this was prompted by the fact that this situation had
broken `make dev.static.credentials` in edx/devstack.

Configuration Pull Request