### PR TITLE
Bump xblock-problem-builder to 4.1.9 for deprecated import fix

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -525,7 +525,7 @@ EDXAPP_EXTRA_REQUIREMENTS: []
 #   - name: git+https://git.myproject.org/MyProject#egg=MyProject
 EDXAPP_PRIVATE_REQUIREMENTS:
     # For Harvard courses:
-    - name: xblock-problem-builder==4.0.0
+    - name: xblock-problem-builder==4.1.9
     # Oppia XBlock
     - name: git+https://github.com/oppia/xblock.git@3b5c17c5832b4f8ef132c6bbf48da8a86df43b3d#egg=oppia-xblock
       extra_args: -e


### PR DESCRIPTION
```
The old version, 4.0.0, referenced an edx-platform path that
is deprecated and will soon be unsupported.
```

Package diff: https://github.com/open-craft/problem-builder/compare/v4.0.0...v4.1.9

Here is the specific change we need for the import fix: https://github.com/open-craft/problem-builder/commit/b7f7a047b85218876d97fb0f336d9c2ea92e9686

(we only need v4.1.8 for the import fix, but it seemed worth going all the way up to the latest version while we're upgrading anyway)

This is related to the [the impending removal of support for deprecated edx-platform import paths](https://github.com/edx/edx-platform/pull/25932).