### PR TITLE
Add EDXAPP_MEDIA_URL to cms nginx configuration.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 Add any new changes to the top(right below this line).
 
+ - 2020-09-18
+     - Role: nginx
+       - Add location to support accessing files from ```EDXAPP_MEDIA_URL``` under the cms site.
+
  - 2020-09-14
      - Playbook: program_manager
        - Removed. It is replaced by program_console

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/cms.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/cms.j2
@@ -132,6 +132,11 @@ error_page {{ k }} {{ v }};
     try_files $uri @proxy_to_cms_app_api;
   }
 
+location ~ ^{{ EDXAPP_MEDIA_URL }}/(?P<file>.*) {
+    root {{ edxapp_media_dir }};
+    try_files /$file =404;
+}
+
 {% if NGINX_ADMIN_ACCESS_CIDRS and EDXAPP_ENABLE_DJANGO_ADMIN_RESTRICTION %}
   location /admin {
     real_ip_header X-Forwarded-For;


### PR DESCRIPTION
This allows for viewing of scorm media (or any files under /media) on the studio view without having to utilize the preview website.

Without this files under /media/* aren't available for viewing when building elements in studio. The lms site configuration already has this code.

Configuration Pull Request
---

Make sure that the following steps are done before merging:
  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [X] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?