### PR TITLE
BOM-2452: Upgraded the xqwatcher to python3.5

### DIFF
--- a/playbooks/roles/xqwatcher/defaults/main.yml
+++ b/playbooks/roles/xqwatcher/defaults/main.yml
@@ -87,7 +87,7 @@ xqwatcher_code_dir: "{{ xqwatcher_app_dir }}/src"
 
 xqwatcher_repo_name: xqueue-watcher.git
 
-xqwatcher_python_version: "python2.7"
+xqwatcher_python_version: "python3.5"
 
 #TODO: change this to /edx/etc after pulling xqwatcher.json out
 xqwatcher_conf_dir: "{{ xqwatcher_app_dir }}"


### PR DESCRIPTION
Configuration Pull Request
---
JIRA Issue: [BOM-2452](https://openedx.atlassian.net/browse/BOM-2452)
PR to upgrade xqueue-watcher to `Python3.5`.

Make sure that the following steps are done before merging:

  - [x] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
