### PR TITLE
[OSPR-5773][BB-3669] Ansible task to install extra edX Django Service requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 Add any new changes to the top (right below this line).
 
+ - 2021-05-13
+     - Role: edx_django_service
+        - Added task that installs extra python packages specified in `edx_django_service_extra_requirements`.
+     - Role: discovery
+        - Installs extra python packages specified in `DISCOVERY_EXTRA_REQUIREMENTS`. 
+     - Role: ecommerce
+        - Installs extra python packages specified in `ECOMMERCE_EXTRA_REQUIREMENTS`. 
+
  - 2021-03-08
     - Remove instruction from ansile-bootstrap.sh that instructed people to activate
       the virtualenv.  This was incorrect for community installations.

--- a/playbooks/roles/discovery/defaults/main.yml
+++ b/playbooks/roles/discovery/defaults/main.yml
@@ -139,6 +139,17 @@ DISCOVERY_REPOS:
     DESTINATION: "{{ discovery_code_dir }}"
     SSH_KEY: "{{ DISCOVERY_GIT_IDENTITY }}"
 
+# List of additional python packages that should be installed into the
+# discovery virtual environment.
+# `name` (required), `version` (optional), and `extra_args` (optional)
+# are supported and correspond to the options of ansible's pip module.
+# Example:
+# DISCOVERY_EXTRA_REQUIREMENTS:
+#   - name: mypackage
+#     version: 1.0.1
+#   - name: git+https://git.myproject.org/MyProject#egg=MyProject
+DISCOVERY_EXTRA_REQUIREMENTS: []
+
 discovery_service_config_overrides:
   ELASTICSEARCH_URL: '{{ DISCOVERY_ELASTICSEARCH_URL }}'
   ELASTICSEARCH_INDEX_NAME: '{{ DISCOVERY_ELASTICSEARCH_INDEX_NAME }}'

--- a/playbooks/roles/discovery/meta/main.yml
+++ b/playbooks/roles/discovery/meta/main.yml
@@ -27,6 +27,7 @@ dependencies:
     edx_django_service_home: '{{ COMMON_APP_DIR }}/{{ discovery_service_name }}'
     edx_django_service_config_overrides: '{{ discovery_service_config_overrides }}'
     edx_django_service_debian_pkgs_extra: '{{ discovery_debian_pkgs }}'
+    edx_django_service_extra_requirements: '{{ DISCOVERY_EXTRA_REQUIREMENTS }}'
     edx_django_service_gunicorn_port: '{{ discovery_gunicorn_port }}'
     edx_django_service_django_settings_module: '{{ DISCOVERY_DJANGO_SETTINGS_MODULE }}'
     edx_django_service_environment_extra: '{{ discovery_environment }}'

--- a/playbooks/roles/ecommerce/defaults/main.yml
+++ b/playbooks/roles/ecommerce/defaults/main.yml
@@ -22,6 +22,17 @@ ECOMMERCE_REPOS:
     DESTINATION: "{{ ecommerce_code_dir }}"
     SSH_KEY: "{{ ECOMMERCE_GIT_IDENTITY }}"
 
+# List of additional python packages that should be installed into the
+# ecommerce virtual environment.
+# `name` (required), `version` (optional), and `extra_args` (optional)
+# are supported and correspond to the options of ansible's pip module.
+# Example:
+# ECOMMERCE_EXTRA_REQUIREMENTS:
+#   - name: mypackage
+#     version: 1.0.1
+#   - name: git+https://git.myproject.org/MyProject#egg=MyProject
+ECOMMERCE_EXTRA_REQUIREMENTS: []
+
 # depends upon Newrelic being enabled via COMMON_ENABLE_NEWRELIC
 # and a key being provided via NEWRELIC_LICENSE_KEY
 ECOMMERCE_NEWRELIC_APPNAME: "{{ COMMON_ENVIRONMENT }}-{{ COMMON_DEPLOYMENT }}-{{ ecommerce_service_name }}"

--- a/playbooks/roles/ecommerce/meta/main.yml
+++ b/playbooks/roles/ecommerce/meta/main.yml
@@ -21,6 +21,7 @@ dependencies:
     edx_django_service_config_overrides: '{{ ecommerce_service_config_overrides }}'
     edx_django_service_debian_pkgs_extra: '{{ ecommerce_debian_pkgs + ecommerce_release_specific_debian_pkgs[ansible_distribution_release] }}'
     edx_django_service_django_settings_module: '{{ ECOMMERCE_DJANGO_SETTINGS_MODULE }}'
+    edx_django_service_extra_requirements: '{{ ECOMMERCE_EXTRA_REQUIREMENTS }}'
     edx_django_service_repos: '{{ ECOMMERCE_REPOS }}'
     edx_django_service_environment_extra: '{{ ecommerce_environment }}'
     edx_django_service_gunicorn_extra: '{{ ECOMMERCE_GUNICORN_EXTRA }}'

--- a/playbooks/roles/edx_django_service/defaults/main.yml
+++ b/playbooks/roles/edx_django_service/defaults/main.yml
@@ -57,6 +57,17 @@ edx_django_service_debian_pkgs_default:
 edx_django_service_debian_pkgs_extra: []
 edx_django_service_debian_pkgs: '{{ edx_django_service_debian_pkgs_default + edx_django_service_debian_pkgs_extra }}'
 
+# List of additional python packages that should be installed into the
+# service virtual environment.
+# `name` (required), `version` (optional), and `extra_args` (optional)
+# are supported and correspond to the options of ansible's pip module.
+# Example:
+# edx_django_service_extra_requirements:
+#   - name: mypackage
+#     version: 1.0.1
+#   - name: git+https://git.myproject.org/MyProject#egg=MyProject
+edx_django_service_extra_requirements: []
+
 edx_django_service_gunicorn_extra: ''
 edx_django_service_gunicorn_extra_conf: ''
 edx_django_service_gunicorn_host: '127.0.0.1'

--- a/playbooks/roles/edx_django_service/tasks/main.yml
+++ b/playbooks/roles/edx_django_service/tasks/main.yml
@@ -180,6 +180,19 @@
     - devstack
     - devstack:install
 
+- name: install extra requirements
+  pip:
+    name: "{{ item.name }}"
+    version: "{{ item.version|default(omit) }}"
+    extra_args: "--exists-action w {{ item.extra_args|default('') }}"
+    virtualenv: "{{ edx_django_service_venv_dir }}"
+    state: present
+  with_items: "{{ edx_django_service_extra_requirements }}"
+  become_user: "{{ edx_django_service_user }}"
+  tags:
+    - install
+    - install:app-requirements
+
 - name: Check for existing make_migrate container
   command: "docker ps -aq --filter name='{{ edx_django_service_name }}.make_migrate'"
   register: edx_django_service_make_migrate_container


### PR DESCRIPTION
Currently, there is no way to specify extra python requirements for any role that depends on `edx_django_service`, `ecommerce` and `discovery` in particular.

This PR adds Ansible task to `edx_django_service` role, which installs extra requirements specified in `edx_django_service_extra_requirements` variable.

Also, it modifies `ecommerce` and `discovery` roles metadata to make use of the new variable.

**JIRA tickets**:
- [OSPR-5773](https://openedx.atlassian.net/browse/OSPR-5773)
- [BB-3669](https://tasks.opencraft.com/browse/BB-3669)

**Discussions**:
- https://github.com/edx/course-discovery/pull/2882#issuecomment-761019948 — initially, we created a pull request that was adding new dependency, but reviewers pointed out that it's better to allow instance operators to specify dependencies via configuration.
- [discuss.openedx.org forum post](https://discuss.openedx.org/t/how-to-install-private-dependencies-while-deploying-idas/4177)

**Sandbox URL**:
- https://stage.manage.opencraft.com/instance/7900/

**Testing instructions**:

1. Connect to sandbox app server:
    ```bash
    ssh pomegranited@54.37.150.161
    ```
1. Activate ecommerce virtual environment:
    ```bash
    source /edx/app/ecommerce/venvs/ecommerce/bin/activate
    ```
1. Ensure that `lolcat` is installed and works:
    ```bash
    lolcat /edx/etc/lms.yml
    ```
1. Deactivate ecommerce virtual environment:
    ```bash
    deactivate
    ```
1. Activate discovery virtual environment:
    ```bash
    source /edx/app/discovery/venvs/discovery/bin/activate
    ```
1. Ensure that `lolcat` is installed and works:
    ```bash
    lolcat /edx/etc/lms.yml
    ```

**Reviewers**
- [ ] @pomegranited 

**Settings**
```yaml
ECOMMERCE_EXTRA_REQUIREMENTS:
  - name: lolcat
    version: 1.4

DISCOVERY_EXTRA_REQUIREMENTS:
  - name: lolcat
    version: 1.4
```