### PR TITLE
fix: Suppress logging when generating EC2 keypair (was logging private key)

### DIFF
--- a/playbooks/continuous_delivery/launch_instance.yml
+++ b/playbooks/continuous_delivery/launch_instance.yml
@@ -46,6 +46,7 @@
       name: "{{ automation_prefix }} {{ unique_key_name.stdout }}"
       region: "{{ ec2_region }}"
     register: ssh_key_register
+    no_log: True
 
   - name: Ensure artifact directory exists
     file:


### PR DESCRIPTION
Make sure that the following steps are done before merging:

  - [ ] Consider whether this should be backported to Lilac
  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [x] N/A: Are you adding any new default values that need to be overridden when this change goes live? If so [...]
  - [x] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [x] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
