### PR TITLE
feat: split apart lms and cms django group management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,14 @@
+
 # Changelog
 
 All notable changes to this project will be documented in this file.
 Add any new changes to the top (right below this line).
+
+ - 2021-05-24
+    - In ``manage_edxapp_users_and_groups.yml`` playbook, allow LMS and CMS
+      groups to be managed separately via ``manage-groups-lms`` and
+      ``manage-groups-cms`` tags. These replace the ``manage-groups`` tag,
+      which will be interepreted as ``manage-groups-lms`` until it is removed.
 
  - 2021-05-18
     - The version of tubular is controlled by RETIREMENT_SERVICE_VERSION.

--- a/playbooks/manage_edxapp_users_and_groups.yml
+++ b/playbooks/manage_edxapp_users_and_groups.yml
@@ -6,8 +6,8 @@
 # code style: https://openedx.atlassian.net/wiki/display/OpenOPS/Ansible+Code+Conventions
 # license:    https://github.com/edx/configuration/blob/master/LICENSE.TXT
 #
-# Usage: ansible-playbook -i lms-host-1, -e@/path/to/group/configfile -e@/path/to/user/configfile
-#
+# Usage: ansible-playbook -i edxapp-host-1, -e@/path/to/configfile-of-users-andor-groups
+#                                           -e 'group_environment=prod-edge'
 # Overview:
 # This playbook ensures that the specified users and groups exist in the targeted
 # edxapp cluster.
@@ -15,25 +15,31 @@
 # Users have the following properties:
 #   - username (required, str)
 #   - email (required, str)
-#   - groups (optional, list[str])
-#   - superuser (optional, bool)
-#   - staff (optional, bool)
+#   - initial_password_hash (optional, str)
 #   - remove (optional, bool): ensures the user does not exist
+#   - staff (optional, bool)
+#   - superuser (optional, bool)
 #   - unusable_password (optional, bool): ensures the password is unusable
+#   - groups (optional, list[str])
+#   - _comment (optional, str): ignored
 #
 # Groups can have the following properties:
 #   - name (required, str)
-#   - permissions (optional, list[str])
+#   - permissions (required, list[str])
 #   - remove (optional, bool): ensures the group does not exist
+#   - _comment (optional, str): ignored
 #
 # Example:
 #
-# users:
+# django_users:
+#
 #   - username: bobby
 #     email: bobby@droptabl.es
-#     groups: [group1, group2]
-#     superuser: true
 #     staff: true
+#     superuser: true
+#     groups:
+#       - group1
+#       - group2
 #
 #   - username: fred
 #     email: fred@smith
@@ -41,7 +47,11 @@
 #
 #   - username: smitty
 #     email: smitty@werbenmanjens.en
-#     groups: [group1]
+#     groups:
+#       - group1
+#     _comment: |
+#       he was
+#       number one!
 #
 #   - username: frank
 #     email: frank@bigcorp.com
@@ -54,19 +64,44 @@
 #     email: zoe@example.com
 #     initial_password_hash: 'pbkdf2_sha256$20000$levJ6jdVYCsu$gdBLGf2DNPqfaKdcETXtFocRU8Kk+sMsIvKkmw1dKbY='
 #
-# groups:
-#   - name: group3
-#     remove: true
+# django_groups:
 #
 #   - name: group1
 #     permissions:
 #       - permission1
 #       - permission2
 #
-#   - name: group2
-#     permissions: [permission3]
+#   - name: group3
+#     remove: true
+#     permissions: []
+#     _comment: |
+#         group3 is the best group
+#         yada yada
 #
-# NB: to get a list of all available permissions, run the following code:
+# Note:
+#
+#    LMS and CMS do still share the edxapp database, and therefore share a
+#    User table and Group table. So, edxapp users are created in an LMS context
+#    but exist in CMS as well.
+#
+#    However, some edxapp Django apps are only installed into CMS (but not LMS),
+#    and vice versa. In order to create a group and grant it permissions,
+#    the permissions must be from apps that are installed into the running
+#    service. So, to create groups for LMS-only apps, we must create groups
+#    in an LMS context, and to create groups for CMS-only apps, we must create
+#    groups in a CMS context. Thus, while users are managed jointly for LMS/CMS,
+#    groups are managed separately.
+#
+#    That being said, note that the groups created in one service variant should be
+#    disjoint with those created the other, as the underlying Group table is sahred.
+#    That is, each group name should be defined for LMS *or* CMS, not both.
+#    Otherwise, whichever group is created second will override the first one.
+#
+#    Of course, the jointly-managed LMS/CMS users can be assigned to any combination
+#    of both LMS and CMS groups. Assigning users to CMS groups does in fact work through
+#    an LMS context, since the actual CMS permissions are not being referenced.
+#
+# Note: to get a list of all available permissions, run the following code within a Django shell:
 #
 #   from django.contrib.auth.models import Permission
 #   for perm in Permission.objects.all():
@@ -79,22 +114,38 @@
     manage_path: /edx/bin/manage.edxapp
     ignore_user_creation_errors: no
     deployment_settings: "{{ EDXAPP_SETTINGS | default('production') }}"
+    group_environment: ""  # By default, create groups for all envs (for backwards compatibility).
   vars_files:
     - roles/common_vars/defaults/main.yml
   tasks:
-    - name: Manage groups
+    - name: Manage LMS groups
       tags:
-        - manage-groups
+        - manage-groups-lms
+        - manage-groups  # Old tag pre-lms/cms-group-split, can be removed after TNL-8274.
       shell: >
         . {{env_path}} && {{ python_path }} {{ manage_path }} lms --settings={{ deployment_settings }}
         manage_group {{ item.name | quote }}
         {% if item.get('permissions', []) | length %}--permissions {{ item.permissions | default([]) | map('quote') | join(' ') }}{% endif %}
         {% if item.get('remove') %}--remove{% endif %}
       with_items: "{{ django_groups }}"
+      when: (not group_environment) or group_environment in item.environments
       become: true
       become_user: "{{ common_web_user }}"
 
-    - name: Manage active users
+    - name: Manage CMS groups
+      tags:
+        - manage-groups-cms
+      shell: >
+        . {{env_path}} && {{ python_path }} {{ manage_path }} cms --settings={{ deployment_settings }}
+        manage_group {{ item.name | quote }}
+        {% if item.get('permissions', []) | length %}--permissions {{ item.permissions | default([]) | map('quote') | join(' ') }}{% endif %}
+        {% if item.get('remove') %}--remove{% endif %}
+      with_items: "{{ django_groups }}"
+      when: (not group_environment) or group_environment in item.environments
+      become: true
+      become_user: "{{ common_web_user }}"
+
+    - name: Manage active LMS/CMS users
       tags:
         - manage-active-users
       shell: >
@@ -115,7 +166,7 @@
       become: true
       become_user: "{{ common_web_user }}"
 
-    - name: Manage inactive users
+    - name: Manage inactive LMS/CMS users
       tags:
         - manage-inactive-users
       shell: >

--- a/playbooks/manage_edxapp_users_and_groups.yml
+++ b/playbooks/manage_edxapp_users_and_groups.yml
@@ -93,7 +93,7 @@
 #    groups are managed separately.
 #
 #    That being said, note that the groups created in one service variant should be
-#    disjoint with those created the other, as the underlying Group table is sahred.
+#    disjoint with those created the other, as the underlying Group table is shared.
 #    That is, each group name should be defined for LMS *or* CMS, not both.
 #    Otherwise, whichever group is created second will override the first one.
 #


### PR DESCRIPTION
In ``manage_edxapp_users_and_groups.yml`` playbook, allow LMS and CMS
groups to be managed separately via ``manage-lms-groups`` and
``manage-cms-groups`` tags. These replace the ``manage-groups`` tag,
which will be interepreted as ``manage-lms-groups`` until it is removed.

No breaking changes; this can merge before app-permissions cutover is complete.

Ticket: https://openedx.atlassian.net/browse/TNL-8274
Related: https://github.com/edx/app-permissions/pull/1442
Blocks:  https://github.com/edx/jenkins-job-dsl/pull/1376