### PR TITLE
added edx-event-routing-backends in PRIVATE_REQUIREMENTS

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -583,6 +583,8 @@ EDXAPP_PRIVATE_REQUIREMENTS:
     # "Pathways" learning context plugin for the LabXchange project
     - name: git+https://github.com/open-craft/lx-pathway-plugin.git@337abf249b7c5ecc1e78a44d2e639e1ab65f2085#egg=lx-pathway-plugin
       extra_args: -e
+    # Caliper and xAPI event routing plugin
+    - name: edx-event-routing-backends==4.1.1
 
 # List of custom middlewares that should be used in edxapp to process
 # incoming HTTP resquests. Should be a list of plain strings that fully


### PR DESCRIPTION
edx-event-routing-backends library transforms edX events according to caliper and xAPI specifications and route them to specifies LRS.