### PR TITLE
feat: Studio uses oauth2 to login

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -228,10 +228,11 @@ EDXAPP_THIRD_PARTY_AUTH_BACKENDS:
   - common.djangoapps.third_party_auth.saml.SAMLAuthBackend
   - common.djangoapps.third_party_auth.lti.LTIAuthBackend
 
+EDXAPP_CMS_SERVICE_NAME: 'edxapp-cms'
 EDXAPP_CMS_SOCIAL_AUTH_EDX_OAUTH2_KEY: 'edxapp-cms-sso-key'
 EDXAPP_CMS_SOCIAL_AUTH_EDX_OAUTH2_SECRET: 'edxapp-cms-sso-secret'
-# EDXAPP_CMS_BACKEND_SERVICE_EDX_OAUTH2_KEY: 'edxapp-cms-backend-service-key'
-# EDXAPP_CMS_BACKEND_SERVICE_EDX_OAUTH2_SECRET: 'edxapp-cms-backend-service-secret'
+EDXAPP_CMS_BACKEND_SERVICE_EDX_OAUTH2_KEY: 'edxapp-cms-backend-service-key'
+EDXAPP_CMS_BACKEND_SERVICE_EDX_OAUTH2_SECRET: 'edxapp-cms-backend-service-secret'
 
 EDXAPP_ENABLE_MOBILE_REST_API: false
 

--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -228,6 +228,20 @@ EDXAPP_THIRD_PARTY_AUTH_BACKENDS:
   - common.djangoapps.third_party_auth.saml.SAMLAuthBackend
   - common.djangoapps.third_party_auth.lti.LTIAuthBackend
 
+
+
+EDXAPP_CMS_SOCIAL_AUTH_EDX_OAUTH2_KEY: 'edxapp-cms-sso-key'
+EDXAPP_CMS_SOCIAL_AUTH_EDX_OAUTH2_SECRET: 'edxapp-cms-sso-secret'
+EDXAPP_CMS_BACKEND_SERVICE_EDX_OAUTH2_KEY: 'edxapp-cms-backend-service-key'
+EDXAPP_CMS_BACKEND_SERVICE_EDX_OAUTH2_SECRET: 'edxapp-cms-backend-service-secret'
+EDXAPP_CMS_LOGOUT_URL: '{{ CMS_BASE }}/logout/'
+# EDXAPP_CMS_SERVICE_USER_NAME: TODO
+
+
+
+
+
+
 EDXAPP_ENABLE_MOBILE_REST_API: false
 
 EDXAPP_ENABLE_BULK_ENROLLMENT_VIEW: false

--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -946,6 +946,11 @@ DISCOVERY_SERVICE_USER_NAME: "discovery_worker"
 ECOMMERCE_SERVICE_USER_EMAIL: "ecommerce_worker@example.com"
 ECOMMERCE_SERVICE_USER_NAME: "ecommerce_worker"
 
+# Configuration needed for LMS to communicate with the Studio service
+EDXAPP_CMS_SERVICE_USER_EMAIL: "edxapp_cms_worker@example.com"
+EDXAPP_CMS_SERVICE_USER_NAME: "edxapp_cms_worker"
+
+
 # Configuration needed for LMS to communicate with the Credentials service
 CREDENTIALS_SERVICE_USER_EMAIL: "credentials_worker@example.com"
 CREDENTIALS_SERVICE_USER_NAME: "credentials_worker"
@@ -1783,6 +1788,10 @@ SERVICE_WORKER_USERS:
     is_superuser: false
   - email: "{{ REGISTRAR_SERVICE_USER_EMAIL }}"
     username: "{{ REGISTRAR_SERVICE_USER_NAME }}"
+    is_staff: true
+    is_superuser: false
+  - email: "{{ EDXAPP_CMS_SERVICE_USER_EMAIL }}"
+    username: "{{ EDXAPP_CMS_SERVICE_USER_NAME }}"
     is_staff: true
     is_superuser: false
   - email: "{{ LICENSE_MANAGER_SERVICE_USER_EMAIL }}"

--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -232,7 +232,6 @@ EDXAPP_CMS_SOCIAL_AUTH_EDX_OAUTH2_KEY: 'edxapp-cms-sso-key'
 EDXAPP_CMS_SOCIAL_AUTH_EDX_OAUTH2_SECRET: 'edxapp-cms-sso-secret'
 # EDXAPP_CMS_BACKEND_SERVICE_EDX_OAUTH2_KEY: 'edxapp-cms-backend-service-key'
 # EDXAPP_CMS_BACKEND_SERVICE_EDX_OAUTH2_SECRET: 'edxapp-cms-backend-service-secret'
-EDXAPP_CMS_LOGOUT_URL: '{{ CMS_BASE }}/logout/'
 
 EDXAPP_ENABLE_MOBILE_REST_API: false
 

--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -228,19 +228,11 @@ EDXAPP_THIRD_PARTY_AUTH_BACKENDS:
   - common.djangoapps.third_party_auth.saml.SAMLAuthBackend
   - common.djangoapps.third_party_auth.lti.LTIAuthBackend
 
-
-
 EDXAPP_CMS_SOCIAL_AUTH_EDX_OAUTH2_KEY: 'edxapp-cms-sso-key'
 EDXAPP_CMS_SOCIAL_AUTH_EDX_OAUTH2_SECRET: 'edxapp-cms-sso-secret'
 EDXAPP_CMS_BACKEND_SERVICE_EDX_OAUTH2_KEY: 'edxapp-cms-backend-service-key'
 EDXAPP_CMS_BACKEND_SERVICE_EDX_OAUTH2_SECRET: 'edxapp-cms-backend-service-secret'
 EDXAPP_CMS_LOGOUT_URL: '{{ CMS_BASE }}/logout/'
-# EDXAPP_CMS_SERVICE_USER_NAME: TODO
-
-
-
-
-
 
 EDXAPP_ENABLE_MOBILE_REST_API: false
 

--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -230,8 +230,8 @@ EDXAPP_THIRD_PARTY_AUTH_BACKENDS:
 
 EDXAPP_CMS_SOCIAL_AUTH_EDX_OAUTH2_KEY: 'edxapp-cms-sso-key'
 EDXAPP_CMS_SOCIAL_AUTH_EDX_OAUTH2_SECRET: 'edxapp-cms-sso-secret'
-EDXAPP_CMS_BACKEND_SERVICE_EDX_OAUTH2_KEY: 'edxapp-cms-backend-service-key'
-EDXAPP_CMS_BACKEND_SERVICE_EDX_OAUTH2_SECRET: 'edxapp-cms-backend-service-secret'
+# EDXAPP_CMS_BACKEND_SERVICE_EDX_OAUTH2_KEY: 'edxapp-cms-backend-service-key'
+# EDXAPP_CMS_BACKEND_SERVICE_EDX_OAUTH2_SECRET: 'edxapp-cms-backend-service-secret'
 EDXAPP_CMS_LOGOUT_URL: '{{ CMS_BASE }}/logout/'
 
 EDXAPP_ENABLE_MOBILE_REST_API: false

--- a/playbooks/roles/edxapp/tasks/service_variant_config.yml
+++ b/playbooks/roles/edxapp/tasks/service_variant_config.yml
@@ -20,7 +20,7 @@
 - name: combined lms auth env for yml
   set_fact:
     lms_combined_config: '{{lms_env_config|combine(lms_auth_config)}}'
-  no_log: true
+  no_log: "{{ COMMON_CONFIG_NO_LOGGING }}"
   when: '"lms" in service_variants_enabled and not EDXAPP_DECRYPT_CONFIG_ENABLED'
   tags:
     - install
@@ -37,7 +37,7 @@
     group: "{{ common_web_group }}"
     mode: 0640
   become: true
-  no_log: true
+  no_log: "{{ COMMON_CONFIG_NO_LOGGING }}"
   with_items: "{{ service_variants_enabled }}"
   when: '"lms" in service_variants_enabled and not EDXAPP_DECRYPT_CONFIG_ENABLED'
   tags:
@@ -50,7 +50,7 @@
 - name: combined cms auth env for yml
   set_fact:
     cms_combined_config: '{{cms_env_config|combine(cms_auth_config)}}'
-  no_log: true
+  no_log: "{{ COMMON_CONFIG_NO_LOGGING }}"
   when: '"cms" in service_variants_enabled and not EDXAPP_DECRYPT_CONFIG_ENABLED'
   tags:
     - install
@@ -67,7 +67,7 @@
     group: "{{ common_web_group }}"
     mode: 0640
   become: true
-  no_log: true
+  no_log: "{{ COMMON_CONFIG_NO_LOGGING }}"
   with_items: "{{ service_variants_enabled }}"
   when: '"cms" in service_variants_enabled and not EDXAPP_DECRYPT_CONFIG_ENABLED'
   tags:
@@ -82,7 +82,7 @@
   become: false
   with_items: "{{ service_variants_enabled }}"
   when: '"lms" in service_variants_enabled and EDXAPP_DECRYPT_CONFIG_ENABLED'
-  no_log: true
+  no_log: "{{ COMMON_CONFIG_NO_LOGGING }}"
   tags:
     - install
     - install:configuration
@@ -95,7 +95,7 @@
   become: false
   with_items: "{{ service_variants_enabled }}"
   when: '"cms" in service_variants_enabled and EDXAPP_DECRYPT_CONFIG_ENABLED'
-  no_log: true
+  no_log: "{{ COMMON_CONFIG_NO_LOGGING }}"
   tags:
     - install
     - install:configuration
@@ -109,7 +109,7 @@
     replace: "{{ COMMON_DEPLOY_HOSTNAME }}"
   with_items: ['lms','studio']
   when: EDXAPP_DECRYPT_CONFIG_ENABLED and SANDBOX_CONFIG
-  no_log: true
+  no_log: "{{ COMMON_CONFIG_NO_LOGGING }}"
   become: false
   delegate_to: localhost
   tags:
@@ -126,7 +126,7 @@
     group: "{{ common_web_group }}"
     mode: 0640
   become: true
-  no_log: true
+  no_log: "{{ COMMON_CONFIG_NO_LOGGING }}"
   with_items: "{{ service_variants_enabled }}"
   when: '"lms" in service_variants_enabled and EDXAPP_COPY_CONFIG_ENABLED'
   tags:
@@ -143,7 +143,7 @@
     group: "{{ common_web_group }}"
     mode: 0640
   become: true
-  no_log: true
+  no_log: "{{ COMMON_CONFIG_NO_LOGGING }}"
   with_items: "{{ service_variants_enabled }}"
   when: '"cms" in service_variants_enabled and EDXAPP_COPY_CONFIG_ENABLED'
   tags:
@@ -160,7 +160,7 @@
     group: "{{ common_web_group }}"
     mode: 0640
   become: true
-  no_log: true
+  no_log: "{{ COMMON_CONFIG_NO_LOGGING }}"
   tags:
     - install
     - install:configuration

--- a/playbooks/roles/edxapp/tasks/service_variant_config.yml
+++ b/playbooks/roles/edxapp/tasks/service_variant_config.yml
@@ -20,7 +20,7 @@
 - name: combined lms auth env for yml
   set_fact:
     lms_combined_config: '{{lms_env_config|combine(lms_auth_config)}}'
-  no_log: "{{ COMMON_CONFIG_NO_LOGGING }}"
+  no_log: true
   when: '"lms" in service_variants_enabled and not EDXAPP_DECRYPT_CONFIG_ENABLED'
   tags:
     - install
@@ -37,7 +37,7 @@
     group: "{{ common_web_group }}"
     mode: 0640
   become: true
-  no_log: "{{ COMMON_CONFIG_NO_LOGGING }}"
+  no_log: true
   with_items: "{{ service_variants_enabled }}"
   when: '"lms" in service_variants_enabled and not EDXAPP_DECRYPT_CONFIG_ENABLED'
   tags:
@@ -50,7 +50,7 @@
 - name: combined cms auth env for yml
   set_fact:
     cms_combined_config: '{{cms_env_config|combine(cms_auth_config)}}'
-  no_log: "{{ COMMON_CONFIG_NO_LOGGING }}"
+  no_log: true
   when: '"cms" in service_variants_enabled and not EDXAPP_DECRYPT_CONFIG_ENABLED'
   tags:
     - install
@@ -67,7 +67,7 @@
     group: "{{ common_web_group }}"
     mode: 0640
   become: true
-  no_log: "{{ COMMON_CONFIG_NO_LOGGING }}"
+  no_log: true
   with_items: "{{ service_variants_enabled }}"
   when: '"cms" in service_variants_enabled and not EDXAPP_DECRYPT_CONFIG_ENABLED'
   tags:
@@ -82,7 +82,7 @@
   become: false
   with_items: "{{ service_variants_enabled }}"
   when: '"lms" in service_variants_enabled and EDXAPP_DECRYPT_CONFIG_ENABLED'
-  no_log: "{{ COMMON_CONFIG_NO_LOGGING }}"
+  no_log: true
   tags:
     - install
     - install:configuration
@@ -95,7 +95,7 @@
   become: false
   with_items: "{{ service_variants_enabled }}"
   when: '"cms" in service_variants_enabled and EDXAPP_DECRYPT_CONFIG_ENABLED'
-  no_log: "{{ COMMON_CONFIG_NO_LOGGING }}"
+  no_log: true
   tags:
     - install
     - install:configuration
@@ -109,7 +109,7 @@
     replace: "{{ COMMON_DEPLOY_HOSTNAME }}"
   with_items: ['lms','studio']
   when: EDXAPP_DECRYPT_CONFIG_ENABLED and SANDBOX_CONFIG
-  no_log: "{{ COMMON_CONFIG_NO_LOGGING }}"
+  no_log: true
   become: false
   delegate_to: localhost
   tags:
@@ -126,7 +126,7 @@
     group: "{{ common_web_group }}"
     mode: 0640
   become: true
-  no_log: "{{ COMMON_CONFIG_NO_LOGGING }}"
+  no_log: true
   with_items: "{{ service_variants_enabled }}"
   when: '"lms" in service_variants_enabled and EDXAPP_COPY_CONFIG_ENABLED'
   tags:
@@ -143,7 +143,7 @@
     group: "{{ common_web_group }}"
     mode: 0640
   become: true
-  no_log: "{{ COMMON_CONFIG_NO_LOGGING }}"
+  no_log: true
   with_items: "{{ service_variants_enabled }}"
   when: '"cms" in service_variants_enabled and EDXAPP_COPY_CONFIG_ENABLED'
   tags:
@@ -160,7 +160,7 @@
     group: "{{ common_web_group }}"
     mode: 0640
   become: true
-  no_log: "{{ COMMON_CONFIG_NO_LOGGING }}"
+  no_log: true
   tags:
     - install
     - install:configuration

--- a/playbooks/roles/oauth_client_setup/defaults/main.yml
+++ b/playbooks/roles/oauth_client_setup/defaults/main.yml
@@ -30,7 +30,7 @@ oauth_client_setup_oauth2_clients:
       }
     - {
         name: "{{ EDXAPP_CMS_SERVICE_NAME | default('None') }}",
-        url_root: "{{ EDXAPP_CMS_BASE | default('None') }}",
+        url_root: "{{ EDXAPP_CMS_URL_ROOT | default('None') }}",
         sso_id: "{{ EDXAPP_CMS_SOCIAL_AUTH_EDX_OAUTH2_KEY | default('None') }}",
         sso_secret: "{{ EDXAPP_CMS_SOCIAL_AUTH_EDX_OAUTH2_SECRET | default('None') }}",
         backend_service_id: "{{ EDXAPP_CMS_BACKEND_SERVICE_EDX_OAUTH2_KEY | default('None') }}",

--- a/playbooks/roles/oauth_client_setup/defaults/main.yml
+++ b/playbooks/roles/oauth_client_setup/defaults/main.yml
@@ -29,7 +29,7 @@ oauth_client_setup_oauth2_clients:
         username: "{{ ECOMMERCE_SERVICE_USER_NAME | default('None') }}",
       }
     - {
-        name: "{{ edxapp_cms_service_name | default('None') }}",
+        name: "{{ EDXAPP_CMS_SERVICE_NAME | default('None') }}",
         url_root: "{{ EDXAPP_CMS_URL_ROOT | default('None') }}",
         sso_id: "{{ EDXAPP_CMS_SOCIAL_AUTH_EDX_OAUTH2_KEY | default('None') }}",
         sso_secret: "{{ EDXAPP_CMS_SOCIAL_AUTH_EDX_OAUTH2_SECRET | default('None') }}",

--- a/playbooks/roles/oauth_client_setup/defaults/main.yml
+++ b/playbooks/roles/oauth_client_setup/defaults/main.yml
@@ -29,6 +29,16 @@ oauth_client_setup_oauth2_clients:
         username: "{{ ECOMMERCE_SERVICE_USER_NAME | default('None') }}",
       }
     - {
+        name: "{{ edxapp_cms_service_name | default('None') }}",
+        url_root: "{{ EDXAPP_CMS_URL_ROOT | default('None') }}",
+        sso_id: "{{ EDXAPP_CMS_SOCIAL_AUTH_EDX_OAUTH2_KEY | default('None') }}",
+        sso_secret: "{{ EDXAPP_CMS_SOCIAL_AUTH_EDX_OAUTH2_SECRET | default('None') }}",
+        backend_service_id: "{{ EDXAPP_CMS_BACKEND_SERVICE_EDX_OAUTH2_KEY | default('None') }}",
+        backend_service_secret: "{{ EDXAPP_CMS_BACKEND_SERVICE_EDX_OAUTH2_SECRET | default('None') }}",
+        logout_uri: "{{ EDXAPP_CMS_LOGOUT_URL | default('None') }}",
+        username: "{{ EDXAPP_CMS_SERVICE_USER_NAME | default('None') }}",
+      }
+    - {
         name: "{{ INSIGHTS_OAUTH2_APP_CLIENT_NAME | default('None') }}",
         url_root: "{{ INSIGHTS_BASE_URL | default('None') }}",
         id: "{{ INSIGHTS_OAUTH2_KEY | default('None') }}",

--- a/playbooks/roles/oauth_client_setup/defaults/main.yml
+++ b/playbooks/roles/oauth_client_setup/defaults/main.yml
@@ -30,7 +30,7 @@ oauth_client_setup_oauth2_clients:
       }
     - {
         name: "{{ EDXAPP_CMS_SERVICE_NAME | default('None') }}",
-        url_root: "{{ EDXAPP_CMS_URL_ROOT | default('None') }}",
+        url_root: "{{ EDXAPP_CMS_BASE | default('None') }}",
         sso_id: "{{ EDXAPP_CMS_SOCIAL_AUTH_EDX_OAUTH2_KEY | default('None') }}",
         sso_secret: "{{ EDXAPP_CMS_SOCIAL_AUTH_EDX_OAUTH2_SECRET | default('None') }}",
         backend_service_id: "{{ EDXAPP_CMS_BACKEND_SERVICE_EDX_OAUTH2_KEY | default('None') }}",

--- a/util/jenkins/ansible-provision.sh
+++ b/util/jenkins/ansible-provision.sh
@@ -396,6 +396,7 @@ if [[ $edx_internal == "true" ]]; then
 EDXAPP_PREVIEW_LMS_BASE: preview-${deploy_host}
 EDXAPP_LMS_BASE: ${deploy_host}
 EDXAPP_CMS_BASE: studio-${deploy_host}
+EDXAPP_CMS_URL_ROOT: "https://{{ EDXAPP_CMS_BASE }}"
 EDXAPP_SITE_NAME: ${deploy_host}
 edx_internal: True
 COMMON_USER_INFO:


### PR DESCRIPTION
Settings to enable oauth2 login through lms for studio in sandbox.

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
