### PR TITLE
refactor: Removing the cert_whitelist command from this role

### DIFF
--- a/playbooks/roles/demo/tasks/deploy.yml
+++ b/playbooks/roles/demo/tasks/deploy.yml
@@ -47,13 +47,6 @@
       - "{{ demo_test_and_staff_users }}"
   when: demo_checkout.changed
 
-- name: add test users to the certificate whitelist
-  shell: ". {{ demo_edxapp_env }} && {{ demo_edxapp_venv_bin }}/python ./manage.py lms --settings={{ demo_edxapp_settings }} --service-variant lms cert_whitelist -a {{ item.email }} -c {{ demo_course_id }}"
-  args:
-    chdir: "{{ demo_edxapp_code_dir }}"
-  with_items: "{{ demo_test_users }}"
-  when: demo_checkout.changed
-
 - name: seed the forums for the demo course
   shell: ". {{ demo_edxapp_env }} && {{ demo_edxapp_venv_bin }}/python ./manage.py lms --settings={{ demo_edxapp_settings }} seed_permissions_roles {{ demo_course_id }}"
   args:


### PR DESCRIPTION
[MICROBA-1052]

The cert_whitelist is being deprecated. We are removing it use here in
this role because it provides no value in the way we currently
generate certificates.

Configuration Pull Request
---

<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##
-->

Make sure that the following steps are done before merging:

  - [x] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [x] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [x] Update the appropriate internal repo (be sure to update for all our environments)
    - [x] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [x] Add an entry to the CHANGELOG.
  - [x] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [x] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?


[MICROBA-1052]: https://openedx.atlassian.net/browse/MICROBA-1052