### PR TITLE
fix: Add retry logic to add apt repository tasks

### DIFF
--- a/playbooks/roles/common/tasks/main.yml
+++ b/playbooks/roles/common/tasks/main.yml
@@ -59,11 +59,21 @@
 - name: Add git apt repository
   apt_repository:
     repo: "{{ common_git_ppa }}"
+    update_cache: yes
+  register: add_repo
+  until: add_repo|success
+  retries: 10
+  delay: 5
   when: ansible_distribution in common_debian_variants
 
 - name: Add ppa for watchman package
   apt_repository:
     repo: "ppa:linuxuprising/apps"
+    update_cache: yes
+  register: add_repo
+  until: add_repo|success
+  retries: 10
+  delay: 5
   when: >
       ansible_distribution in common_debian_variants and 
       ({{ devstack | default(False) }} or {{ edx_django_service_is_devstack | default(False) }})
@@ -100,6 +110,11 @@
 - name: add deadsnakes repository
   apt_repository:
     repo: "ppa:deadsnakes/ppa"
+    update_cache: yes
+  register: add_repo
+  until: add_repo|success
+  retries: 10
+  delay: 5
   when: ansible_distribution_release == 'bionic' or ansible_distribution_release == 'focal'
   tags:
     - install


### PR DESCRIPTION
Configuration Pull Request
---

<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##
-->

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
