### PR TITLE
[SE-3405] Add gdpr retirement api to nginx

### DIFF
--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
@@ -287,6 +287,7 @@ error_page {{ k }} {{ v }};
     try_files $uri @proxy_to_lms_app;
   }
 
+  # No basic auth, uses oauth2 for authentication
   location /v1/accounts/gdpr_retire_users {
     try_files $uri @proxy_to_lms_app;
   }

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
@@ -287,6 +287,10 @@ error_page {{ k }} {{ v }};
     try_files $uri @proxy_to_lms_app;
   }
 
+  location /v1/accounts/gdpr_retire_users {
+    try_files $uri @proxy_to_lms_app;
+  }
+
 location ~ ^{{ EDXAPP_MEDIA_URL }}/(?P<file>.*) {
     root {{ edxapp_media_dir }};
     try_files /$file =404;


### PR DESCRIPTION
This PR adds an nginx entry for the gdpr user retirement api introduced in [edx-platform#25800](https://github.com/edx/edx-platform/pull/25800). Without this entry, nginx will reject the api requests made.

**Jira Tickets:** [OSPR-5292](https://openedx.atlassian.net/browse/OSPR-5292)

**Dependencies:**
-  [edx-platform#25800](https://github.com/edx/edx-platform/pull/25800)

**Sandbox URL:** TBD

**Testing Instructions:**
See testing instructions in [edx-platform#25800](https://github.com/edx/edx-platform/pull/25800)

**Reviewers:**
- [ ] @mavidser
- [ ] edX reviewer[s] TBD
