### PR TITLE
[BACKPORT] feat: Payment and Ecommerce MFEs support in Native Installation

### DIFF
--- a/playbooks/openedx_native.yml
+++ b/playbooks/openedx_native.yml
@@ -32,6 +32,12 @@
     EDXAPP_ACCOUNT_MICROFRONTEND_URL: "{{ EDXAPP_LMS_BASE_SCHEME }}://{{ MFE_BASE }}/account"
     EDXAPP_LMS_NGINX_PORT: '80'
     EDX_PLATFORM_VERSION: 'master'
+    EDXAPP_ORDER_HISTORY_MICROFRONTEND_URL: "{{ EDXAPP_LMS_BASE_SCHEME }}://{{ MFE_BASE }}/ecommerce/orders"
+    EDXAPP_SITE_CONFIGURATION:
+      - site_id: 1
+        values:
+          ENABLE_ORDER_HISTORY_MICROFRONTEND: true
+
     # Set to false if deployed behind another proxy/load balancer.
     NGINX_SET_X_FORWARDED_HEADERS: True
     DISCOVERY_URL_ROOT: 'http://localhost:{{ DISCOVERY_NGINX_PORT }}'
@@ -51,8 +57,17 @@
     ECOMMERCE_ENABLE_COMPREHENSIVE_THEMING: false
     EDXAPP_ENABLE_MEMCACHE: true
     EDXAPP_ENABLE_ELASTIC_SEARCH: true
+    # Ecommerce
+    ECOMMERCE_CORS_ORIGIN_WHITELIST: [
+      "{{ EDXAPP_LMS_BASE_SCHEME }}://{{ MFE_BASE }}",
+    ]
+    ECOMMERCE_CSRF_TRUSTED_ORIGINS: [
+      "{{ EDXAPP_LMS_BASE_SCHEME }}://{{ MFE_BASE }}",
+    ]
+    ECOMMERCE_CORS_ALLOW_CREDENTIALS: true
     # For the mfe role.
     COMMON_ECOMMERCE_BASE_URL: '{{ ECOMMERCE_ECOMMERCE_URL_ROOT }}'
+    ECOMMERCE_ENABLE_PAYMENT_MFE: true
   roles:
     - role: swapfile
       SWAPFILE_SIZE: 4GB

--- a/playbooks/roles/ecommerce/defaults/main.yml
+++ b/playbooks/roles/ecommerce/defaults/main.yml
@@ -190,6 +190,7 @@ ECOMMERCE_DISCOVERY_SERVICE_URL: 'http://localhost:8008'
 ECOMMERCE_ENTERPRISE_URL: '{{ ECOMMERCE_LMS_URL_ROOT }}'
 
 ECOMMERCE_CORS_ORIGIN_WHITELIST: []
+ECOMMERCE_CSRF_TRUSTED_ORIGINS: []
 ECOMMERCE_CORS_URLS_REGEX: ''
 ECOMMERCE_CORS_ALLOW_CREDENTIALS: false
 
@@ -239,6 +240,7 @@ ecommerce_config:
   SESSION_COOKIE_SECURE: '{{ ECOMMERCE_SESSION_COOKIE_SECURE}}'
 
   CORS_ORIGIN_WHITELIST: "{{ ECOMMERCE_CORS_ORIGIN_WHITELIST }}"
+  CSRF_TRUSTED_ORIGINS: "{{ ECOMMERCE_CSRF_TRUSTED_ORIGINS }}"
   CORS_URLS_REGEX: "{{ ECOMMERCE_CORS_URLS_REGEX }}"
   CORS_ALLOW_CREDENTIALS: "{{ ECOMMERCE_CORS_ALLOW_CREDENTIALS }}"
 
@@ -270,6 +272,9 @@ ECOMMERCE_HERMES_ENABLED: "{{ COMMON_HERMES_ENABLED }}"
 
 ECOMMERCE_DECRYPT_CONFIG_ENABLED: "{{ COMMON_DECRYPT_CONFIG_ENABLED }}"
 ECOMMERCE_COPY_CONFIG_ENABLED: "{{ COMMON_COPY_CONFIG_ENABLED }}"
+
+# MFEs default settings
+ECOMMERCE_ENABLE_PAYMENT_MFE: false
 
 #
 # vars are namespace with the module name.
@@ -325,7 +330,23 @@ ecommerce_redhat_pkgs: []
 ecommerce_post_migrate_commands:
   - command: './manage.py oscar_populate_countries --initial-only'
     when: true
-  - command: './manage.py create_or_update_site --site-id=1 --site-domain={{ ECOMMERCE_ECOMMERCE_URL_ROOT.split("://")[1] }} --partner-code=edX --partner-name="Open edX" --lms-url-root={{ ECOMMERCE_LMS_URL_ROOT }} --client-side-payment-processor=cybersource --payment-processors=cybersource,paypal --sso-client-id={{ ECOMMERCE_SOCIAL_AUTH_EDX_OAUTH2_KEY }} --sso-client-secret={{ ECOMMERCE_SOCIAL_AUTH_EDX_OAUTH2_SECRET }} --backend-service-client-id={{ ECOMMERCE_BACKEND_SERVICE_EDX_OAUTH2_KEY }} --backend-service-client-secret={{ ECOMMERCE_BACKEND_SERVICE_EDX_OAUTH2_SECRET }} --from-email staff@example.com --discovery_api_url={{ ECOMMERCE_DISCOVERY_SERVICE_URL }}/api/v1/'
+  - command: >
+      ./manage.py create_or_update_site
+      --site-id=1
+      --site-domain={{ ECOMMERCE_ECOMMERCE_URL_ROOT.split("://")[1] }}
+      --partner-code=edX --partner-name="Open edX"
+      --lms-url-root={{ ECOMMERCE_LMS_URL_ROOT }}
+      --client-side-payment-processor=cybersource
+      --payment-processors=cybersource,paypal
+      --sso-client-id={{ ECOMMERCE_SOCIAL_AUTH_EDX_OAUTH2_KEY }}
+      --sso-client-secret={{ ECOMMERCE_SOCIAL_AUTH_EDX_OAUTH2_SECRET }}
+      --backend-service-client-id={{ ECOMMERCE_BACKEND_SERVICE_EDX_OAUTH2_KEY }}
+      --backend-service-client-secret={{ ECOMMERCE_BACKEND_SERVICE_EDX_OAUTH2_SECRET }}
+      --from-email staff@example.com
+      --discovery_api_url={{ ECOMMERCE_DISCOVERY_SERVICE_URL }}/api/v1/
+      {{ " --enable-microfrontend-for-basket-page=true" if ECOMMERCE_ENABLE_PAYMENT_MFE else "" }}
+      {{ " --payment-microfrontend-url="~EDXAPP_LMS_BASE_SCHEME~"://"~MFE_BASE~"/payment" if ECOMMERCE_ENABLE_PAYMENT_MFE else "" }}
+
     when: '{{ ecommerce_create_demo_data }}'
   - command: './manage.py create_demo_data --partner=edX'
     when: '{{ ecommerce_create_demo_data }}'

--- a/playbooks/roles/mfe_deployer/defaults/main.yml
+++ b/playbooks/roles/mfe_deployer/defaults/main.yml
@@ -17,6 +17,12 @@ MFES:
   - name: account
     repo: frontend-app-account
     public_path: "/account/"
+  - name: payment
+    repo: frontend-app-payment
+    public_path: "/payment/"
+  - name: ecommerce
+    repo: frontend-app-ecommerce
+    public_path: "/ecommerce/"
 
 MFE_DEPLOY_PUBLIC_PATH: "/"
 MFE_DEPLOY_SITE_NAME: ""

--- a/playbooks/roles/mfe_flags_setup/defaults/main.yml
+++ b/playbooks/roles/mfe_flags_setup/defaults/main.yml
@@ -2,3 +2,4 @@
 
 MFE_FLAGS_SETUP_FLAGS_LIST:
   - account.redirect_to_microfrontend
+  - order_history.redirect_to_microfrontend


### PR DESCRIPTION
Backport from https://github.com/edx/configuration/pull/6408

Changes:
- add ecommerce configuration for mfe
- set CORS_ALLOW_CREDENTIALS to true
- update ecommerce site configuration, set ecommerce waffle flag
- set LMS SiteConfiguration
- add ORDER_HISTORY_MICROFRONTEND_URL
- add new COMMON_ENABLE_PAYMENT_MFE variable to be able to control payment mfe in ecommerce SiteConfiguration

Configuration Pull Request
---

<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##
-->

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
