### PR TITLE
SE-3327 fix simple-theme build by removing lms-main-v2 / discussion-main templates

### DIFF
--- a/playbooks/roles/simple_theme/files/default_skeleton/lms/static/sass/discussion/lms-discussion-main.scss
+++ b/playbooks/roles/simple_theme/files/default_skeleton/lms/static/sass/discussion/lms-discussion-main.scss
@@ -1,2 +1,0 @@
-@import 'lms/static/sass/discussion/lms-discussion-main';
-@import '../lms-overrides';

--- a/playbooks/roles/simple_theme/files/default_skeleton/lms/static/sass/lms-main-v2.scss
+++ b/playbooks/roles/simple_theme/files/default_skeleton/lms/static/sass/lms-main-v2.scss
@@ -1,3 +1,0 @@
-@import 'lms/static/sass/lms-main-v2';
-
-@import 'lms-overrides';


### PR DESCRIPTION
This was removed in edx-platform in https://github.com/edx/edx-platform/pull/24624

This should fix this error or equivalent:

```
sass.CompileError: b"Error: File to import not found or unreadable: lms/static/sass/lms-main-v2
    Parent style sheet: /edx/var/edxapp/themes/simple-theme/lms/static/sass/lms-main-v2.scss
    on line 1 of ../../../var/edxapp/themes/simple-theme/lms/static/sass/lms-main-v2.scss
    >> @import 'lms/static/sass/lms-main-v2';
       ^
```

**JIRA tickets**: [OSPR-5019](https://openedx.atlassian.net/browse/OSPR-5019)

**Dependencies**: None


**Sandbox URL**: TBD - sandbox is being provisioned.

**Merge deadline**: "None"

**Testing instructions**:

1. provision an instance using this branch and with the simple-theme role enabled
1. verify that it completes successfully and that the theme is compiled and displays as expected

**Author notes**:

- this is temporarily based on https://github.com/edx/configuration/pull/6047 for internal testing purposes. Will update soon.

**Reviewers**
- [x] @bradenmacdonald 
- [ ] edX reviewer[s] TBD

**Settings**
```yaml
```
