### PR TITLE
WS-1825 remove pip from prospectus build

### DIFF
--- a/playbooks/roles/prospectus/tasks/main.yml
+++ b/playbooks/roles/prospectus/tasks/main.yml
@@ -74,33 +74,6 @@
     - install
     - install:system-requirements
 
-- name: build virtualenv with python2.7
-  command: "virtualenv --python=python2.7 {{ prospectus_venv_dir }}"
-  args:
-    creates: "{{ prospectus_venv_dir }}/bin/pip"
-  become_user: "{{ prospectus_user }}"
-  when: not prospectus_use_python3
-  tags:
-    - install
-    - install:system-requirements
-
-- name: build virtualenv with python3.8
-  command: "virtualenv --python=python3.8 {{ prospectus_venv_dir }}"
-  args:
-    creates: "{{ prospectus_venv_dir }}/bin/pip"
-  become_user: "{{ prospectus_user }}"
-  when: prospectus_use_python3
-  tags:
-    - install
-    - install:system-requirements
-
-- name: Pin pip to a specific version.
-  command: "{{ prospectus_venv_dir }}/bin/pip install pip=={{ COMMON_PIP_VERSION }}"
-  become_user: "{{ prospectus_user }}"
-  tags:
-    - install
-    - install:system-requirements
-
 - name: Add prospectus configuration file
   template:
     src: ".env.environment.j2"
@@ -109,10 +82,9 @@
     owner: "{{ prospectus_user }}"
     group: "{{ prospectus_user }}"
 
-# NOTE (CCB): Ideally we should use the pip Ansible command,
-# but that doesn't seem to work with the Python 3.x virtualenv.
-- name: install nodenv
-  command: pip install nodeenv
+- name: Install nodeenv
+  apt:
+    name: nodeenv
   become_user: "{{ prospectus_user }}"
   environment: "{{ prospectus_env_vars }}"
   tags:
@@ -120,8 +92,10 @@
     - install:system-requirements
 
 # Install node
-- name: create nodeenv
-  shell: "{{ prospectus_venv_dir }}/bin/nodeenv {{ prospectus_nodeenv_dir }} --node={{ PROSPECTUS_NODE_VERSION }} --prebuilt --force"
+- name: Create nodeenv
+  shell: "nodeenv {{ prospectus_nodeenv_dir }} --node={{ PROSPECTUS_NODE_VERSION }} --prebuilt --force"
+  become_user: "{{ prospectus_user }}"
+  environment: "{{ prospectus_env_vars }}"
   tags:
     - install
     - install:system-requirements


### PR DESCRIPTION
Configuration Pull Request
---

<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##
-->

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?