### PR TITLE
Verified user will now be enrolled in verified mode

### DIFF
--- a/playbooks/roles/demo/defaults/main.yml
+++ b/playbooks/roles/demo/defaults/main.yml
@@ -25,22 +25,26 @@ demo_test_users:
     hashed_password: "{{ demo_hashed_password }}"
     is_staff: false
     is_superuser: false
+    mode: audit
   - email: 'audit@example.com'
     username: audit
     hashed_password: "{{ demo_hashed_password }}"
     is_staff: false
     is_superuser: false
+    mode: audit
   - email: 'verified@example.com'
     username: verified
     hashed_password: "{{ demo_hashed_password }}"
     is_staff: false
     is_superuser: false
+    mode: verified
 demo_staff_user:
   email: 'staff@example.com'
   username: staff
   hashed_password: "{{ demo_hashed_password }}"
   is_staff: true
   is_superuser: false
+  mode: audit
 SANDBOX_EDXAPP_USERS: []
 demo_edxapp_user: 'edxapp'
 demo_edxapp_settings: '{{ COMMON_EDXAPP_SETTINGS }}'

--- a/playbooks/roles/demo/tasks/deploy.yml
+++ b/playbooks/roles/demo/tasks/deploy.yml
@@ -39,7 +39,7 @@
   when: demo_checkout.changed
 
 - name: enroll test users in the demo course
-  shell: ". {{ demo_edxapp_env }} && {{ demo_edxapp_venv_bin }}/python ./manage.py lms --settings={{ demo_edxapp_settings }} --service-variant lms enroll_user_in_course -e {{ item.email }} -c {{ demo_course_id }}"
+  shell: ". {{ demo_edxapp_env }} && {{ demo_edxapp_venv_bin }}/python ./manage.py lms --settings={{ demo_edxapp_settings }} --service-variant lms enroll_user_in_course -e {{ item.email }} -c {{ demo_course_id }} -m {{ item.mode }}"
   args:
     chdir: "{{ demo_edxapp_code_dir }}"
   become_user: "{{ common_web_user }}"


### PR DESCRIPTION
Previously, the verified test user would be enrolled in the audit
mode in the demo course which made things difficult if you wanted to
test logic specific to verified learners. Now the verified learner
will be in the verified enrollment track from the start

Unclear if desired or not, but I have confirmed that this will not have any effect on existing users. So for the already created Verified user, they will remain in the Audit mode. On the next full provision (creating new data), the user will be created with the Verified enrollment (note: this is not to say that you should do that. Provisioning is expensive. Cheaper ways to get a verified learner exist via database updates or `update_enrollment` functions).

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
