### PR TITLE
[BACKPORT] Conditional ecommerce MFEs build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,26 @@
 All notable changes to this project will be documented in this file.
 Add any new changes to the top (right below this line).
 
+ - 2021-06-07
+    - In `openedx_native.yml`
+       - Added configuration variable ECOMMERCE_CSRF_TRUSTED_ORIGINS to allow payment mfe to interact with ecommerce service
+       - Added configuration variable ECOMMERCE_CORS_ORIGIN_WHITELIST to allow cross domain interation between mfes and ecommerce service
+       - Added new conditional variable MFE_DEPLOY_ECOMMERCE_MFES to not build ecommerce related MFEs w/o ecommerce service
+       - Created SiteConfiguration for default Site to enable ecommerce MFE
+       - Added configuration variable EDXAPP_ORDER_HISTORY_MICROFRONTEND_URL
+       - Set ECOMMERCE_CORS_ALLOW_CREDENTIALS to true
+       - Added new configuration variable ECOMMERCE_ENABLE_PAYMENT_MFE
+    - Role ecommerce
+       - Added new configuration variable ECOMMERCE_ENABLE_PAYMENT_MFE with default value to false
+       - Updated `create_or_update_site` management command to set `enable-microfrontend-for-basket-page` and `payment-microfrontend-url` flags
+    - Role mfe_deployer
+      - Added MFES_ECOMMERCE list for ecommerce related MFEs
+      - Added new configuration variable MFE_DEPLOY_ECOMMERCE_MFES
+      - Added new deploy_mfes variable to collect list of all MFEs to deploy
+      - Changed looping from `MFES` to `deploy_mfes` list internally
+    - Role mfe_flags_setup
+       - Added new flag `order_history.redirect_to_microfrontend`
+
  - 2021-05-18
     - The version of tubular is controlled by RETIREMENT_SERVICE_VERSION.
       Previously it was always "master", which broke older Open edX re-installations.

--- a/playbooks/openedx_native.yml
+++ b/playbooks/openedx_native.yml
@@ -135,4 +135,5 @@
     - role: user_retirement_pipeline
       when: COMMON_RETIREMENT_SERVICE_SETUP
     - role: mfe_deployer
+      MFE_DEPLOY_ECOMMERCE_MFES: "{{ SANDBOX_ENABLE_ECOMMERCE }}"
     - role: mfe_flags_setup

--- a/playbooks/openedx_native.yml
+++ b/playbooks/openedx_native.yml
@@ -34,9 +34,8 @@
     EDX_PLATFORM_VERSION: 'master'
     EDXAPP_ORDER_HISTORY_MICROFRONTEND_URL: "{{ EDXAPP_LMS_BASE_SCHEME }}://{{ MFE_BASE }}/ecommerce/orders"
     EDXAPP_SITE_CONFIGURATION:
-      - site_id: 1
-        values:
-          ENABLE_ORDER_HISTORY_MICROFRONTEND: true
+      - values:
+          ENABLE_ORDER_HISTORY_MICROFRONTEND: "{{ SANDBOX_ENABLE_ECOMMERCE }}"
 
     # Set to false if deployed behind another proxy/load balancer.
     NGINX_SET_X_FORWARDED_HEADERS: True

--- a/playbooks/roles/mfe_deployer/README.rst
+++ b/playbooks/roles/mfe_deployer/README.rst
@@ -34,6 +34,14 @@ When running this role, you'll need to set the following variables:
         - **site_name**: Used to define the Environment SITE_NAME, used to build the MFE. By default it takes the value of ``MFE_DEPLOY_SITE_NAME``.
         - **standalone_nginx**: To indicate if the MFE will be deployed in a separated nginx file or if it will be in a shared nginx file with the other MFEs, by default it takes the value of ``MFE_DEPLOY_STANDALONE_NGINX``.
 
+
+- ``MFES_ECOMMERCE``: list of all ecommerce related MFEs you want to install. The structure matches MFES list.
+
+
+Ecommerce related MFEs will be built in case of ecommerce service to be installed.
+``MFE_DEPLOY_ECOMMERCE_MFES`` conditional variable is responsible for this and based on ``SANDBOX_ENABLE_ECOMMERCE`` variable.
+
+
 Deployment using subdirectories
 _______________________________
 
@@ -51,6 +59,14 @@ By default ``MFE_DEPLOY_STANDALONE_NGINX`` is false, which means that all the mi
       - name: account
         repo: frontend-app-account
         public_path: "/account/"
+
+    MFES_ECOMMERCE:
+      - name: payment
+        repo: frontend-app-payment
+        public_path: "/payment/"
+      - name: ecommerce
+        repo: frontend-app-ecommerce
+        public_path: "/ecommerce/"
 
     ### edxapp Configurations
     ### See comprehensive example below
@@ -74,6 +90,14 @@ If we want to deploy the microfrontends in different subdomains, we should turn 
         repo: frontend-app-gradebook
       - name: account
         repo: frontend-app-account
+
+    MFES_ECOMMERCE:
+      - name: payment
+        repo: frontend-app-payment
+        public_path: "/payment/"
+      - name: ecommerce
+        repo: frontend-app-ecommerce
+        public_path: "/ecommerce/"
 
     MFE_DEPLOY_STANDALONE_NGINX: true
 
@@ -123,6 +147,14 @@ __________________________________________________________
       repo: frontend-app-account
       public_path: "/account/"
 
+  MFES_ECOMMERCE:
+    - name: payment
+      repo: frontend-app-payment
+      public_path: "/payment/"
+    - name: ecommerce
+      repo: frontend-app-ecommerce
+      public_path: "/ecommerce/"
+
   MFE_DEPLOY_STANDALONE_NGINX: false
   MFE_DEPLOY_COMMON_HOSTNAME: '{{ MFE_BASE }}'
   
@@ -147,10 +179,25 @@ __________________________________________________________
     - "{{ EDXAPP_CMS_BASE }}"
     - "{{ MFE_BASE }}"
 
+  EDXAPP_SITE_CONFIGURATION:
+    - values:
+        ENABLE_ORDER_HISTORY_MICROFRONTEND: "{{ SANDBOX_ENABLE_ECOMMERCE }}"
+
   # MFE Links
   EDXAPP_LMS_WRITABLE_GRADEBOOK_URL: 'https://{{ MFE_BASE}}/gradebook'
   EDXAPP_PROFILE_MICROFRONTEND_URL: 'https://{{ MFE_BASE}}/profile/u/'
   EDXAPP_ACCOUNT_MICROFRONTEND_URL: 'https://{{ MFE_BASE}}/account'
+  EDXAPP_ORDER_HISTORY_MICROFRONTEND_URL: 'https://{{ MFE_BASE }}/ecommerce/orders'
+
+  ## ecommerce Configuration
+  ECOMMERCE_CORS_ORIGIN_WHITELIST: [
+    "{{ EDXAPP_LMS_BASE_SCHEME }}://{{ MFE_BASE }}",
+  ]
+  ECOMMERCE_CSRF_TRUSTED_ORIGINS: [
+    "{{ EDXAPP_LMS_BASE_SCHEME }}://{{ MFE_BASE }}",
+  ]
+  ECOMMERCE_CORS_ALLOW_CREDENTIALS: true
+  ECOMMERCE_ENABLE_PAYMENT_MFE: true
 
 .. _decision record about asymmetric JWT: https://github.com/edx/edx-platform/blob/master/openedx/core/djangoapps/oauth_dispatch/docs/decisions/0008-use-asymmetric-jwts.rst
 .. _Developer Documentation: https://edx.readthedocs.io/projects/edx-developer-docs/en/latest/developers_guide/micro_frontends_in_open_edx.html#overriding-brand-specific-elements

--- a/playbooks/roles/mfe_deployer/defaults/main.yml
+++ b/playbooks/roles/mfe_deployer/defaults/main.yml
@@ -17,12 +17,20 @@ MFES:
   - name: account
     repo: frontend-app-account
     public_path: "/account/"
+
+MFES_ECOMMERCE:
   - name: payment
     repo: frontend-app-payment
     public_path: "/payment/"
   - name: ecommerce
     repo: frontend-app-ecommerce
     public_path: "/ecommerce/"
+
+MFE_DEPLOY_ECOMMERCE_MFES: false
+ecommerce_mfes: "{{ MFE_DEPLOY_ECOMMERCE_MFES | ternary(MFES_ECOMMERCE, []) }}"
+
+# Collect list of all MFEs to deploy
+deploy_mfes: "{{ MFES + ecommerce_mfes }}"
 
 MFE_DEPLOY_PUBLIC_PATH: "/"
 MFE_DEPLOY_SITE_NAME: ""

--- a/playbooks/roles/mfe_deployer/tasks/main.yml
+++ b/playbooks/roles/mfe_deployer/tasks/main.yml
@@ -17,7 +17,7 @@
     MFE_PUBLIC_PATH: '{{ custom_mfe.public_path | default(MFE_DEPLOY_PUBLIC_PATH) }}'
     MFE_SITE_NAME: '{{ custom_mfe.site_name | default(MFE_DEPLOY_SITE_NAME) }}'
     MFE_STANDALONE_NGINX: '{{ custom_mfe.standalone_nginx | default(MFE_DEPLOY_STANDALONE_NGINX) }}'
-  loop: "{{ MFES }}"
+  loop: "{{ deploy_mfes }}"
   loop_control:
     loop_var: custom_mfe
   tags:

--- a/playbooks/roles/mfe_deployer/templates/edx/app/nginx/sites-available/concerns/mfe.j2
+++ b/playbooks/roles/mfe_deployer/templates/edx/app/nginx/sites-available/concerns/mfe.j2
@@ -1,4 +1,4 @@
-{% for mfe in MFES %}
+{% for mfe in deploy_mfes %}
 
   location ~ ^{{ mfe.public_path }}?(.*)$  {
       root  {{ COMMON_APP_DIR }}/{{ mfe.name }}/{{ mfe.repo }}/dist/;


### PR DESCRIPTION
Branch [open-release/lilac.master](https://github.com/edx/configuration/tree/open-release/lilac.master) already [has](https://github.com/edx/configuration/pull/6409) Payment and Ecommerce MFEs installed by default for the native installation (for testing speedup). Here we are adding conditional build for ecommerce related MFEs and LMS SiteConfiguration improvement.

[BTR task for ecommerce mfe](https://github.com/openedx/build-test-release-wg/issues/64)
[BTR task for payment mfe](https://github.com/openedx/build-test-release-wg/issues/65)

Changes:
- feat: use default SITE_ID for LMS SiteConfiguration
- feat: Install ecommerce mfes only if ecommerce is deployed
- docs: update CHANGELOG.md and mfe_deployer README.rst