### PR TITLE
Increase code jail timeout to prevent failing on first run

### DIFF
--- a/docker/build/edxapp/lms.yml
+++ b/docker/build/edxapp/lms.yml
@@ -136,7 +136,7 @@ CODE_JAIL:
         CPU: 1
         FSIZE: 1048576
         PROXY: 0
-        REALTIME: 3
+        REALTIME: 6
         VMEM: 536870912
     python_bin: ''
     user: sandbox

--- a/docker/build/edxapp/studio.yml
+++ b/docker/build/edxapp/studio.yml
@@ -102,7 +102,7 @@ CODE_JAIL:
         CPU: 1
         FSIZE: 1048576
         PROXY: 0
-        REALTIME: 3
+        REALTIME: 6
         VMEM: 536870912
     python_bin: ''
     user: sandbox

--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -619,7 +619,7 @@ EDXAPP_CODE_JAIL_LIMITS:
   # infinite (512MiB in bytes)
   VMEM: 536870912
   # Time in seconds that the jailed process has to run.
-  REALTIME: 3
+  REALTIME: 6
   # Needs to be non-zero so that jailed code can use it as their temp directory.(1MiB in bytes)
   FSIZE: 1048576
   CPU: 1


### PR DESCRIPTION
New Juniper instances, code jail seems to throw an error while running for the first time. It has been observed that increasing ``REALTIME`` value helps. This PR increases code jail timeout from 3 sec to 6 sec.

**JIRA tickets**: https://tasks.opencraft.com/browse/BB-3004

~~**Discussions**:~~

**Dependencies**: None

~~**Screenshots**:~~
~~**Sandbox URL**:~~

**Merge deadline**: "None"

**Testing instructions**:
1. Provision a new juniper instance.
2. Visit - https://lms_ocim_link_here/courses/course-v1:edX+DemoX+Demo_Course/courseware/interactive_demonstrations/basic_questions/?activate_block_id=block-v1%3AedX%2BDemoX%2BDemo_Course%2Btype%40sequential%2Bblock%40basic_questions
3. Submit Chemical equation
4. It should not show any error log. It would just check if the given value is correct or incorrect.


~~**Author notes and concerns**:~~


**Reviewers**
- [ ] @0x29a 
- [ ] edX reviewer[s] TBD

~~**Settings**~~