### PR TITLE
fix: repair neo4j role and upgrade it to 3.5.28

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 All notable changes to this project will be documented in this file.
 Add any new changes to the top (right below this line).
 
+ - 2021-10-20
+    - Role neo4j
+      - Bring Neo4j role closer in with what we really deploy:
+        - Change Neo4j version from 3.2.2 to 3.3.1.
+        - Expose Bolt on 0.0.0.0:7687 with optional encryption.
+        - Enable `dbms.allow_upgrade`, which is the new name of the `dbms.allow_format_migration` key.
+        - Remove http->https redirection logic when NGINX_ENABLE_SSL is false.
+
  - 2021-09-28
     - Role nginx
       - Add `NGINX_ENABLE_IPV6` configuration variable to make nginx

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Add any new changes to the top (right below this line).
 
  - 2021-10-20
     - Role neo4j
+       - Upgrade Neo4j from 3.2.2 to 3.5.28.
+
+ - 2021-08-26
+    - Role neo4j
       - Bring Neo4j role closer in with what we really deploy:
         - Change Neo4j version from 3.2.2 to 3.3.1.
         - Expose Bolt on 0.0.0.0:7687 with optional encryption.

--- a/playbooks/roles/neo4j/defaults/main.yml
+++ b/playbooks/roles/neo4j/defaults/main.yml
@@ -19,10 +19,19 @@
 NEO4J_SERVER_NAME: "localhost"
 NEO4J_AUTH_ENABLED: "true"
 
-neo4j_gpg_key_url: https://debian.neo4j.org/neotechnology.gpg.key
-neo4j_apt_repository: "deb http://debian.neo4j.org/repo stable/"
+# When updating this version, please update the corresponding
+# neo4j Docker image tag used by the Devstack coursegraph service
+# (see github.com/edx/devstack/tree/master/docker-compose.yml).
+# Note that the corresponding docker image tag does not include the
+# epoch prefix ('1:') -- it's just 'Major.Minor.Patch'.
+NEO4J_VERSION: "1:3.5.28"
+
+# If upgrading to a Major.Minor series other than 3.5, you'll need
+# to change the '3.5' repository component below accordingly.
+neo4j_apt_repository: "deb https://debian.neo4j.com stable 3.5"
+
+neo4j_gpg_key_url: https://debian.neo4j.com/neotechnology.gpg.key
 neo4j_defaults_file: "/etc/default/neo4j"
-NEO4J_VERSION: "3.3.1"
 neo4j_server_config_file: "/etc/neo4j/neo4j.conf"
 neo4j_bolt_port: 7687  # default in package is 7687
 neo4j_https_port: 7473  # default in package is 7473

--- a/playbooks/roles/neo4j/defaults/main.yml
+++ b/playbooks/roles/neo4j/defaults/main.yml
@@ -22,8 +22,9 @@ NEO4J_AUTH_ENABLED: "true"
 neo4j_gpg_key_url: https://debian.neo4j.org/neotechnology.gpg.key
 neo4j_apt_repository: "deb http://debian.neo4j.org/repo stable/"
 neo4j_defaults_file: "/etc/default/neo4j"
-NEO4J_VERSION: "3.2.2"
+NEO4J_VERSION: "3.3.1"
 neo4j_server_config_file: "/etc/neo4j/neo4j.conf"
+neo4j_bolt_port: 7687  # default in package is 7687
 neo4j_https_port: 7473  # default in package is 7473
 neo4j_http_port: 7474  # default in package is 7474
 neo4j_listen_address: "0.0.0.0"
@@ -32,6 +33,8 @@ neo4j_page_cache_size: "6000m"
 neo4j_log_dir: "/var/log/neo4j"
 
 # Properties file settings
+neo4j_bolt_settings_key: "dbms.connector.bolt.listen_address"
+neo4j_bolt_tls_key: "dbms.connector.bolt.tls_level"
 neo4j_https_settings_key: "dbms.connector.https.listen_address"
 neo4j_http_settings_key: "dbms.connector.http.listen_address"
 

--- a/playbooks/roles/neo4j/tasks/main.yml
+++ b/playbooks/roles/neo4j/tasks/main.yml
@@ -98,8 +98,28 @@
 - name: allow format migration (when updating neo4j versions)
   lineinfile:
     dest: "{{ neo4j_server_config_file }}"
-    regexp: "dbms.allow_format_migration="
-    line: "dbms.allow_format_migration=true"
+    regexp: "dbms.allow_upgrade="
+    line: "dbms.allow_upgrade=true"
+  tags:
+    - install
+    - install:configuration
+
+- name: set to listen on specific port for bolt
+  lineinfile:
+    create: yes
+    dest: "{{ neo4j_server_config_file }}"
+    regexp: "{{ neo4j_bolt_settings_key }}="
+    line: "{{ neo4j_bolt_settings_key }}={{ neo4j_listen_address }}:{{ neo4j_bolt_port }}"
+  tags:
+    - install
+    - install:configuration
+
+- name: allow both encrypted and unencrypted bolt connections
+  lineinfile:
+    create: yes
+    dest: "{{ neo4j_server_config_file }}"
+    regexp: "{{ neo4j_bolt_tls_key }}="
+    line: "{{ neo4j_bolt_tls_key }}=OPTIONAL"
   tags:
     - install
     - install:configuration

--- a/playbooks/roles/neo4j/tasks/main.yml
+++ b/playbooks/roles/neo4j/tasks/main.yml
@@ -65,6 +65,16 @@
   register: neo4j_apt_pkg
   until: neo4j_apt_pkg is succeeded
 
+# For what it's worth: We purposely do not prefix these line-replacement
+# regex with ^ or suffix them with $. That's because we cannot be
+# confident whether these lines initially (i) exist in file commented-out,
+# or (ii) exist in the file with a value already set. So, we purposefully
+# leave the regexes without beginning- or end-of-line matches so that
+# they can handle both scenario (i) and (ii).
+# In the future, it'd be good to get rid of these tasks, and instead
+# just include j2-templated configuration files to wholesale replace
+# what's on the box.
+
 - name: enable or disable authentication
   lineinfile:
     dest: "{{ neo4j_server_config_file }}"

--- a/playbooks/roles/neo4j/templates/edx/app/nginx/sites-available/coursegraph.j2
+++ b/playbooks/roles/neo4j/templates/edx/app/nginx/sites-available/coursegraph.j2
@@ -39,6 +39,8 @@ server {
     proxy_pass http://127.0.0.1:{{ neo4j_http_port }};
   }
 
+  {% if NGINX_ENABLE_SSL %}
+
   # Forward to HTTPS if we're an HTTP request...
   if ($http_x_forwarded_proto = "http") {
     set $do_redirect "true";
@@ -48,4 +50,7 @@ server {
   if ($do_redirect = "true") {
     rewrite ^ https://$host$request_uri? permanent;
   }
+
+  {% endif %}
+
 }


### PR DESCRIPTION
## Description

Two commits here:

###  fix: bring neo4j role in line with reality 

The Neo4j ansible role seems to have drifted from
what edX has deployed. These changes bring it closer
to what is running on coursegraph.edx.org,
and also make it possbile to get CourseGraph
working out-of-the-box on an Ubuntu 18.04 sandbox:
 * Change Neo4j version from 3.2.2 to 3.3.1.
 * Expose Bolt on 0.0.0.0:7687 with optional encryption.
 * Enable `dbms.allow_upgrade`, which is the new name
   of the `dbms.allow_format_migration` key.
 * Remove http->https redirection logic when
   NGINX_ENABLE_SSL is false (this is necessary
   on sandboxes, and also just makes sense...
   we shouldn't redirect to https if https
   is disabled).

### fix: upgrade py2neo from 3.3.1 to 3.5.28 

After we upgraded edxapp from python3.5 to
python3.8, the dump_to_neo4j management
command (which we use to dump modulestore
data to into coursegraph) stopped working. Our
working hypothesis is that the py2neo version that
edx-platform pins (3.1.2) does not support python3.8.

In order upgrade to a py2neo that python3.8 supports
*and* that hasn't been deleted from Neo4j's
documentation, we must first upgrade the version of
neo4j itself that we install. By upgrading to 3.5.28,
we upgrade as far into the 3.x series as possible without
having to deal with potential breaking changes in 4.x.

According to Neo4j's docs, this should be a painless
upgrade, although it will trigger an automatic db
migration when neo4j starts up again. It should allow
us to upgrade to any py2neo version series between
4.x (the next major version) to 2021.x (the latest).


## Supporting Information

Ticket: https://openedx.atlassian.net/browse/TNL-8386
SRE support tickets: https://openedx.atlassian.net/browse/PSRE-986 and https://openedx.atlassian.net/browse/PSRE-987

In a separate edx-platform PR, I am [upgrading the version of py2neo to be 4.x or higher](https://github.com/edx/edx-platform/pull/28480). Since the dump_to_neo4j job is broken anyway, it is fine to ship these PRs in either order.

Finally, here is the corresponding devstack image update, which I'll merge last: https://github.com/edx/devstack/pull/824

## Operational considerations

* SRE just backed up the volume via the AWS console. We can restore it if this goes awry.

* I have SSH access to the Coursegraph box, which I will use to run the Ansible playbook off of this branch once this PR is approved. Upon successful application of the playbook, I'll merge this PR.

* I will notify #coursegraph and advise of impending downtime prior to attempting the upgrade.

* ~We should cherry-pick this into Lilac when coursegraph is finally working again.~
  * Jk, afaik Coursegraph isn't part of the community installation, so it should be fine to just let this upgrade go out with the Maple branches.

* Once both this PR and the edx-platform PR are deployed, I will [kick off this Jenkins job](https://tools-edx-jenkins.edx.org/job/Coursegraph/job/prod-edx-dump_to_neo4j/), which will hopefully  (🤞🏻) successfully refresh Coursegraph with new data from LMS.

* I will record my process in https://openedx.atlassian.net/wiki/spaces/PT/pages/3119972411/CourseGraph+Operations.

### What I plan on running (from my machine)

See https://openedx.atlassian.net/wiki/spaces/PT/pages/3119972411/CourseGraph+Operations#Running-Ansible-against-Coursegraph.

I am using this PR's config branch, [this PR's](https://github.com/edx/edx-internal/pull/5371) internal branch, and [this PR's](https://github.com/edx-ops/edx-secure/pull/1856) secure branch.

## Test process

Here is how I tested the changes in this PR:

### Testing without these changes

Follow [the instructions to set up CourseGraph on a sandbox](https://openedx.atlassian.net/wiki/spaces/PT/pages/161135512/Setting+up+CourseGraph+on+a+sandbox), which I recently brought up to date.

Confirm that CourseGraph is accessible. From edx-platform master, confirm that the `Dump data ... from local` process does **not** work. This is due to the out-of-date py2neo package.

### Testing with "bring role in line with reality" commit

Follow [the same instructions](https://openedx.atlassian.net/wiki/spaces/PT/pages/161135512/Setting+up+CourseGraph+on+a+sandbox), but skip `Fixing {nginx,neo4j} configuration`, as my commit fixes those gaps.

Confirm that CourseGraph is accessible. From edx-platform master, confirm that the `Dump data ... from local` process still does **not** work. Again, this is due to the out-of-date py2neo package.

The results of this are live on http://coursegraph33.sandbox.edx.org

### Testing with the "upgrade to 3.5.28" commit

Follow [the same instructions](https://openedx.atlassian.net/wiki/spaces/PT/pages/161135512/Setting+up+CourseGraph+on+a+sandbox), again skipping `Fixing {nginx,neo4j} configuration`.

Confirm that CourseGraph is accessible. Check out the `kdmccormick/py2neo2021` branch of edx-platform and `make requirements` in an LMS shell. Confirm that the `Dump data ... from local` process **does** work, using a non-sensitive test course.

The results of this are live on http://coursegraph35.sandbox.edx.org

## Prior art

### Upgrade to 3.3.1

This is not documented anywhere. It seems to have happened outside of version control, with the upgrade applied directly on the deployed CourseGraph box, either intentionally or by accident.

### Upgrade to 3.2.2

The last person to upgrade neo4j via this repository was Adam Palay with Fred Smith's help, four years ago:
* https://github.com/edx/configuration/pull/3968
* https://openedx.atlassian.net/browse/OPS-2265

The only concern I can glean from that PR and linked OPS ticket is that Neo4j may need up to 2x its current disk space in order to perform an in-place schema upgrade. I will check on that.
  * Update: the volume is 148 GB, and only 28% of it is used, so we're good here 👍🏻 

### Upgrade to 3.0.3

The oldest upgrade I can find record of is this one: https://github.com/edx/configuration/pull/2974. No record of what Ansible commands were run or how it went is to be found.

