### PR TITLE
fix: It was removed accidentally. Adding it back to installed django.txt file packages

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -1715,6 +1715,7 @@ sandbox_base_requirements:  "{{ edxapp_code_dir }}/requirements/edx-sandbox/{% i
 edxapp_requirements_files:
   - "{{ custom_requirements_file }}"
   - "{{ base_requirements_file }}"
+  - "{{ django_requirements_file }}"
 
 # All edxapp requirements files potentially containing Github URLs.  When using a custom
 # Github mirror, occurrences of "github.com" are replaced by the custom mirror in these


### PR DESCRIPTION
 It was removed accidentally. Adding it back to run django.txt related packages.

For more context check this [PR](https://github.com/edx/edx-platform/pull/28750)

https://openedx.atlassian.net/browse/BOM-2752