### PR TITLE
feat: update hermes role to use python3.8

### DIFF
--- a/playbooks/roles/hermes/tasks/main.yml
+++ b/playbooks/roles/hermes/tasks/main.yml
@@ -20,17 +20,8 @@
 #
 #
 
-# The deadsnakes PPA is required to install python3.6 on Xenial.
-# Bionic comes with python3.6 installed.
-- name: add deadsnakes repository
-  apt_repository:
-    repo: "ppa:fkrull/deadsnakes"
-  when: ansible_distribution_release == 'xenial'
-  tags:
-    - install
-    - install:system-requirements
-
-- name: install python3.6
+# Install python3.8 on Bionic.Focal comes with python3.8 installed.
+- name: install python3.8
   apt:
     name: "{{ item }}"
     update_cache: yes
@@ -39,15 +30,15 @@
   retries: 10
   delay: 5
   with_items:
-    - python3.6
+    - python3.8
     - python3-pip
-  when: ansible_distribution_release == 'xenial' or ansible_distribution_release == 'focal'
+  when: ansible_distribution_release == 'bionic'
   tags:
     - install
     - install:system-requirements
 
 - name: build virtualenv with python3
-  command: "virtualenv --python=/usr/bin/python3.6 {{ hermes_venv_dir }}"
+  command: "virtualenv --python=/usr/bin/python3.8 {{ hermes_venv_dir }}"
   args:
     creates: "{{ hermes_venv_dir }}/bin/pip"
   become_user: "{{ hermes_user }}"


### PR DESCRIPTION
Configuration Pull Request
---

<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##
-->

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
