### PR TITLE
Revert "Verified user will now be enrolled in verified mode"

### DIFF
--- a/playbooks/roles/demo/defaults/main.yml
+++ b/playbooks/roles/demo/defaults/main.yml
@@ -25,26 +25,22 @@ demo_test_users:
     hashed_password: "{{ demo_hashed_password }}"
     is_staff: false
     is_superuser: false
-    mode: audit
   - email: 'audit@example.com'
     username: audit
     hashed_password: "{{ demo_hashed_password }}"
     is_staff: false
     is_superuser: false
-    mode: audit
   - email: 'verified@example.com'
     username: verified
     hashed_password: "{{ demo_hashed_password }}"
     is_staff: false
     is_superuser: false
-    mode: verified
 demo_staff_user:
   email: 'staff@example.com'
   username: staff
   hashed_password: "{{ demo_hashed_password }}"
   is_staff: true
   is_superuser: false
-  mode: audit
 SANDBOX_EDXAPP_USERS: []
 demo_edxapp_user: 'edxapp'
 demo_edxapp_settings: '{{ COMMON_EDXAPP_SETTINGS }}'

--- a/playbooks/roles/demo/tasks/deploy.yml
+++ b/playbooks/roles/demo/tasks/deploy.yml
@@ -39,7 +39,7 @@
   when: demo_checkout.changed
 
 - name: enroll test users in the demo course
-  shell: ". {{ demo_edxapp_env }} && {{ demo_edxapp_venv_bin }}/python ./manage.py lms --settings={{ demo_edxapp_settings }} --service-variant lms enroll_user_in_course -e {{ item.email }} -c {{ demo_course_id }} -m {{ item.mode }}"
+  shell: ". {{ demo_edxapp_env }} && {{ demo_edxapp_venv_bin }}/python ./manage.py lms --settings={{ demo_edxapp_settings }} --service-variant lms enroll_user_in_course -e {{ item.email }} -c {{ demo_course_id }}"
   args:
     chdir: "{{ demo_edxapp_code_dir }}"
   become_user: "{{ common_web_user }}"


### PR DESCRIPTION
Reverts edx/configuration#6287

Sandbox builds began failing after this merged because the verified mode could not be found on the Demo course. Will investigate at a later point.