### PR TITLE
WIP: [FAL-1865] Create new openjdk role for use by openedx_native and its dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 Add any new changes to the top (right below this line).
 
+ - 2021-05-05
+    - Role: openjdk
+        - Added a new role to install OpenJDK.
+        - Configure the version used with `OPENJDK_MAJOR_VERSION` (defaults to version 8).
+    - Playbook: openedx_native
+        - Modify to use the new `openjdk` role (instead of the default `oraclejdk`) when the `USE_OPENJDK` flag is set.
+    - Role: elasticsearch
+        - Modify to use the new `openjdk` role (instead of the default `oraclejdk`) when the `USE_OPENJDK` flag is set.
+        
  - 2021-03-08
     - Remove instruction from ansile-bootstrap.sh that instructed people to activate
       the virtualenv.  This was incorrect for community installations.

--- a/playbooks/openedx_native.yml
+++ b/playbooks/openedx_native.yml
@@ -41,6 +41,7 @@
     EDXAPP_ENABLE_ELASTIC_SEARCH: true
     # For the mfe role.
     COMMON_ECOMMERCE_BASE_URL: '{{ ECOMMERCE_ECOMMERCE_URL_ROOT }}'
+    USE_OPENJDK: false
   roles:
     - role: swapfile
       SWAPFILE_SIZE: 4GB
@@ -88,7 +89,10 @@
     - role: demo
       when: DEMO_ROLE_ENABLED
     - oauth_client_setup
-    - oraclejdk
+    - role: openjdk
+      when: USE_OPENJDK|default(false)|bool
+    - role: oraclejdk
+      when: not USE_OPENJDK|default(false)|bool
     - role: elasticsearch
       when: EDXAPP_ENABLE_ELASTIC_SEARCH
     - forum

--- a/playbooks/roles/elasticsearch/meta/main.yml
+++ b/playbooks/roles/elasticsearch/meta/main.yml
@@ -1,4 +1,9 @@
 ---
 dependencies:
-  - common
-  - oraclejdk
+  - role: common
+
+  - role: openjdk
+    when: USE_OPENJDK|default(false)|bool
+
+  - role: oraclejdk
+    when: not USE_OPENJDK|default(false)|bool

--- a/playbooks/roles/elasticsearch/tasks/main.yml
+++ b/playbooks/roles/elasticsearch/tasks/main.yml
@@ -5,7 +5,7 @@
 # Dependencies:
 #
 #   * common
-#   * oraclejdk
+#   * openjdk
 #
 # Example play:
 #
@@ -25,7 +25,7 @@
 # -  hosts: tag_role_elasticsearch:&tag_environment_stage
 #    roles:
 #    - common
-#    - oraclejdk
+#    - openjdk
 #    - elasticsearch
 #
 

--- a/playbooks/roles/openjdk/defaults/main.yml
+++ b/playbooks/roles/openjdk/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+# Set this to 8 for Juniper and earlier releases
+OPENJDK_MAJOR_VERSION: 8

--- a/playbooks/roles/openjdk/tasks/main.yml
+++ b/playbooks/roles/openjdk/tasks/main.yml
@@ -1,0 +1,12 @@
+---
+# oraclejdk
+#
+# Example play:
+#
+#   roles:
+#   - oraclejdk
+
+- name: OpenJDK has been installed with its dependencies
+  apt:
+    name: "openjdk-{{OPENJDK_MAJOR_VERSION}}-jdk"
+    update_cache: true


### PR DESCRIPTION
## Description

Changes to facilitate swapping out Orcale's JDK for OpenJDK.

- Adds a new role `openjdk` to install OpenJDK as a system package.  
- Configure the version used with `OPENJDK_MAJOR_VERSION` (defaults to version 8).
- Modifies the `openedx_native.yml` playbook to use the new `openjdk` role (instead of the default `oraclejdk`) if and only if the `USE_OPENJDK` flag is set.
- Modifies the `elasticsearch`  to use the new `openjdk` role (instead of the default `oraclejdk`) if and only if the  `USE_OPENJDK` flag is set.  This is required since the `elasticsearch` role is a dependency of the `openedx_native.yml` playbook.

The above design ensures there is no effect on existing users, however, if the user explicitly sets the `USE_OPENJDK` variable in the `openedx_native.yml` playbook then OpenJDK will be installed and used by the  `elasticsearch` role.

There is no provision for removing existing Oracle JDK installations and it is assumed that this feature will only be used for new installs.

The approach leaves open the possibility of the new `openjdk` role being used by other playbooks and roles that require a JDK.

## Supporting information

Inspired by issues reliably downloading Oracle JDK:

* https://app.slack.com/client/T02SNA1T6/C01AGTSB1LL/thread/C01AGTSB1LL-1607368151.210900
* https://app.slack.com/client/T02SNA1T6/C01AGTSB1LL/thread/C01AGTSB1LL-1610012252.003500

## Testing instructions

1. Check this [Ocim sandbox](https://manage.opencraft.com/instance/26850/edx-appserver/19234/) and note that it has been configured to load this branch and sets  `USE_OPENJDK: true`
2. Shell into the corresponding appserver:
```
ssh 213.32.78.125
```
3. Check that elasticsearch is running and that it is using the system `/bin/java`:
```console
$ ps -ef | grep -i elasticsearch
elastic+     356       1  0 May04 ?        00:00:28 /bin/java -Xms512m -Xmx512m -Djava.awt.headless=true -XX:+UseParNewGC -XX:+UseConcMarkSweepGC -XX:CMSInitiatingOccupancyFraction=75 -XX:+UseCMSInitiatingOccupancyOnly -XX:+HeapDumpOnOutOfMemoryError -XX:+DisableExplicitGC -Dfile.encoding=UTF-8 -Delasticsearch -Des.foreground=yes -Des.path.home=/usr/share/elasticsearch -cp :/usr/share/elasticsearch/lib/elasticsearch-1.5.2.jar:/usr/share/elasticsearch/lib/*:/usr/share/elasticsearch/lib/sigar/* -Des.default.config= -Des.default.path.home=/usr/share/elasticsearch -Des.default.path.logs=/edx/var/log/elasticsearch -Des.default.path.data=/edx/var -Des.default.path.work= -Des.default.path.conf=/edx/etc/elasticsearch org.elasticsearch.bootstrap.Elasticsearch
tartans+    3922    3722  0 01:36 pts/0    00:00:00 grep --color=auto java
```
4. Check that the system `/bin/java` is OpenJDK:
```console
$ /bin/java -version
openjdk version "1.8.0_292"
OpenJDK Runtime Environment (build 1.8.0_292-8u292-b10-0ubuntu1~20.04-b10)
OpenJDK 64-Bit Server VM (build 25.292-b10, mixed mode)
$ 
```


## Deadline

"None" 

## Reviewer checklist?

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
