### PR TITLE
docs: remove venv activation instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog
-All notable changes to this project will be documented in this file.
-Add any new changes to the top(right below this line).
 
- - 2021-07-03
+All notable changes to this project will be documented in this file.
+Add any new changes to the top (right below this line).
+
+ - 2021-03-08
+    - Remove instruction from ansile-bootstrap.sh that instructed people to activate
+      the virtualenv.  This was incorrect for community installations.
+
+ - 2021-03-07
     - Role: ecommerce
       - Added new configuration variable ECOMMERCE_EXTRA_CONFIG_OVERRIDES, which will allow override any ecommerce settings.
 

--- a/util/install/ansible-bootstrap.sh
+++ b/util/install/ansible-bootstrap.sh
@@ -176,9 +176,6 @@ if [[ "true" == "${RUN_ANSIBLE}" ]]; then
     ******************************************************************************
 
     Done bootstrapping, edx_ansible is now installed in /edx/app/edx_ansible.
-    Time to run some plays.  Activate the virtual env with
-
-    > . /edx/app/edx_ansible/venvs/edx_ansible/bin/activate
 
     ******************************************************************************
 EOF


### PR DESCRIPTION
If one runs the Native Installation instructions, which includes running
ansible-bootstrap.sh, then activates the bootstrapped ansible
virtualenv, then proceeds to run native.sh, this will result in a
clobbered python3-pkg-resources package, necessitating its reinstallation.

Thus, we remove these instructions from the output of
ansible-bootstrap.sh.

(cherry picked from commit 3cc14096239e03b9a2ccc4a1f4232d71892c41a7)

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
