### PR TITLE
mariadb: Use a negated "is skipped" check for mariadb_new_debian_cnf

### DIFF
--- a/playbooks/roles/mariadb/tasks/cluster.yml
+++ b/playbooks/roles/mariadb/tasks/cluster.yml
@@ -32,7 +32,7 @@
 
 - name: copy fetched file to other cluster members
   copy: src=/tmp/debian.cnf dest=/etc/mysql/debian.cnf
-  when: mariadb_new_debian_cnf is defined  
+  when: not (mariadb_new_debian_cnf is skipped)
 
 - name: start everything
   service: name=mysql state=started


### PR DESCRIPTION
In the `mariadb` role's `cluster.yml` playbook, the `copy fetched file to other cluster members` task uses an `is defined` test on the `mariadb_new_debian_cnf` fact to determine whether the preceding `fetch debian.cnf file so start-stop will work properly` task ran or not.

`is defined` is the wrong test to use here. As [the Ansible documentation](https://docs.ansible.com/ansible/latest/user_guide/playbooks_conditionals.html#conditions-based-on-registered-variables) explains, if a task registers a variable, an `is defined` test on a subsequent task will always return `true`, even if the task has been skipped. Thus, we instead need to check with `is skipped` to see if the task has been skipped (and in this case, we want the reverse, so we negate the test).

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
