### PR TITLE
Fix DeprecatedEdxPlatformImportWarning due to EDXAPP_THIRD_PARTY_AUTH…

### DIFF
--- a/docker/build/edxapp/lms.yml
+++ b/docker/build/edxapp/lms.yml
@@ -24,10 +24,10 @@ AUDIT_CERT_CUTOFF_DATE: null
 AUTH_DOCUMENTATION_URL: http://course-catalog-api-guide.readthedocs.io/en/latest/authentication/index.html
 AUTH_PASSWORD_VALIDATORS:
 -   NAME: django.contrib.auth.password_validation.UserAttributeSimilarityValidator
--   NAME: util.password_policy_validators.MinimumLengthValidator
+-   NAME: common.djangoapps.util.password_policy_validators.MinimumLengthValidator
     OPTIONS:
         min_length: 2
--   NAME: util.password_policy_validators.MaximumLengthValidator
+-   NAME: common.djangoapps.util.password_policy_validators.MaximumLengthValidator
     OPTIONS:
         max_length: 75
 AWS_ACCESS_KEY_ID: null
@@ -54,47 +54,47 @@ BULK_EMAIL_ROUTING_KEY_SMALL_JOBS: edx.lms.core.default
 CACHES:
     celery:
         BACKEND: django.core.cache.backends.memcached.MemcachedCache
-        KEY_FUNCTION: util.memcache.safe_key
+        KEY_FUNCTION: common.djangoapps.util.memcache.safe_key
         KEY_PREFIX: celery
         LOCATION:
         - edx.devstack.memcached:11211
         TIMEOUT: '7200'
     configuration:
         BACKEND: django.core.cache.backends.memcached.MemcachedCache
-        KEY_FUNCTION: util.memcache.safe_key
+        KEY_FUNCTION: common.djangoapps.util.memcache.safe_key
         KEY_PREFIX: 1001c6274ca4
         LOCATION:
         - edx.devstack.memcached:11211
     course_structure_cache:
         BACKEND: django.core.cache.backends.memcached.MemcachedCache
-        KEY_FUNCTION: util.memcache.safe_key
+        KEY_FUNCTION: common.djangoapps.util.memcache.safe_key
         KEY_PREFIX: course_structure
         LOCATION:
         - edx.devstack.memcached:11211
         TIMEOUT: '7200'
     default:
         BACKEND: django.core.cache.backends.memcached.MemcachedCache
-        KEY_FUNCTION: util.memcache.safe_key
+        KEY_FUNCTION: common.djangoapps.util.memcache.safe_key
         KEY_PREFIX: default
         LOCATION:
         - edx.devstack.memcached:11211
         VERSION: '1'
     general:
         BACKEND: django.core.cache.backends.memcached.MemcachedCache
-        KEY_FUNCTION: util.memcache.safe_key
+        KEY_FUNCTION: common.djangoapps.util.memcache.safe_key
         KEY_PREFIX: general
         LOCATION:
         - edx.devstack.memcached:11211
     mongo_metadata_inheritance:
         BACKEND: django.core.cache.backends.memcached.MemcachedCache
-        KEY_FUNCTION: util.memcache.safe_key
+        KEY_FUNCTION: common.djangoapps.util.memcache.safe_key
         KEY_PREFIX: mongo_metadata_inheritance
         LOCATION:
         - edx.devstack.memcached:11211
         TIMEOUT: 300
     staticfiles:
         BACKEND: django.core.cache.backends.memcached.MemcachedCache
-        KEY_FUNCTION: util.memcache.safe_key
+        KEY_FUNCTION: common.djangoapps.util.memcache.safe_key
         KEY_PREFIX: 1001c6274ca4_general
         LOCATION:
         - edx.devstack.memcached:11211

--- a/docker/build/edxapp/studio.yml
+++ b/docker/build/edxapp/studio.yml
@@ -5,10 +5,10 @@ ANALYTICS_DASHBOARD_NAME: Your Platform Name Here Insights
 ANALYTICS_DASHBOARD_URL: http://localhost:18110/courses
 AUTH_PASSWORD_VALIDATORS:
 -   NAME: django.contrib.auth.password_validation.UserAttributeSimilarityValidator
--   NAME: util.password_policy_validators.MinimumLengthValidator
+-   NAME: common.djangoapps.util.password_policy_validators.MinimumLengthValidator
     OPTIONS:
         min_length: 2
--   NAME: util.password_policy_validators.MaximumLengthValidator
+-   NAME: common.djangoapps.util.password_policy_validators.MaximumLengthValidator
     OPTIONS:
         max_length: 75
 AWS_ACCESS_KEY_ID: null
@@ -34,47 +34,47 @@ BULK_EMAIL_LOG_SENT_EMAILS: false
 CACHES:
     celery:
         BACKEND: django.core.cache.backends.memcached.MemcachedCache
-        KEY_FUNCTION: util.memcache.safe_key
+        KEY_FUNCTION: common.djangoapps.util.memcache.safe_key
         KEY_PREFIX: celery
         LOCATION:
         - edx.devstack.memcached:11211
         TIMEOUT: '7200'
     configuration:
         BACKEND: django.core.cache.backends.memcached.MemcachedCache
-        KEY_FUNCTION: util.memcache.safe_key
+        KEY_FUNCTION: common.djangoapps.util.memcache.safe_key
         KEY_PREFIX: 1001c6274ca4
         LOCATION:
         - edx.devstack.memcached:11211
     course_structure_cache:
         BACKEND: django.core.cache.backends.memcached.MemcachedCache
-        KEY_FUNCTION: util.memcache.safe_key
+        KEY_FUNCTION: common.djangoapps.util.memcache.safe_key
         KEY_PREFIX: course_structure
         LOCATION:
         - edx.devstack.memcached:11211
         TIMEOUT: '7200'
     default:
         BACKEND: django.core.cache.backends.memcached.MemcachedCache
-        KEY_FUNCTION: util.memcache.safe_key
+        KEY_FUNCTION: common.djangoapps.util.memcache.safe_key
         KEY_PREFIX: default
         LOCATION:
         - edx.devstack.memcached:11211
         VERSION: '1'
     general:
         BACKEND: django.core.cache.backends.memcached.MemcachedCache
-        KEY_FUNCTION: util.memcache.safe_key
+        KEY_FUNCTION: common.djangoapps.util.memcache.safe_key
         KEY_PREFIX: general
         LOCATION:
         - edx.devstack.memcached:11211
     mongo_metadata_inheritance:
         BACKEND: django.core.cache.backends.memcached.MemcachedCache
-        KEY_FUNCTION: util.memcache.safe_key
+        KEY_FUNCTION: common.djangoapps.util.memcache.safe_key
         KEY_PREFIX: mongo_metadata_inheritance
         LOCATION:
         - edx.devstack.memcached:11211
         TIMEOUT: 300
     staticfiles:
         BACKEND: django.core.cache.backends.memcached.MemcachedCache
-        KEY_FUNCTION: util.memcache.safe_key
+        KEY_FUNCTION: common.djangoapps.util.memcache.safe_key
         KEY_PREFIX: 1001c6274ca4_general
         LOCATION:
         - edx.devstack.memcached:11211

--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -221,10 +221,10 @@ EDXAPP_THIRD_PARTY_AUTH_BACKENDS:
   - social_core.backends.linkedin.LinkedinOAuth2
   - social_core.backends.facebook.FacebookOAuth2
   - social_core.backends.azuread.AzureADOAuth2
-  - third_party_auth.appleid.AppleIdAuth
-  - third_party_auth.identityserver3.IdentityServer3
-  - third_party_auth.saml.SAMLAuthBackend
-  - third_party_auth.lti.LTIAuthBackend
+  - common.djangoapps.third_party_auth.appleid.AppleIdAuth
+  - common.djangoapps.third_party_auth.identityserver3.IdentityServer3
+  - common.djangoapps.third_party_auth.saml.SAMLAuthBackend
+  - common.djangoapps.third_party_auth.lti.LTIAuthBackend
 
 EDXAPP_ENABLE_MOBILE_REST_API: false
 

--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -990,10 +990,10 @@ EDXAPP_BASE_COOKIE_DOMAIN: "{{ EDXAPP_LMS_SITE_NAME }}"
 # Account password configuration
 EDXAPP_AUTH_PASSWORD_VALIDATORS:
   - NAME: 'django.contrib.auth.password_validation.UserAttributeSimilarityValidator'
-  - NAME: 'util.password_policy_validators.MinimumLengthValidator'
+  - NAME: 'common.djangoapps.util.password_policy_validators.MinimumLengthValidator'
     OPTIONS:
       min_length: 2
-  - NAME: 'util.password_policy_validators.MaximumLengthValidator'
+  - NAME: 'common.djangoapps.util.password_policy_validators.MaximumLengthValidator'
     OPTIONS:
       max_length: 75
 
@@ -1252,7 +1252,7 @@ edxapp_generic_auth_config:  &edxapp_generic_auth
 
 generic_cache_config: &default_generic_cache
   BACKEND:  "{{ EDXAPP_CACHE_BACKEND }}"
-  KEY_FUNCTION:  'util.memcache.safe_key'
+  KEY_FUNCTION:  'common.djangoapps.util.memcache.safe_key'
 
 edxapp_revisions_config:
   EDX_PLATFORM_REVISION: "{{ EDX_PLATFORM_VERSION }}"


### PR DESCRIPTION
This change would remove the warning that is ocurring in the devstack due to the default value of THIRD_PARTY_AUTH:

```python
2020-11-20 18:25:35,403 WARNING 376 [py.warnings] [user None] [ip None] warnings.py:109 - /edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/social_core/utils.py:56: DeprecatedEdxPlatformImportWarning: Importing third_party_auth instead of common.djangoapps.third_party_auth is deprecated
  __import__(name)

2020-11-20 18:25:35,403 WARNING 376 [py.warnings] [user None] [ip None] warnings.py:109 - /edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/social_core/utils.py:56: DeprecatedEdxPlatformImportWarning: Importing third_party_auth.appleid instead of common.djangoapps.third_party_auth.appleid is deprecated
  __import__(name)

2020-11-20 18:25:35,404 WARNING 376 [py.warnings] [user None] [ip None] warnings.py:109 - /edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/social_core/utils.py:56: DeprecatedEdxPlatformImportWarning: Importing third_party_auth.identityserver3 instead of common.djangoapps.third_party_auth.identityserver3 is deprecated
  __import__(name)

2020-11-20 18:25:35,405 WARNING 376 [py.warnings] [user None] [ip None] warnings.py:109 - /edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/social_core/utils.py:56: DeprecatedEdxPlatformImportWarning: Importing third_party_auth.saml instead of common.djangoapps.third_party_auth.saml is deprecated
  __import__(name)

2020-11-20 18:25:35,405 WARNING 376 [py.warnings] [user None] [ip None] warnings.py:109 - /edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/social_core/utils.py:56: DeprecatedEdxPlatformImportWarning: Importing third_party_auth.lti instead of common.djangoapps.third_party_auth.lti is deprecated
  __import__(name)
```

The second commit similarly fixes these warnings:
```python
2020-11-20 18:28:00,178 WARNING 390 [py.warnings] [user None] [ip None] warnings.py:109 - /edx/app/edxapp/venvs/edxapp/lib/python3.8/importlib/__init__.py:127: DeprecatedEdxPlatformImportWarning: Importing util instead of common.djangoapps.util is deprecated
  return _bootstrap._gcd_import(name[level:], package, level)

2020-11-20 18:28:00,179 WARNING 390 [py.warnings] [user None] [ip None] warnings.py:109 - /edx/app/edxapp/venvs/edxapp/lib/python3.8/importlib/__init__.py:127: DeprecatedEdxPlatformImportWarning: Importing util.memcache instead of common.djangoapps.util.memcache is deprecated
  return _bootstrap._gcd_import(name[level:], package, level)
```

See: https://github.com/edx/edx-platform/commit/151bd136667d27bf85256e382ed5b5ea0144e00f#diff-36f01c1bdefd7361ecd07d4dd79c8a8538a71cb8b109f477942a798ac19eca11