### PR TITLE
Tidy up some bash in create_virtualenv

### DIFF
--- a/util/jenkins/virtualenv_tools.sh
+++ b/util/jenkins/virtualenv_tools.sh
@@ -1,4 +1,4 @@
- #!/usr/bin/env bash
+#!/usr/bin/env bash
 
 # function to create a virtual environment in a directory separate from
 # where it is called. Its name is predictable based on where the script
@@ -11,7 +11,7 @@
 # Optional Environmental Variables:
 # 
 # JOBVENVDIR - where on the system to create the virtualenv
-#            - e.g. /edx/var/jenkins/jobvenvs/
+#            - e.g. /edx/var/jenkins/jobvenvs
 #
 # Reason for existence: shiningpanda, the jenkins plugin that manages our
 # virtualenvironments for jenkins jobs, is no longer supported so we need
@@ -29,22 +29,19 @@
 # parse.
 
 function create_virtualenv () {
-    if [ -z "$JOBVENVDIR" ]
+    if [ -z "${JOBVENVDIR:-}" ]
     then
         echo "No JOBVENVDIR found. Using default value." >&2
-        JOBVENVDIR="/edx/var/jenkins/jobvenvs/"
+        JOBVENVDIR="/edx/var/jenkins/jobvenvs"
     fi
 
-    local job_location=`pwd`
     # create a unique hash for the job based location of where job is run
-    venvname=($(echo -n "$job_location" | md5sum))
+    venvname="$(pwd | md5sum | cut -d' ' -f1)"
 
-    # go create the virtualenv and come back
-    cd $JOBVENVDIR
-    virtualenv $@ "$venvname"
-    cd $job_location
+    # create the virtualenv
+    virtualenv "$@" "$JOBVENVDIR/$venvname"
 
     # This variable is created in global scope if function is sourced
     # so we can access it after running this function.
-    venvpath="$JOBVENVDIR$venvname"
+    venvpath="$JOBVENVDIR/$venvname"
 }


### PR DESCRIPTION
- Fix shebang
- Assume lack of trailing slash in `JOBVENVDIR` for ease of use
- Quote some things for safety
- Use variable defaulting for `JOBVENVDIR` to allow `set -u`
- Avoid having to cd back and forth
- Simplify venvname pipeline (and less magic for avoiding trailing slash in md5sum output)

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
