### PR TITLE
update the edx-notes-api config to use python 3.8

### DIFF
--- a/playbooks/roles/edx_notes_api/defaults/main.yml
+++ b/playbooks/roles/edx_notes_api/defaults/main.yml
@@ -142,5 +142,6 @@ edx_notes_api_debian_pkgs:
   - python-mysqldb
   - libssl-dev # needed for mysqlclient python library
   - python3-dev
+  - python3.8-dev
 
 edx_notes_api_redhat_pkgs: []

--- a/playbooks/roles/edx_notes_api/tasks/main.yml
+++ b/playbooks/roles/edx_notes_api/tasks/main.yml
@@ -48,7 +48,7 @@
     virtualenv: "{{ edx_notes_api_home }}/venvs/{{ edx_notes_api_service_name }}"
     state: present
     extra_args: "--exists-action w"
-    virtualenv_python: 'python3.5'
+    virtualenv_python: 'python3.8'
   become_user: "{{ edx_notes_api_user }}"
   with_items: "{{ edx_notes_api_requirements }}"
   tags:


### PR DESCRIPTION
Configuration Pull Request
---
Relevant JIRA issue here: https://openedx.atlassian.net/browse/BOM-1965

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
