### PR TITLE
[BB-3801] feat: allow writing extra requirements to a requirements file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 All notable changes to this project will be documented in this file.
 Add any new changes to the top (right below this line).
 
+ - 2021-07-19
+     - Role: edx_django_service
+        - Allows writing extra requirements to an 'extra.txt' requirements file in the service's requirements directory.
+     - Role: ecommerce
+        - Adds an optional flag to write the extra requirements to an 'extra.txt' file since many of the app's setup commands
+          use tox and that creates its own environments separate from the default ecommerce virtualenv environment where the
+          `ECOMMERCE_EXTRA_REQUIREMENTS` requirements are installed.
+
  - 2021-06-17
     - Role credentials
        - Installs extra python packages specified in `CREDENTIALS_EXTRA_REQUIREMENTS` (defaults to `[]`).

--- a/playbooks/roles/ecommerce/defaults/main.yml
+++ b/playbooks/roles/ecommerce/defaults/main.yml
@@ -32,6 +32,7 @@ ECOMMERCE_REPOS:
 #     version: 1.0.1
 #   - name: git+https://git.myproject.org/MyProject#egg=MyProject
 ECOMMERCE_EXTRA_REQUIREMENTS: []
+ECOMMERCE_ADD_EXTRA_REQUIREMENTS_TO_REQUIREMENTS_FILE: false
 
 # depends upon Newrelic being enabled via COMMON_ENABLE_NEWRELIC
 # and a key being provided via NEWRELIC_LICENSE_KEY

--- a/playbooks/roles/ecommerce/meta/main.yml
+++ b/playbooks/roles/ecommerce/meta/main.yml
@@ -22,6 +22,7 @@ dependencies:
     edx_django_service_debian_pkgs_extra: '{{ ecommerce_debian_pkgs + ecommerce_release_specific_debian_pkgs[ansible_distribution_release] }}'
     edx_django_service_django_settings_module: '{{ ECOMMERCE_DJANGO_SETTINGS_MODULE }}'
     edx_django_service_extra_requirements: '{{ ECOMMERCE_EXTRA_REQUIREMENTS }}'
+    edx_django_service_add_extra_requirements_to_requirements_file: '{{ ECOMMERCE_ADD_EXTRA_REQUIREMENTS_TO_REQUIREMENTS_FILE }}'
     edx_django_service_repos: '{{ ECOMMERCE_REPOS }}'
     edx_django_service_environment_extra: '{{ ecommerce_environment }}'
     edx_django_service_gunicorn_extra: '{{ ECOMMERCE_GUNICORN_EXTRA }}'

--- a/playbooks/roles/edx_django_service/tasks/main.yml
+++ b/playbooks/roles/edx_django_service/tasks/main.yml
@@ -193,6 +193,17 @@
     - install
     - install:app-requirements
 
+- name: add extra requirements to extra.txt
+  lineinfile:
+    path: "{{ edx_django_service_code_dir }}/requirements/extra.txt"
+    line: "{{ item.name }}"
+  become_user: "{{ edx_django_service_user }}"
+  with_items: "{{ edx_django_service_extra_requirements }}"
+  when: edx_django_service_add_extra_requirements_to_requirements_file is defined and edx_django_service_add_extra_requirements_to_requirements_file
+  tags:
+    - install
+    - install:app-requirements
+
 - name: Check for existing make_migrate container
   command: "docker ps -aq --filter name='{{ edx_django_service_name }}.make_migrate'"
   register: edx_django_service_make_migrate_container


### PR DESCRIPTION
Ecommerce uses `tox` to run the migrations during provisioning (`make migrate`). When extra requirements for Ecommerce are defined via `ECOMMERCE_EXTRA_REQUIREMENTS`, they are installed in the `ecommerce` virtualenv environment but not the `tox` environments used for some operations like `migrate`. When an extra requirement is added to the `INSTALLED_APPS`, this causes Django to complain about being unable to find the extra requirement in the `tox` environment that management commands are run in.

This PR writes the extra requirements to `requirements/extra.txt` (added in the related `ecommerce` PR) when `ECOMMERCE_ADD_EXTRA_REQUIREMENTS_TO_REQUIREMENTS_FILE` (default: `false`) is set to `true`.

This is useful for apps like ecommerce, which use tox to run the
migrations and the dependencies for the tox environments are expected
to be defined in a requirements file. This is useful when specifying extra requirements in `ECOMMERCE_EXTRA_REQUIREMENTS` which don't get installed in the `tox` environments currently.

**Testing instructions**
* Deploy an Open edX instance with ecommerce using the source branch of this PR and the `openedx_native.yml` playbook. Specify an extra requirement (like `git+https://github.com/open-craft/ecommerce-hyperpay.git#egg=hyperpay-ecommerce`) for ecommerce using `ECOMMERCE_EXTRA_REQUIREMENTS`.
* Verify that after the playbook finishes successfully, the requirements specified in the previous step are added to `requirements/extra.txt`.
* Verify that the same requirements are installed in the `tox` environment used by the `make migrate` command.

**Note: https://github.com/edx/ecommerce/pull/3478 is the related `ecommerce` PR.**

**Reviewers**:
- [ ] @kaizoku 
- [ ] edX reviewers/core committer reviewers (TBD)

Configuration Pull Request
---

<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##
-->

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
