### PR TITLE
Revert "udpate python version prospectus (#6221)"

### DIFF
--- a/playbooks/roles/prospectus/defaults/main.yml
+++ b/playbooks/roles/prospectus/defaults/main.yml
@@ -59,4 +59,3 @@ prospectus_env_vars:
 prospectus_git_identity: "{{ prospectus_app_dir }}/prospectus-git-identity"
 prospectus_code_dir: "{{ prospectus_app_dir }}/prospectus"
 prospectus_ssl_nginx_port: 443
-prospectus_use_python3: true

--- a/playbooks/roles/prospectus/tasks/main.yml
+++ b/playbooks/roles/prospectus/tasks/main.yml
@@ -59,37 +59,12 @@
   register: prospectus_checkout
   when: PROSPECTUS_GIT_IDENTITY == "none"
 
-- name: add deadsnakes repo
-  apt_repository:
-      repo: ppa:deadsnakes/ppa
-  when: prospectus_use_python3
-
-- name: install python3.8
-  apt:
-    pkg:
-      - python3.8-dev
-      - python3.8-distutils
-  when: prospectus_use_python3
-  tags:
-    - install
-    - install:system-requirements
-
 - name: build virtualenv with python2.7
   command: "virtualenv --python=python2.7 {{ prospectus_venv_dir }}"
   args:
     creates: "{{ prospectus_venv_dir }}/bin/pip"
   become_user: "{{ prospectus_user }}"
-  when: not prospectus_use_python3
-  tags:
-    - install
-    - install:system-requirements
-
-- name: build virtualenv with python3.8
-  command: "virtualenv --python=python3.8 {{ prospectus_venv_dir }}"
-  args:
-    creates: "{{ prospectus_venv_dir }}/bin/pip"
-  become_user: "{{ prospectus_user }}"
-  when: prospectus_use_python3
+  when: not edx_django_service_use_python3
   tags:
     - install
     - install:system-requirements


### PR DESCRIPTION
I am reverting this change for now to reduce the amount
of variables for sake of testing this importlib issue

This reverts commit 8ece76384e33b84dc1a04684c24c7c65f911691f.

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
