### PR TITLE
Switch to mongo_4_0 role in openedx_native.yml

### DIFF
--- a/playbooks/openedx_native.yml
+++ b/playbooks/openedx_native.yml
@@ -86,7 +86,7 @@
       when: EDXAPP_MYSQL_HOST == 'localhost'
     - role: memcache
       when: EDXAPP_ENABLE_MEMCACHE
-    - role: mongo_3_6
+    - role: mongo_4_0
       when: "'localhost' in EDXAPP_MONGO_HOSTS"
     - role: redis
       when: SANDBOX_ENABLE_REDIS


### PR DESCRIPTION
**Description**

This cherry-picks the changes from https://github.com/edx/configuration/pull/6416 into the open-release/lilac.master branch.

MongoDB 3.6 reached end of life on April 30, 2021 and is no longer receiving security updates. We want to use Mongo 4 by default for new Lilac installations.

This PR updates local MongoDB version installed by the `openedx_native.yml` playbook from 3.6 to 4.0.

Also see discussion at https://github.com/openedx/build-test-release-wg/issues/47.

<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##
-->

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
