### PR TITLE
Remove deprecated virtualenv flag and avoid symlinks

### DIFF
--- a/playbooks/roles/codejail/tasks/main.yml
+++ b/playbooks/roles/codejail/tasks/main.yml
@@ -16,7 +16,7 @@
     group: '{{ codejail_sandbox_group }}'
     state: present
 - name: Create sandboxed virtual environments for every Python installation
-  shell: "virtualenv -p {{ item  }} --always-copy --no-site-packages {{ codejail_sandbox_env }}-{{ item }}"
+  shell: "virtualenv -p {{ item  }} --always-copy {{ codejail_sandbox_env }}-{{ item }}"
   become: true
   with_items: "{{ CODEJAIL_PYTHON_VERSIONS }}"
 - name: Clone codejail repo

--- a/playbooks/roles/edxapp/tasks/deploy.yml
+++ b/playbooks/roles/edxapp/tasks/deploy.yml
@@ -107,7 +107,7 @@
     - install:app-requirements
 
 - name: Create the virtualenv to install the Python requirements
-  command: "virtualenv {{ edxapp_venv_dir }} -p {{ EDXAPP_PYTHON_VERSION }}"
+  command: "virtualenv {{ edxapp_venv_dir }} -p {{ EDXAPP_PYTHON_VERSION }} --always-copy"
   args:
     chdir: "{{ edxapp_code_dir }}"
     creates: "{{ edxapp_venv_dir }}/bin/pip"
@@ -261,7 +261,7 @@
     - install:app-requirements
 
 - name: Create the virtualenv to install the Python sandbox requirements
-  command: "virtualenv {{ edxapp_sandbox_venv_dir }} -p {{ edxapp_sandbox_python_version }}"
+  command: "virtualenv {{ edxapp_sandbox_venv_dir }} -p {{ edxapp_sandbox_python_version }} --always-copy"
   args:
     chdir: "{{ edxapp_code_dir }}"
     creates: "{{ edxapp_sandbox_venv_dir }}/bin/pip"

--- a/playbooks/roles/xqwatcher/tasks/code_jail.yml
+++ b/playbooks/roles/xqwatcher/tasks/code_jail.yml
@@ -14,7 +14,7 @@
 
 # Do this first so symlinks can be resolved in the next step
 - name: Create jail virtualenv
-  shell: "/usr/local/bin/virtualenv --python={{ item.PYTHON_EXECUTABLE }} --no-site-packages {{ xqwatcher_app_dir }}/venvs/{{ item.QUEUE_CONFIG.HANDLERS[0].CODEJAIL.name }}"
+  shell: "/usr/local/bin/virtualenv --python={{ item.PYTHON_EXECUTABLE }} --always-copy {{ xqwatcher_app_dir }}/venvs/{{ item.QUEUE_CONFIG.HANDLERS[0].CODEJAIL.name }}"
   args:
     creates: "{{ xqwatcher_app_dir }}/venvs/{{ item.QUEUE_CONFIG.HANDLERS[0].CODEJAIL.name }}/bin/pip"
   with_items: "{{ XQWATCHER_COURSES }}"


### PR DESCRIPTION
- Added the `always-copy` flag to virtualenv commands for sandboxes in order to ensure consistency in how virtualenvs are created. This prevents apparmor profiles from accidentally applying to a globally used Python binary.
- Removed the deprecated `no-site-packages` flag to maintain compatibility with newer versions of virtualenv

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
