### PR TITLE
fix: sandbox termination date reporting via message of the day

### DIFF
--- a/playbooks/roles/edx-sandbox/tasks/main.yml
+++ b/playbooks/roles/edx-sandbox/tasks/main.yml
@@ -25,7 +25,7 @@
 - name: update the termination date and time as motd
   template:
     dest: "/etc/update-motd.d/999-terminate-sandbox"
-    src: "etc/update-motd.d/temiate_motd.j2"
+    src: "etc/update-motd.d/terminate_motd.j2"
     mode: 0755
     owner: root
     group: root

--- a/playbooks/roles/edx-sandbox/templates/etc/update-motd.d/terminate_motd.j2
+++ b/playbooks/roles/edx-sandbox/templates/etc/update-motd.d/terminate_motd.j2
@@ -10,7 +10,7 @@ instance_id = get_instance_metadata()['instance-id']
 reservations = ec2.get_all_instances(instance_ids=[instance_id])
 instance = reservations[0].instances[0]
 
-if instance.tags.has_key('instance_termination_time'):
+if 'instance_termination_time' in instance.tags:
     terminate_time = datetime.strptime(str(instance.tags['instance_termination_time']), "%m-%d-%Y %H:%M:%S")
 else:
     terminate_time = datetime.strptime(instance.launch_time, "%Y-%m-%dT%H:%M:%S.%fZ") + timedelta(days=7)


### PR DESCRIPTION
i.e. the message that gets spit out when you ssh in to such a sandbox
appears to've been broken by the 20.04 upgrade which moved system
python into 3.whatever

[JIRA:EDUCATOR-5913](https://openedx.atlassian.net/browse/EDUCATOR-5913)

Configuration Pull Request
---

<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##
-->

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
