### PR TITLE
SE-3327 Validate certs, fix url for digicert ca download

### DIFF
--- a/playbooks/roles/common/tasks/main.yml
+++ b/playbooks/roles/common/tasks/main.yml
@@ -20,7 +20,7 @@
   get_url:
     url: "{{ common_digicert_base_url }}/{{ common_digicert_name }}.pem"
     dest: "/usr/local/share/ca-certificates/{{ common_digicert_name }}"
-    validate_certs: no
+    validate_certs: yes
   when: update_ca_certificates is defined and update_ca_certificates.results[0].stat.exists == True
 
 - name: Update CA Certificates

--- a/playbooks/roles/common_vars/defaults/main.yml
+++ b/playbooks/roles/common_vars/defaults/main.yml
@@ -55,7 +55,7 @@ COMMON_NPM_MIRROR_URL: 'https://registry.npmjs.org'
 COMMON_UBUNTU_APT_KEYSERVER: "http://keyserver.ubuntu.com/pks/lookup?op=get&fingerprint=on&search="
 
 common_digicert_name: "DigiCertSHA2SecureServerCA.crt"
-common_digicert_base_url: "https://dl.cacerts.digicert.com/"
+common_digicert_base_url: "https://cacerts.digicert.com/"
 
 COMMON_EDX_PPA: "deb http://ppa.edx.org {{ ansible_distribution_release }} main"
 COMMON_EDX_PPA_KEY_SERVER: "keyserver.ubuntu.com"


### PR DESCRIPTION
This fixes a minor security issue where ssl certificate is not validated for the digicert ca certificates download task.  It does this by using a url that has a certificate that is able to be validated on a base ubuntu image, and enables validate_certs on the ansible get_url task.

This is important, because without validating certs here, it's possible for undesired ca certificates to be added to the root trust if this playbook is run on an untrusted network.


**JIRA tickets**: [OSPR-5011](https://openedx.atlassian.net/browse/OSPR-5011)

**Dependencies**: None


**Sandbox URL**: TBD - sandbox is being provisioned.

**Merge deadline**: "None"

**Testing instructions**:

1. provision an open edx instance using this branch of configuration, and the default value of `common_digicert_base_url`
2. verify that the `Download digicert intermediate Certificate` task succeeds



**Reviewers**
- [x] @bradenmacdonald 
- [x] edX reviewer[s] TBD

**Settings**
```yaml

```