### PR TITLE
fix: change old jenkins timestamp patterns to use ZZ

### DIFF
--- a/playbooks/roles/jenkins_data_engineering/defaults/main.yml
+++ b/playbooks/roles/jenkins_data_engineering/defaults/main.yml
@@ -251,4 +251,6 @@ jenkins_private_keyfile: "{{ jenkins_user_home }}/.ssh/id_rsa"
 jenkins_public_keyfile: "{{ jenkins_private_keyfile }}.pub"
 
 # Be clear about which time zone the console log timestamps are in!!!
-de_jenkins_timestamper_system_time: "'<b>'HH:mm:ssXX'</b> '"
+# use ZZ for Jenkins < 2.222.x
+# use XX for Jenkins >= 2.222.x
+de_jenkins_timestamper_system_time: "'<b>'HH:mm:ssZZ'</b> '"

--- a/playbooks/roles/jenkins_data_engineering_new/defaults/main.yml
+++ b/playbooks/roles/jenkins_data_engineering_new/defaults/main.yml
@@ -288,4 +288,6 @@ jenkins_private_keyfile: "{{ jenkins_user_home }}/.ssh/id_rsa"
 jenkins_public_keyfile: "{{ jenkins_private_keyfile }}.pub"
 
 # Be clear about which time zone the console log timestamps are in!!!
+# use ZZ for Jenkins < 2.222.x
+# use XX for Jenkins >= 2.222.x
 de_jenkins_timestamper_system_time: "'<b>'HH:mm:ssXX'</b> '"


### PR DESCRIPTION
Old jenkins uses an older version of Java's timestamp pattern format.
X or XX was introduced later (available in new jenkins).  I'm not really
sure if this is a Jenkins limitation or a Java JRE limitation.