### PR TITLE
Rename rebuild_index to rebuild_indices, as used in forum

### DIFF
--- a/playbooks/roles/forum/tasks/deploy.yml
+++ b/playbooks/roles/forum/tasks/deploy.yml
@@ -72,8 +72,8 @@
     - migrate
     - migrate:db
 
-- name: rebuild elasticsearch indexes
-  command: "{{ forum_code_dir }}/bin/rake search:rebuild_index"
+- name: rebuild elasticsearch indices
+  command: "{{ forum_code_dir }}/bin/rake search:rebuild_indices"
   args:
     chdir: "{{ forum_code_dir }}"
   become_user: "{{ forum_user }}"


### PR DESCRIPTION
This fixes an error caused by calling an [invalid rake command](https://groups.google.com/g/open-edx-btr-notifications/c/mf6Ae7jZyY8/m/JhmwyqKaCAAJ) while setting up elasticsearch for forum. This PR updates the command to the current [identifier](https://github.com/edx/cs_comments_service/blob/573567e4f85baed76a6bb06e0a2110052d5ad53a/lib/tasks/search.rake#L13)

**JIRA Ticket**: [OSPR-5362](https://openedx.atlassian.net/browse/OSPR-5362), [Opencraft/SE-3586](https://tasks.opencraft.com/browse/SE-3586)

**Testing instruction**: Setup forum using the playbooks, and verify that it passes through successfully.

---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
