### PR TITLE
Fix ECOMMERCE_USE_PYTHON3 is undefined error

### DIFF
--- a/playbooks/roles/ecommerce/meta/main.yml
+++ b/playbooks/roles/ecommerce/meta/main.yml
@@ -30,7 +30,6 @@ dependencies:
     edx_django_service_gunicorn_workers: "{{ ECOMMERCE_GUNICORN_WORKERS }}"
     edx_django_service_nginx_port: '{{ ECOMMERCE_NGINX_PORT }}'
     edx_django_service_ssl_nginx_port: '{{ ECOMMERCE_SSL_NGINX_PORT }}'
-    edx_django_service_use_python3: '{{ ECOMMERCE_USE_PYTHON3 }}'
     edx_django_service_use_python38: '{{ ECOMMERCE_USE_PYTHON38 }}'
     edx_django_service_language_code: '{{ ECOMMERCE_LANGUAGE_CODE }}'
     edx_django_service_secret_key: '{{ ECOMMERCE_SECRET_KEY }}'


### PR DESCRIPTION
I tried to run a native installation, and it failed because ECOMMERCE_USE_PYTHON3 is undefined.


The default value of edx_django_service_use_python3 is true, so it is not necessary to override that configuration.

The config is undefined since this change:

https://github.com/edx/configuration/commit/5027cf76f3c955d657e19de61704c1b5e74672da

