### PR TITLE
Make nginx listen on both the IPv4 and IPv6 wildcard addresses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 All notable changes to this project will be documented in this file.
 Add any new changes to the top (right below this line).
 
+ - 2021-09-28
+    - Role nginx
+      - Add `NGINX_ENABLE_IPV6` configuration variable to make nginx
+        services listen on the IPv6 wildcard address (in addition to
+        the IPv4 one, where services always listen). Defaults to true.
+
  - 2021-09-19
     - Remove configuration for edx-certificates, as that repo and service are no longer used.
 

--- a/playbooks/roles/nginx/defaults/main.yml
+++ b/playbooks/roles/nginx/defaults/main.yml
@@ -36,6 +36,8 @@ PROSPECTUS_PREVIEW_NGINX_USERS:
     password: "{{ PROSPECTUS_PREVIEW_HTPASSWD_PASS }}"
     state: present
 
+NGINX_ENABLE_IPV6: True
+
 NGINX_ENABLE_SSL: False
 NGINX_REDIRECT_TO_HTTPS: False
 # Disable handling IP disclosure for private IP addresses. This is needed by ELB to run the health checks while using `NGINX_ENABLE_SSL`.

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/analytics_api.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/analytics_api.j2
@@ -6,6 +6,9 @@ upstream analytics_api_app_server {
 
 server {
   listen {{ ANALYTICS_API_NGINX_PORT }} default_server;
+  {% if NGINX_ENABLE_IPV6 %}
+  listen [::]:{{ ANALYTICS_API_NGINX_PORT }} default_server;
+  {% endif %}
 
   # Nginx does not support nested condition or or conditions so
   # there is an unfortunate mix of conditonals here.

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/cms.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/cms.j2
@@ -54,10 +54,16 @@ error_page {{ k }} {{ v }};
 {% include "empty_json.j2" %}
 
   listen {{ EDXAPP_CMS_NGINX_PORT }} {{ default_site }};
+  {% if NGINX_ENABLE_IPV6 %}
+  listen [::]:{{ EDXAPP_CMS_NGINX_PORT }} {{ default_site }};
+  {% endif %}
 
   {% if NGINX_ENABLE_SSL %}
 
   listen {{ EDXAPP_CMS_SSL_NGINX_PORT }} ssl;
+  {% if NGINX_ENABLE_IPV6 %}
+  listen [::]:{{ EDXAPP_CMS_SSL_NGINX_PORT }} ssl;
+  {% endif %}
 
   ssl_certificate /etc/ssl/certs/{{ NGINX_SSL_CERTIFICATE|basename }};
   ssl_certificate_key /etc/ssl/private/{{ NGINX_SSL_KEY|basename }};

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/conductor.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/conductor.j2
@@ -26,6 +26,9 @@ server {
   {% endif %}
 
   listen {{ CONDUCTOR_NGINX_PORT }} {{ default_site }};
+  {% if NGINX_ENABLE_IPV6 %}
+  listen [::]:{{ CONDUCTOR_NGINX_PORT }} {{ default_site }};
+  {% endif %}
 
   # Redirects using the client port instead of the port the service is running
   # on. This prevents redirects to the local 8000 port.

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/edx_notes_api.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/edx_notes_api.j2
@@ -12,10 +12,16 @@ upstream {{ edx_notes_api_service_name }}_app_server {
 
 server {
   listen {{ edx_notes_api_nginx_port }} {{ default_site }};
+  {% if NGINX_ENABLE_IPV6 %}
+  listen [::]:{{ edx_notes_api_nginx_port }} {{ default_site }};
+  {% endif %}
 
   {% if NGINX_ENABLE_SSL %}
 
   listen {{ edx_notes_api_ssl_nginx_port }} ssl;
+  {% if NGINX_ENABLE_IPV6 %}
+  listen [::]:{{ edx_notes_api_ssl_nginx_port }} ssl;
+  {% endif %}
 
   ssl_certificate /etc/ssl/certs/{{ NGINX_SSL_CERTIFICATE|basename }};
   ssl_certificate_key /etc/ssl/private/{{ NGINX_SSL_KEY|basename }};

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/forum.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/forum.j2
@@ -33,6 +33,9 @@ server {
 
   server_name forum.*;
   listen {{ FORUM_NGINX_PORT }} {{ default_site }};
+  {% if NGINX_ENABLE_IPV6 %}
+  listen [::]:{{ FORUM_NGINX_PORT }} {{ default_site }};
+  {% endif %}
   client_max_body_size {{ NGINX_FORUM_CLIENT_MAX_BODY_SIZE }};
   proxy_read_timeout {{ NGINX_FORUM_PROXY_READ_TIMEOUT }};
   keepalive_timeout 5;

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/gh_mirror.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/gh_mirror.j2
@@ -1,5 +1,8 @@
 server {
     listen       {{ gh_mirror_nginx_port }};
+    {% if NGINX_ENABLE_IPV6 %}
+    listen [::]:      {{ gh_mirror_nginx_port }};
+    {% endif %}
     server_name  {{ gh_mirror_server_name }};
     location ~ (/.*) {
         root {{ gh_mirror_data_dir }};

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/gitreload.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/gitreload.j2
@@ -6,6 +6,9 @@ upstream gitreload_app_server {
 
 server {
   listen {{ GITRELOAD_NGINX_PORT }} default_server;
+  {% if NGINX_ENABLE_IPV6 %}
+  listen [::]:{{ GITRELOAD_NGINX_PORT }} default_server;
+  {% endif %}
 
   location / {
      auth_basic            "Restricted";

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/grafana.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/grafana.j2
@@ -15,6 +15,9 @@ upstream grafana_app_server {
 server {
   server_name grafana.*;
   listen {{ GRAFANA_NGINX_PORT }} {{ default_site }};
+  {% if NGINX_ENABLE_IPV6 %}
+  listen [::]:{{ GRAFANA_NGINX_PORT }} {{ default_site }};
+  {% endif %}
   client_max_body_size 1M;
   keepalive_timeout 5;
 

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/graphite.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/graphite.j2
@@ -22,6 +22,9 @@ upstream graphite_app_server {
 server {
   server_name graphite.*;
   listen {{ GRAPHITE_NGINX_PORT }} {{ default_site }};
+  {% if NGINX_ENABLE_IPV6 %}
+  listen [::]:{{ GRAPHITE_NGINX_PORT }} {{ default_site }};
+  {% endif %}
   client_max_body_size 1M;
   keepalive_timeout 5;
 

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/insights.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/insights.j2
@@ -19,9 +19,15 @@ map $http_origin $cors_origin {
 
 server {
   listen {{ INSIGHTS_NGINX_PORT }} default_server;
+  {% if NGINX_ENABLE_IPV6 %}
+  listen [::]:{{ INSIGHTS_NGINX_PORT }} default_server;
+  {% endif %}
 
   {% if NGINX_ENABLE_SSL %}
   listen {{ INSIGHTS_NGINX_SSL_PORT }} ssl;
+  {% if NGINX_ENABLE_IPV6 %}
+  listen [::]:{{ INSIGHTS_NGINX_SSL_PORT }} ssl;
+  {% endif %}
 
   {% include "common-settings.j2" %}
 

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/jenkins.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/jenkins.j2
@@ -1,5 +1,8 @@
 server {
   listen {{ jenkins_nginx_port }};
+  {% if NGINX_ENABLE_IPV6 %}
+  listen [::]:{{ jenkins_nginx_port }};
+  {% endif %}
   server_name {{ jenkins_server_name }};
 
   location / {

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/kibana.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/kibana.j2
@@ -14,13 +14,22 @@ server {
   {% if NGINX_ENABLE_SSL %}
 
   listen {{ KIBANA_NGINX_PORT }} {{ default_site }};
+  {% if NGINX_ENABLE_IPV6 %}
+  listen [::]:{{ KIBANA_NGINX_PORT }} {{ default_site }};
+  {% endif %}
   listen {{ KIBANA_SSL_NGINX_PORT }} {{ default_site }} ssl;
+  {% if NGINX_ENABLE_IPV6 %}
+  listen [::]:{{ KIBANA_SSL_NGINX_PORT }} {{ default_site }} ssl;
+  {% endif %}
 
   ssl_certificate /etc/ssl/certs/{{ NGINX_SSL_CERTIFICATE|basename }};
   ssl_certificate_key /etc/ssl/private/{{ NGINX_SSL_KEY|basename }};
 
   {% else %}
   listen {{ KIBANA_NGINX_PORT }} {{ default_site }};
+  {% if NGINX_ENABLE_IPV6 %}
+  listen [::]:{{ KIBANA_NGINX_PORT }} {{ default_site }};
+  {% endif %}
   {% endif %}
   
   {% include "handle-tls-redirect-and-ip-disclosure.j2" %}

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/learner_portal.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/learner_portal.j2
@@ -6,6 +6,9 @@
 
 server {
   listen {{ LEARNER_PORTAL_NGINX_PORT }} {{ default_site }};
+  {% if NGINX_ENABLE_IPV6 %}
+  listen [::]:{{ LEARNER_PORTAL_NGINX_PORT }} {{ default_site }};
+  {% endif %}
   server_name ~^((stage|prod)-)?learner-portal.*;
   location / {
     root /edx/app/learner_portal/learner_portal/dist;
@@ -15,6 +18,9 @@ server {
 
 server {
   listen {{ LEARNER_PORTAL_SSL_NGINX_PORT }} ssl;
+  {% if NGINX_ENABLE_IPV6 %}
+  listen [::]:{{ LEARNER_PORTAL_SSL_NGINX_PORT }} ssl;
+  {% endif %}
   server_name ~^((stage|prod)-)?learner-portal.*;
   ssl_certificate /etc/ssl/certs/wildcard.sandbox.edx.org.pem;
   ssl_certificate_key /etc/ssl/private/wildcard.sandbox.edx.org.key;

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
@@ -87,9 +87,15 @@ error_page {{ k }} {{ v }};
 {% include "empty_json.j2" %}
 
   listen {{ EDXAPP_LMS_NGINX_PORT }} {{ default_site }};
+  {% if NGINX_ENABLE_IPV6 %}
+  listen [::]:{{ EDXAPP_LMS_NGINX_PORT }} {{ default_site }};
+  {% endif %}
 
   {% if NGINX_ENABLE_SSL %}
   listen {{ EDXAPP_LMS_SSL_NGINX_PORT }} {{ default_site }} ssl;
+  {% if NGINX_ENABLE_IPV6 %}
+  listen [::]:{{ EDXAPP_LMS_SSL_NGINX_PORT }} {{ default_site }} ssl;
+  {% endif %}
 
   ssl_certificate /etc/ssl/certs/{{ NGINX_SSL_CERTIFICATE|basename }};
   ssl_certificate_key /etc/ssl/private/{{ NGINX_SSL_KEY|basename }};

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/nginx_redirect.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/nginx_redirect.j2
@@ -6,9 +6,15 @@
 
 server {
   listen {{ REDIRECT_NGINX_PORT }} {{ default_site }};
+  {% if NGINX_ENABLE_IPV6 %}
+  listen [::]:{{ REDIRECT_NGINX_PORT }} {{ default_site }};
+  {% endif %}
 
   {% if "ssl" in item.value and item.value['ssl'] == true -%}
   listen {{ REDIRECT_SSL_NGINX_PORT }} {{ default_site }} ssl;
+  {% if NGINX_ENABLE_IPV6 %}
+  listen [::]:{{ REDIRECT_SSL_NGINX_PORT }} {{ default_site }} ssl;
+  {% endif %}
   ssl_certificate /etc/ssl/certs/{{ NGINX_SSL_CERTIFICATE|basename }};
   ssl_certificate_key /etc/ssl/private/{{ NGINX_SSL_KEY|basename }};
   {% endif -%}

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/program_console.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/program_console.j2
@@ -6,6 +6,9 @@
 
 server {
   listen {{ PROGRAM_CONSOLE_NGINX_PORT }} {{ default_site }};
+  {% if NGINX_ENABLE_IPV6 %}
+  listen [::]:{{ PROGRAM_CONSOLE_NGINX_PORT }} {{ default_site }};
+  {% endif %}
   server_name ~^((stage|prod)-)?program-console.*;
 
   {% include "handle-tls-redirect-and-ip-disclosure.j2" %}
@@ -18,6 +21,9 @@ server {
 
 server {
   listen {{ PROGRAM_CONSOLE_SSL_NGINX_PORT }} ssl;
+  {% if NGINX_ENABLE_IPV6 %}
+  listen [::]:{{ PROGRAM_CONSOLE_SSL_NGINX_PORT }} ssl;
+  {% endif %}
   server_name ~^((stage|prod)-)?program-console.*;
   ssl_certificate /etc/ssl/certs/wildcard.sandbox.edx.org.pem;
   ssl_certificate_key /etc/ssl/private/wildcard.sandbox.edx.org.key;

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/prospectus.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/prospectus.j2
@@ -14,6 +14,9 @@ server {
   {% if NGINX_ENABLE_SSL %}
 
   listen {{ prospectus_ssl_nginx_port }} ssl;
+  {% if NGINX_ENABLE_IPV6 %}
+  listen [::]:{{ prospectus_ssl_nginx_port }} ssl;
+  {% endif %}
 
   ssl_certificate /etc/ssl/certs/{{ NGINX_SSL_CERTIFICATE|basename }};
   ssl_certificate_key /etc/ssl/private/{{ NGINX_SSL_KEY|basename }};
@@ -30,6 +33,9 @@ server {
   {% endif %}
 
   listen {{ PROSPECTUS_NGINX_PORT }} {{ default_site }};
+  {% if NGINX_ENABLE_IPV6 %}
+  listen [::]:{{ PROSPECTUS_NGINX_PORT }} {{ default_site }};
+  {% endif %}
 
   root {{ PROSPECTUS_DATA_DIR }};
 

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/xqueue.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/xqueue.j2
@@ -6,9 +6,15 @@ upstream xqueue_app_server {
 
 server {
   listen {{ XQUEUE_NGINX_PORT }} default_server;
+  {% if NGINX_ENABLE_IPV6 %}
+  listen [::]:{{ XQUEUE_NGINX_PORT }} default_server;
+  {% endif %}
 
   {% if NGINX_ENABLE_SSL %}
   listen {{ XQUEUE_NGINX_SSL_PORT }} ssl;
+  {% if NGINX_ENABLE_IPV6 %}
+  listen [::]:{{ XQUEUE_NGINX_SSL_PORT }} ssl;
+  {% endif %}
 
   {% include "common-settings.j2" %}
 


### PR DESCRIPTION
The nginx role always assumes that Open edX services listen on the wildcard address (we can only ever configure ports, not listen addresses). However, if nginx is configured with a `listen` directive that contains just a port number, it will listen only on the IPv4 wildcard address, `0.0.0.0`.

For IPv6-enabled hosts, that means that Open edX services will not be accessible through the system's IPv6 address or AAAA hostname.

Add a variable, `NGINX_ENABLE_IPV6`, and set its default to `True`. Conditionally add a `listen` directive for the IPv6 wildcard address, `[::]`.

There is a shorthand available for this, which is to use only a `listen` directive for the IPv6 wildcard and then the `ipv6only=off` option. We cannot use that here because that doesn't work with multiple vhosts, causing nginx to quit with:

```
nginx: [emerg] duplicate listen options for [::]:80 in /etc/nginx/sites-enabled/lms:40
nginx: configuration file /etc/nginx/nginx.conf test failed
```

So, instead inject the additional `listen` directive specifically for the IPv6 wildcard address.

See also:
* https://nginx.org/en/docs/http/ngx_http_core_module.html#listen
* https://serverfault.com/questions/638367/do-you-need-separate-ipv4-and-ipv6-listen-directives-in-nginx