### PR TITLE
Update ecommerce docker image to Ubuntu 20.04

### DIFF
--- a/docker/build/ecommerce/Dockerfile
+++ b/docker/build/ecommerce/Dockerfile
@@ -8,7 +8,7 @@
 # with the currently checked-out configuration repo.
 
 ARG BASE_IMAGE_TAG=latest
-FROM edxops/xenial-common:${BASE_IMAGE_TAG}
+FROM edxops/focal-common:${BASE_IMAGE_TAG}
 LABEL maintainer="edxops"
 USER root
 ENTRYPOINT ["/edx/app/ecommerce/devstack.sh"]

--- a/docker/build/ecommerce/ecommerce.yml
+++ b/docker/build/ecommerce/ecommerce.yml
@@ -5,6 +5,7 @@ API_ROOT: null
 BACKEND_SERVICE_EDX_OAUTH2_KEY: ecommerce-backend-service-key
 BACKEND_SERVICE_EDX_OAUTH2_PROVIDER_URL: http://localhost:18000/oauth2
 BACKEND_SERVICE_EDX_OAUTH2_SECRET: ecommerce-backend-service-secret
+ECOMMERCE_WORKER_BROKER_HOST: 172.17.0.2
 BROKER_URL: amqp://celery:celery@172.17.0.2:5672
 CACHES:
     default:

--- a/playbooks/roles/browsers/defaults/main.yml
+++ b/playbooks/roles/browsers/defaults/main.yml
@@ -11,8 +11,8 @@ multiverse_urls:
 browser_deb_pkgs:
     - dbus-x11
     - gdebi
-    - libcurl3
-    - libgconf2-4
+    - libcurl4
+    - libgconf-2-4
     - libnss3
     - libxss1
     - ubuntu-restricted-extras

--- a/playbooks/roles/mysql/defaults/main.yml
+++ b/playbooks/roles/mysql/defaults/main.yml
@@ -13,9 +13,9 @@ mysql_release_specific_debian_pkgs:
 mysql_debian_pkgs: "{{ mysql_debian_pkgs_default + mysql_release_specific_debian_pkgs[ansible_distribution_release] }}"
 
 mysql_server_pkg: "{{ 'mysql-server-5.7' if mysql_server_version_5_7 is defined and (mysql_server_version_5_7 | bool) else 'mysql-server-5.6' }}"
-mysql_server_5_7_pkg: "mysql-server=5.7.31-1ubuntu18.04"
-mysql_client_5_7_pkg: "mysql-client=5.7.31-1ubuntu18.04"
-mysql_community_server_5_7_pkg: "mysql-server=5.7.31-1ubuntu18.04"
+mysql_server_5_7_pkg: "mysql-server=5.7.32-1ubuntu18.04"
+mysql_client_5_7_pkg: "mysql-client=5.7.32-1ubuntu18.04"
+mysql_community_server_5_7_pkg: "mysql-server=5.7.32-1ubuntu18.04"
 
 mysql_dir: /etc/mysql
 


### PR DESCRIPTION
[REV-1578](https://openedx.atlassian.net/browse/REV-1578). 

A previous attempt was reverted here https://github.com/edx/configuration/pull/6125 to unblock ecommerce from Travis failures due to pip vs. pip3 compatibilities. Original PR https://github.com/edx/configuration/pull/6107 

This will be merged with https://github.com/edx/ecommerce/pull/3220
Sandbox build - https://tools-edx-jenkins.edx.org/job/sandboxes/job/CreateSandbox/34480/