### PR TITLE
Move credentials docker container to 20.04 image

### DIFF
--- a/docker/build/credentials/Dockerfile
+++ b/docker/build/credentials/Dockerfile
@@ -8,7 +8,7 @@
 # with the currently checked-out configuration repo.
 
 ARG BASE_IMAGE_TAG=latest
-FROM edxops/xenial-common:${BASE_IMAGE_TAG}
+FROM edxops/focal-common:${BASE_IMAGE_TAG}
 LABEL maintainer="edxops"
 USER root
 ENTRYPOINT ["/edx/app/credentials/devstack.sh"]


### PR DESCRIPTION
As part of the 16.04 => 20.04 upgrade, we need to upgrade the version in
the container.

[MICROBA-545]

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?


[MICROBA-545]: https://openedx.atlassian.net/browse/MICROBA-545