### PR TITLE
[FAL-1792] fix: required jenkins package no longer supported

### DIFF
--- a/playbooks/roles/jenkins_master/defaults/main.yml
+++ b/playbooks/roles/jenkins_master/defaults/main.yml
@@ -8,7 +8,7 @@ jenkins_protocol_https: true
 jenkins_job_venv_dir: "/edx/var/jenkins/jobvenvs/"
 
 JENKINS_VERSION: '1.651.3'
-jenkins_deb_url: "https://pkg.jenkins.io/debian-stable/binary/jenkins_{{ JENKINS_VERSION }}_all.deb"
+jenkins_deb_url: "http://mirrors.jenkins-ci.org/debian-stable/jenkins_{{ JENKINS_VERSION }}_all.deb"
 jenkins_deb: "jenkins_{{ JENKINS_VERSION }}_all.deb"
 # Jenkins jvm args are set when starting the Jenkins service, e.g., "-Xmx1024m"
 jenkins_jvm_args: ""

--- a/playbooks/roles/jenkins_master/defaults/main.yml
+++ b/playbooks/roles/jenkins_master/defaults/main.yml
@@ -8,7 +8,7 @@ jenkins_protocol_https: true
 jenkins_job_venv_dir: "/edx/var/jenkins/jobvenvs/"
 
 JENKINS_VERSION: '1.651.3'
-jenkins_deb_url: "http://mirrors.jenkins-ci.org/debian-stable/jenkins_{{ JENKINS_VERSION }}_all.deb"
+jenkins_deb_url: "https://archives.jenkins-ci.org/debian-stable/jenkins_{{ JENKINS_VERSION }}_all.deb"
 jenkins_deb: "jenkins_{{ JENKINS_VERSION }}_all.deb"
 # Jenkins jvm args are set when starting the Jenkins service, e.g., "-Xmx1024m"
 jenkins_jvm_args: ""


### PR DESCRIPTION
The Jenkins packages available from pkg.jenkins.io no longer support the command-line scripts run by `jenkins_analytics`.
Need to download the old Jenkins package from the mirror site instead.

**Testing instructions**

To do a full test, the `analytics-jenkins.yml` playbook needs to be run on a new VM.

However, this small change can be tested using curl:

```
export JENKINS_VERSION=1.651.3
curl -L http://mirrors.jenkins-ci.org/debian-stable/jenkins_${JENKINS_VERSION}_all.deb -o jenkins_${JENKINS_VERSION}_all.deb
```

**Author Notes & Concerns**

1. This fix should be pulled into Lilac.
2. This old version of Jenkins contains a number of security issues that were fixed in later versions.
   However, attempts to use later versions of Jenkins fail with errors, e.g. [jenkins_analytics: add credentials](https://github.com/edx/configuration/blob/open-release/koa.3/playbooks/roles/jenkins_analytics/tasks/main.yml#L133-L138):
   * `JENKINS_VERSION: '2.235.5'` or `'2.263.4'` :

      ```
      TASK [jenkins_analytics : execute command]    ****************************************************************************************************************
      fatal: [172.31.9.214]: FAILED! => {"changed": true, "cmd": " java -jar /tmp/jenkins-cli/ubuntu/jenkins_cli.jar -s http://localhost:8080  groovy /tmp/credentials/addCredentials.groovy", "delta": "0:00:01.437013", "end": "2021-05-24 06:18:49.108469", "msg": "non-zero return code", "rc": 5, "start": "2021-05-24 06:18:47.671456", "stderr": "\nERROR: This command is requesting the -remoting mode which is no longer supported. See https://jenkins.io/redirect/cli-command-requires-channel", "stderr_lines": ["", "ERROR: This command is requesting the -remoting mode which is no longer supported. See https://jenkins.io/redirect/cli-command-requires-channel"], "stdout": "", "stdout_lines": []}
      ```
   * `JENKINS_VERSION: '2.277.4'` :

      ```
      TASK [jenkins_analytics : execute command] ****************************************************************************************************************
      fatal: [172.31.9.214]: FAILED! => {"changed": true, "cmd": " java -jar /tmp/jenkins-cli/ubuntu/jenkins_cli.jar -s http://localhost:8080  groovy /tmp/credentials/addCredentials.groovy", "delta": "0:00:00.602915", "end": "2021-05-24 07:10:07.900148", "msg": "non-zero return code", "rc": 6, "start": "2021-05-24 07:10:07.297233", "stderr": "\nERROR: anonymous is missing the Overall/Read permission", "stderr_lines": ["", "ERROR: anonymous is missing the Overall/Read permission"], "stdout": "", "stdout_lines": []}
      ```

**Reviewer**

- [ ] @eLRuLL
- [ ] edx/devops 

Configuration Pull Request
---

<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##
-->

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [x] Are you adding any new default values that need to be overridden when this change goes live? No.
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [x] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  N/A
  - [x] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release? N/A
