### PR TITLE
build: add automerge workflow for open-release Maintainers

### DIFF
--- a/.github/workflows/pr-automerge-open-release.yml
+++ b/.github/workflows/pr-automerge-open-release.yml
@@ -1,0 +1,86 @@
+# For non-draft changes to Named Release branches:
+# - Check if the user belongs to a maintainers team. If so,
+#   - approve the pull request
+#   - tag community-engineering
+#   - if it also has '[automerge]' in the PR body,
+#     label it as 'automerge', then merge it.
+---
+name: automerge BTR open-release PRs
+on:
+  pull_request_target:
+    branches:
+    - open-release/*.master
+    types:
+    - labeled
+    - unlabeled
+    - synchronize
+    - opened
+    - edited
+    - ready_for_review
+    - reopened
+    - unlocked
+  pull_request_review:
+    branches:
+    - open-release/*.master
+    types:
+    - submitted
+  check_suite:
+    branches:
+    - open-release/*.master
+    types:
+    - completed
+  status:
+    branches:
+    - open-release/*.master
+jobs:
+  automerge:
+    runs-on: ubuntu-latest
+    steps:
+    - run: echo "${{ toJSON(github) }}"
+    - run: echo "TEAM_CONTRIBUTORS=ceng-test" >> "${GITHUB_ENV}"
+    - run: echo "TEAM_CHAMPIONS=openedx/ceng-test" >> "${GITHUB_ENV}"
+    - run: echo 'TEAM_CHAMPIONS_ARRAY=["stvstnfrd"]' >> "${GITHUB_ENV}"
+    - name: lookup teams
+      id: teams
+      if: ${{ !github.event.pull_request.draft }}
+      uses: tspascoal/get-user-teams-membership@v1
+      with:
+        username: "${{ github.actor }}"
+        team: ${{ env.TEAM_CONTRIBUTORS }}
+        GITHUB_TOKEN: "${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}"
+    - name: tag team on all Named Release PRs
+      if: ${{ steps.teams.outputs.isTeamMember && github.event.action == 'opened' }}
+      run: |
+        curl \
+          -X POST \
+          -H 'Accept: application/vnd.github.v3+json' \
+          -H "authorization: Bearer ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}" \
+          https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/requested_reviewers \
+          -d '{"reviewers": ${{ env.TEAM_CHAMPIONS_ARRAY }}}' \
+        ;
+    - name: approve PR
+      if: ${{ !github.event.pull_request.draft && steps.teams.outputs.isTeamMember && github.event.action == 'opened' }}
+      uses: andrewmusgrave/automatic-pull-request-review@0.0.5
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        event: APPROVE
+        body: |
+          :+1:
+
+          When you're ready to merge, edit the PR description and add this to it: `[automerge]`;
+          we'll handle the rest.
+          CC: @${{ env.TEAM_CHAMPIONS }}
+    - name: label PR as auto-mergeable
+      if: ${{ !github.event.pull_request.draft && steps.teams.outputs.isTeamMember && contains(github.event.pull_request.body, '[automerge]') }}
+      uses: andymckay/labeler@978f846c4ca6299fd136f465b42c5e87aca28cac
+      with:
+        add-labels: 'automerge'
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+    - name: automerge
+      uses: "pascalgn/automerge-action@v0.13.1"
+      env:
+        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        MERGE_COMMIT_MESSAGE: |
+          merge: PR #{pullRequest.number}: {pullRequest.title}
+
+          {pullRequest.body}

--- a/.github/workflows/pr-automerge-open-release.yml
+++ b/.github/workflows/pr-automerge-open-release.yml
@@ -1,8 +1,8 @@
 # For non-draft changes to Named Release branches:
-# - Check if the user belongs to a maintainers team. If so,
-#   - approve the pull request
-#   - tag community-engineering
-#   - if it also has '[automerge]' in the PR body,
+# - Always tag community-engineering (for now).
+# - Check if the user belongs to a maintainers team.
+# - If so, approve the pull request.
+#   - If it also has '[automerge]' in the PR body,
 #     label it as 'automerge', then merge it.
 # Required organization secrets
 # - CC_GITHUB_TOKEN=...
@@ -13,39 +13,27 @@
 ---
 name: automerge BTR open-release PRs
 on:
+  issue_comment:
+    branches:
+    - open-release/*.master
+    types:
+    - created
+    - edited
   pull_request_target:
     branches:
     - open-release/*.master
     types:
-    - labeled
-    - unlabeled
-    - synchronize
     - opened
     - edited
     - ready_for_review
-    - reopened
-    - unlocked
-  pull_request_review:
-    branches:
-    - open-release/*.master
-    types:
-    - submitted
-  check_suite:
-    branches:
-    - open-release/*.master
-    types:
-    - completed
-  status:
-    branches:
-    - open-release/*.master
 jobs:
   automerge:
+    if: ${{ (github.event.issue.pull_request && !github.event.issue.pull_request.draft) || (github.event.pull_request && !github.event.pull_request.draft) }}
     runs-on: ubuntu-latest
     steps:
     - run: echo "${{ toJSON(github) }}"
     - name: lookup teams
       id: teams
-      if: ${{ !github.event.pull_request.draft }}
       uses: tspascoal/get-user-teams-membership@v1
       with:
         username: "${{ github.actor }}"
@@ -53,7 +41,7 @@ jobs:
         team: ${{ secrets.CC_TEAM_CONTRIBUTORS_TEAM }}
         GITHUB_TOKEN: "${{ secrets.CC_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}"
     - name: tag team on all Named Release PRs
-      if: ${{ steps.teams.outputs.isTeamMember && github.event.action == 'opened' }}
+      if: ${{ github.event.action == 'opened' || github.event.action == 'ready_for_review' }}
       run: |
         curl \
           -X POST \
@@ -62,8 +50,10 @@ jobs:
           https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/requested_reviewers \
           -d '{"reviewers": ${{ secrets.CC_TEAM_CHAMPIONS_PEOPLE_ARRAY }}}' \
         ;
+    - name: debug
+      run: echo "${{ toJSON(steps.teams) }}"
     - name: approve PR
-      if: ${{ !github.event.pull_request.draft && steps.teams.outputs.isTeamMember && github.event.action == 'opened' }}
+      if: ${{ steps.teams.outputs.isTeamMember == 'true' && (github.event.action == 'opened' || github.event.action == 'ready_for_review') }}
       uses: andrewmusgrave/automatic-pull-request-review@0.0.5
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -75,7 +65,13 @@ jobs:
           we'll handle the rest.
           CC: @${{ secrets.CC_TEAM_CHAMPIONS }}
     - name: label PR as auto-mergeable
-      if: ${{ !github.event.pull_request.draft && steps.teams.outputs.isTeamMember && contains(github.event.pull_request.body, '[automerge]') }}
+      if: ${{ steps.teams.outputs.isTeamMember == 'true' && contains(github.event.pull_request.body, '[automerge]') }}
+      uses: andymckay/labeler@978f846c4ca6299fd136f465b42c5e87aca28cac
+      with:
+        add-labels: 'automerge'
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+    - name: label PR as auto-mergeable
+      if: ${{ steps.teams.outputs.isTeamMember == 'true' && contains(github.event.comment.body, '[automerge]') }}
       uses: andymckay/labeler@978f846c4ca6299fd136f465b42c5e87aca28cac
       with:
         add-labels: 'automerge'

--- a/.github/workflows/pr-automerge-open-release.yml
+++ b/.github/workflows/pr-automerge-open-release.yml
@@ -4,6 +4,12 @@
 #   - tag community-engineering
 #   - if it also has '[automerge]' in the PR body,
 #     label it as 'automerge', then merge it.
+# Required organization secrets
+# - CC_GITHUB_TOKEN=...
+# - CC_TEAM_CHAMPIONS=org/team-name
+# - CC_TEAM_CHAMPIONS_PEOPLE_ARRAY=["username1"]
+# - CC_TEAM_CONTRIBUTORS_ORG=org
+# - CC_TEAM_CONTRIBUTORS_TEAM=team-name
 ---
 name: automerge BTR open-release PRs
 on:
@@ -37,26 +43,24 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - run: echo "${{ toJSON(github) }}"
-    - run: echo "TEAM_CONTRIBUTORS=ceng-test" >> "${GITHUB_ENV}"
-    - run: echo "TEAM_CHAMPIONS=openedx/ceng-test" >> "${GITHUB_ENV}"
-    - run: echo 'TEAM_CHAMPIONS_ARRAY=["stvstnfrd"]' >> "${GITHUB_ENV}"
     - name: lookup teams
       id: teams
       if: ${{ !github.event.pull_request.draft }}
       uses: tspascoal/get-user-teams-membership@v1
       with:
         username: "${{ github.actor }}"
-        team: ${{ env.TEAM_CONTRIBUTORS }}
-        GITHUB_TOKEN: "${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}"
+        organization: ${{ secrets.CC_TEAM_CONTRIBUTORS_ORG }}
+        team: ${{ secrets.CC_TEAM_CONTRIBUTORS_TEAM }}
+        GITHUB_TOKEN: "${{ secrets.CC_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}"
     - name: tag team on all Named Release PRs
       if: ${{ steps.teams.outputs.isTeamMember && github.event.action == 'opened' }}
       run: |
         curl \
           -X POST \
           -H 'Accept: application/vnd.github.v3+json' \
-          -H "authorization: Bearer ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}" \
+          -H "authorization: Bearer ${{ secrets.CC_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}" \
           https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/requested_reviewers \
-          -d '{"reviewers": ${{ env.TEAM_CHAMPIONS_ARRAY }}}' \
+          -d '{"reviewers": ${{ secrets.CC_TEAM_CHAMPIONS_PEOPLE_ARRAY }}}' \
         ;
     - name: approve PR
       if: ${{ !github.event.pull_request.draft && steps.teams.outputs.isTeamMember && github.event.action == 'opened' }}
@@ -69,7 +73,7 @@ jobs:
 
           When you're ready to merge, edit the PR description and add this to it: `[automerge]`;
           we'll handle the rest.
-          CC: @${{ env.TEAM_CHAMPIONS }}
+          CC: @${{ secrets.CC_TEAM_CHAMPIONS }}
     - name: label PR as auto-mergeable
       if: ${{ !github.event.pull_request.draft && steps.teams.outputs.isTeamMember && contains(github.event.pull_request.body, '[automerge]') }}
       uses: andymckay/labeler@978f846c4ca6299fd136f465b42c5e87aca28cac
@@ -82,5 +86,5 @@ jobs:
         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         MERGE_COMMIT_MESSAGE: |
           merge: PR #{pullRequest.number}: {pullRequest.title}
-
+ 
           {pullRequest.body}


### PR DESCRIPTION
Story
=====
As a core contributor and maintainer of the build-test-release group,
we want to be able to update named-release branches
without edx intervention
so we can lead in community-driven development of Named Releases.

As a core contributor's champion,
we want to delegate control of the named release branches,
without granting wider access to the repository
so we can empower community-driven development of Named Releases.

Behavior
========
This workflow only runs on PRs against a Named Release branch,
`open-release/*.master`. If the PR is from a user in the specified
maintainers group, we will automerge the PR once triggered by the
developer (by adding `[automerge]` to the PR description).
The workflow should also tag the community-engineering team, for the
time being.