### PR TITLE
fix: remove programtypes created by disco migrations

### DIFF
--- a/playbooks/roles/discovery/defaults/main.yml
+++ b/playbooks/roles/discovery/defaults/main.yml
@@ -189,6 +189,8 @@ discovery_service_config_overrides:
 # See edx_django_service_automated_users for an example of what this should be
 DISCOVERY_AUTOMATED_USERS: {}
 
+DISCOVERY_POST_MIGRATE_COMMANDS: []
+
 DISCOVERY_CSRF_COOKIE_SECURE: false
 DISCOVERY_CORS_ORIGIN_WHITELIST: []
 

--- a/playbooks/roles/discovery/meta/main.yml
+++ b/playbooks/roles/discovery/meta/main.yml
@@ -49,6 +49,7 @@ dependencies:
     edx_django_service_session_expire_at_browser_close: '{{ DISCOVERY_SESSION_EXPIRE_AT_BROWSER_CLOSE }}'
     edx_django_service_node_version: '{{ DISCOVERY_NODE_VERSION }}'
     edx_django_service_automated_users: '{{ DISCOVERY_AUTOMATED_USERS }}'
+    edx_django_service_post_migrate_commands: '{{ DISCOVERY_POST_MIGRATE_COMMANDS }}'
     edx_django_service_enable_newrelic_distributed_tracing: '{{ DISCOVERY_ENABLE_NEWRELIC_DISTRIBUTED_TRACING }}'
     edx_django_service_decrypt_config_enabled: '{{ DISCOVERY_DECRYPT_CONFIG_ENABLED }}'
     edx_django_service_copy_config_enabled: '{{ DISCOVERY_COPY_CONFIG_ENABLED }}'

--- a/util/jenkins/ansible-provision.sh
+++ b/util/jenkins/ansible-provision.sh
@@ -543,8 +543,11 @@ video_pipeline_integration=${video_pipeline:-false}
 # ansible overrides for master's integration environment setup
 if [[ $registrar == "true" ]]; then
     cat << EOF >> $extra_vars_file
-COMMON_ENABLE_SPLUNKFORWARDER: true,
-EDXAPP_ENABLE_ENROLLMENT_RESET: true,
+COMMON_ENABLE_SPLUNKFORWARDER: true
+EDXAPP_ENABLE_ENROLLMENT_RESET: true
+DISCOVERY_POST_MIGRATE_COMMANDS:
+  - command: "./manage.py remove_program_types_from_migrations"
+    when: true
 EOF
 fi
 


### PR DESCRIPTION
this is done on the creation of a sandbox because these
migration-created program types will end up conflicting with the ones
we load via fixtures from production data. We want to load these via
only one method, since it simplifies each piece of the puzzle.

relies on https://github.com/edx/course-discovery/pull/3150

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
