### PR TITLE
FAL-2077 add ansible tasks to init mongodb indexes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 All notable changes to this project will be documented in this file.
 Add any new changes to the top (right below this line).
 
+ - 2021-07-29
+    - Role edxapp
+       - Add `EDXAPP_ENABLE_MONGODB_INDEXES` configuration variable to optionally set up indexes on edxapp mongodb.
+    - Role forum
+       - Add `FORUM_ENABLE_MONGODB_INDEXES` configuration variable to optionally set up indexes on forum mongodb.
+
  - 2021-07-19
      - Role: edx_django_service
         - Allows writing extra requirements to an 'extra.txt' requirements file in the service's requirements directory.

--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -1819,3 +1819,5 @@ edxapp_staticfiles_storage_overrides: !!null
 # SiteConfiguration instance.
 
 EDXAPP_SITE_CONFIGURATION: {}
+
+EDXAPP_ENABLE_MONGODB_INDEXES: false

--- a/playbooks/roles/edxapp/tasks/deploy.yml
+++ b/playbooks/roles/edxapp/tasks/deploy.yml
@@ -529,3 +529,14 @@
   tags:
     - manage
     - manage:db
+
+- name: ensure indexes on contentstore and modulestore dbs
+  shell: ". {{ edxapp_app_dir }}/edxapp_env && {{ edxapp_venv_bin }}/python ./manage.py lms --settings={{ edxapp_settings }} ensure_indexes"
+  args:
+    chdir: "{{ edxapp_code_dir }}"
+  become_user: "{{ common_web_user }}"
+  when: EDXAPP_ENABLE_MONGODB_INDEXES
+  run_once: yes
+  tags:
+    - manage
+    - manage:db

--- a/playbooks/roles/forum/defaults/main.yml
+++ b/playbooks/roles/forum/defaults/main.yml
@@ -54,6 +54,8 @@ FORUM_RESTART_DELAY: 60
 # Set to rebuild the forum ElasticSearch index from the database.
 FORUM_REBUILD_INDEX: false
 
+FORUM_ENABLE_MONGODB_INDEXES: false
+
 forum_base_env: &forum_base_env
   RBENV_ROOT: "{{ forum_rbenv_root }}"
   GEM_HOME: "{{ forum_gem_root }}"

--- a/playbooks/roles/forum/tasks/deploy.yml
+++ b/playbooks/roles/forum/tasks/deploy.yml
@@ -108,6 +108,18 @@
   tags:
     - manage
 
+- name: ensure indexes on forum mongo db
+  command: "{{ forum_code_dir }}/bin/rake db:init"
+  args:
+    chdir: "{{ forum_code_dir }}"
+  become_user: "{{ forum_user }}"
+  environment: "{{ forum_base_env }}"
+  when: FORUM_ENABLE_MONGODB_INDEXES
+  run_once: yes
+  tags:
+    - manage
+    - manage:db
+
 - include: test.yml
   tags:
     - deploy


### PR DESCRIPTION
[FAL-2077](https://tasks.opencraft.com/browse/FAL-2077)

Add optional tasks to create mongo db indexes.

**JIRA tickets**: [OSPR-5889](https://openedx.atlassian.net/browse/OSPR-5889)

**Dependencies**: None

**Sandbox URL**:

-    LMS: https://fal-2077-test.opencraft.hosting/
-   Studio: https://studio.fal-2077-test.opencraft.hosting/

**Merge deadline**: None

**Testing instructions**:

1. set the `EDXAPP_ENABLE_MONGODB_INDEXES` ansible configuration variable to `true`, and the `FORUM_ENABLE_MONGODB_INDEXES` ansible configuration variable to `true`.
2. provision an appserver 
1. verify that appserver provisioned successfully (check that the ansible tasks added here ran and ran successfully)
2. spot check the forum on a demo course
3. spot check things that use contentstore and modulestore (create and edit an xblock in a course?)
4. provision an appserver again using the same mongodb database to verify idempotency
4. verify that indexes are created on the mongodb databases (optional?; as long as we know that the correct commands have been run, we can trust that those commands are doing their job?)


**Reviewers**:

- [x] @mtyaka 
- [x] @pomegranited 

**Settings**:

```yaml
EDXAPP_ENABLE_MONGODB_INDEXES: true
FORUM_ENABLE_MONGODB_INDEXES: true
```