### PR TITLE
WIP: Testing setuptools install issue in sandboxes

### DIFF
--- a/playbooks/roles/common/tasks/main.yml
+++ b/playbooks/roles/common/tasks/main.yml
@@ -168,7 +168,7 @@
     group: root
     mode: "0440"
 
-- name: pip install virtualenv
+- name: pip install virtualenv & common_pip_pkgs
   pip:
     name: "{{ common_pip_pkgs }}"
     state: present

--- a/playbooks/roles/common_vars/defaults/main.yml
+++ b/playbooks/roles/common_vars/defaults/main.yml
@@ -155,7 +155,7 @@ COMMON_PIP_VERSION: '20.3.4'
 common_pip_pkgs:
   - pip=={{ COMMON_PIP_VERSION }}
   - configparser==4.0.2
-  - setuptools==44.1.0
+  - setuptools==57.0.0
   - virtualenv==20.2.0
   - zipp==1.2.0
   - boto3

--- a/playbooks/roles/common_vars/defaults/main.yml
+++ b/playbooks/roles/common_vars/defaults/main.yml
@@ -155,7 +155,7 @@ COMMON_PIP_VERSION: '20.3.4'
 common_pip_pkgs:
   - pip=={{ COMMON_PIP_VERSION }}
   - configparser==4.0.2
-  - setuptools==57.0.0
+  - setuptools==56.0.0
   - virtualenv==20.2.0
   - zipp==1.2.0
   - boto3

--- a/playbooks/roles/common_vars/defaults/main.yml
+++ b/playbooks/roles/common_vars/defaults/main.yml
@@ -128,6 +128,7 @@ common_debian_pkgs_default:
   - unzip
   - net-tools
   - python3-pip
+  - python3-pkg-resources
 
 common_release_specific_debian_pkgs:
   xenial:

--- a/playbooks/roles/launch_ec2/tasks/main.yml
+++ b/playbooks/roles/launch_ec2/tasks/main.yml
@@ -110,4 +110,4 @@
 
 - name: Wait for python to install
   pause:
-    minutes: "10"
+    minutes: "{{ launch_ec2_wait_time }}"

--- a/playbooks/roles/launch_ec2/tasks/main.yml
+++ b/playbooks/roles/launch_ec2/tasks/main.yml
@@ -110,4 +110,4 @@
 
 - name: Wait for python to install
   pause:
-    minutes: "{{ launch_ec2_wait_time }}"
+    minutes: "10"


### PR DESCRIPTION
<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##
-->

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?