### PR TITLE
Pin configparser to work around pip resolution bug BOM-2015

### DIFF
--- a/playbooks/roles/common_vars/defaults/main.yml
+++ b/playbooks/roles/common_vars/defaults/main.yml
@@ -152,6 +152,7 @@ old_python_debian_pkgs:
 COMMON_PIP_VERSION: '20.0.2'
 
 common_pip_pkgs:
+  - configparser==4.0.2
   - pip=={{ COMMON_PIP_VERSION }}
   - setuptools==44.1.0
   - virtualenv==20.1.0


### PR DESCRIPTION
Followup to https://github.com/edx/configuration/pull/6083 and https://github.com/edx/configuration/pull/6115 .  pip is also erroneously getting a version of `configparser` that has dropped Python 2.7 support, so pinning to an older version until we finish upgrading the version of Python running Ansible.