### PR TITLE
Increase nginx large_client_header_buffers from 4->8 buffers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 Add any new changes to the top(right below this line).
 
+ - 2021-01-15
+     - Role: nginx
+        - Increase large_client_header_buffers from 4->8 buffers to handle browsers with too much cookie data
+
  - 2021-01-12
      - Playbook: go-server
         - Removed

--- a/playbooks/roles/mfe/templates/edx/app/nginx/sites-available/app.j2
+++ b/playbooks/roles/mfe/templates/edx/app/nginx/sites-available/app.j2
@@ -7,7 +7,7 @@ server {
   listen {{ MFE_NGINX_PORT }};
 
   # Increase accepted header size to account for overenthusiastic usage of cookies
-  large_client_header_buffers 4 16k;
+  large_client_header_buffers 8 16k;
 
 
 {% if NGINX_ENABLE_SSL %}

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/common-settings.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/common-settings.j2
@@ -5,4 +5,4 @@
 server_tokens off;
 
 # Increase accepted header size to account for overenthusiastic usage of cookies
-large_client_header_buffers 4 16k;
+large_client_header_buffers 8 16k;

--- a/playbooks/roles/nginx/templates/etc/nginx/nginx.conf.j2
+++ b/playbooks/roles/nginx/templates/etc/nginx/nginx.conf.j2
@@ -24,7 +24,7 @@ http {
         {% endif %}
         # increase header buffer for for https://edx-wiki.atlassian.net/browse/LMS-467&gt
         # see http://orensol.com/2009/01/18/nginx-and-weird-400-bad-request-responses/
-        large_client_header_buffers 4 16k;
+        large_client_header_buffers 8 16k;
         server_tokens off;
 
         # server_names_hash_bucket_size 64;


### PR DESCRIPTION
Trying this as a followon to 4d064a27, in order to address issues
with clients that are sending too many cookies and running into
header size limits.

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
