### PR TITLE
Upgrade celery to match edx-platform, fix for py38

### DIFF
--- a/requirements/celery_progress.in
+++ b/requirements/celery_progress.in
@@ -7,4 +7,4 @@ click==6.7
 futures ; python_version == "2.7"   # via s3transfer
 redis==2.10.6
 opsgenie-sdk==0.3.1
-celery==3.1.25
+celery==4.4.7

--- a/util/jenkins/check_celery_progress/requirements.txt
+++ b/util/jenkins/check_celery_progress/requirements.txt
@@ -4,33 +4,33 @@
 #
 #    make upgrade
 #
-amqp==1.4.9               # via kombu
-anyjson==0.3.3            # via kombu
+amqp==2.6.1               # via kombu
 awscli==1.14.32           # via -r requirements/celery_progress.in
 backoff==1.4.3            # via -r requirements/celery_progress.in
-billiard==3.3.0.23        # via celery
+billiard==3.6.4.0         # via celery
 boto3==1.5.4              # via -r requirements/celery_progress.in
 botocore==1.8.36          # via awscli, boto3, s3transfer
-celery==3.1.25            # via -r requirements/celery_progress.in
-certifi==2020.6.20        # via opsgenie-sdk, requests
-chardet==3.0.4            # via requests
+celery==4.4.7             # via -r requirements/celery_progress.in
+certifi==2020.12.5        # via opsgenie-sdk, requests
+chardet==4.0.0            # via requests
 click==6.7                # via -r requirements/celery_progress.in
 colorama==0.3.7           # via awscli
-docutils==0.16            # via awscli, botocore
+docutils==0.17            # via awscli, botocore
 idna==2.10                # via requests
 jmespath==0.10.0          # via boto3, botocore
-kombu==3.0.37             # via celery
+kombu==4.6.11             # via celery
 opsgenie-sdk==0.3.1       # via -r requirements/celery_progress.in
 pyasn1==0.4.8             # via rsa
 python-dateutil==2.8.1    # via botocore, opsgenie-sdk
-pytz==2020.1              # via celery, opsgenie-sdk
+pytz==2021.1              # via celery, opsgenie-sdk
 pyyaml==3.12              # via awscli
 redis==2.10.6             # via -r requirements/celery_progress.in
-requests==2.24.0          # via opsgenie-sdk
+requests==2.25.1          # via opsgenie-sdk
 rsa==3.4.2                # via awscli
 s3transfer==0.1.13        # via awscli, boto3
 six==1.15.0               # via opsgenie-sdk, python-dateutil
-urllib3==1.25.10          # via opsgenie-sdk, requests
+urllib3==1.26.4           # via opsgenie-sdk, requests
+vine==1.3.0               # via amqp, celery
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/util/jenkins/update_celery_monitoring/requirements.txt
+++ b/util/jenkins/update_celery_monitoring/requirements.txt
@@ -10,7 +10,7 @@ boto3==1.5.4              # via -r requirements/celery.in
 botocore==1.8.36          # via awscli, boto3, s3transfer
 click==6.7                # via -r requirements/celery.in
 colorama==0.3.7           # via awscli
-docutils==0.16            # via awscli, botocore
+docutils==0.17            # via awscli, botocore
 jmespath==0.10.0          # via boto3, botocore
 pyasn1==0.4.8             # via rsa
 python-dateutil==2.8.1    # via botocore


### PR DESCRIPTION
Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
