### PR TITLE
Pin version of zipp

### DIFF
--- a/playbooks/roles/common_vars/defaults/main.yml
+++ b/playbooks/roles/common_vars/defaults/main.yml
@@ -155,6 +155,7 @@ common_pip_pkgs:
   - pip=={{ COMMON_PIP_VERSION }}
   - setuptools==44.1.0
   - virtualenv==20.1.0
+  - zipp==1.2.0
   - boto3
 
 common_web_user: www-data


### PR DESCRIPTION
edxapp pipeline was blocked at build_edxapp_amis.run_play after #6083 was merged:
```Could not get output from /usr/local/bin/virtualenv --help: Traceback (most recent call last):
  File "/usr/local/bin/virtualenv", line 7, in <module>
    from virtualenv.__main__ import run_with_catch
  File "/usr/local/lib/python2.7/dist-packages/virtualenv/__init__.py", line 3, in <module>
    from .run import cli_run, session_via_cli
  File "/usr/local/lib/python2.7/dist-packages/virtualenv/run/__init__.py", line 11, in <module>
    from .plugin.activators import ActivationSelector
  File "/usr/local/lib/python2.7/dist-packages/virtualenv/run/plugin/activators.py", line 6, in <module>
    from .base import ComponentBuilder
  File "/usr/local/lib/python2.7/dist-packages/virtualenv/run/plugin/base.py", line 9, in <module>
    from importlib_metadata import entry_points
  File "/usr/local/lib/python2.7/dist-packages/importlib_metadata/__init__.py", line 9, in <module>
    import zipp
ImportError: No module named zipp
```
We figured it is trying to install the latest version which has dropped support for Python 2.7, Pinning it to last supported version.