### PR TITLE
MFE role: fix branding override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 All notable changes to this project will be documented in this file.
 Add any new changes to the top(right below this line).
 
+ - 2020-11-10
+     - Role: mfe
+       - Added role deploy to deploy MFE in a single machine with nginx.
+     - Open edX
+       - Use new role to deploy gradebook, profile and account MFEs in native installation.
+
  - 2020-11-04
      - Role: edxapp
        - Stopped rendering legacy auth and env json files that edxapp is no longer reading. Rendering can be reenabled by setting EDXAPP_ENABLE_LEGACY_JSON_CONFIGS to true

--- a/playbooks/roles/mfe/tasks/main.yml
+++ b/playbooks/roles/mfe/tasks/main.yml
@@ -18,10 +18,9 @@
 #
 # Example play:
 #
-# Rather than being included in the play, this role
-# is included as a dependency by other roles in the meta/main.yml
-# file.  The including role should add the following
-# depency definition.
+# It is recommended to deploy MFE directly using the mfe_deployer role instead of this one.
+# This role can be used as a dependency by other roles in the meta/main.yml
+# file.  The including role should add the following dependency definition.
 #
 # dependencies:
 #   - role: mfe
@@ -31,8 +30,21 @@
 #   MFE_SITE_NAME: "{{ PROFILE_SITE_NAME }}"
 #   MFE_APP_VERSION: "{{ PROFILE_VERSION }}"
 #   MFE_NODE_VERSION: "{{ PROFILE_NODE_VERSION }}"
-
-
+#
+# This role can also be used directly in the playbooks
+#
+#- name: Configure instance(s)
+#  hosts: all
+#  become: True
+#  gather_facts: True
+#  roles:
+#    - role: mfe
+#      MFE_NAME: profile
+#    - role: mfe
+#      MFE_NAME: gradebook
+#    - role: mfe
+#      MFE_NAME: account
+#
 
 - name: install needed packages
   apt:
@@ -69,19 +81,18 @@
   become_user: "{{ MFE_USER }}"
   environment: "{{ MFE_ENVIRONMENT }}"
   tags:
-    - install
-    - install:app-requirements
+    - install:base
 
 - name: install npm overrides
-  npm:
-    name: "{{ MFE_NPM_OVERRIDES }}"
-    path: "{{ MFE_CODE_DIR }}"
+  shell: "npm install {{ item }} --no-save"
+  args:
+    chdir: "{{ MFE_CODE_DIR }}"
   become_user: "{{ MFE_USER }}"
   environment: "{{ MFE_ENVIRONMENT }}"
-  when: MFE_NPM_OVERRIDES | bool
+  with_items: "{{ MFE_NPM_OVERRIDES }}"
   tags:
     - install
-    - install:app-requirements
+    - install:base
 
 - name: build MFE
   command: "npm run build"

--- a/playbooks/roles/mfe/tasks/main.yml
+++ b/playbooks/roles/mfe/tasks/main.yml
@@ -81,7 +81,8 @@
   become_user: "{{ MFE_USER }}"
   environment: "{{ MFE_ENVIRONMENT }}"
   tags:
-    - install:base
+    - install
+    - install:app-requirements
 
 - name: install npm overrides
   shell: "npm install {{ item }} --no-save"
@@ -92,7 +93,7 @@
   with_items: "{{ MFE_NPM_OVERRIDES }}"
   tags:
     - install
-    - install:base
+    - install:app-requirements
 
 - name: build MFE
   command: "npm run build"

--- a/playbooks/roles/mfe/templates/edx/app/nginx/sites-available/app.j2
+++ b/playbooks/roles/mfe/templates/edx/app/nginx/sites-available/app.j2
@@ -13,11 +13,12 @@ server {
   {% if NGINX_REDIRECT_TO_HTTPS %}
     {% include "concerns/handle-tls-terminated-elsewhere-ip-disclosure.j2" %}
     {% include "concerns/handle-tls-terminated-elsewhere-redirect.j2" %}
+  {% else %}
+    {% include "concerns/mfe-common.j2" %}
+    {% include "concerns/mfe.j2" %}
   {% endif %}
-  {% include "concerns/mfe-common.j2" %}
 {% endif %}
 
-  {% include "concerns/mfe.j2" %}
 }
 
 {% if NGINX_ENABLE_SSL %}


### PR DESCRIPTION
Part 2 of the MFE deployment reference for the community.

In this PR, it was fixed the part that install the npm aliases for the MFEs.

Specifically, I used:

https://github.com/eduNEXT/frontend-component-header-edunext/ by changing the value of  MFE_NPM_OVERRIDES to
```yaml
MFE_NPM_OVERRIDES: [
   "@edx/frontend-component-header@git+https://github.com/edunext/frontend-component-header-edunext.git"
]
```

So right now, https://profile.mfe.stage.edunext.co/ and https://account.mfe.stage.edunext.co/ are using the header of that repo (I only changed the logo and some extra changes to the package.json in order to allow the installation from github).

I also started to add documentation for the role.


Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
