### PR TITLE
Re-add docker-tools, as the jenkins worker role expects its presence.

### DIFF
--- a/playbooks/jenkins_worker_user_retire.yml
+++ b/playbooks/jenkins_worker_user_retire.yml
@@ -12,4 +12,5 @@
   roles:
     - role: aws
       when: COMMON_ENABLE_AWS_ROLE
+    - docker-tools
     - jenkins_worker

--- a/playbooks/jenkins_worker_user_retire.yml
+++ b/playbooks/jenkins_worker_user_retire.yml
@@ -8,6 +8,7 @@
     serial_count: 1
     COMMON_SECURITY_UPDATES: yes
     SECURITY_UPGRADE_ON_ANSIBLE: true
+    jenkins_worker_install_python27: false
   serial: "{{ serial_count }}"
   roles:
     - role: aws

--- a/playbooks/roles/jenkins_worker/defaults/main.yml
+++ b/playbooks/roles/jenkins_worker/defaults/main.yml
@@ -23,6 +23,9 @@ packer_url: "https://releases.hashicorp.com/packer/1.4.4/packer_1.4.4_linux_amd6
 JENKINS_NODE_VERSION: "12"
 ansible_distribution_release: "xenial"
 
+# Flag which will override the '2.7' entry below when false.
+jenkins_worker_install_python27: true
+
 jenkins_worker_python_versions:
   - 2.7
   - 3.5

--- a/playbooks/roles/jenkins_worker/tasks/python.yml
+++ b/playbooks/roles/jenkins_worker/tasks/python.yml
@@ -33,6 +33,20 @@
     update_cache: yes
   with_items: '{{ jenkins_worker_distutils_versions }}'
 
+# For Python version 3.5, install pip via Ubuntu apt-get, as get-pip.py can no longer be used.
+# get-pip.py also doesn't support Python2.7 - that version's install is broken at the moment.
+- name: Install distro pip for Python3 to accomodate Python 3.5.
+  apt:
+    name: python3-pip
+    state: present
+    update_cache: yes
+
+- name: Upgrade pip for installed python version 3.5.
+  shell:
+    cmd: "python{{ item }} -m pip install --upgrade pip==20.3.4"
+  when: item == 3.5
+  with_items: '{{ jenkins_worker_python_versions }}'
+  register: python_versions
 
 - name: Fetch get-pip.py from pypa
   get_url:
@@ -41,18 +55,11 @@
 
 - name: Install most recent 'pip' for installed python versions 3.6 and greater.
   shell:
-    cmd: "python{{ item }} /tmp/get-pip.py"
-  when:
-    - item != '3.5'
-    - item != '2.7'
-  with_items: '{{ jenkins_worker_python_versions }}'
-  register: python_versions
-
-- name: Install pinned 'pip' for installed python version 3.5 and lower.
-  shell:
-    cmd: "python{{ item }} /tmp/get-pip.py pip<21.0"
+    cmd: "python{{ item.item }} /tmp/get-pip.py"
   with_items: '{{ python_versions.results }}'
-  when: item | skipped
+  when:
+    - item | skipped
+    - item.item != 2.7 or (item.item == 2.7 and jenkins_worker_install_python27)
 
 # Requests library is required for the github status script.
 - name: Install requests Python library
@@ -61,4 +68,6 @@
     state: present
     executable: 'pip{{ item }}'
   with_items: "{{ jenkins_worker_python_versions }}"
+  when:
+    - item != 2.7 or (item == 2.7 and jenkins_worker_install_python27)
 


### PR DESCRIPTION
Configuration Pull Request
---

Follow-on to this PR: https://github.com/edx/configuration/pull/6266

Current run of build-packer-ami failed with the following error:
```
17:36:34     amazon-ebs: <127.0.0.1> EXEC /bin/sh -c 'rm -f -r /home/ubuntu/.ansible/tmp/ansible-tmp-1611614194.3095176-24714-147893050588280/ > /dev/null 2>&1 && sleep 0'
17:36:34     amazon-ebs: fatal: [127.0.0.1]: FAILED! => {
17:36:34     amazon-ebs:     "changed": false,
17:36:34     amazon-ebs:     "invocation": {
17:36:34     amazon-ebs:         "module_args": {
17:36:34     amazon-ebs:             "append": true,
17:36:34     amazon-ebs:             "authorization": null,
17:36:34     amazon-ebs:             "comment": null,
17:36:34     amazon-ebs:             "create_home": true,
17:36:34     amazon-ebs:             "expires": null,
17:36:34     amazon-ebs:             "force": false,
17:36:34     amazon-ebs:             "generate_ssh_key": null,
17:36:34     amazon-ebs:             "group": null,
17:36:34     amazon-ebs:             "groups": [
17:36:34     amazon-ebs:                 "jenkins",
17:36:34     amazon-ebs:                 "docker"
17:36:34     amazon-ebs:             ],
17:36:34     amazon-ebs:             "hidden": null,
17:36:34     amazon-ebs:             "home": null,
17:36:34     amazon-ebs:             "local": null,
17:36:34     amazon-ebs:             "login_class": null,
17:36:34     amazon-ebs:             "move_home": false,
17:36:34     amazon-ebs:             "name": "jenkins",
17:36:34     amazon-ebs:             "non_unique": false,
17:36:34     amazon-ebs:             "password": null,
17:36:34     amazon-ebs:             "password_lock": null,
17:36:34     amazon-ebs:             "profile": null,
17:36:34     amazon-ebs:             "remove": false,
17:36:34     amazon-ebs:             "role": null,
17:36:34     amazon-ebs:             "seuser": null,
17:36:34     amazon-ebs:             "shell": "/bin/bash",
17:36:34     amazon-ebs:             "skeleton": null,
17:36:34     amazon-ebs:             "ssh_key_bits": 0,
17:36:34     amazon-ebs:             "ssh_key_comment": "ansible-generated on ip-10-47-254-98",
17:36:34     amazon-ebs:             "ssh_key_file": null,
17:36:34     amazon-ebs:             "ssh_key_passphrase": null,
17:36:34     amazon-ebs:             "ssh_key_type": "rsa",
17:36:34     amazon-ebs:             "state": "present",
17:36:34     amazon-ebs:             "system": false,
17:36:34     amazon-ebs:             "uid": null,
17:36:34     amazon-ebs:             "update_password": "always"
17:36:34     amazon-ebs:         }
17:36:34     amazon-ebs:     },
17:36:34     amazon-ebs:     "msg": "Group docker does not exist"
17:36:34     amazon-ebs: }
```

so the docker-tools role is expected by the jenkins-worker role.

===

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
