### PR TITLE
Add blockstore cache configuration

### DIFF
--- a/docker/build/edxapp/lms.yml
+++ b/docker/build/edxapp/lms.yml
@@ -98,6 +98,13 @@ CACHES:
         KEY_PREFIX: 1001c6274ca4_general
         LOCATION:
         - edx.devstack.memcached:11211
+    blockstore:
+        BACKEND: django.core.cache.backends.memcached.MemcachedCache
+        KEY_FUNCTION: util.memcache.safe_key
+        KEY_PREFIX: blockstore
+        LOCATION:
+        - edx.devstack.memcached:11211
+        TIMEOUT: '86400'
 CAS_ATTRIBUTE_CALLBACK: ''
 CAS_EXTRA_LOGIN_PARAMS: ''
 CAS_SERVER_URL: ''

--- a/docker/build/edxapp/studio.yml
+++ b/docker/build/edxapp/studio.yml
@@ -78,6 +78,13 @@ CACHES:
         KEY_PREFIX: 1001c6274ca4_general
         LOCATION:
         - edx.devstack.memcached:11211
+    blockstore:
+        BACKEND: django.core.cache.backends.memcached.MemcachedCache
+        KEY_FUNCTION: util.memcache.safe_key
+        KEY_PREFIX: blockstore
+        LOCATION:
+        - edx.devstack.memcached:11211
+        TIMEOUT: '86400'
 CAS_ATTRIBUTE_CALLBACK: ''
 CAS_EXTRA_LOGIN_PARAMS: ''
 CAS_SERVER_URL: ''

--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -602,7 +602,7 @@ EDXAPP_COURSES_WITH_UNSAFE_CODE: []
 EDXAPP_SESSION_COOKIE_DOMAIN: ""
 EDXAPP_SESSION_COOKIE_NAME: "sessionid"
 
-# django-session-cookie middleware 
+# django-session-cookie middleware
 EDXAPP_DCS_SESSION_COOKIE_SAMESITE: "{{ 'None' if NGINX_ENABLE_SSL | default(False) else 'Lax' }}"
 EDXAPP_DCS_SESSION_COOKIE_SAMESITE_FORCE_ALL: True
 
@@ -1401,6 +1401,11 @@ generic_env_config:  &edxapp_generic_env
       KEY_PREFIX:  'celery'
       LOCATION: "{{ EDXAPP_MEMCACHE }}"
       TIMEOUT: "7200"
+    blockstore:
+      <<: *default_generic_cache
+      KEY_PREFIX: 'blockstore'
+      LOCATION: "{{ EDXAPP_MEMCACHE }}"
+      TIMEOUT: "86400"
     course_structure_cache:
       <<: *default_generic_cache
       KEY_PREFIX: 'course_structure'


### PR DESCRIPTION
OpenedX production settings can override `CACHES`, but the [blockstore cache](https://github.com/edx/edx-platform/blob/master/lms/envs/common.py#L737) is not passed. It's necessary to improve blockstore usage performance, caching large files which need to be cached for a long period (1 day), if this is not set, it uses the `default` cache, caching those documents only 5 minutes.

---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
