### PR TITLE
jq is required to be able to conveniently use aws sts assume-role

### DIFF
--- a/playbooks/roles/jenkins_analytics/defaults/main.yml
+++ b/playbooks/roles/jenkins_analytics/defaults/main.yml
@@ -1,10 +1,13 @@
 ---
 # See README.rst for variable descriptions
 
-# Packages required to build edx-analytics-pipeline
 JENKINS_ANALYTICS_EXTRA_PKGS:
+  # Packages required to build edx-analytics-pipeline
   - libpq-dev
   - libffi-dev
+  # Packages required to use aws sts assume-role
+  - jq
+
 
 # Change this default password: (see README.rst to see how you can do it)
 JENKINS_ANALYTICS_USER_PASSWORD_PLAIN: jenkins


### PR DESCRIPTION
Otherwise, you would need to parse the JSON output with sed or python.

DENG-382

---

FYI, I already installed jq so we don't need to run this ansible.