### PR TITLE
fix: update script exit status with gpg STDERR

### DIFF
--- a/util/create_data_czar/create_data_czar.py
+++ b/util/create_data_czar/create_data_czar.py
@@ -1,6 +1,7 @@
 import boto3
 import argparse
 import gnupg
+import sys
 
 # Assumes you have GPG already installed
 # Assumes that the Data Czars already have your public key
@@ -52,3 +53,6 @@ gpgfile.write(encrypted_string)
 print('ok: ', encrypted_data.ok)
 print('status: ', encrypted_data.status)
 print('stderr: ', encrypted_data.stderr)
+
+if encrypted_data.stderr:
+    sys.exit(1)


### PR DESCRIPTION
The create_data_czar script was failing  ( https://tools-edx-jenkins.edx.org/job/Data%20Czar/job/create-data-czar/12/console ) as GPG was not able to read the recipient and encrypt secret but the job was still running with success. This fix will change the status of the build failed if GPG returns with errors.