### PR TITLE
fix: Mongo script broken by deprecation warning

### DIFF
--- a/playbooks/roles/ad_hoc_reporting/templates/etc/mongorc.js.j2
+++ b/playbooks/roles/ad_hoc_reporting/templates/etc/mongorc.js.j2
@@ -1,5 +1,5 @@
 // we only ever connect to secondaries, avoid people needing to remember to type this
-rs.slaveOk();
+rs.secondaryOk();
 
 // This uses the DB name rather than the replica set, which I think is more useful
 var prompt = function() {


### PR DESCRIPTION
Mongo 4.2 prints a deprecation message to stdout which screws up our
mongo replica scripts. This fixes the setting that's been renamed to
get rid of the deprecation warning.

Mongo has changesd rs.slaveOk() to rs.secondaryOk()

Configuration Pull Request
---

<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##
-->

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
