### PR TITLE
Revert "update the registrar config to use python 3.8 deployment"

### DIFF
--- a/playbooks/roles/registrar/defaults/main.yml
+++ b/playbooks/roles/registrar/defaults/main.yml
@@ -26,7 +26,7 @@ registrar_venvs_dir: "{{ registrar_app_dir }}/venvs"
 registrar_venv_dir: "{{ registrar_venvs_dir }}/registrar"
 registrar_celery_default_queue: 'registrar.default'
 
-REGISTRAR_USE_PYTHON38: True
+REGISTRAR_USE_PYTHON38: false
 
 REGISTRAR_CELERY_ALWAYS_EAGER: false
 REGISTRAR_CELERY_BROKER_TRANSPORT: ''


### PR DESCRIPTION
This reverts commit c96735d98f37239b041afe864e94de0fc65babec.

Motivated by some runtime errors we saw with celery dependencies using `async` as an identifier, which is a reserved word in python 3.8. More details on that in [JIRA:BOM-1986](https://openedx.atlassian.net/browse/BOM-1986)