### PR TITLE
fixing apt-key get command for build jenkins upgrade

### DIFF
--- a/playbooks/roles/jenkins_common/tasks/main.yml
+++ b/playbooks/roles/jenkins_common/tasks/main.yml
@@ -175,12 +175,14 @@
     - jenkins:local-dev
 
 - name: Repository Signing Key for Jenkins 2.235.3
-  command: wget -q -O - https://pkg.jenkins.io/debian-stable/jenkins.io.key | apt-key add -
-  become: yes
-  become_user: '{{ jenkins_common_user }}'
+  apt_key:
+    url: "https://pkg.jenkins.io/debian-stable/jenkins.io.key"
+    state: present
   tags:
     - install
     - install:app-requirements
+    - christag
+  become: yes
 
 - name: Download Jenkins war file
   get_url:

--- a/playbooks/roles/jenkins_common/tasks/main.yml
+++ b/playbooks/roles/jenkins_common/tasks/main.yml
@@ -181,7 +181,6 @@
   tags:
     - install
     - install:app-requirements
-    - christag
   become: yes
 
 - name: Download Jenkins war file


### PR DESCRIPTION
Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
