### PR TITLE
WS-1232: add healthcheck back into nginx config

### DIFF
--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/prospectus.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/prospectus.j2
@@ -32,6 +32,11 @@ server {
 
   root {{ PROSPECTUS_DATA_DIR }};
 
+  # Ignore the rollout group headers for the health check endpoint.
+  location /HealthCheck {
+    try_files $uri $uri/ $uri/index.html;
+  }
+
   location /es/bio/ {
     try_files $uri $uri/ /es/bio/index.html;
   }


### PR DESCRIPTION
Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
