### PR TITLE
ENT-3336: Added Transmission API limit of 1 for SAP, this will limit api calls o sap in enterprise integrated channels and avoid throttling.

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -701,6 +701,13 @@ EDXAPP_SYSTEM_WIDE_ROLE_CLASSES: []
 # Setting for enterprise marketing footer query params
 EDXAPP_ENTERPRISE_MARKETING_FOOTER_QUERY_PARAMS: {}
 
+# Setting for limiting API calls for integrated channel transmission.
+# The setting key maps to the channel code (e.g. 'SAP' for success factors), Channel code is defined as
+# part of django model of each integrated channel in edx-enterprise.
+# The absence of a key/value pair translates to NO LIMIT on the number of "chunks" transmitted per cycle.
+EDXAPP_INTEGRATED_CHANNELS_API_CHUNK_TRANSMISSION_LIMIT:
+  SAP: 1
+
 # E-Commerce Related Settings
 EDXAPP_ECOMMERCE_PUBLIC_URL_ROOT: "http://localhost:8002"
 EDXAPP_ECOMMERCE_API_URL: "http://localhost:8002/api/v2"
@@ -1324,6 +1331,7 @@ generic_env_config:  &edxapp_generic_env
   SYSTEM_WIDE_ROLE_CLASSES: "{{ EDXAPP_SYSTEM_WIDE_ROLE_CLASSES }}"
 
   ENTERPRISE_MARKETING_FOOTER_QUERY_PARAMS: "{{ EDXAPP_ENTERPRISE_MARKETING_FOOTER_QUERY_PARAMS }}"
+  INTEGRATED_CHANNELS_API_CHUNK_TRANSMISSION_LIMIT: "{{ EDXAPP_INTEGRATED_CHANNELS_API_CHUNK_TRANSMISSION_LIMIT }}"
 
   #must end in slash (https://docs.djangoproject.com/en/1.4/ref/settings/#media-url)
   MEDIA_URL:  "{{ EDXAPP_MEDIA_URL }}/"


### PR DESCRIPTION
__Description:__
This PR Adds Transmission API limit of 1 for SAP, this will limit API calls to SAP in enterprise integrated channels and avoid throttling.

Setting `INTEGRATED_CHANNELS_API_CHUNK_TRANSMISSION_LIMIT` was introduced in https://github.com/edx/edx-enterprise/pull/935 and https://github.com/edx/edx-platform/pull/24854 

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
