### PR TITLE
Make prospectus setup more similar to the learner_portal setup

### DIFF
--- a/util/jenkins/ansible-provision.sh
+++ b/util/jenkins/ansible-provision.sh
@@ -90,7 +90,6 @@ sandbox_secure_vars_file="${WORKSPACE}/configuration-secure/ansible/vars/develop
 sandbox_internal_vars_file="${WORKSPACE}/configuration-internal/ansible/vars/developer-sandbox.yml"
 extra_var_arg="-e@${extra_vars_file}"
 program_manager="false"
-prospectus="false"
 
 if [[ $edx_internal == "true" ]]; then
     # if this is a an edx server include
@@ -193,12 +192,16 @@ if [[ -z $learner_portal_version ]]; then
   LEARNER_PORTAL_VERSION="master"
 fi
 
-if [[ $registrar == 'true' ]]; then
-  program_manager="true"
+if [[ -z $prospectus ]]; then
+  prospectus="false"
 fi
 
-if [[ $prospectus == 'true' ]]; then
-  prospectus="true"
+if [[ -z $prospectus_version ]]; then
+  PROSPECTUS_VERSION="master"
+fi
+
+if [[ $registrar == 'true' ]]; then
+  program_manager="true"
 fi
 
 # Lowercase the dns name to deal with an ansible bug


### PR DESCRIPTION
Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
