### PR TITLE
chore: upgrade problem-builder from 4.1.10 to 4.1.11

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -525,7 +525,7 @@ EDXAPP_EXTRA_REQUIREMENTS: []
 #   - name: git+https://git.myproject.org/MyProject#egg=MyProject
 EDXAPP_PRIVATE_REQUIREMENTS:
     # For Harvard courses:
-    - name: xblock-problem-builder==4.1.10
+    - name: xblock-problem-builder==4.1.11
     # Oppia XBlock
     - name: git+https://github.com/oppia/xblock.git@3b5c17c5832b4f8ef132c6bbf48da8a86df43b3d#egg=oppia-xblock
       extra_args: -e


### PR DESCRIPTION
The new version just fixes more instances of DeprecatedEdxPlatformImportWarning. There should be no change to functionality.

Pulls in https://github.com/open-craft/problem-builder/pull/324

This is a prerequisite to [disabling and removing the import shims](https://github.com/edx/edx-platform/pull/25932).