### PR TITLE
Enforcing read committed isolation level for edxapp MySQL database

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -91,7 +91,14 @@ EDXAPP_MYSQL_USER_ADMIN: 'root'
 EDXAPP_MYSQL_PASSWORD: 'password'
 EDXAPP_MYSQL_PASSWORD_READ_ONLY: 'password'
 EDXAPP_MYSQL_PASSWORD_ADMIN: 'password'
-EDXAPP_MYSQL_OPTIONS: {}
+# From Django 2.0 the default isolation level used for the MySQL database backend is 'read commited'
+# (refer to https://github.com/django/django/pull/7978). However, this isolation level is enforced
+# from the Django database configuration options to prevent possible inconsistencies or malfunctions.
+# Changing the isolation level can lead to unexpected behaviors, so please proceed only if you
+# what you're doing. Refer to https://docs.djangoproject.com/en/2.2/ref/databases/#mysql-isolation-level
+# to get further information.
+EDXAPP_MYSQL_OPTIONS:
+  isolation_level: "read committed"
 EDXAPP_MYSQL_ATOMIC_REQUESTS: True
 EDXAPP_MYSQL_REPLICA_DB_NAME: "{{ EDXAPP_MYSQL_DB_NAME }}"
 EDXAPP_MYSQL_REPLICA_USER: "{{ EDXAPP_MYSQL_USER }}"


### PR DESCRIPTION
# Description

MySQL uses **Isolation Levels** to define how concurrent transactions must be handled (more details [here](https://dev.mysql.com/doc/refman/5.7/en/innodb-transaction-isolation-levels.html) ). This is the "I" part of the "ACID" acronym (atomicity, consistency, isolation, durability) which MySQL is compliant with. The default Isolation level in MySQL is "REPEATABLE READ", but it can be set to a different value per transaction.

In Django version prior to 2.0, transactions did not set an isolation level by default, so unless you changed the MySQL database [connection options](https://docs.djangoproject.com/en/2.2/ref/settings/#std:setting-OPTIONS), you would end up relying on the insolation level defined in MySQL. At some point, in edx-platform was necessary to force the "READ COMMITTED" isolation level in specific transactions to prevent data inconsistencies or malfunctions. This enforcement can be checked [here](https://github.com/edx/edx-platform/blob/6cb62f2697bcca1380854e139857678b2ddc35e0/common/djangoapps/util/db.py#L176-L179). 

From version 2.0 Django use the "READ COMMITTED" isolation level by [default](https://github.com/django/django/pull/7978) in the transactions handled by the MySQL backend (indeed this is the [recommended](https://docs.djangoproject.com/en/2.2/ref/databases/#mysql-isolation-level) isolation level to work with Django). In this order of ideas, it is no longer necessary to perform isolation level enforcements in the edx-platform code. This motivated the creation of the PR in https://github.com/edx/edx-platform/pull/28161 (it is ready to merge) which remove such enforcements.

This PR aims to complement the changes in edx-platform by adding a note in the edxapp configuration role explaining why "READ COMMITTED" is used and enforced, and what are the possible consequences of changing this configuration. This PR could affect installations where an isolation level other than "READ COMMITTED" is configured. However, I wonder if there are cases where this value is changed since the Django docs suggest, and indeed defaults to "READ COMMITTED". 



Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
