### PR TITLE
Split out a simpler jenkins worker for user retirement.

### DIFF
--- a/playbooks/jenkins_worker_user_retire.yml
+++ b/playbooks/jenkins_worker_user_retire.yml
@@ -1,0 +1,16 @@
+# Configure a Jenkins worker instance to run the user retirement jobs.
+
+- name: Configure instance(s)
+  hosts: jenkins_worker
+  become: True
+  gather_facts: True
+  vars:
+    serial_count: 1
+    COMMON_SECURITY_UPDATES: yes
+    SECURITY_UPGRADE_ON_ANSIBLE: true
+  serial: "{{ serial_count }}"
+  roles:
+    - role: aws
+      when: COMMON_ENABLE_AWS_ROLE
+    - jenkins_worker
+    - newrelic_infrastructure

--- a/playbooks/roles/jenkins_worker/tasks/python.yml
+++ b/playbooks/roles/jenkins_worker/tasks/python.yml
@@ -39,10 +39,20 @@
     url: "https://bootstrap.pypa.io/get-pip.py"
     dest: "/tmp/get-pip.py"
 
-- name: Install 'pip' for each installed version of python.
+- name: Install most recent 'pip' for installed python versions 3.6 and greater.
   shell:
     cmd: "python{{ item }} /tmp/get-pip.py"
+  when:
+    - item != '3.5'
+    - item != '2.7'
   with_items: '{{ jenkins_worker_python_versions }}'
+  register: python_versions
+
+- name: Install pinned 'pip' for installed python version 3.5 and lower.
+  shell:
+    cmd: "python{{ item }} /tmp/get-pip.py pip<21.0"
+  with_items: '{{ python_versions.results }}'
+  when: item | skipped
 
 # Requests library is required for the github status script.
 - name: Install requests Python library

--- a/util/packer/jenkins_worker_user_retire.json
+++ b/util/packer/jenkins_worker_user_retire.json
@@ -1,0 +1,68 @@
+{
+  "variables": {
+    "aws_access_key": "{{env `AWS_ACCESS_KEY_ID`}}",
+    "aws_secret_key": "{{env `AWS_SECRET_ACCESS_KEY`}}",
+    "playbook_remote_dir": "/tmp/packer-edx-playbooks",
+    "venv_dir": "/edx/app/edx_ansible/venvs/edx_ansible",
+    "ami": "{{env `JENKINS_WORKER_AMI`}}",
+    "security_group": "{{env `AWS_SECURITY_GROUP`}}",
+    "delete_or_keep": "{{env `DELETE_OR_KEEP_AMI`}}",
+    "remote_branch": "{{env `REMOTE_BRANCH`}}",
+    "jenkins_worker_key_url": "{{env `JENKINS_WORKER_KEY_URL`}}"
+  },
+  "builders": [{
+    "type": "amazon-ebs",
+    "access_key": "{{user `aws_access_key`}}",
+    "secret_key": "{{user `aws_secret_key`}}",
+    "ami_name": "jenkins_worker-{{isotime | clean_ami_name}}",
+    "instance_type": "m3.large",
+    "region": "us-east-1",
+    "source_ami": "{{user `ami`}}",
+    "ssh_username": "ubuntu",
+    "ami_description": "jenkins worker",
+    "iam_instance_profile": "jenkins-worker",
+    "security_group_id": "{{user `security_group`}}",
+    "tags": {
+      "delete_or_keep": "{{user `delete_or_keep`}}"
+    },
+    "launch_block_device_mappings": [{
+      "delete_on_termination": true,
+      "device_name": "/dev/sda1",
+      "volume_size": "40",
+      "volume_type": "gp2"
+    }]
+  }],
+  "provisioners": [{
+    "type": "shell",
+    "inline": ["rm -rf {{user `playbook_remote_dir`}}",
+      "mkdir {{user `playbook_remote_dir`}}"]
+  }, {
+    "type": "file",
+    "source": "stop-automatic-updates.sh",
+    "destination": "{{user `playbook_remote_dir`}}/stop-automatic-updates.sh"
+  }, {
+    "type": "file",
+    "source": "../../util/install/ansible-bootstrap.sh",
+    "destination": "{{user `playbook_remote_dir`}}/ansible-bootstrap.sh"
+  }, {
+    "type": "shell",
+    "inline": ["cd {{user `playbook_remote_dir`}}",
+      "export CONFIGURATION_VERSION='{{user `remote_branch`}}'",
+      "sudo bash ./stop-automatic-updates.sh",
+      "sudo bash ./ansible-bootstrap.sh"
+    ]
+  }, {
+    "type": "shell-local",
+    "command": "rm ../../playbooks/edx-east"
+  }, {
+    "type": "ansible-local",
+    "playbook_file": "../../playbooks/jenkins_worker_user_retire.yml",
+    "playbook_dir": "../../playbooks",
+    "command": ". {{user `venv_dir`}}/bin/activate && ansible-playbook",
+    "inventory_groups": "jenkins_worker",
+    "extra_arguments": [
+      "-e \"jenkins_worker_key_url='{{user `jenkins_worker_key_url`}}'\"",
+      "-vvv"
+      ]
+  }]
+}


### PR DESCRIPTION
...with less things.

Add logic to python pip install to pin the pip version for Python 3.5 and below.

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
