### PR TITLE
BOM-1997 : Update XQueue configuration to use Python 3.8

### DIFF
--- a/playbooks/roles/xqueue/defaults/main.yml
+++ b/playbooks/roles/xqueue/defaults/main.yml
@@ -183,4 +183,6 @@ xqueue_debian_pkgs:
   - python3-dev
 
 # flag to run xqueue on python3
-xqueue_use_python3: true
+xqueue_use_python3: false
+# flag to run xqueue on python3.8
+xqueue_use_python38: true

--- a/playbooks/roles/xqueue/tasks/main.yml
+++ b/playbooks/roles/xqueue/tasks/main.yml
@@ -1,5 +1,22 @@
 ---
 ######## BEGIN PYTHON3 ########
+- name: add deadsnakes repo
+  apt_repository:
+      repo: ppa:deadsnakes/ppa
+      update_cache: yes
+  when: xqueue_use_python38
+
+- name: install python3.8
+  apt:
+    name: "{{ item }}"
+  when: xqueue_use_python38
+  with_items:
+    - python3.8-dev
+    - python3.8-distutils
+  tags:
+    - install
+    - install:system-requirements
+
 - name: install python3
   apt:
     name: "{{ item }}"
@@ -7,6 +24,16 @@
   with_items:
     - python3-pip
     - python3-dev
+  tags:
+    - install
+    - install:system-requirements
+
+- name: build virtualenv with python3.8
+  command: "virtualenv --python=python3.8 {{ xqueue_venv_dir }}"
+  args:
+    creates: "{{ xqueue_venv_dir }}/bin/pip"
+  become_user: "{{ xqueue_user }}"
+  when: xqueue_use_python38
   tags:
     - install
     - install:system-requirements
@@ -20,6 +47,19 @@
   tags:
     - install
     - install:system-requirements
+
+- name: "Install python3.8 requirements"
+  pip:
+    requirements: "{{ xqueue_requirements_file }}"
+    virtualenv: "{{ xqueue_venv_dir }}"
+    virtualenv_python: 'python3.8'
+    state: present
+    extra_args: "-i {{ COMMON_PYPI_MIRROR_URL }} --exists-action w"
+  become_user: "{{ xqueue_user }}"
+  when: xqueue_use_python38
+  tags:
+    - install
+    - install:app-requirements
 
 - name: "Install python3 requirements"
   pip:
@@ -41,7 +81,7 @@
   args:
     creates: "{{ xqueue_venv_dir }}/bin/pip"
   become_user: "{{ xqueue_user }}"
-  when: not xqueue_use_python3
+  when: not xqueue_use_python3 and not xqueue_use_python38
   tags:
     - install
     - install:system-requirements
@@ -117,7 +157,7 @@
     state: present
     extra_args: "-i {{ COMMON_PYPI_MIRROR_URL }} --exists-action w"
   become_user: "{{ xqueue_user }}"
-  when: not xqueue_use_python3
+  when: not xqueue_use_python3 and not xqueue_use_python38
   tags:
     - install
     - install:app-requirements


### PR DESCRIPTION
Relevant JIRA : https://openedx.atlassian.net/browse/BOM-1997

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
