### PR TITLE
A marker that is more reliable

### DIFF
--- a/util/install/native.sh
+++ b/util/install/native.sh
@@ -176,8 +176,10 @@ if [[ $ansible_status -ne 0 ]]; then
     echo "------------------------------------------------------------"
     echo " "
     echo "Decoded error:"
-    # Find the FAILED line before the "to retry," line, and decode it.
-    awk '/to +retry,/{if (bad) print bad} /FAILED/{bad=$0}' $log_file | python3 /var/tmp/configuration/util/ansible_msg.py
+    # Find the FAILED line before the "NO MORE HOSTS" line, and decode it.
+    # The plusses in the regex are because if I run this with -x, the awk line
+    # will be added to the log, and the regex would find itself if it didn't have plusses.
+    awk '/NO +MORE +HOSTS/{if (bad) print bad} /FAILED/{bad=$0}' $log_file | python3 /var/tmp/configuration/util/ansible_msg.py
     echo " "
     echo "============================================================"
     echo "Installation failed!"


### PR DESCRIPTION
This script that tries to find and decode the ansible error message was failing to find one recently, because "to retry" wasn't in the output? But "NO MORE HOSTS" still was, so let's use that.