### PR TITLE
fix: Add jenkins user in docker group

### DIFF
--- a/playbooks/roles/jenkins_data_engineering_new/meta/main.yml
+++ b/playbooks/roles/jenkins_data_engineering_new/meta/main.yml
@@ -51,3 +51,8 @@ dependencies:
     jenkins_common_python_installations: '{{ de_jenkins_python_installations }}'
     jenkins_common_snap_pkgs: '{{ de_jenkins_snap_pkgs }}'
     jenkins_common_timestamper_system_clock_format: '{{ de_jenkins_timestamper_system_time }}'
+
+  # Needed to be able to build docker images. Used by Docker Image Builder Jobs.
+  - role: docker-tools
+    docker_users:
+        - '{{ jenkins_user }}'


### PR DESCRIPTION
In order to run and build docker images user that runs docker should be added in docker group that mapping was missing. DENG-934

Configuration Pull Request
---

<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##
-->

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
