### PR TITLE
Second iteration of user retirement jenkins worker

### DIFF
--- a/playbooks/jenkins_worker_user_retire.yml
+++ b/playbooks/jenkins_worker_user_retire.yml
@@ -13,4 +13,3 @@
     - role: aws
       when: COMMON_ENABLE_AWS_ROLE
     - jenkins_worker
-    - newrelic_infrastructure

--- a/playbooks/roles/common_vars/defaults/main.yml
+++ b/playbooks/roles/common_vars/defaults/main.yml
@@ -158,7 +158,7 @@ common_pip_pkgs:
   - virtualenv==20.2.0
   - zipp==1.2.0
   - boto3
-  - importlib-resources==3.3.1
+  - importlib-resources==3.2.1
 
 common_web_user: www-data
 common_web_group: www-data


### PR DESCRIPTION
Configuration Pull Request
---

Pin importlib-resources to a earlier version that supports Python 3.5. Remove unused NewRelic dependency.

The pinning of importlib-resources was recently done in this PR:
https://github.com/edx/configuration/pull/6226

The building of a Jenkins worker via build-packer-ami currently fails with this Ansible error:
```
{
   "changed":false,
   "cmd":[
      "/tmp/bootstrap/bin/pip3",
      "install",
      "-i",
      "https://pypi.python.org/simple",
      "pip==20.0.2",
      "configparser==4.0.2",
      "setuptools==44.1.0",
      "virtualenv==20.2.0",
      "zipp==1.2.0",
      "boto3",
      "importlib-resources==3.3.1"
   ],
   "msg":
"stdout: Looking in indexes: https://pypi.python.org/simple
Requirement already satisfied: pip==20.0.2 in ./bootstrap/lib/python3.5/site-packages (20.0.2)
Collecting configparser==4.0.2
  Downloading configparser-4.0.2-py2.py3-none-any.whl (22 kB)
Collecting setuptools==44.1.0
  Using cached setuptools-44.1.0-py2.py3-none-any.whl (583 kB)
Collecting virtualenv==20.2.0
  Downloading virtualenv-20.2.0-py2.py3-none-any.whl (4.9 MB)
Collecting zipp==1.2.0
  Downloading zipp-1.2.0-py2.py3-none-any.whl (4.8 kB)
Requirement already satisfied: boto3 in ./bootstrap/lib/python3.5/site-packages (1.10.45)

:stderr: ERROR: Could not find a version that satisfies the requirement importlib-resources==3.3.1 (from versions: 0.1.0, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 1.0, 1.0.1, 1.0.2, 1.1.0, 1.2.0, 1.3.0, 1.3.1, 1.4.0, 1.5.0, 2.0.0, 2.0.1, 3.0.0, 3.1.0, 3.1.1, 3.2.0, 3.2.1)
ERROR: No matching distribution found for importlib-resources==3.3.1
WARNING: You are using pip version 20.0.2; however, version 20.3.4 is available.
You should consider upgrading via the '/tmp/bootstrap/bin/python3.5 -m pip install --upgrade pip' command."
}
```

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
