### PR TITLE
Remove symlinks to virtualenv binaries BOM-2015

### DIFF
--- a/playbooks/continuous_delivery/rollback_migrations.yml
+++ b/playbooks/continuous_delivery/rollback_migrations.yml
@@ -44,7 +44,7 @@
   become: true
 
   vars:
-    COMMAND_PREFIX: ". {{ APPLICATION_PATH }}/{{ APPLICATION_NAME }}_env; DB_MIGRATION_USER={{ DB_MIGRATION_USER }} DB_MIGRATION_PASS='{{ DB_MIGRATION_PASS }}' /edx/bin/python.{{ APPLICATION_NAME }} /edx/bin/manage.{{ APPLICATION_NAME }} "
+    COMMAND_PREFIX: ". {{ APPLICATION_PATH }}/{{ APPLICATION_NAME }}_env; DB_MIGRATION_USER={{ DB_MIGRATION_USER }} DB_MIGRATION_PASS='{{ DB_MIGRATION_PASS }}' {{ APPLICATION_PATH }}/venvs/{{ APPLICATION_NAME }}/bin/python /edx/bin/manage.{{ APPLICATION_NAME }} "
     EDX_PLATFORM_SETTINGS: "production"
     rollback_result: rollback_result.yml
     original_state: original_state.yml

--- a/playbooks/continuous_delivery/run_management_command.yml
+++ b/playbooks/continuous_delivery/run_management_command.yml
@@ -23,7 +23,7 @@
 - hosts: all
   vars:
     EDX_PLATFORM_SETTINGS: "production"
-    COMMAND_PREFIX: " . {{ APPLICATION_PATH }}/{{ APPLICATION_NAME }}_env; /edx/bin/python.{{ APPLICATION_NAME }} /edx/bin/manage.{{ APPLICATION_NAME }}"
+    COMMAND_PREFIX: " . {{ APPLICATION_PATH }}/{{ APPLICATION_NAME }}_env; {{ APPLICATION_PATH }}/venvs/{{ APPLICATION_NAME }}/bin/python /edx/bin/manage.{{ APPLICATION_NAME }}"
   gather_facts: False
   become: True
   tasks:
@@ -36,4 +36,4 @@
   - name: run edxapp management command
     shell: '{{ COMMAND_PREFIX }} {{ COMMAND }} --settings "{{ EDX_PLATFORM_SETTINGS }}"'
     become_user: "{{ APPLICATION_USER }}"
-    when: APPLICATION_NAME == "edxapp" 
+    when: APPLICATION_NAME == "edxapp"

--- a/playbooks/continuous_delivery/run_migrations.yml
+++ b/playbooks/continuous_delivery/run_migrations.yml
@@ -36,7 +36,7 @@
     migration_plan: migration_plan.yml
     migration_result: migration_result.yml
     EDX_PLATFORM_SETTINGS: "production"
-    COMMAND_PREFIX: " . {{ APPLICATION_PATH }}/{{ APPLICATION_NAME }}_env; DB_MIGRATION_USER={{ DB_MIGRATION_USER }} DB_MIGRATION_PASS={{ DB_MIGRATION_PASS }} /edx/bin/python.{{ APPLICATION_NAME }} /edx/bin/manage.{{ APPLICATION_NAME }}"
+    COMMAND_PREFIX: " . {{ APPLICATION_PATH }}/{{ APPLICATION_NAME }}_env; DB_MIGRATION_USER={{ DB_MIGRATION_USER }} DB_MIGRATION_PASS={{ DB_MIGRATION_PASS }} {{ APPLICATION_PATH }}/venvs/{{ APPLICATION_NAME }}/bin/python /edx/bin/manage.{{ APPLICATION_NAME }}"
   vars_files:
     - roles/edxapp/defaults/main.yml
   gather_facts: False

--- a/playbooks/continuous_delivery/upload_assets.yml
+++ b/playbooks/continuous_delivery/upload_assets.yml
@@ -26,7 +26,7 @@
     # Both LMS and Studio gather their assets to the same directory,
     # so most of the time leaving the default sub-application will be fine.
     SUB_APPLICATION_NAME: "lms"
-    COMMAND_PREFIX: " . {{ APPLICATION_PATH }}/{{ APPLICATION_NAME }}_env; /edx/bin/python.{{ APPLICATION_NAME }} /edx/bin/manage.{{ APPLICATION_NAME }}"
+    COMMAND_PREFIX: " . {{ APPLICATION_PATH }}/{{ APPLICATION_NAME }}_env; {{ APPLICATION_PATH }}/venvs/{{ APPLICATION_NAME }}/bin/python /edx/bin/manage.{{ APPLICATION_NAME }}"
     STATIC_ROOT: >-
       $({{ COMMAND_PREFIX }} shell --command "from django.conf import settings; print(getattr(settings, 'STATIC_ROOT', ''))")
     STATIC_ROOT_EDXAPP: >-

--- a/playbooks/manage_edxapp_users_and_groups.yml
+++ b/playbooks/manage_edxapp_users_and_groups.yml
@@ -75,7 +75,7 @@
 - hosts: all
   vars:
     env_path: /edx/app/edxapp/edxapp_env
-    python_path: /edx/bin/python.edxapp
+    python_path: /edx/app/edxapp/venvs/edxapp/bin/python
     manage_path: /edx/bin/manage.edxapp
     ignore_user_creation_errors: no
     deployment_settings: "{{ EDXAPP_SETTINGS | default('production') }}"

--- a/playbooks/populate_configuration_model.yml
+++ b/playbooks/populate_configuration_model.yml
@@ -34,7 +34,7 @@
 
 - hosts: all
   vars:
-    python_path: /edx/bin/python.edxapp
+    python_path: /edx/app/edxapp/venvs/edxapp/bin/python
     manage_path: /edx/bin/manage.edxapp
     lms_env: /edx/app/edxapp/edxapp_env
   become_user: www-data

--- a/playbooks/roles/ansible-role-django-ida/templates/tasks/main.yml.j2
+++ b/playbooks/roles/ansible-role-django-ida/templates/tasks/main.yml.j2
@@ -127,19 +127,6 @@
     - manage
     - manage:start
 
-- name: create symlinks from the venv bin dir
-  file:
-    src: "{{ '{{' }} {{ role_name|lower }}_venv_dir }}/bin/{{ '{{' }} item }}"
-    dest: "{{ '{{' }} COMMON_BIN_DIR }}/{{ '{{' }} item.split('.')[0] }}.{{ role_name }}"
-    state: link
-  with_items:
-    - python
-    - pip
-    - django-admin.py
-  tags:
-    - install
-    - install:app-requirements
-
 - name: create symlinks from the repo dir
   file:
     src: "{{ '{{' }} {{ role_name }}_code_dir }}/{{ '{{' }} item }}"

--- a/playbooks/roles/edx_django_service/meta/main.yml
+++ b/playbooks/roles/edx_django_service/meta/main.yml
@@ -11,7 +11,7 @@ dependencies:
     supervisor_spec:
       - service: "{{ edx_django_service_name }}"
         migration_check_services: "{{ edx_django_service_migration_check_services }}"
-        python: "python.{{ edx_django_service_name }}"
+        python: "{{ edx_django_service_venv_bin_dir }}/python"
         code: "{{ edx_django_service_code_dir }}"
         env: "{{ edx_django_service_home }}/{{ edx_django_service_name }}_env"
   - role: automated

--- a/playbooks/roles/edx_django_service/tasks/main.yml
+++ b/playbooks/roles/edx_django_service/tasks/main.yml
@@ -325,20 +325,6 @@
     - manage
     - manage:start
 
-- name: create symlinks from the venv bin dir
-  file:
-    src: "{{ edx_django_service_venv_dir }}/bin/{{ item }}"
-    dest: "{{ COMMON_BIN_DIR }}/{{ item.split('.')[0] }}.{{ edx_django_service_name }}"
-    state: link
-  when: not edx_django_service_enable_experimental_docker_shim
-  with_items:
-    - python
-    - pip
-    - django-admin.py
-  tags:
-    - install
-    - install:app-requirements
-
 - name: create symlinks from the repo dir
   file:
     src: "{{ edx_django_service_code_dir }}/{{ item }}"

--- a/playbooks/roles/edx_django_service_with_rendered_config/tasks/main.yml
+++ b/playbooks/roles/edx_django_service_with_rendered_config/tasks/main.yml
@@ -211,19 +211,6 @@
     - manage
     - manage:start
 
-- name: create symlinks from the venv bin dir
-  file:
-    src: "{{ edx_django_service_with_rendered_config_venv_dir }}/bin/{{ item }}"
-    dest: "{{ COMMON_BIN_DIR }}/{{ item.split('.')[0] }}.{{ edx_django_service_with_rendered_config_service_name }}"
-    state: link
-  with_items:
-    - python
-    - pip
-    - django-admin.py
-  tags:
-    - install
-    - install:app-requirements
-
 - name: create symlinks from the repo dir
   file:
     src: "{{ edx_django_service_with_rendered_config_code_dir }}/{{ item }}"

--- a/playbooks/roles/edx_notes_api/tasks/main.yml
+++ b/playbooks/roles/edx_notes_api/tasks/main.yml
@@ -158,19 +158,6 @@
     - manage
     - manage:start
 
-- name: Create symlinks from the venv bin dir
-  file:
-    src: "{{ edx_notes_api_home }}/venvs/{{ edx_notes_api_service_name }}/bin/{{ item }}"
-    dest: "{{ COMMON_BIN_DIR }}/{{ item.split('.', 1) | first }}.{{ edx_notes_api_service_name }}"
-    state: link
-  with_items:
-    - python
-    - pip
-    - django-admin.py
-  tags:
-    - install
-    - install:app-requirements
-
 - name: Create manage.py symlink
   file:
     src: "{{ edx_notes_api_manage }}"

--- a/playbooks/roles/edxapp/meta/main.yml
+++ b/playbooks/roles/edxapp/meta/main.yml
@@ -5,7 +5,7 @@ dependencies:
     supervisor_spec:
       - service: edxapp
         migration_check_services: "lms,cms,workers"
-        python: python.edxapp
+        python: "{{ edxapp_venv_bin }}/python"
         code: "{{ edxapp_code_dir | default(None) }}"
         env: "{{ edxapp_app_dir | default(None) }}/edxapp_env"
   - edxapp_common

--- a/playbooks/roles/edxapp/tasks/deploy.yml
+++ b/playbooks/roles/edxapp/tasks/deploy.yml
@@ -411,15 +411,12 @@
   tags:
     - manage
 
-- name: create symlinks from the venv bin dir and repo dir
+- name: create symlinks from the repo dir
   file:
     src: "{{ item }}"
     dest: "{{ COMMON_BIN_DIR }}/{{ (item | basename).split('.', 1) | first }}.edxapp"
     state: link
   with_items:
-    - '{{ edxapp_venv_bin }}/python'
-    - '{{ edxapp_venv_bin }}/pip'
-    - '{{ edxapp_venv_bin }}/django-admin.py'
     - '{{ edxapp_code_dir }}/manage.py'
   tags:
     - install

--- a/playbooks/roles/insights/meta/main.yml
+++ b/playbooks/roles/insights/meta/main.yml
@@ -9,14 +9,14 @@
 #
 ##
 # Role includes for role insights
-# 
+#
 dependencies:
   - common
   - role: supervisor
     supervisor_spec:
       - service: "{{ insights_service_name }}"
         migration_check_services: "{{ insights_service_name }}"
-        python: "python.{{ insights_service_name }}"
+        python: "{{ insights_venv_dir }}/bin/python"
         code: "{{ insights_code_dir | default(None) }}"
         env: "{{ insights_home | default(None) }}/insights_env"
   - role: edx_service

--- a/playbooks/roles/insights/tasks/main.yml
+++ b/playbooks/roles/insights/tasks/main.yml
@@ -137,19 +137,6 @@
     - manage
     - manage:start
 
-- name: create symlinks from the venv bin dir
-  file:
-    src: "{{ insights_venv_dir }}/bin/{{ item }}"
-    dest: "{{ COMMON_BIN_DIR }}/{{ item.split('.')[0] }}.{{ insights_service_name }}"
-    state: link
-  with_items:
-  - python
-  - pip
-  - django-admin.py
-  tags:
-    - install
-    - install:base
-
 - name: create manage.py symlink
   file:
     src: "{{ insights_manage }}"

--- a/playbooks/roles/oauth_client_setup/tasks/main.yml
+++ b/playbooks/roles/oauth_client_setup/tasks/main.yml
@@ -23,7 +23,7 @@
 
 - name: Create OAuth2 django-oauth-toolkit SSO Applications
   shell: >
-    {{ COMMON_BIN_DIR }}/python.edxapp {{ COMMON_BIN_DIR }}/manage.edxapp lms --settings={{ COMMON_EDXAPP_SETTINGS }}
+    {{ edxapp_venv_bin }}/python {{ COMMON_BIN_DIR }}/manage.edxapp lms --settings={{ COMMON_EDXAPP_SETTINGS }}
     create_dot_application
     --grant-type authorization-code
     --redirect-uris "{{ item.url_root }}/complete/edx-oauth2/"
@@ -46,7 +46,7 @@
 
 - name: Create OAuth2 django-oauth-toolkit Backend Service Applications
   shell: >
-    {{ COMMON_BIN_DIR }}/python.edxapp {{ COMMON_BIN_DIR }}/manage.edxapp lms --settings={{ COMMON_EDXAPP_SETTINGS }}
+    {{ edxapp_venv_bin }}/python {{ COMMON_BIN_DIR }}/manage.edxapp lms --settings={{ COMMON_EDXAPP_SETTINGS }}
     create_dot_application
     --grant-type client-credentials
     --client-id {{ item.backend_service_id }}

--- a/playbooks/roles/supervisor/templates/etc/init/supervisor-systemd.service.j2
+++ b/playbooks/roles/supervisor/templates/etc/init/supervisor-systemd.service.j2
@@ -10,7 +10,7 @@ After=network.target
 ExecStartPre={{ supervisor_venv_dir }}/bin/python {{ supervisor_app_dir }}/pre_supervisor_checks.py \
   {% for item in supervisor_spec -%}
     {%- if item.code -%}
-      --check-migrations --check-migrations-service-names {{ item.migration_check_services }} --app-python {{ COMMON_BIN_DIR }}/{{ item.python }} --app-code-dir {{ item.code }}
+      --check-migrations --check-migrations-service-names {{ item.migration_check_services }} --app-python {{ item.python }} --app-code-dir {{ item.code }}
       {%- if item.env is defined %} --app-env {{ item.env }}{% endif %} \
     {% endif %}
   {%- endfor -%}

--- a/playbooks/roles/veda_pipeline_worker/templates/edx/app/veda_pipeline_worker/veda_pipeline_worker.sh.j2
+++ b/playbooks/roles/veda_pipeline_worker/templates/edx/app/veda_pipeline_worker/veda_pipeline_worker.sh.j2
@@ -3,4 +3,4 @@
 # {{ ansible_managed }}
 
 source {{ veda_pipeline_worker_home }}/{{ veda_pipeline_worker_service_name }}_env
-{{ COMMON_BIN_DIR }}/python.{{ veda_pipeline_worker_service_name }} {{ veda_pipeline_worker_home }}/{{ veda_pipeline_worker_service_name }}/bin/{{ item }}
+{{ veda_pipeline_worker_venv_bin }}/python {{ veda_pipeline_worker_home }}/{{ veda_pipeline_worker_service_name }}/bin/{{ item }}

--- a/playbooks/roles/veda_web_frontend/tasks/main.yml
+++ b/playbooks/roles/veda_web_frontend/tasks/main.yml
@@ -24,7 +24,7 @@
 # This is creating a client in VEDA application not LMS.
 - name: create OAuth application clients
   shell: >
-    {{ COMMON_BIN_DIR }}/python.{{ veda_web_frontend_service_name }} {{ COMMON_BIN_DIR }}/manage.{{ veda_web_frontend_service_name }} create_oauth_client --settings={{ VEDA_WEB_FRONTEND_DJANGO_SETTINGS_MODULE }}
+    {{ veda_web_frontend_venv_dir }}/bin/python {{ COMMON_BIN_DIR }}/manage.{{ veda_web_frontend_service_name }} create_oauth_client --settings={{ VEDA_WEB_FRONTEND_DJANGO_SETTINGS_MODULE }}
     {{ VIDEO_PIPELINE_BASE_OAUTH_CLIENT_ID }}
     confidential
     client-credentials

--- a/playbooks/roles/video_pipeline_integration/tasks/main.yml
+++ b/playbooks/roles/video_pipeline_integration/tasks/main.yml
@@ -23,7 +23,7 @@
 
 - name: create edxapp video pipeline integration
   shell: >
-    {{ COMMON_BIN_DIR }}/python.edxapp {{ COMMON_BIN_DIR }}/manage.edxapp lms --settings={{ COMMON_EDXAPP_SETTINGS }}
+    {{ COMMON_APP_DIR }}/edxapp/venvs/edxapp/bin/python {{ COMMON_BIN_DIR }}/manage.edxapp lms --settings={{ COMMON_EDXAPP_SETTINGS }}
     create_video_pipeline_integration {{ item.client_name}} {{ item.api_url }} {{ item.service_username }} --enabled
   args:
     chdir: "{{ edxapp_code_dir }}"

--- a/playbooks/roles/xqueue/meta/main.yml
+++ b/playbooks/roles/xqueue/meta/main.yml
@@ -6,7 +6,7 @@ dependencies:
     supervisor_spec:
       - service: "{{ xqueue_service_name }}"
         migration_check_services: "{{ xqueue_service_name }}"
-        python: "python.{{ xqueue_service_name }}"
+        python: "{{ xqueue_venv_bin }}/python"
         code: "{{ xqueue_code_dir | default(None) }}"
         env: "{{ xqueue_app_dir | default(none) }}/xqueue_env"
   - role: edx_service_with_rendered_config

--- a/util/jenkins/django-admin.sh
+++ b/util/jenkins/django-admin.sh
@@ -5,7 +5,7 @@ pip install -r requirements.txt
 env
 
 ansible="ansible first_in_tag_Name_${environment}-${deployment}-worker -i playbooks/ec2.py -u ubuntu -s -U www-data -m shell -a"
-manage="cd /edx/app/edxapp/edx-platform && /edx/bin/python.edxapp ./manage.py  chdir=/edx/app/edxapp/edx-platform"
+manage="cd /edx/app/edxapp/edx-platform && /edx/app/edxapp/venvs/edxapp/bin/python ./manage.py  chdir=/edx/app/edxapp/edx-platform"
 
 if [ "$service_variant" != "UNSET" ]; then
   manage="$manage $service_variant --settings aws"


### PR DESCRIPTION
Symlinks to binaries in the virtualenv bin dir will stop working once we upgrade virtualenv due to changes in how it sets up the virtual environments (using some symlinks itself).  We had to revert the last upgrade attempt because we missed some of these, so trying to update them first this time.  This PR:

* Changes all use of such symlinks to use the link's target directly instead
* Stops creating these symlinks, since they'll stop working soon anyway

If we can get this deployed without incident, we should be clear to re-attempt the reverted https://github.com/edx/configuration/pull/6083 (after applying the configparser and zipp pins from https://github.com/edx/configuration/pull/6115 and https://github.com/edx/configuration/pull/6116).

More details on why such symlinks stopped working in virtualenv 20+:

* https://github.com/pypa/virtualenv/issues/1599
* https://github.com/pypa/virtualenv/issues/1773

---

Make sure that the following steps are done before merging:

  - [x] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
