### PR TITLE
feat: Add timezones to DE jenkins console log timestamps

### DIFF
--- a/playbooks/roles/jenkins_data_engineering/defaults/main.yml
+++ b/playbooks/roles/jenkins_data_engineering/defaults/main.yml
@@ -249,3 +249,6 @@ jenkins_connection_delay: 1
 
 jenkins_private_keyfile: "{{ jenkins_user_home }}/.ssh/id_rsa"
 jenkins_public_keyfile: "{{ jenkins_private_keyfile }}.pub"
+
+# Be clear about which time zone the console log timestamps are in!!!
+de_jenkins_timestamper_system_time: "'<b>'HH:mm:ssXX'</b> '"

--- a/playbooks/roles/jenkins_data_engineering/meta/main.yml
+++ b/playbooks/roles/jenkins_data_engineering/meta/main.yml
@@ -81,5 +81,6 @@ dependencies:
           - hudson.scm.SCM.Tag
         USERS: '{{ JENKINS_DATA_ENGINEERING_AUTH_ADMINISTRATORS }}'
     jenkins_common_main_env_vars: '{{ jenkins_base_environment_variables }} + {{ jenkins_additional_environment_variables }}'
+    jenkins_common_timestamper_system_clock_format: '{{ de_jenkins_timestamper_system_time }}'
 
   - role: mongo_client

--- a/playbooks/roles/jenkins_data_engineering_new/defaults/main.yml
+++ b/playbooks/roles/jenkins_data_engineering_new/defaults/main.yml
@@ -286,3 +286,6 @@ jenkins_connection_delay: 1
 
 jenkins_private_keyfile: "{{ jenkins_user_home }}/.ssh/id_rsa"
 jenkins_public_keyfile: "{{ jenkins_private_keyfile }}.pub"
+
+# Be clear about which time zone the console log timestamps are in!!!
+de_jenkins_timestamper_system_time: "'<b>'HH:mm:ssXX'</b> '"

--- a/playbooks/roles/jenkins_data_engineering_new/meta/main.yml
+++ b/playbooks/roles/jenkins_data_engineering_new/meta/main.yml
@@ -50,3 +50,4 @@ dependencies:
     jenkins_common_python_versions: '{{ de_jenkins_python_versions }}'
     jenkins_common_python_installations: '{{ de_jenkins_python_installations }}'
     jenkins_common_snap_pkgs: '{{ de_jenkins_snap_pkgs }}'
+    jenkins_common_timestamper_system_clock_format: '{{ de_jenkins_timestamper_system_time }}'


### PR DESCRIPTION
This has frustrated me for literally years.  Timestamps should either be
in UTC, or clearly show the timezone, plain and simple.