### PR TITLE
fix: better decoding of ansible errors

### DIFF
--- a/util/install/native.sh
+++ b/util/install/native.sh
@@ -174,10 +174,8 @@ if [[ $ansible_status -ne 0 ]]; then
     echo "------------------------------------------------------------"
     echo " "
     echo "Decoded error:"
-    # Find the FAILED line before the "NO MORE HOSTS" line, and decode it.
-    # The plusses in the regex are because if I run this with -x, the awk line
-    # will be added to the log, and the regex would find itself if it didn't have plusses.
-    awk '/NO +MORE +HOSTS/{if (bad) print bad} /FAILED/{bad=$0}' $log_file | python3 /var/tmp/configuration/util/ansible_msg.py
+    # Find the last "failed" or "fatal" line and decode it.
+    awk '/^(failed|fatal):/{bad=$0} END {if (bad) print bad}' $log_file | python3 /var/tmp/configuration/util/ansible_msg.py
     echo " "
     echo "============================================================"
     echo "Installation failed!"


### PR DESCRIPTION
Some failed log lines say "FAILED", but some don't, depending on whether
the task is loop or not.  Sometimes an earlier FAILED message is
actually ignored, but is found by the old check.

Look for the leading "failed:" or "fatal:" lable instead to always get
the actual error that stopped the playbook.

Configuration Pull Request
---

<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##
-->

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
