### PR TITLE
Add variable for configuring THIRD_PARTY_AUTH_BACKENDS

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -203,6 +203,15 @@ EDXAPP_ENABLE_AUTO_AUTH: false
 # Settings for enabling and configuring third party authorization
 EDXAPP_ENABLE_THIRD_PARTY_AUTH: true
 EDXAPP_ENABLE_OAUTH2_PROVIDER: false
+EDXAPP_THIRD_PARTY_AUTH_BACKENDS:
+  - social_core.backends.google.GoogleOAuth2
+  - social_core.backends.linkedin.LinkedinOAuth2
+  - social_core.backends.facebook.FacebookOAuth2
+  - social_core.backends.azuread.AzureADOAuth2
+  - third_party_auth.appleid.AppleIdAuth
+  - third_party_auth.identityserver3.IdentityServer3
+  - third_party_auth.saml.SAMLAuthBackend
+  - third_party_auth.lti.LTIAuthBackend
 
 EDXAPP_ENABLE_MOBILE_REST_API: false
 
@@ -1505,6 +1514,7 @@ lms_env_config:
   OAUTH_EXPIRE_PUBLIC_CLIENT_DAYS: "{{ EDXAPP_OAUTH_EXPIRE_PUBLIC_CLIENT_DAYS }}"
   OAUTH_DELETE_EXPIRED: "{{ EDXAPP_OAUTH_DELETE_EXPIRED }}"
   PAID_COURSE_REGISTRATION_CURRENCY: "{{ EDXAPP_PAID_COURSE_REGISTRATION_CURRENCY }}"
+  THIRD_PARTY_AUTH_BACKENDS: "{{ EDXAPP_THIRD_PARTY_AUTH_BACKENDS }}"
   GIT_REPO_DIR: "{{ EDXAPP_GIT_REPO_DIR }}"
   SITE_NAME:  "{{ EDXAPP_LMS_SITE_NAME }}"
   HTTPS: "{{ EDXAPP_LMS_HTTPS }}"


### PR DESCRIPTION
Configuration Pull Request

This PR adds a configuration variable to allow for configuration of third party authentication backends.
The defaults are filled in from the [current defaults in env files on master](https://github.com/edx/edx-platform/blob/ed5d592af0553e554e920513e7a71c7143f0afcb/lms/envs/production.py#L622) to prevent altering default behavior.
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?