### PR TITLE
Fix retire_host.yml

### DIFF
--- a/playbooks/retire_host.yml
+++ b/playbooks/retire_host.yml
@@ -43,7 +43,7 @@
       with_items:
       - { src: '/lms/', dest: '{{ COMMON_OBJECT_STORE_EDX_LOG_SYNC_PREFIX }}lms/' }
       - { src: '/cms/', dest: '{{ COMMON_OBJECT_STORE_EDX_LOG_SYNC_PREFIX }}cms/' }
-      when: COMMON_OBJECT_STORE_EDX_LOG_SYNC
+      when: (COMMON_OBJECT_STORE_EDX_LOG_SYNC is defined) and COMMON_OBJECT_STORE_EDX_LOG_SYNC is true
     
 - name: Run minos verification
   hosts: "{{TARGET}}"


### PR DESCRIPTION
Configuration Pull Request
---

<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##
-->

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
