### PR TITLE
postfix_queue: Add the ability to set recipient canonical maps

### DIFF
--- a/playbooks/roles/postfix_queue/defaults/main.yml
+++ b/playbooks/roles/postfix_queue/defaults/main.yml
@@ -22,6 +22,13 @@ POSTFIX_QUEUE_EXTERNAL_SMTP_PASSWORD: ''
 #   someuser@example.com otheruser@myschool.org
 POSTFIX_QUEUE_SENDER_CANONICAL_MAPS: ''
 
+# Set this to content of recipient_canonical_maps postfix configuration file (optional).
+# Example:
+# POSTFIX_QUEUE_RECIPIENT_CANONICAL_MAPS: |-
+#   @internal @external.com
+#   someuser@example.com otheruser@myschool.org
+POSTFIX_QUEUE_RECIPIENT_CANONICAL_MAPS: ''
+
 # Set this to content of header_checks postfix configuration file (optional).
 # Example:
 # POSTFIX_QUEUE_HEADER_CHECKS: |-
@@ -33,6 +40,7 @@ POSTFIX_QUEUE_HEADER_CHECKS: ''
 
 postfix_queue_password_file: "/etc/postfix/sasl/passwd"
 postfix_queue_sender_canonical_maps_file: "/etc/postfix/sender_canonical_maps"
+postfix_queue_recipient_canonical_maps_file: "/etc/postfix/recipient_canonical_maps"
 postfix_queue_header_checks_file: "/etc/postfix/header_checks"
 
 postfix_queue_smtp_sasl_auth_enable: "yes"

--- a/playbooks/roles/postfix_queue/tasks/main.yml
+++ b/playbooks/roles/postfix_queue/tasks/main.yml
@@ -24,6 +24,7 @@
     - "smtp_tls_security_level = {{ postfix_queue_smtp_tls_security_level }}"
     - "smtp_tls_mandatory_ciphers = {{ postfix_queue_smtp_tls_mandatory_ciphers }}"
     - "sender_canonical_maps = hash:{{ postfix_queue_sender_canonical_maps_file }}"
+    - "recipient_canonical_maps = hash:{{ postfix_queue_recipient_canonical_maps_file }}"
     - "header_checks = regexp:{{ postfix_queue_header_checks_file }}"
 
 - name: Explain postfix authentication
@@ -59,6 +60,20 @@
 - name: Hash postfix sender canonical maps file
   command: "postmap hash:{{ postfix_queue_sender_canonical_maps_file }}"
   when: postfix_queue_sender_canonical_maps.changed
+
+- name: Configure postfix recipient canonical maps
+  copy:
+    dest: "{{ postfix_queue_recipient_canonical_maps_file }}"
+    content: "# Configured by Ansible:\n{{ POSTFIX_QUEUE_RECIPIENT_CANONICAL_MAPS }}"
+    force: true
+    owner: root
+    group: root
+    mode: "0600"
+  register: postfix_queue_recipient_canonical_maps
+
+- name: Hash postfix recipient canonical maps file
+  command: "postmap hash:{{ postfix_queue_recipient_canonical_maps_file }}"
+  when: postfix_queue_recipient_canonical_maps.changed
 
 - name: Configure postfix header checks
   copy:


### PR DESCRIPTION
Koa backport for #6251:

Just like `POSTFIX_QUEUE_SENDER_CANONICAL_MAPS`, also support `POSTFIX_QUEUE_RECIPIENT_CANONICAL_MAPS` (for the purpose of redirecting email for the local `root` user, for example).

(cherry picked from commit 10b2d9dbbb4018520cb57c2b88bd065e60eea0fa)

