### PR TITLE
[FAL-2409] fix: RETIREMENT_SERVICE_VERSION should match release

### DIFF
--- a/playbooks/roles/user_retirement_pipeline/defaults/main.yml
+++ b/playbooks/roles/user_retirement_pipeline/defaults/main.yml
@@ -31,7 +31,7 @@ retirement_service_pip_version: "19.0.3"
 retirement_service_environment:
   PATH: '{{ retirement_service_venv_dir }}/bin:{{ ansible_env.PATH }}'
 
-RETIREMENT_SERVICE_VERSION: "master"
+RETIREMENT_SERVICE_VERSION: "open-release/lilac.master"
 
 # Set up git repos
 RETIREMENT_SERVICE_GIT_IDENTITY: !!null


### PR DESCRIPTION
This PR is updating default version of https://github.com/edx/tubular for Lilac release.

Related pull request: https://github.com/edx/tubular/pull/531