### PR TITLE
feat: Install python 3.8 & 3.9 on New DE Jenkins

### DIFF
--- a/playbooks/roles/jenkins_data_engineering_new/defaults/main.yml
+++ b/playbooks/roles/jenkins_data_engineering_new/defaults/main.yml
@@ -36,6 +36,8 @@ de_jenkins_snap_pkgs:
 de_jenkins_python_versions:
   - python3.5
   - python3.7
+  - python3.8
+  - python3.9
 
 # Jenkins aliases to installed Python binaries
 de_jenkins_python_installations:
@@ -50,6 +52,9 @@ de_jenkins_python_installations:
     PYTHON_PROPERTIES: []
   - PYTHON_ALIAS: 'PYTHON_3.8'
     PYTHON_PATH: '/usr/bin/python3.8'
+    PYTHON_PROPERTIES: []
+  - PYTHON_ALIAS: 'PYTHON_3.9'
+    PYTHON_PATH: '/usr/bin/python3.9'
     PYTHON_PROPERTIES: []
 
 jenkins_base_environment_variables:


### PR DESCRIPTION
Python3.8 is not installed in New DE Jenkins, I have encountered some packages are not availble in < python3.8 in order to deploy prefect flows, so installing python3.8 and python3.9

Configuration Pull Request
---

<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##
-->

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
