### PR TITLE
updated the registrar config to use python 3.8

### DIFF
--- a/playbooks/roles/registrar/defaults/main.yml
+++ b/playbooks/roles/registrar/defaults/main.yml
@@ -26,7 +26,7 @@ registrar_venvs_dir: "{{ registrar_app_dir }}/venvs"
 registrar_venv_dir: "{{ registrar_venvs_dir }}/registrar"
 registrar_celery_default_queue: 'registrar.default'
 
-REGISTRAR_USE_PYTHON38: false
+REGISTRAR_USE_PYTHON38: True
 
 REGISTRAR_CELERY_ALWAYS_EAGER: false
 REGISTRAR_CELERY_BROKER_TRANSPORT: ''


### PR DESCRIPTION
Configuration Pull Request
---
Configuration changes to switch registrar to use python 3.8 was reverted in https://github.com/edx/configuration/pull/5952
Since Registrar is now updated with the latest version of `celery` as covered in [BOM-1986](https://openedx.atlassian.net/browse/BOM-1986)
Registrar now should be ready to switch to use python 3.8