### PR TITLE
Increase header size limit for gunicorn.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 Add any new changes to the top(right below this line).
 
+ - 2021-01-19
+     - Role: edxapp, edx_notes_api, gitreload, xqueue, xserver
+        - Increase gunicorn limit_request_field_size to 16384 in order to accomodate large cookies.
+
  - 2021-01-15
      - Role: nginx
         - Increase large_client_header_buffers from 4->8 buffers to handle browsers with too much cookie data

--- a/playbooks/roles/edx_notes_api/templates/edx/app/edx_notes_api/edx_notes_api_gunicorn.py.j2
+++ b/playbooks/roles/edx_notes_api/templates/edx/app/edx_notes_api/edx_notes_api_gunicorn.py.j2
@@ -9,6 +9,7 @@ preload_app = True
 timeout = {{ edx_notes_api_gunicorn_timeout }}
 bind = "{{ edx_notes_api_gunicorn_host }}:{{ edx_notes_api_gunicorn_port }}"
 pythonpath = "{{ edx_notes_api_code_dir }}"
+limit_request_field_size = 16384
 
 {% if EDX_NOTES_API_WORKERS %}
 workers = {{ EDX_NOTES_API_WORKERS }}

--- a/playbooks/roles/edxapp/templates/cms_gunicorn.py.j2
+++ b/playbooks/roles/edxapp/templates/cms_gunicorn.py.j2
@@ -9,6 +9,7 @@ preload_app = False
 timeout = {{ EDXAPP_CMS_GUNICORN_TIMEOUT }}
 bind = "{{ edxapp_cms_gunicorn_host }}:{{ edxapp_cms_gunicorn_port }}"
 pythonpath = "{{ edxapp_code_dir }}"
+limit_request_field_size = 16384
 
 {% if EDXAPP_CMS_MAX_REQ -%}
 max_requests = {{ EDXAPP_CMS_MAX_REQ }}

--- a/playbooks/roles/edxapp/templates/lms_gunicorn.py.j2
+++ b/playbooks/roles/edxapp/templates/lms_gunicorn.py.j2
@@ -9,6 +9,7 @@ preload_app = False
 timeout = {{ EDXAPP_LMS_GUNICORN_TIMEOUT }}
 bind = "{{ edxapp_lms_gunicorn_host }}:{{ edxapp_lms_gunicorn_port }}"
 pythonpath = "{{ edxapp_code_dir }}"
+limit_request_field_size = 16384
 
 {% if EDXAPP_LMS_MAX_REQ -%}
 max_requests = {{ EDXAPP_LMS_MAX_REQ }}

--- a/playbooks/roles/gitreload/templates/edx/app/gitreload/gitreload_gunicorn.py.j2
+++ b/playbooks/roles/gitreload/templates/edx/app/gitreload/gitreload_gunicorn.py.j2
@@ -8,6 +8,7 @@ import multiprocessing
 preload_app = True
 timeout = 10
 bind = "{{ gitreload_gunicorn_host }}:{{ gitreload_gunicorn_port }}"
+limit_request_field_size = 16384
 
 workers = {{ gitreload_gunicorn_workers }}
 

--- a/playbooks/roles/xqueue/templates/xqueue_gunicorn.py.j2
+++ b/playbooks/roles/xqueue/templates/xqueue_gunicorn.py.j2
@@ -9,6 +9,7 @@ preload_app = True
 timeout = 300
 bind = "{{ xqueue_gunicorn_host }}:{{ xqueue_gunicorn_port }}"
 pythonpath = "{{ xqueue_code_dir }}"
+limit_request_field_size = 16384
 
 {% if XQUEUE_WORKERS %}
 workers = {{ XQUEUE_WORKERS }}

--- a/playbooks/roles/xserver/templates/xserver_gunicorn.py.j2
+++ b/playbooks/roles/xserver/templates/xserver_gunicorn.py.j2
@@ -9,5 +9,6 @@ timeout = 30
 bind = "{{ xserver_gunicorn_host }}:{{ xserver_gunicorn_port }}"
 pythonpath = "{{ xserver_code_dir }}"
 workers = {{ xserver_gunicorn_workers }}
+limit_request_field_size = 16384
 
 {{ XSERVER_GUNICORN_EXTRA_CONF }}


### PR DESCRIPTION
This is to mitigate the issue we have with having too many cookies.

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
