### PR TITLE
SE-2989 Update labxchange-xblocks hash to include case study updates

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -547,7 +547,7 @@ EDXAPP_PRIVATE_REQUIREMENTS:
     - name: git+https://github.com/edx/xblock-image-modal@20262ae713bf307f7b13afe73c8a32c5c56b4fd6#egg=xblock-image-modal
       extra_args: -e
     # XBlocks associated with the LabXchange project
-    - name: git+https://github.com/open-craft/labxchange-xblocks.git@3830256088845c23eedaf6bc8c5b29c0ebc46fbb#egg=labxchange-xblocks
+    - name: git+https://github.com/open-craft/labxchange-xblocks.git@907a7848e6c1d49b4e88b8a7e6adfdde3452f41e#egg=labxchange-xblocks
       extra_args: -e
     # "Pathways" learning context plugin for the LabXchange project
     - name: git+https://github.com/open-craft/lx-pathway-plugin.git@337abf249b7c5ecc1e78a44d2e639e1ab65f2085#egg=lx-pathway-plugin


### PR DESCRIPTION
See https://github.com/open-craft/labxchange-xblocks/pull/10 - this adds customizable sections and attachments to the labxchange case study xblock.

**Dependencies**: None

**Merge deadline**: None

**Testing instructions**:

1. verify that the updated hash/revision of the labxchange-xblocks dependency is valid and matches the commit that merged https://github.com/open-craft/labxchange-xblocks/pull/10
1. provision the platform with this configuration
2. verify that labxchange-xblocks is installed successfully in the environment.

**Reviewers**
- [x] @s0b0lev
- [x] edX reviewer[s] (@pomegranited )

**Settings**
```yaml
```