### PR TITLE
fix: native.sh should exit with ansible's status

### DIFF
--- a/util/install/native.sh
+++ b/util/install/native.sh
@@ -190,3 +190,5 @@ if [[ $ansible_status -ne 0 ]]; then
     env | egrep -i 'version|release' | sed -e 's/^/        /'
     echo "============================================================"
 fi
+
+exit $ansible_status


### PR DESCRIPTION
This script was always exiting with a success status, which made it
difficult to use it in a CI setting.  Now we exit with the status of the
ansible command.
