### PR TITLE
fix: follow-up from #6444

### DIFF
--- a/playbooks/roles/registrar/defaults/main.yml
+++ b/playbooks/roles/registrar/defaults/main.yml
@@ -128,9 +128,9 @@ registrar_service_config_overrides:
   CELERY_BROKER_PASSWORD: '{{ REGISTRAR_CELERY_BROKER_PASSWORD }}'
   CELERY_BROKER_HOSTNAME: '{{ REGISTRAR_CELERY_BROKER_HOSTNAME }}'
   CELERY_BROKER_VHOST: '{{ REGISTRAR_CELERY_BROKER_VHOST }}'
-  CELERY_DEFAULT_EXCHANGE: 'registrar'
-  CELERY_DEFAULT_ROUTING_KEY: 'registrar'
-  CELERY_DEFAULT_QUEUE: '{{ registrar_celery_default_queue }}'
+  CELERY_TASK_DEFAULT_EXCHANGE: 'registrar'
+  CELERY_TASK_DEFAULT_ROUTING_KEY: 'registrar'
+  CELERY_TASK_DEFAULT_QUEUE: '{{ registrar_celery_default_queue }}'
 
 # See edx_django_service_automated_users for an example of what this should be
 REGISTRAR_AUTOMATED_USERS: {}


### PR DESCRIPTION
Follow-up from https://github.com/edx/configuration/pull/6444

  - [x] ~A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.~ we own all the services
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
