### PR TITLE
fix: retry accessing ppa for when launchpad is being finnicky

### DIFF
--- a/playbooks/roles/common/tasks/main.yml
+++ b/playbooks/roles/common/tasks/main.yml
@@ -127,6 +127,10 @@
     install_recommends: yes
     state: present
     update_cache: yes
+  register: add_pkgs
+  until: add_pkgs|success
+  retries: 10
+  delay: 5
   when: ansible_distribution in common_debian_variants
 
 - name: Install role-independent packages useful for devstack.
@@ -148,6 +152,10 @@
     install_recommends: yes
     state: present
     update_cache: yes
+  register: add_pkgs
+  until: add_pkgs|success
+  retries: 10
+  delay: 5
   when: >
     ansible_distribution in common_debian_variants and
     ansible_distribution_release in old_python_ppa_releases and

--- a/playbooks/roles/nginx/tasks/main.yml
+++ b/playbooks/roles/nginx/tasks/main.yml
@@ -62,6 +62,11 @@
   apt_repository:
     repo: "{{ NGINX_APT_REPO }}"
     state: present
+    update_cache: yes
+  register: add_repo
+  until: add_repo|success
+  retries: 10
+  delay: 5
   notify: restart nginx
   tags:
     - install

--- a/playbooks/roles/prospectus/tasks/main.yml
+++ b/playbooks/roles/prospectus/tasks/main.yml
@@ -62,6 +62,11 @@
 - name: add deadsnakes repo
   apt_repository:
       repo: ppa:deadsnakes/ppa
+      update_cache: yes
+  register: add_repo
+  until: add_repo|success
+  retries: 10
+  delay: 5
   when: prospectus_use_python3
 
 - name: install python3.8
@@ -69,6 +74,10 @@
     pkg:
       - python3.8-dev
       - python3.8-distutils
+  register: add_pkgs
+  until: add_pkgs|success
+  retries: 10
+  delay: 5
   when: prospectus_use_python3
   tags:
     - install
@@ -87,6 +96,10 @@
     name: nodeenv
   become_user: "{{ prospectus_user }}"
   environment: "{{ prospectus_env_vars }}"
+  register: add_pkg
+  until: add_pkg|success
+  retries: 10
+  delay: 5
   tags:
     - install
     - install:system-requirements
@@ -157,6 +170,10 @@
 - name: Install pngquant
   apt:
     name: "pngquant"
+  register: add_pkg
+  until: add_pkg|success
+  retries: 10
+  delay: 5
   tags:
     - install
     - install:system-requirements


### PR DESCRIPTION
JIRA:DOS-2550

Configuration Pull Request
---

<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##
-->

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
