### PR TITLE
Increase large_client_header_buffers to 16K for nginx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 Add any new changes to the top(right below this line).
- 
+
+ - 2021-01-12
+     - Role: nginx
+        - Increase large_client_header_buffers to 16K to handle browsers with too much cookie data
+
  - 2021-01-08
      - Role: tinymce_plugins
         - Installs `tinymce_plugins` specified in `TINYMCE_ADDITIONAL_PLUGINS_LIST` configuration variable

--- a/playbooks/roles/mfe/templates/edx/app/nginx/sites-available/app.j2
+++ b/playbooks/roles/mfe/templates/edx/app/nginx/sites-available/app.j2
@@ -6,10 +6,14 @@ server {
   server_name {{ MFE_HOSTNAME }};
   listen {{ MFE_NGINX_PORT }};
 
+  # Increase accepted header size to account for overenthusiastic usage of cookies
+  large_client_header_buffers 4 16k;
+
+
 {% if NGINX_ENABLE_SSL %}
   {% include "concerns/handle-ip-disclosure.j2" %}
   rewrite ^ https://$host$request_uri? permanent;
-{% else %}  
+{% else %}
   {% if NGINX_REDIRECT_TO_HTTPS %}
     {% include "concerns/handle-tls-terminated-elsewhere-ip-disclosure.j2" %}
     {% include "concerns/handle-tls-terminated-elsewhere-redirect.j2" %}

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/common-settings.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/common-settings.j2
@@ -4,3 +4,5 @@
 # Disables server version feedback on pages and in headers
 server_tokens off;
 
+# Increase accepted header size to account for overenthusiastic usage of cookies
+large_client_header_buffers 4 16k;


### PR DESCRIPTION
This was necessary to allow for headers that exceeded 8K (because
we're sending too much cookie data).

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
