### PR TITLE
fix: rate exceeded and throttling exception in check_rds_config script

### DIFF
--- a/util/check_rds_configs/check_rds_configs.py
+++ b/util/check_rds_configs/check_rds_configs.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 from __future__ import print_function
 import boto3
+from botocore.config import Config
 import click
 
 tags_key_list = ["deployment", "environment", "cluster"]
@@ -168,5 +169,5 @@ def cli(db_engine, ignore):
 
 if __name__ == '__main__':
 
-    rds = boto3.client('rds')
+    rds = boto3.client('rds', config=Config(connect_timeout=5, read_timeout=60, retries={'max_attempts': 15}))
     cli()


### PR DESCRIPTION
Configuration Pull Request
---

<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##
-->

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
