### PR TITLE
Add mongo role back into user retirement Jenkins worker.

### DIFF
--- a/playbooks/jenkins_worker_user_retire.yml
+++ b/playbooks/jenkins_worker_user_retire.yml
@@ -5,13 +5,17 @@
   become: True
   gather_facts: True
   vars:
+    mongo_enable_journal: False
     serial_count: 1
     COMMON_SECURITY_UPDATES: yes
     SECURITY_UPGRADE_ON_ANSIBLE: true
+    MONGO_AUTH: false
     jenkins_worker_install_python27: false
   serial: "{{ serial_count }}"
   roles:
     - role: aws
       when: COMMON_ENABLE_AWS_ROLE
     - docker-tools
+    - memcache
+    - mongo_3_2
     - jenkins_worker

--- a/util/packer/jenkins_worker_user_retire.json
+++ b/util/packer/jenkins_worker_user_retire.json
@@ -19,7 +19,7 @@
     "region": "us-east-1",
     "source_ami": "{{user `ami`}}",
     "ssh_username": "ubuntu",
-    "ami_description": "jenkins worker",
+    "ami_description": "jenkins worker for user retirement",
     "iam_instance_profile": "jenkins-worker",
     "security_group_id": "{{user `security_group`}}",
     "tags": {
@@ -61,7 +61,7 @@
     "command": ". {{user `venv_dir`}}/bin/activate && ansible-playbook",
     "inventory_groups": "jenkins_worker",
     "extra_arguments": [
-      "-e \"jenkins_worker_key_url='{{user `jenkins_worker_key_url`}}'\"",
+      "-e \"initialize_replica_set=false mongo_configure_replica_set=false jenkins_worker_key_url='{{user `jenkins_worker_key_url`}}'\"",
       "-vvv"
       ]
   }]


### PR DESCRIPTION
Configuration Pull Request
---

The current version of the new user retirement-specific Jenkins worker is erroring upon startup with this message:
```
2021-01-27T22:51:59.063+0000 E QUERY    [thread1] Error: listDatabases failed:{
	"ok" : 0,
	"errmsg" : "not authorized on admin to execute command { listDatabases: 1.0 }",
	"code" : 13
} :
_getErrorWithCode@src/mongo/shell/utils.js:25:13
Mongo.prototype.getDBs@src/mongo/shell/mongo.js:62:1
Mongo.prototype.getDBNames@src/mongo/shell/mongo.js:109:12
@(shell eval):1:1
Jan 27, 2021 10:51:59 PM hudson.plugins.ec2.EC2Cloud
WARNING: init script failed: exit code=252
```
The PR adds back in Mongo with all related parameters to attempt to fix the error above.

This PR is a continuation of the work in this PR: https://github.com/edx/configuration/pull/6267

I've tested a build-packer-ami build, which ran successfully here:
https://build.testeng.edx.org/job/build-packer-ami/15114/console

---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
