### PR TITLE
Optionally allow nginx to listen on both the IPv4 and IPv6 wildcard addresses (Lilac backport)

### DIFF
--- a/playbooks/roles/nginx/defaults/main.yml
+++ b/playbooks/roles/nginx/defaults/main.yml
@@ -36,6 +36,8 @@ PROSPECTUS_PREVIEW_NGINX_USERS:
     password: "{{ PROSPECTUS_PREVIEW_HTPASSWD_PASS }}"
     state: present
 
+NGINX_ENABLE_IPV6: False
+
 NGINX_ENABLE_SSL: False
 NGINX_REDIRECT_TO_HTTPS: False
 # Disable handling IP disclosure for private IP addresses. This is needed by ELB to run the health checks while using `NGINX_ENABLE_SSL`.

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/analytics_api.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/analytics_api.j2
@@ -6,6 +6,9 @@ upstream analytics_api_app_server {
 
 server {
   listen {{ ANALYTICS_API_NGINX_PORT }} default_server;
+  {% if NGINX_ENABLE_IPV6 %}
+  listen [::]:{{ ANALYTICS_API_NGINX_PORT }} default_server;
+  {% endif %}
 
   # Nginx does not support nested condition or or conditions so
   # there is an unfortunate mix of conditonals here.

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/certs.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/certs.j2
@@ -1,5 +1,8 @@
 server {
   listen {{ CERTS_NGINX_PORT }} default_server;
+  {% if NGINX_ENABLE_IPV6 %}
+  listen [::]:{{ CERTS_NGINX_PORT }} default_server;
+  {% endif %}
 
   location / {
     root {{ CERTS_WEB_ROOT }};

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/cms.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/cms.j2
@@ -54,10 +54,16 @@ error_page {{ k }} {{ v }};
 {% include "empty_json.j2" %}
 
   listen {{ EDXAPP_CMS_NGINX_PORT }} {{ default_site }};
+  {% if NGINX_ENABLE_IPV6 %}
+  listen [::]:{{ EDXAPP_CMS_NGINX_PORT }} {{ default_site }};
+  {% endif %}
 
   {% if NGINX_ENABLE_SSL %}
 
   listen {{ EDXAPP_CMS_SSL_NGINX_PORT }} ssl;
+  {% if NGINX_ENABLE_IPV6 %}
+  listen [::]:{{ EDXAPP_CMS_SSL_NGINX_PORT }} ssl;
+  {% endif %}
 
   ssl_certificate /etc/ssl/certs/{{ NGINX_SSL_CERTIFICATE|basename }};
   ssl_certificate_key /etc/ssl/private/{{ NGINX_SSL_KEY|basename }};

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/conductor.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/conductor.j2
@@ -26,6 +26,9 @@ server {
   {% endif %}
 
   listen {{ CONDUCTOR_NGINX_PORT }} {{ default_site }};
+  {% if NGINX_ENABLE_IPV6 %}
+  listen [::]:{{ CONDUCTOR_NGINX_PORT }} {{ default_site }};
+  {% endif %}
 
   # Redirects using the client port instead of the port the service is running
   # on. This prevents redirects to the local 8000 port.

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/edx_notes_api.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/edx_notes_api.j2
@@ -12,10 +12,16 @@ upstream {{ edx_notes_api_service_name }}_app_server {
 
 server {
   listen {{ edx_notes_api_nginx_port }} {{ default_site }};
+  {% if NGINX_ENABLE_IPV6 %}
+  listen [::]:{{ edx_notes_api_nginx_port }} {{ default_site }};
+  {% endif %}
 
   {% if NGINX_ENABLE_SSL %}
 
   listen {{ edx_notes_api_ssl_nginx_port }} ssl;
+  {% if NGINX_ENABLE_IPV6 %}
+  listen [::]:{{ edx_notes_api_ssl_nginx_port }} ssl;
+  {% endif %}
 
   ssl_certificate /etc/ssl/certs/{{ NGINX_SSL_CERTIFICATE|basename }};
   ssl_certificate_key /etc/ssl/private/{{ NGINX_SSL_KEY|basename }};

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/forum.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/forum.j2
@@ -33,6 +33,9 @@ server {
 
   server_name forum.*;
   listen {{ FORUM_NGINX_PORT }} {{ default_site }};
+  {% if NGINX_ENABLE_IPV6 %}
+  listen [::]:{{ FORUM_NGINX_PORT }} {{ default_site }};
+  {% endif %}
   client_max_body_size {{ NGINX_FORUM_CLIENT_MAX_BODY_SIZE }};
   proxy_read_timeout {{ NGINX_FORUM_PROXY_READ_TIMEOUT }};
   keepalive_timeout 5;

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/gh_mirror.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/gh_mirror.j2
@@ -1,5 +1,8 @@
 server {
     listen       {{ gh_mirror_nginx_port }};
+    {% if NGINX_ENABLE_IPV6 %}
+    listen [::]:      {{ gh_mirror_nginx_port }};
+    {% endif %}
     server_name  {{ gh_mirror_server_name }};
     location ~ (/.*) {
         root {{ gh_mirror_data_dir }};

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/gitreload.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/gitreload.j2
@@ -6,6 +6,9 @@ upstream gitreload_app_server {
 
 server {
   listen {{ GITRELOAD_NGINX_PORT }} default_server;
+  {% if NGINX_ENABLE_IPV6 %}
+  listen [::]:{{ GITRELOAD_NGINX_PORT }} default_server;
+  {% endif %}
 
   location / {
      auth_basic            "Restricted";

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/grafana.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/grafana.j2
@@ -15,6 +15,9 @@ upstream grafana_app_server {
 server {
   server_name grafana.*;
   listen {{ GRAFANA_NGINX_PORT }} {{ default_site }};
+  {% if NGINX_ENABLE_IPV6 %}
+  listen [::]:{{ GRAFANA_NGINX_PORT }} {{ default_site }};
+  {% endif %}
   client_max_body_size 1M;
   keepalive_timeout 5;
 

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/graphite.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/graphite.j2
@@ -22,6 +22,9 @@ upstream graphite_app_server {
 server {
   server_name graphite.*;
   listen {{ GRAPHITE_NGINX_PORT }} {{ default_site }};
+  {% if NGINX_ENABLE_IPV6 %}
+  listen [::]:{{ GRAPHITE_NGINX_PORT }} {{ default_site }};
+  {% endif %}
   client_max_body_size 1M;
   keepalive_timeout 5;
 

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/insights.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/insights.j2
@@ -19,9 +19,15 @@ map $http_origin $cors_origin {
 
 server {
   listen {{ INSIGHTS_NGINX_PORT }} default_server;
+  {% if NGINX_ENABLE_IPV6 %}
+  listen [::]:{{ INSIGHTS_NGINX_PORT }} default_server;
+  {% endif %}
 
   {% if NGINX_ENABLE_SSL %}
   listen {{ INSIGHTS_NGINX_SSL_PORT }} ssl;
+  {% if NGINX_ENABLE_IPV6 %}
+  listen [::]:{{ INSIGHTS_NGINX_SSL_PORT }} ssl;
+  {% endif %}
 
   {% include "common-settings.j2" %}
 

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/jenkins.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/jenkins.j2
@@ -1,5 +1,8 @@
 server {
   listen {{ jenkins_nginx_port }};
+  {% if NGINX_ENABLE_IPV6 %}
+  listen [::]:{{ jenkins_nginx_port }};
+  {% endif %}
   server_name {{ jenkins_server_name }};
 
   location / {

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/kibana.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/kibana.j2
@@ -14,13 +14,22 @@ server {
   {% if NGINX_ENABLE_SSL %}
 
   listen {{ KIBANA_NGINX_PORT }} {{ default_site }};
+  {% if NGINX_ENABLE_IPV6 %}
+  listen [::]:{{ KIBANA_NGINX_PORT }} {{ default_site }};
+  {% endif %}
   listen {{ KIBANA_SSL_NGINX_PORT }} {{ default_site }} ssl;
+  {% if NGINX_ENABLE_IPV6 %}
+  listen [::]:{{ KIBANA_SSL_NGINX_PORT }} {{ default_site }} ssl;
+  {% endif %}
 
   ssl_certificate /etc/ssl/certs/{{ NGINX_SSL_CERTIFICATE|basename }};
   ssl_certificate_key /etc/ssl/private/{{ NGINX_SSL_KEY|basename }};
 
   {% else %}
   listen {{ KIBANA_NGINX_PORT }} {{ default_site }};
+  {% if NGINX_ENABLE_IPV6 %}
+  listen [::]:{{ KIBANA_NGINX_PORT }} {{ default_site }};
+  {% endif %}
   {% endif %}
   
   {% include "handle-tls-redirect-and-ip-disclosure.j2" %}

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/learner_portal.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/learner_portal.j2
@@ -6,6 +6,9 @@
 
 server {
   listen {{ LEARNER_PORTAL_NGINX_PORT }} {{ default_site }};
+  {% if NGINX_ENABLE_IPV6 %}
+  listen [::]:{{ LEARNER_PORTAL_NGINX_PORT }} {{ default_site }};
+  {% endif %}
   server_name ~^((stage|prod)-)?learner-portal.*;
   location / {
     root /edx/app/learner_portal/learner_portal/dist;
@@ -15,6 +18,9 @@ server {
 
 server {
   listen {{ LEARNER_PORTAL_SSL_NGINX_PORT }} ssl;
+  {% if NGINX_ENABLE_IPV6 %}
+  listen [::]:{{ LEARNER_PORTAL_SSL_NGINX_PORT }} ssl;
+  {% endif %}
   server_name ~^((stage|prod)-)?learner-portal.*;
   ssl_certificate /etc/ssl/certs/wildcard.sandbox.edx.org.pem;
   ssl_certificate_key /etc/ssl/private/wildcard.sandbox.edx.org.key;

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/license_manager.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/license_manager.j2
@@ -4,10 +4,16 @@ upstream {{ license_manager_service_name }}_app_server {
 
 server {
   listen {{ license_manager_nginx_port }};
+  {% if NGINX_ENABLE_IPV6 %}
+  listen [::]:{{ license_manager_nginx_port }};
+  {% endif %}
 
   {% if NGINX_ENABLE_SSL %}
 
   listen {{ license_manager_ssl_nginx_port }} ssl;
+  {% if NGINX_ENABLE_IPV6 %}
+  listen [::]:{{ license_manager_ssl_nginx_port }} ssl;
+  {% endif %}
 
   ssl_certificate /etc/ssl/certs/{{ NGINX_SSL_CERTIFICATE|basename }};
   ssl_certificate_key /etc/ssl/private/{{ NGINX_SSL_KEY|basename }};

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
@@ -87,9 +87,15 @@ error_page {{ k }} {{ v }};
 {% include "empty_json.j2" %}
 
   listen {{ EDXAPP_LMS_NGINX_PORT }} {{ default_site }};
+  {% if NGINX_ENABLE_IPV6 %}
+  listen [::]:{{ EDXAPP_LMS_NGINX_PORT }} {{ default_site }};
+  {% endif %}
 
   {% if NGINX_ENABLE_SSL %}
   listen {{ EDXAPP_LMS_SSL_NGINX_PORT }} {{ default_site }} ssl;
+  {% if NGINX_ENABLE_IPV6 %}
+  listen [::]:{{ EDXAPP_LMS_SSL_NGINX_PORT }} {{ default_site }} ssl;
+  {% endif %}
 
   ssl_certificate /etc/ssl/certs/{{ NGINX_SSL_CERTIFICATE|basename }};
   ssl_certificate_key /etc/ssl/private/{{ NGINX_SSL_KEY|basename }};

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/nginx_redirect.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/nginx_redirect.j2
@@ -6,9 +6,15 @@
 
 server {
   listen {{ REDIRECT_NGINX_PORT }} {{ default_site }};
+  {% if NGINX_ENABLE_IPV6 %}
+  listen [::]:{{ REDIRECT_NGINX_PORT }} {{ default_site }};
+  {% endif %}
 
   {% if "ssl" in item.value and item.value['ssl'] == true -%}
   listen {{ REDIRECT_SSL_NGINX_PORT }} {{ default_site }} ssl;
+  {% if NGINX_ENABLE_IPV6 %}
+  listen [::]:{{ REDIRECT_SSL_NGINX_PORT }} {{ default_site }} ssl;
+  {% endif %}
   ssl_certificate /etc/ssl/certs/{{ NGINX_SSL_CERTIFICATE|basename }};
   ssl_certificate_key /etc/ssl/private/{{ NGINX_SSL_KEY|basename }};
   {% endif -%}

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/program_console.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/program_console.j2
@@ -6,6 +6,9 @@
 
 server {
   listen {{ PROGRAM_CONSOLE_NGINX_PORT }} {{ default_site }};
+  {% if NGINX_ENABLE_IPV6 %}
+  listen [::]:{{ PROGRAM_CONSOLE_NGINX_PORT }} {{ default_site }};
+  {% endif %}
   server_name ~^((stage|prod)-)?program-console.*;
 
   {% include "handle-tls-redirect-and-ip-disclosure.j2" %}
@@ -18,6 +21,9 @@ server {
 
 server {
   listen {{ PROGRAM_CONSOLE_SSL_NGINX_PORT }} ssl;
+  {% if NGINX_ENABLE_IPV6 %}
+  listen [::]:{{ PROGRAM_CONSOLE_SSL_NGINX_PORT }} ssl;
+  {% endif %}
   server_name ~^((stage|prod)-)?program-console.*;
   ssl_certificate /etc/ssl/certs/wildcard.sandbox.edx.org.pem;
   ssl_certificate_key /etc/ssl/private/wildcard.sandbox.edx.org.key;

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/prospectus.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/prospectus.j2
@@ -14,6 +14,9 @@ server {
   {% if NGINX_ENABLE_SSL %}
 
   listen {{ prospectus_ssl_nginx_port }} ssl;
+  {% if NGINX_ENABLE_IPV6 %}
+  listen [::]:{{ prospectus_ssl_nginx_port }} ssl;
+  {% endif %}
 
   ssl_certificate /etc/ssl/certs/{{ NGINX_SSL_CERTIFICATE|basename }};
   ssl_certificate_key /etc/ssl/private/{{ NGINX_SSL_KEY|basename }};
@@ -30,6 +33,9 @@ server {
   {% endif %}
 
   listen {{ PROSPECTUS_NGINX_PORT }} {{ default_site }};
+  {% if NGINX_ENABLE_IPV6 %}
+  listen [::]:{{ PROSPECTUS_NGINX_PORT }} {{ default_site }};
+  {% endif %}
 
   root {{ PROSPECTUS_DATA_DIR }};
 

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/xqueue.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/xqueue.j2
@@ -6,9 +6,15 @@ upstream xqueue_app_server {
 
 server {
   listen {{ XQUEUE_NGINX_PORT }} default_server;
+  {% if NGINX_ENABLE_IPV6 %}
+  listen [::]:{{ XQUEUE_NGINX_PORT }} default_server;
+  {% endif %}
 
   {% if NGINX_ENABLE_SSL %}
   listen {{ XQUEUE_NGINX_SSL_PORT }} ssl;
+  {% if NGINX_ENABLE_IPV6 %}
+  listen [::]:{{ XQUEUE_NGINX_SSL_PORT }} ssl;
+  {% endif %}
 
   {% include "common-settings.j2" %}
 


### PR DESCRIPTION
This is the companion PR to #6557, with the following differences to the original change:

* The `NGINX_ENABLE_IPV6` variable default is set to `False`.
* The `certs.j2` and `license_manager.j2` templates are included (these templates are still present in `open-release/lilac.master` but have been removed from `master`).