### PR TITLE
mariadb: Use a negated "is skipped" check for mariadb_new_debian_cnf (Juniper)

### DIFF
--- a/playbooks/roles/mariadb/tasks/cluster.yml
+++ b/playbooks/roles/mariadb/tasks/cluster.yml
@@ -32,7 +32,7 @@
 
 - name: copy fetched file to other cluster members
   copy: src=/tmp/debian.cnf dest=/etc/mysql/debian.cnf
-  when: mariadb_new_debian_cnf is defined  
+  when: not (mariadb_new_debian_cnf is skipped)
 
 - name: start everything
   service: name=mysql state=started


### PR DESCRIPTION
This is the Juniper backport of #6127.