### PR TITLE
feat: Add mfe_flags_setup role

### DIFF
--- a/playbooks/mfe_flags_setup.yml
+++ b/playbooks/mfe_flags_setup.yml
@@ -1,0 +1,11 @@
+---
+
+- name: Setup required MFE waffle flags
+  hosts: all
+  become: True
+  gather_facts: True
+  vars_files:
+    - "roles/common_vars/defaults/main.yml"
+    - "roles/edxapp/defaults/main.yml"
+  roles:
+    - role: mfe_flags_setup

--- a/playbooks/openedx_native.yml
+++ b/playbooks/openedx_native.yml
@@ -121,3 +121,4 @@
     - role: user_retirement_pipeline
       when: COMMON_RETIREMENT_SERVICE_SETUP
     - role: mfe_deployer
+    - role: mfe_flags_setup

--- a/playbooks/roles/mfe_flags_setup/defaults/main.yml
+++ b/playbooks/roles/mfe_flags_setup/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+
+MFE_FLAGS_SETUP_FLAGS_LIST:
+  - account.redirect_to_microfrontend

--- a/playbooks/roles/mfe_flags_setup/tasks/main.yml
+++ b/playbooks/roles/mfe_flags_setup/tasks/main.yml
@@ -1,0 +1,37 @@
+---
+#
+# edX Configuration
+#
+# github:     https://github.com/edx/configuration
+# wiki:       https://openedx.atlassian.net/wiki/display/OpenOPS
+# code style: https://openedx.atlassian.net/wiki/display/OpenOPS/Ansible+Code+Conventions
+# license:    https://github.com/edx/configuration/blob/master/LICENSE.TXT
+#
+#
+#
+# Tasks for role mfe_flags_setup
+#
+# Overview:
+#
+#
+# Dependencies:
+#
+#
+# Example play:
+#
+#
+
+- name: Get edxapp waffle flags list
+  shell: >
+    {{ edxapp_venv_bin }}/python {{ COMMON_BIN_DIR }}/manage.edxapp lms waffle_flag -l --settings={{ COMMON_EDXAPP_SETTINGS }}
+  become_user: "{{ edxapp_user }}"
+  environment: "{{ edxapp_environment }}"
+  register: edxapp_waffle_flags_list
+
+- name: Create MFE waffle flag if it does not exist
+  shell: >
+    {{ edxapp_venv_bin }}/python {{ COMMON_BIN_DIR }}/manage.edxapp lms waffle_flag {{ item }} --everyone --create --settings={{ COMMON_EDXAPP_SETTINGS }}
+  become_user: "{{ edxapp_user }}"
+  environment: "{{ edxapp_environment }}"
+  when: item not in edxapp_waffle_flags_list.stdout
+  loop: "{{ MFE_FLAGS_SETUP_FLAGS_LIST }}"


### PR DESCRIPTION
## Description

This PR creates a new role whose unique responsibility is to create the edx-platform waffle flags required to activate Lilac MFE's. For now, only account MFE waffle flag is created. We decided to run this in a separate role since these waffle flags will be deprecated hopefully in the next OpenedX major release so these routines are easy to remove.
The logic of flag creation works like this: if the flag exists, it is left as it is, otherwise, the flag is created and enabled for all user types.

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
