### PR TITLE
Install Firefox on Ubuntu 20.04.

### DIFF
--- a/playbooks/roles/browsers/tasks/main.yml
+++ b/playbooks/roles/browsers/tasks/main.yml
@@ -51,13 +51,13 @@
     - install
     - install:system-requirements
 
-- name: download xenial/bionic browser packages from S3
+- name: download xenial/bionic/focal browser packages from S3
   get_url:
     dest: /tmp/{{ item.name }}
     url: "{{ item.url }}"
   register: download_xenial_deb
   with_items: "{{ browser_s3_deb_pkgs }}"
-  when: ansible_distribution_release == 'xenial' or ansible_distribution_release == 'bionic'
+  when: ansible_distribution_release == 'xenial' or ansible_distribution_release == 'bionic' or ansible_distribution_release == 'focal'
   tags:
     - install
     - install:system-requirements
@@ -71,11 +71,11 @@
     - install
     - install:system-requirements
 
-- name: install xenial/bionic browser packages
+- name: install xenial/bionic/focal browser packages
   shell: gdebi -nq /tmp/{{ item.name }}
   with_items: "{{ browser_s3_deb_pkgs }}"
   when: download_xenial_deb.changed and
-        ansible_distribution_release == 'xenial' or ansible_distribution_release == 'bionic'
+        ansible_distribution_release == 'xenial' or ansible_distribution_release == 'bionic' or ansible_distribution_release == 'focal'
   tags:
     - install
     - install:system-requirements


### PR DESCRIPTION
This change is to make sure that Firefox (version 61) is installed on the Ubuntu 20.04 (also known as the 'Focal' release) container used by Travis and devstack. This is to allow our integration tests that use Firefox to run during our CI process.

Related PR: https://github.com/edx/ecommerce/pull/3244#issuecomment-724198954