### PR TITLE
feat: Move prospectus to install Node directly instead of using nodeenv.

### DIFF
--- a/playbooks/roles/prospectus/defaults/main.yml
+++ b/playbooks/roles/prospectus/defaults/main.yml
@@ -37,16 +37,12 @@ PROSPECTUS_GIT_IDENTITY: "none"
 prospectus_repo: 'ssh://git@github.com/edx/prospectus.git'
 PROSPECTUS_VERSION: 'master'
 edx_django_service_use_python3: false
-PROSPECTUS_NODE_VERSION:  '12.21.0'
+PROSPECTUS_NODE_VERSION:  '12'
 prospectus_service_name: 'prospectus'
 prospectus_home: '{{ COMMON_APP_DIR }}/{{ prospectus_service_name }}'
-prospectus_venv_dir: '{{ prospectus_home }}/venvs/{{ prospectus_service_name }}'
-prospectus_nodeenv_dir: '{{ prospectus_home }}/nodeenvs/{{ prospectus_service_name }}'
-prospectus_nodeenv_bin: '{{prospectus_nodeenv_dir}}/bin'
 prospectus_app_dir: "{{ COMMON_APP_DIR }}/prospectus"
 prospectus_user: 'root'
 prospectus_env_vars:
-  PATH: "{{ prospectus_nodeenv_bin }}:{{ prospectus_venv_dir }}/bin:{{ ansible_env.PATH }}"
   NODE_ENV: "{{ PROSPECTUS_ENVIRONMENT }}"
   ACTIVE_ENV: "{{ PROSPECTUS_ENVIRONMENT }}"
   USE_COURSE_URL_SLUGS: "{{ PROSPECTUS_USE_COURSE_URL_SLUGS }}"

--- a/playbooks/roles/prospectus/defaults/main.yml
+++ b/playbooks/roles/prospectus/defaults/main.yml
@@ -37,7 +37,8 @@ PROSPECTUS_GIT_IDENTITY: "none"
 prospectus_repo: 'ssh://git@github.com/edx/prospectus.git'
 PROSPECTUS_VERSION: 'master'
 edx_django_service_use_python3: false
-PROSPECTUS_NODE_VERSION:  '12'
+PROSPECTUS_NODE_MAJOR_VERSION: '12'
+PROSPECTUS_NODE_VERSION:  '12.21.0'
 prospectus_service_name: 'prospectus'
 prospectus_home: '{{ COMMON_APP_DIR }}/{{ prospectus_service_name }}'
 prospectus_app_dir: "{{ COMMON_APP_DIR }}/prospectus"

--- a/playbooks/roles/prospectus/tasks/main.yml
+++ b/playbooks/roles/prospectus/tasks/main.yml
@@ -77,7 +77,7 @@
 
 - name: Install the nodejs LTS repos
   apt_repository:
-    repo: "deb https://deb.nodesource.com/node_{{ PROSPECTUS_NODE_VERSION }}.x {{ ansible_distribution_release }} main"
+    repo: "deb https://deb.nodesource.com/node_{{ PROSPECTUS_NODE_MAJOR_VERSION }}.x {{ ansible_distribution_release }} main"
     state: present
     update_cache: yes
   tags:
@@ -86,8 +86,8 @@
 
 - name: Install node
   apt:
-    name: nodejs
     state: present
+    deb: "https://deb.nodesource.com/node_12.x/pool/main/n/nodejs/nodejs_{{ PROSPECTUS_NODE_VERSION }}-deb-1nodesource1_amd64.deb"
   tags:
     - install
     - install:system-requirements

--- a/playbooks/roles/prospectus/tasks/main.yml
+++ b/playbooks/roles/prospectus/tasks/main.yml
@@ -59,26 +59,10 @@
   register: prospectus_checkout
   when: PROSPECTUS_GIT_IDENTITY == "none"
 
-- name: add deadsnakes repo
-  apt_repository:
-      repo: ppa:deadsnakes/ppa
-      update_cache: yes
-  register: add_repo
-  until: add_repo|success
-  retries: 10
-  delay: 5
-  when: prospectus_use_python3
-
-- name: install python3.8
-  apt:
-    pkg:
-      - python3.8-dev
-      - python3.8-distutils
-  register: add_pkgs
-  until: add_pkgs|success
-  retries: 10
-  delay: 5
-  when: prospectus_use_python3
+- name: Install the gpg key for nodejs LTS
+  apt_key:
+    url: "https://deb.nodesource.com/gpgkey/nodesource.gpg.key"
+    state: present
   tags:
     - install
     - install:system-requirements
@@ -91,24 +75,19 @@
     owner: "{{ prospectus_user }}"
     group: "{{ prospectus_user }}"
 
-- name: Install nodeenv
-  apt:
-    name: nodeenv
-  become_user: "{{ prospectus_user }}"
-  environment: "{{ prospectus_env_vars }}"
-  register: add_pkg
-  until: add_pkg|success
-  retries: 10
-  delay: 5
+- name: Install the nodejs LTS repos
+  apt_repository:
+    repo: "deb https://deb.nodesource.com/node_{{ PROSPECTUS_NODE_VERSION }}.x {{ ansible_distribution_release }} main"
+    state: present
+    update_cache: yes
   tags:
     - install
     - install:system-requirements
 
-# Install node
-- name: Create nodeenv
-  shell: "nodeenv {{ prospectus_nodeenv_dir }} --node={{ PROSPECTUS_NODE_VERSION }} --prebuilt --force"
-  become_user: "{{ prospectus_user }}"
-  environment: "{{ prospectus_env_vars }}"
+- name: Install node
+  apt:
+    name: nodejs
+    state: present
   tags:
     - install
     - install:system-requirements
@@ -145,9 +124,8 @@
     - install
     - install:app-requirements
 
-# Install with the shell command instead of the ansible npm module so we don't accidentally re-write package.json
 - name: install node dependencies
-  shell: "{{ prospectus_nodeenv_bin }}/npm install --unsafe-perm=true --allow-root"
+  shell: "npm install --unsafe-perm=true --allow-root"
   args:
     chdir: "{{ prospectus_code_dir }}"
   environment: "{{ prospectus_env_vars }}"
@@ -156,9 +134,8 @@
     - install
     - install:app-requirements
 
-# Install with the shell command instead of the ansible npm module so we don't accidentally re-write package.json
 - name: run prospectus build
-  shell: "{{ prospectus_nodeenv_bin }}/npm run build"
+  shell: "npm run build"
   args:
     chdir: "{{ prospectus_code_dir }}"
   environment: "{{ prospectus_env_vars }}"


### PR DESCRIPTION
Configuration Pull Request
---

<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##
-->

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
