### PR TITLE
 fix: exit with ansible exit code. 

### DIFF
--- a/util/install/native.sh
+++ b/util/install/native.sh
@@ -189,4 +189,5 @@ if [[ $ansible_status -ne 0 ]]; then
     echo "    Your environment:"
     env | egrep -i 'version|release' | sed -e 's/^/        /'
     echo "============================================================"
+    exit ${ansible_status}
 fi


### PR DESCRIPTION
Configuration Pull Request
---

This should finx this issue https://github.com/openedx/build-test-release-wg/issues/59

@nedbat I  just saw that you were assigned to this issue. Maybe this can help you.


## How to test

In a clean ubuntu 20.04 instance, run:

Without this change, this will return 0 as exit code when there is a failure in ansible:

```
    export OPENEDX_RELEASE=open-release/lilac.master
    wget https://raw.githubusercontent.com/edx/configuration/$OPENEDX_RELEASE/util/install/ansible-bootstrap.sh -O - | sudo -E bash
   wget https://raw.githubusercontent.com/edx/configuration/$OPENEDX_RELEASE/util/install/generate-passwords.sh -O - | bash
   echo -e "EDXAPP_LMS_BASE: '$(curl ipinfo.io/ip)'\nEDXAPP_CMS_BASE: '$(curl ipinfo.io/ip):18010'" > config.yml
   wget https://raw.githubusercontent.com/edx/configuration/$OPENEDX_RELEASE/util/install/native.sh -O - | bash
```

After this changes, this won't return 0 as exit code when there is a failure in ansible.

```
    export OPENEDX_RELEASE=open-release/lilac.master
    wget https://raw.githubusercontent.com/edx/configuration/$OPENEDX_RELEASE/util/install/ansible-bootstrap.sh -O - | sudo -E bash
   wget https://raw.githubusercontent.com/edx/configuration/$OPENEDX_RELEASE/util/install/generate-passwords.sh -O - | bash
   echo -e "EDXAPP_LMS_BASE: '$(curl ipinfo.io/ip)'\nEDXAPP_CMS_BASE: '$(curl ipinfo.io/ip):18010'" > config.yml
   wget https://raw.githubusercontent.com/edunext/configuration/lmm/exit_code_lilac/util/install/native.sh -O - | bash
```

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
