### PR TITLE
Downgrade xblock-problem-builder pin from 4.1.9 to 4.1.8

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -525,7 +525,7 @@ EDXAPP_EXTRA_REQUIREMENTS: []
 #   - name: git+https://git.myproject.org/MyProject#egg=MyProject
 EDXAPP_PRIVATE_REQUIREMENTS:
     # For Harvard courses:
-    - name: xblock-problem-builder==4.1.9
+    - name: xblock-problem-builder==4.1.8
     # Oppia XBlock
     - name: git+https://github.com/oppia/xblock.git@3b5c17c5832b4f8ef132c6bbf48da8a86df43b3d#egg=oppia-xblock
       extra_args: -e


### PR DESCRIPTION
```
There is no 4.1.9 release on PyPI. We've notified
OpenCraft of the missing release; however, in the mean
time, the easiest thing to do is to stick with the 4.1.8
release, which has all the changes we need.
```

We noticed the issue when the AMI build failed with:
```
ERROR: Could not find a version that satisfies the requirement xblock-problem-builder==4.1.9 (from versions: 3.1.3, 3.1.5, 3.1.6, 3.2.0, 3.2.1, 3.3.0, 3.3.1, 3.3.4, 3.3.5, 3.3.6, 3.3.7, 3.3.8, 3.3.9, 3.3.10, 3.3.11, 3.3.12, 3.3.13, 3.3.14, 3.3.15, 3.4.0, 3.4.1, 3.4.2, 3.4.6, 3.4.7, 3.4.10, 3.4.11, 3.4.12, 3.4.13, 3.4.14, 3.4.16, 3.4.17, 3.4.19, 3.4.20, 3.4.21, 3.4.22, 3.4.23, 3.5.0, 3.5.2, 3.5.3, 3.5.4, 3.5.5, 3.5.6, 3.5.7, 4.0.0, 4.0.1, 4.0.2, 4.0.3, 4.0.4, 4.0.5, 4.0.6, 4.0.7, 4.1.0, 4.1.2, 4.1.3, 4.1.4, 4.1.5, 4.1.7, 4.1.8)
ERROR: No matching distribution found for xblock-problem-builder==4.1.9
```

I had originally [upgraded the pin from 4.0.0 to 4.1.9](https://github.com/edx/configuration/pull/6246), so I can confirm that downgrading to 4.1.8 isn't a problem.

[I opened an issue in problem-builder](https://github.com/open-craft/problem-builder/issues/322) for OpenCraft's own visibility, but we aren't blocked on the 4.1.9 release at all.