### PR TITLE
Use Python 3.8 for `edx-certs`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 Add any new changes to the top(right below this line).
 
+ - 2020-09-23
+     - Role: certs
+       - Changed Python version used for creating virtualenv from the system's default (2.7) to 3.5.
+
  - 2020-09-18
      - Role: nginx
        - Add location to support accessing files from ```EDXAPP_MEDIA_URL``` under the cms site.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Add any new changes to the top(right below this line).
 
  - 2020-09-23
      - Role: certs
-       - Changed Python version used for creating virtualenv from the system's default (2.7) to 3.5.
+       - Changed Python version used for creating virtualenv from the system's default (2.7) to 3.8.
 
  - 2020-09-18
      - Role: nginx

--- a/playbooks/roles/certs/tasks/deploy.yml
+++ b/playbooks/roles/certs/tasks/deploy.yml
@@ -79,6 +79,7 @@
     virtualenv: "{{ certs_venv_dir }}"
     state: present
     extra_args: "-i {{ COMMON_PYPI_MIRROR_URL }}"
+    virtualenv_python: python3.5
   become_user: "{{ certs_user }}"
 
   # call supervisorctl update. this reloads

--- a/playbooks/roles/certs/tasks/deploy.yml
+++ b/playbooks/roles/certs/tasks/deploy.yml
@@ -79,7 +79,7 @@
     virtualenv: "{{ certs_venv_dir }}"
     state: present
     extra_args: "-i {{ COMMON_PYPI_MIRROR_URL }}"
-    virtualenv_python: python3.5
+    virtualenv_python: python3.8
   become_user: "{{ certs_user }}"
 
   # call supervisorctl update. this reloads

--- a/playbooks/roles/certs/tasks/main.yml
+++ b/playbooks/roles/certs/tasks/main.yml
@@ -94,6 +94,18 @@
   become_user: "{{ common_web_user }}"
   when: certs_gpg_key.changed
 
+- name: add deadsnakes repo
+  apt_repository:
+      repo: ppa:deadsnakes/ppa
+  when: ansible_distribution_version is version('20.04', '<')
+
+- name: install python3.8
+  apt:
+    pkg:
+      - python3.8-dev
+      - python3.8-distutils
+  when: ansible_distribution_version is version('20.04', '<')
+
 - include: deploy.yml
   tags:
     - deploy


### PR DESCRIPTION
Python 2.7 support has been dropped in edx/edx-certificates#70.

**Reviewers**
- [x] @kelketek
- [ ] edX reviewer[s] TBD

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
