### PR TITLE
Upgrade problem builder from 4.1.8 to 4.1.10

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -525,7 +525,7 @@ EDXAPP_EXTRA_REQUIREMENTS: []
 #   - name: git+https://git.myproject.org/MyProject#egg=MyProject
 EDXAPP_PRIVATE_REQUIREMENTS:
     # For Harvard courses:
-    - name: xblock-problem-builder==4.1.8
+    - name: xblock-problem-builder==4.1.10
     # Oppia XBlock
     - name: git+https://github.com/oppia/xblock.git@3b5c17c5832b4f8ef132c6bbf48da8a86df43b3d#egg=oppia-xblock
       extra_args: -e


### PR DESCRIPTION
```
Incorporates xblock-problem-builder fix to
correctly import edx-platform code pre-Koa,
on Koa, and after Koa.
```

Diff: https://github.com/open-craft/problem-builder/compare/v4.1.8...v4.1.10

This is part of the [import shims removal effort](https://github.com/edx/edx-platform/pull/25932).