### PR TITLE
[SE-3613] Python2.7 deprecation means htpasswd now requires python3-passlib

### DIFF
--- a/playbooks/roles/nginx/defaults/main.yml
+++ b/playbooks/roles/nginx/defaults/main.yml
@@ -130,7 +130,7 @@ nginx_default_sites: []
 
 nginx_release_specific_debian_pkgs:
   xenial:
-    - python-passlib
+    - python3-passlib
   bionic:
     - python-passlib
   focal:


### PR DESCRIPTION
Native deployments on `xenial` which require basic authentication are failing with the following error:

```
TASK [nginx : Write out htpasswd file] *********************************************
2020-11-11 05:20:33+1030 INFO
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: ImportError: No module named 'passlib'
2020-11-11 05:20:33+1030 ERROR
failed: [213.32.72.33] (item={u'state': u'present', u'password': u'9449ecc70b8ee44c', u'name': u'397bf39ead3d3751'}) => {"ansible_loop_var": "item", "changed": false, "item": {"name": "397bf39ead3d3751", "password": "9449ecc70b8ee44c", "state": "present"}, "msg": "Failed to import the required Python library (passlib) on edxapp-periodic-buil-appserver-1039's Python /usr/bin/python3. Please read module documentation and install in the appropriate location"}
```

**JIRA tickets**: [OSPR-5124](https://openedx.atlassian.net/browse/OSPR-5124)

**Discussions**: [Periodic master build failure report](https://groups.google.com/g/open-edx-btr-notifications/c/Qy68eTORzto/m/eynvc_SMAwAJ)

**Sandbox URL**: TBD - sandbox is being provisioned.

* LMS: https://configpr6143.sandbox.opencraft.hosting/
* Studio: https://studio.configpr6143.sandbox.opencraft.hosting/

**Merge deadline**: ASAP, as this is breaking master deployments.

**Testing instructions**:

No independent testing instructions -- core review and the successful deployment of the sandbox is sufficient.

**Reviewers**
- [ ] @mtyaka 


Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [x] <strike>Are you adding any new default values that need to be overridden when this change goes live?</strike> N/A If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [x] <strike>If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)</strike>? N/A
  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [x] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release? N/A
