### PR TITLE
BOM-2474: Update xqueue watcher to use Python38 environment

### DIFF
--- a/playbooks/roles/xqwatcher/defaults/main.yml
+++ b/playbooks/roles/xqwatcher/defaults/main.yml
@@ -87,7 +87,7 @@ xqwatcher_code_dir: "{{ xqwatcher_app_dir }}/src"
 
 xqwatcher_repo_name: xqueue-watcher.git
 
-xqwatcher_python_version: "python3.5"
+xqwatcher_python_version: "python3.8"
 
 #TODO: change this to /edx/etc after pulling xqwatcher.json out
 xqwatcher_conf_dir: "{{ xqwatcher_app_dir }}"


### PR DESCRIPTION
**Issue:** [BOM-2474](https://openedx.atlassian.net/browse/BOM-2474)

## Description
- Update x-queue watcher to use `Python 3.8` environment.