### PR TITLE
No longer need a lib that won't install on Ubuntu 20

### DIFF
--- a/playbooks/roles/edx_notes_api/defaults/main.yml
+++ b/playbooks/roles/edx_notes_api/defaults/main.yml
@@ -139,7 +139,6 @@ edx_notes_api_requirements:
 #
 edx_notes_api_debian_pkgs:
   - libmysqlclient-dev
-  - python-mysqldb
   - libssl-dev # needed for mysqlclient python library
   - python3-dev
   - python3.8-dev


### PR DESCRIPTION
The native installation fails if you use SANDBOX_ENABLE_NOTES to install Notes also:
```
TASK [edx_service : Install a bunch of system packages on which edx_service relies] ***
fatal: [localhost]: FAILED! => {"changed": false, "msg": "No package matching 'python-mysqldb' is available"}
```

edx-notes-api doesn't seem to need this package anymore.

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
