### PR TITLE
chore: upgrade devstack edx-platform es to 7.10

### DIFF
--- a/docker/build/edxapp/lms.yml
+++ b/docker/build/edxapp/lms.yml
@@ -241,7 +241,7 @@ EDXNOTES_PUBLIC_API: http://localhost:18120/api/v1
 EDX_API_KEY: PUT_YOUR_API_KEY_HERE
 EDX_PLATFORM_REVISION: master
 ELASTIC_SEARCH_CONFIG:
--   host: edx.devstack.elasticsearch
+-   host: edx.devstack.elasticsearch710
     port: 9200
     use_ssl: false
 EMAIL_BACKEND: django.core.mail.backends.smtp.EmailBackend

--- a/docker/build/edxapp/studio.yml
+++ b/docker/build/edxapp/studio.yml
@@ -217,7 +217,7 @@ ECOMMERCE_PUBLIC_URL_ROOT: http://localhost:8002
 EDXMKTG_USER_INFO_COOKIE_NAME: edx-user-info
 EDX_PLATFORM_REVISION: master
 ELASTIC_SEARCH_CONFIG:
--   host: edx.devstack.elasticsearch
+-   host: edx.devstack.elasticsearch710
     port: 9200
     use_ssl: false
 EMAIL_BACKEND: django.core.mail.backends.smtp.EmailBackend


### PR DESCRIPTION
Configuration Pull Request
chore: upgrade devstack edx-platform es to 7.10

As part of larger elasticsearch upgrade work, we must move edx-platform to use the 7.10 container.

This will ensure future compatibility and maybe make performance improvements to es calls.

Presently, edx-platofrm uses elasticsearch for searching within the content-library. Searching through the [changelogs](https://www.elastic.co/guide/en/elasticsearch/reference/current/migrating-7.10.html#breaking-changes-7.10), no functionality should change in the present formation, as edx-platform es usage is relatively rudimentary.

Testing involved running unit, e2e, and hand testing of the creation and indexing of course content. Attention was paid to its usage in the teams api as well, as that is a notable edge usage.

Part of [TNL-8484](ES 7.10 - Upgrade and Test edx-platform Devstack on Elasticsearch 7.10) and the larger ES upgrade efforts:

https://openedx.atlassian.net/wiki/spaces/AC/pages/2923561087/Elasticsearch+7.10

Parallel to: https://github.com/edx/devstack/pull/813

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
