### PR TITLE
fix: install libmysqlclient-dev on gha runner and update version (DOS-2555)

### DIFF
--- a/docker/build/github-actions-runner/Dockerfile
+++ b/docker/build/github-actions-runner/Dockerfile
@@ -1,13 +1,14 @@
 FROM ubuntu:focal
 
 # Set the github runner version
-ARG RUNNER_VERSION="2.277.1"
+ARG RUNNER_VERSION="2.279.0"
 
 ENV GITHUB_ORGANIZATION=""
 ENV GITHUB_ACCESS_TOKEN=""
 
 # Update and install necessary packages
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y curl iputils-ping jq software-properties-common build-essential libssl-dev libffi-dev python3 python3-venv python3-dev yamllint
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y curl iputils-ping jq software-properties-common build-essential libssl-dev \
+    libffi-dev python3 python3-venv python3-dev libmysqlclient-dev yamllint
 
 # Add a github action runner user
 RUN useradd -m actions-runner


### PR DESCRIPTION
Configuration Pull Request
---

<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##
-->

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
