### PR TITLE
Revert "Add role to cluster task for create_rds playbook."

### DIFF
--- a/playbooks/create_rds.yml
+++ b/playbooks/create_rds.yml
@@ -72,16 +72,5 @@
     retries: 20
     delay: 60
 
-  - name: Add role to DB cluster
-    command: "aws rds add-role-to-db-cluster
-              --db-cluster-identifier {{ cluster_name }}
-              --role-arn {{ cluster_role_arn }}
-              "
-    register: add_role_result
-    failed_when: >
-      add_role_result.rc !=0 and ('DBClusterRoleAlreadyExists' not in add_role_result.stderr)
-    changed_when: "add_role_result.rc == 0"
-    when: cluster_name is defined and cluster_role_arn is defined
-
 - include: create_db_and_users.yml
   when: database_connection.login_host is defined


### PR DESCRIPTION
Reverts edx/configuration#6259

This doesn't work and isn't the right place to capture this anyway.