### PR TITLE
[SE-3613] Install both python-passlib and python3-passlib

### DIFF
--- a/playbooks/roles/nginx/defaults/main.yml
+++ b/playbooks/roles/nginx/defaults/main.yml
@@ -131,6 +131,7 @@ nginx_default_sites: []
 nginx_release_specific_debian_pkgs:
   xenial:
     - python-passlib
+    - python3-passlib
   bionic:
     - python-passlib
   focal:


### PR DESCRIPTION
Since some xenial deployments still use python2.7, both `python-passlib` and `python3-passlib` need to be installed in order to use the ansible `htpasswd` module.

**JIRA tickets**: [OSPR-5156](https://openedx.atlassian.net/browse/OSPR-5156)

**Discussions**: https://github.com/edx/configuration/pull/6143#issuecomment-729287147, [Periodic master build failure report](https://groups.google.com/g/open-edx-btr-notifications/c/Qy68eTORzto/m/eynvc_SMAwAJ)

**Sandbox URL**: 

* LMS: https://configpr6143.sandbox.opencraft.hosting/
* Studio: https://studio.configpr6143.sandbox.opencraft.hosting/

**Merge deadline**: ASAP, as this is breaking master deployments.

**Testing instructions**:

No independent testing instructions -- code review and the successful deployment of the sandbox is sufficient.

**Reviewers**
- [ ] @mtyaka 

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [x] <strike>Are you adding any new default values that need to be overridden when this change goes live?</strike> N/A If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [x] <strike>If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)</strike>? N/A
  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [x] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release? N/A