### PR TITLE
feat: update devstack configurations for forum to use elasticsearch 7.10

### DIFF
--- a/playbooks/roles/forum/defaults/main.yml
+++ b/playbooks/roles/forum/defaults/main.yml
@@ -85,7 +85,7 @@ devstack_forum_env:
   RACK_ENV: "development"
   SINATRA_ENV: "development"
   SEARCH_SERVER: "http://edx.devstack.elasticsearch:9200/"
-  SEARCH_SERVER_ES7: "http://edx.devstack.elasticsearch7:9200/"
+  SEARCH_SERVER_ES7: "http://edx.devstack.elasticsearch710:9200/"
   MONGOHQ_URL: "mongodb://cs_comments_service:password@edx.devstack.mongo:27017/cs_comments_service"
   MONGOID_AUTH_MECH: "{{ FORUM_MONGO_AUTH_MECH }}"
 


### PR DESCRIPTION
### [TNL-8489](https://openedx.atlassian.net/browse/TNL-8489)

Update devstack configuration for forum service to use updated `elasticsearch`.

Related PR https://github.com/edx/devstack/pull/806

Configuration Pull Request
---

<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##
-->

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
