### PR TITLE
Updated edxapp configuration to switch from ubuntu 16.04 to 20.04

### DIFF
--- a/docker/build/edxapp/Dockerfile
+++ b/docker/build/edxapp/Dockerfile
@@ -8,7 +8,7 @@
 # with the currently checked-out configuration repo.
 
 ARG BASE_IMAGE_TAG=latest
-FROM edxops/xenial-common:${BASE_IMAGE_TAG}
+FROM edxops/focal-common:${BASE_IMAGE_TAG}
 LABEL maintainer="edxops"
 USER root
 ENTRYPOINT ["/edx/app/edxapp/devstack.sh"]


### PR DESCRIPTION
Configuration Pull Request
---
this PR needs the following PRs (for MySql 5.7 upgrade) to merge before it can be merged:
1. https://github.com/edx/configuration/pull/6074 (updates MySQL to 5.7 for edxapp)[**Merged**]
2. https://github.com/edx/devstack/pull/643 (updates `docker-compose.yml` to use MySql 5.7 for lms and studio containers)[**Merged**]
3. https://github.com/edx/edx-platform/pull/25362 (updates edx-platform configurations to use MySql 5.7 container named `mysql57`)[**Merged**]

Make sure that the following steps are done before merging:

  - [x] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
