### PR TITLE
sandboxes now run mongo4 and no longer run mongo 3.6

### DIFF
--- a/playbooks/edx_continuous_integration.yml
+++ b/playbooks/edx_continuous_integration.yml
@@ -22,7 +22,7 @@
     - role: edxlocal
       tags: edxlocal
     - memcache
-    - mongo_3_6
+    - mongo_4_0
     - role: redis
     - { role: 'edxapp', celery_worker: True }
     - edxapp

--- a/playbooks/roles/mysql/defaults/main.yml
+++ b/playbooks/roles/mysql/defaults/main.yml
@@ -15,7 +15,7 @@ mysql_debian_pkgs: "{{ mysql_debian_pkgs_default + mysql_release_specific_debian
 mysql_server_pkg: "{{ 'mysql-server-5.7' if mysql_server_version_5_7 is defined and (mysql_server_version_5_7 | bool) else 'mysql-server-5.6' }}"
 mysql_server_5_7_pkg: "mysql-server=5.7.33-1ubuntu18.04"
 mysql_client_5_7_pkg: "mysql-client=5.7.33-1ubuntu18.04"
-mysql_community_server_5_7_pkg: "mysql-server=5.7.32-1ubuntu18.04"
+mysql_community_server_5_7_pkg: "mysql-server=5.7.33-1ubuntu18.04"
 
 mysql_dir: /etc/mysql
 

--- a/playbooks/roles/mysql/defaults/main.yml
+++ b/playbooks/roles/mysql/defaults/main.yml
@@ -13,8 +13,8 @@ mysql_release_specific_debian_pkgs:
 mysql_debian_pkgs: "{{ mysql_debian_pkgs_default + mysql_release_specific_debian_pkgs[ansible_distribution_release] }}"
 
 mysql_server_pkg: "{{ 'mysql-server-5.7' if mysql_server_version_5_7 is defined and (mysql_server_version_5_7 | bool) else 'mysql-server-5.6' }}"
-mysql_server_5_7_pkg: "mysql-server=5.7.32-1ubuntu18.04"
-mysql_client_5_7_pkg: "mysql-client=5.7.32-1ubuntu18.04"
+mysql_server_5_7_pkg: "mysql-server=5.7.33-1ubuntu18.04"
+mysql_client_5_7_pkg: "mysql-client=5.7.33-1ubuntu18.04"
 mysql_community_server_5_7_pkg: "mysql-server=5.7.32-1ubuntu18.04"
 
 mysql_dir: /etc/mysql


### PR DESCRIPTION
Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
