### PR TITLE
Clean up deprecated edx-platform imports of edxmako

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,13 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 Add any new changes to the top(right below this line).
-
+ 
+ - 2020-12-09
+     - Role: edxapp
+        - Updated renderer options to reference `common.djangoapps.edxmako`
+          instead of `edxmako`. The latter import path is deprecated.
+          Other than removing warnings, there should be no functional
+          change.
 
  - 2020-12-02
     - Role: mfe

--- a/docker/build/edxapp/lms.yml
+++ b/docker/build/edxapp/lms.yml
@@ -389,7 +389,7 @@ MODULESTORE:
                 OPTIONS:
                     default_class: xmodule.hidden_module.HiddenDescriptor
                     fs_root: /edx/var/edxapp/data
-                    render_template: edxmako.shortcuts.render_to_string
+                    render_template: common.djangoapps.edxmako.shortcuts.render_to_string
             -   DOC_STORE_CONFIG:
                     auth_source: null
                     collection: modulestore
@@ -409,7 +409,7 @@ MODULESTORE:
                 OPTIONS:
                     default_class: xmodule.hidden_module.HiddenDescriptor
                     fs_root: /edx/var/edxapp/data
-                    render_template: edxmako.shortcuts.render_to_string
+                    render_template: common.djangoapps.edxmako.shortcuts.render_to_string
 OAUTH_DELETE_EXPIRED: true
 OAUTH_ENFORCE_SECURE: false
 OAUTH_EXPIRE_CONFIDENTIAL_CLIENT_DAYS: 365

--- a/docker/build/edxapp/studio.yml
+++ b/docker/build/edxapp/studio.yml
@@ -349,7 +349,7 @@ MODULESTORE:
                 OPTIONS:
                     default_class: xmodule.hidden_module.HiddenDescriptor
                     fs_root: /edx/var/edxapp/data
-                    render_template: edxmako.shortcuts.render_to_string
+                    render_template: common.djangoapps.edxmako.shortcuts.render_to_string
             -   DOC_STORE_CONFIG:
                     auth_source: null
                     collection: modulestore
@@ -369,7 +369,7 @@ MODULESTORE:
                 OPTIONS:
                     default_class: xmodule.hidden_module.HiddenDescriptor
                     fs_root: /edx/var/edxapp/data
-                    render_template: edxmako.shortcuts.render_to_string
+                    render_template: common.djangoapps.edxmako.shortcuts.render_to_string
 ORA2_FILE_PREFIX: default_env-default_deployment/ora2
 PARSE_KEYS: {}
 PARTNER_SUPPORT_EMAIL: ''

--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -1516,14 +1516,14 @@ lms_auth_config:
               OPTIONS:
                 default_class: 'xmodule.hidden_module.HiddenDescriptor'
                 fs_root:  "{{ edxapp_course_data_dir }}"
-                render_template: 'edxmako.shortcuts.render_to_string'
+                render_template: 'common.djangoapps.edxmako.shortcuts.render_to_string'
             - NAME: 'draft'
               ENGINE: 'xmodule.modulestore.mongo.DraftMongoModuleStore'
               DOC_STORE_CONFIG: "{{ EDXAPP_LMS_DRAFT_DOC_STORE_CONFIG }}"
               OPTIONS:
                 default_class: 'xmodule.hidden_module.HiddenDescriptor'
                 fs_root:  "{{ edxapp_course_data_dir }}"
-                render_template: 'edxmako.shortcuts.render_to_string'
+                render_template: 'common.djangoapps.edxmako.shortcuts.render_to_string'
   SOCIAL_AUTH_OAUTH_SECRETS: "{{ EDXAPP_SOCIAL_AUTH_OAUTH_SECRETS }}"
   ACE_CHANNEL_SAILTHRU_API_KEY: "{{ EDXAPP_ACE_CHANNEL_SAILTHRU_API_KEY }}"
   ACE_CHANNEL_SAILTHRU_API_SECRET: "{{ EDXAPP_ACE_CHANNEL_SAILTHRU_API_SECRET }}"
@@ -1619,14 +1619,14 @@ cms_auth_config:
               OPTIONS:
                 default_class: 'xmodule.hidden_module.HiddenDescriptor'
                 fs_root:  "{{ edxapp_course_data_dir }}"
-                render_template: 'edxmako.shortcuts.render_to_string'
+                render_template: 'common.djangoapps.edxmako.shortcuts.render_to_string'
             - NAME: 'draft'
               ENGINE: 'xmodule.modulestore.mongo.DraftMongoModuleStore'
               DOC_STORE_CONFIG: "{{ EDXAPP_CMS_DOC_STORE_CONFIG }}"
               OPTIONS:
                 default_class: 'xmodule.hidden_module.HiddenDescriptor'
                 fs_root:  "{{ edxapp_course_data_dir }}"
-                render_template: 'edxmako.shortcuts.render_to_string'
+                render_template: 'common.djangoapps.edxmako.shortcuts.render_to_string'
   SEGMENT_KEY: "{{ EDXAPP_CMS_SEGMENT_KEY }}"
   PARSE_KEYS: "{{ EDXAPP_PARSE_KEYS }}"
   FERNET_KEYS: "{{ EDXAPP_FERNET_KEYS }}"


### PR DESCRIPTION
Cleaning up a bunch of usages of deprecated import `edxmako` in favor of `common.djangoapps.edxmako` across several repositories. These changes should have no functional effect other than squashing warnings.

This is part of the import-shims cleanup, which resulted from the sys.path-hack removal effort. See the [forum post](https://discuss.openedx.org/t/koa-will-change-how-edx-platform-code-is-imported/3610) for details.

I'm keeping track of the list of these PRs on this edx-platform "parent PR": https://github.com/edx/edx-platform/pull/25684