### PR TITLE
BOM-2128 : Upgrade XQueue to Ubuntu 20.04

### DIFF
--- a/docker/build/xqueue/Dockerfile
+++ b/docker/build/xqueue/Dockerfile
@@ -8,7 +8,7 @@
 # with the currently checked-out configuration repo.
 
 ARG BASE_IMAGE_TAG=latest
-FROM edxops/xenial-common:${BASE_IMAGE_TAG}
+FROM edxops/focal-common:${BASE_IMAGE_TAG}
 LABEL maintainer="edxops"
 ENTRYPOINT ["/edx/app/xqueue/devstack.sh"]
 CMD ["start"]


### PR DESCRIPTION
Relevant JIRA : https://openedx.atlassian.net/browse/BOM-2128