### PR TITLE
ENT-3885 | setting proxy_buffer_size behind the EDXAPP_SET_PROXY_BUFFER_SIZE…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 Add any new changes to the top(right below this line).
- 
+ - 2021-01-05
+     - Role: edxapp
+        - setting `proxy_buffer_size` behind the EDXAPP_SET_PROXY_BUFFER_SIZE flag.
  - 2020-12-11
     - Role: jenkins_master
        - Adding variable/tasks to create directories for job virtual

--- a/playbooks/roles/nginx/defaults/main.yml
+++ b/playbooks/roles/nginx/defaults/main.yml
@@ -229,3 +229,5 @@ NGINX_ADMIN_ACCESS_CIDRS: []
 
 # Set trusted network subnets or IP addresses to send correct replacement addresses
 NGINX_TRUSTED_IP_CIDRS: "0.0.0.0/0"
+
+EDXAPP_SET_PROXY_BUFFER_SIZE: False

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms_proxy.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms_proxy.j2
@@ -16,4 +16,10 @@
     proxy_redirect off;
     proxy_pass http://lms-backend;
 
+{% if EDXAPP_SET_PROXY_BUFFER_SIZE %}
+    proxy_buffer_size          128k;
+    proxy_buffers              4 256k;
+    proxy_busy_buffers_size    256k;
+{% endif %}
+
     {{ NGINX_EDXAPP_LMS_APP_EXTRA }}


### PR DESCRIPTION
### Ticket
https://openedx.atlassian.net/browse/ENT-3885

### Background:

we were getting a 502 page while login in (mostly for users who are linked with many enterprises.)

### Example ERROR Page:
<img width="1672" alt="Screen Shot 2021-01-05 at 5 07 13 PM" src="https://user-images.githubusercontent.com/29247391/103644615-76a31080-4f78-11eb-9168-84b2de0647a1.png">

### ERROR LOG
```
2021/01/05 12:06:41 [error] 17912#17912: *9612373 upstream sent too big header while reading response header from upstream, client: 10.2.0.72, server: , request: "GET /auth/complete/azuread-oauth2/?code=0.AAAAxW-7oI_rPkikuciyQ7ZA5bDRol4TF2lAp2Qb6PQKYhBaALU.AQABAAIAAABeStGSRwwnTq2vHplZ9KL4EQv7rU-dikuLes57ajy2U_LT9Bmz4yGSM92Vzzv0mjgXzU_7_frxxmt_pu9vF_bJvWNaoxPGZ_AeHPx-aZNhRpHn27YBdDfFDnV9EWYC2_qRWQGOZUUMusIyeW1ikTV7ICzKdJI7dJxshzuv1ZNEP4Kg9zWXkfmcc-iO23tp5Tsr3unGmqMuboTtD_bBesgX0u2DE661rM-7XoH7CBB1J6pEZnJutpAA9RfkMyJtNBlWNk1NZYme-A7XfGocqMMgsHqeQ1MbuB5CyTalGw2tedBJG1ToMvBi51dv08b1CCRo_b1f6lshNnolLEijilSjN5QWRHkoJ49vw5x9TowuhfRhLPSmu2CcFCr1kFiyDvj3tAkSs16ccHjvRnXxEXSTcYfCsZg8_zspto_tQwCQhNtuuNtJPXLQB8TZbsufu767dPiD_g0NLnHwZqTYiiTlv02LJ2ZP965JK7nGxH970NzOfVxd7TVWeX4rTD_eSy9RegtMZmiY68z5UCbyxENzDjuE5O2Zgaas1HKnCLzpk15g5E2t934Ab5MiMDhexwvANgft6czkxICh4tKwMCRihCCfC4aOSsaJrlKtGUZA-Jp9clnm4tWmg5gnkur0_M3o_Jxa0RhYK0cYsCFQLMaPhWOuDiVQJ277a5FzPYRdrif9BhffM2bFJBEJGjztcZEgAA&state=u7DqdDbqk6eHcxL5af9MJ2wcu08x1EcQ&session_state=4fd30e79-0ccd-45b4-a74e-a26815fd2c64 HTTP/1.1", upstream: "http://127.0.0.1:8000/auth/complete/azuread-oauth2/?code=0.AAAAxW-7oI_rPkikuciyQ7ZA5bDRol4TF2lAp2Qb6PQKYhBaALU.AQABAAIAAABeStGSRwwnTq2vHplZ9KL4EQv7rU-dikuLes57ajy2U_LT9Bmz4yGSM92Vzzv0mjgXzU_7_frxxmt_pu9vF_bJvWNaoxPGZ_AeHPx-aZNhRpHn27YBdDfFDnV9EWYC2_qRWQGOZUUMusIyeW1ikTV7ICzKdJI7dJxshzuv1ZNEP4Kg9zWXkfmcc-iO23tp5Tsr3unGmqMuboTtD_bBesgX0u2DE661rM-7XoH7CBB1J6pEZnJutpAA9RfkMyJtNBlWNk1NZYme-A7XfGocqMMgsHqeQ1MbuB5CyTalGw2tedBJG1ToMvBi51dv08b1CCRo_b1f6lshNnolLEijilSjN5QWRHkoJ49vw5x9TowuhfRhLPSmu2CcFCr1kFiyDvj3tAkSs16ccHjvRnXxEXSTcYfCsZg8_zspto_tQwCQhNtuuNtJPXLQB8TZbsufu767dPiD_g0NLnHwZqTYiiTlv02LJ2ZP965JK7nGxH970NzOfVxd7TVWeX4rTD_eSy9RegtMZmiY68z5UCbyxENzDjuE5O2Zgaas1HKnCLzpk15g5E2t934Ab5MiMDhexwvANgft6czkxICh4tKwMCRihCCfC4aOSsaJrlKtGUZA-Jp9clnm4tWmg5gnkur0_M3o_Jxa0RhYK0cYsCFQLMaPhWOuDiVQJ277a5FzPYRdrif9BhffM2bFJBEJGjztcZEgAA&state=u7DqdDbqk6eHcxL5af9MJ2wcu08x1EcQ&session_state=4fd30e79-0ccd-45b4-a74e-a26815fd2c64", host: "courses.edx.org", referrer: "h
host = ip-10-2-11-100 source = /edx/var/log/nginx/error.log sourcetype = nginx
```

### Proposed Solution
 
After some discovery, we found out that it could be due to buffer size in Nginx.
So, we decided to set proxy_buffer_size ONLY for STAGE to confirm that problem is related to buffer.
In this PR setting proxy_buffer_size behind the EDXAPP_SET_PROXY_BUFFER_SIZE flag
and setting this flag on only for the stage env here https://github.com/edx/edx-internal/pull/4112

### Related PR
https://github.com/edx/edx-internal/pull/4112

### Next Step
If the error page disappears after this PR, we will be setting buffer size for prod.

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [x] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [x] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [x] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
