### PR TITLE
WS-1625 step 1: toggle edx_django_service_use_python3

### DIFF
--- a/playbooks/roles/prospectus/defaults/main.yml
+++ b/playbooks/roles/prospectus/defaults/main.yml
@@ -36,7 +36,7 @@ NGINX_PROSPECTUS_TURN_OFF_DRUPAL: false
 PROSPECTUS_GIT_IDENTITY: "none"
 prospectus_repo: 'ssh://git@github.com/edx/prospectus.git'
 PROSPECTUS_VERSION: 'master'
-edx_django_service_use_python3: false
+edx_django_service_use_python3: true
 PROSPECTUS_NODE_VERSION:  '12.19.0'
 prospectus_service_name: 'prospectus'
 prospectus_home: '{{ COMMON_APP_DIR }}/{{ prospectus_service_name }}'


### PR DESCRIPTION
Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?