### PR TITLE
Switch LMS urls to use localhost:18000 instead of edx.devstack.lms

### DIFF
--- a/docker/build/edxapp/lms.yml
+++ b/docker/build/edxapp/lms.yml
@@ -346,7 +346,7 @@ JWT_PRIVATE_SIGNING_KEY: null
 LANGUAGE_CODE: en
 LANGUAGE_COOKIE: openedx-language-preference
 LEARNER_PORTAL_URL_ROOT: https://learner-portal-edx.devstack.lms:18000
-LMS_BASE: http://localhost:18000
+LMS_BASE: localhost:18000
 LMS_INTERNAL_ROOT_URL: http://localhost:18000
 LMS_ROOT_URL: http://localhost:18000
 LOCAL_LOGLEVEL: INFO

--- a/docker/build/edxapp/lms.yml
+++ b/docker/build/edxapp/lms.yml
@@ -346,9 +346,9 @@ JWT_PRIVATE_SIGNING_KEY: null
 LANGUAGE_CODE: en
 LANGUAGE_COOKIE: openedx-language-preference
 LEARNER_PORTAL_URL_ROOT: https://learner-portal-edx.devstack.lms:18000
-LMS_BASE: edx.devstack.lms:18000
-LMS_INTERNAL_ROOT_URL: http://edx.devstack.lms:18000
-LMS_ROOT_URL: http://edx.devstack.lms:18000
+LMS_BASE: http://localhost:18000
+LMS_INTERNAL_ROOT_URL: http://localhost:18000
+LMS_ROOT_URL: http://localhost:18000
 LOCAL_LOGLEVEL: INFO
 LOGGING_ENV: sandbox
 LOGIN_REDIRECT_WHITELIST: []

--- a/docker/build/edxapp/studio.yml
+++ b/docker/build/edxapp/studio.yml
@@ -309,9 +309,9 @@ JWT_PRIVATE_SIGNING_KEY: null
 LANGUAGE_CODE: en
 LANGUAGE_COOKIE: openedx-language-preference
 LEARNER_PORTAL_URL_ROOT: https://learner-portal-edx.devstack.lms:18000
-LMS_BASE: edx.devstack.lms:18000
-LMS_INTERNAL_ROOT_URL: http://edx.devstack.lms:18000
-LMS_ROOT_URL: http://edx.devstack.lms:18000
+LMS_BASE: http://localhost:18000
+LMS_INTERNAL_ROOT_URL: http://localhost:18000
+LMS_ROOT_URL: http://localhost:18000
 LOCAL_LOGLEVEL: INFO
 LOGGING_ENV: sandbox
 LOGIN_REDIRECT_WHITELIST: []

--- a/docker/build/edxapp/studio.yml
+++ b/docker/build/edxapp/studio.yml
@@ -309,7 +309,7 @@ JWT_PRIVATE_SIGNING_KEY: null
 LANGUAGE_CODE: en
 LANGUAGE_COOKIE: openedx-language-preference
 LEARNER_PORTAL_URL_ROOT: https://learner-portal-edx.devstack.lms:18000
-LMS_BASE: http://localhost:18000
+LMS_BASE: localhost:18000
 LMS_INTERNAL_ROOT_URL: http://localhost:18000
 LMS_ROOT_URL: http://localhost:18000
 LOCAL_LOGLEVEL: INFO


### PR DESCRIPTION
Setting the urls to edx.devstack.lms causes issues with redirects from frontend.

These settings are already set to localhost:18000 in edx-platform/lms/envs/devstack.py.
This just does it such that the value changes in edx-platform/lms/envs/production.py.

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
