### PR TITLE
Specify mongo replica set protocolVersion.

### DIFF
--- a/playbooks/roles/mongo_4_0/defaults/main.yml
+++ b/playbooks/roles/mongo_4_0/defaults/main.yml
@@ -59,6 +59,7 @@ MONGO_CLUSTER_KEY: "CHANGEME"
 # Fed directly into mongodb_replica_set module
 MONGO_RS_CONFIG:
   _id: '{{ MONGO_REPL_SET }}'
+  protocolVersion: 1
   members:
     - host: '127.0.0.1'
 


### PR DESCRIPTION
This cherry-picks the fix from https://github.com/edx/configuration/pull/6468 into lilac.master.


<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##
-->

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
