### PR TITLE
Adding JSON log format for Nginx logs

### DIFF
--- a/playbooks/roles/nginx/templates/etc/nginx/nginx.conf.j2
+++ b/playbooks/roles/nginx/templates/etc/nginx/nginx.conf.j2
@@ -51,6 +51,45 @@ http {
                                'request_time=$request_time request_id=$request_id upstream_response_time=$upstream_response_time '
                                'upstream_connect_time=$upstream_connect_time upstream_header_time=$upstream_header_time';
 
+        log_format json_analytics escape=json '{'
+                   '"msec": "$msec", ' # request unixtime in seconds with a milliseconds resolution
+                   '"connection": "$connection", ' # connection serial number
+                   '"connection_requests": "$connection_requests", ' # number of requests made in connection
+                   '"pid": "$pid", ' # process pid
+                   '"request_id": "$request_id", ' # the unique request id
+                   '"request_length": "$request_length", ' # request length (including headers and body)
+                   '"remote_addr": "$remote_addr", ' # client IP
+                   '"remote_user": "$remote_user", ' # client HTTP username
+                   '"remote_port": "$remote_port", ' # client port
+                   '"time_local": "$time_local", '
+                   '"time_iso8601": "$time_iso8601", ' # local time in the ISO 8601 standard format
+                   '"request": "$request", ' # full path no arguments of the request
+                   '"request_uri": "$request_uri", ' # full path and arguments of the request
+                   '"args": "$args", ' # args
+                   '"status": "$status", ' # response status code
+                   '"body_bytes_sent": "$body_bytes_sent", ' # the number of body bytes exclude headers sent to a client
+                   '"bytes_sent": "$bytes_sent", ' # the number of bytes sent to a client
+                   '"http_referer": "$http_referer", ' # HTTP referer
+                   '"http_user_agent": "$http_user_agent", ' # user agent
+                   '"http_x_forwarded_for": "$http_x_forwarded_for", ' # http_x_forwarded_for
+                   '"http_host": "$http_host", ' # the request Host: header
+                   '"server_name": "$server_name", ' # the name of the vhost serving the request
+                   '"request_time": "$request_time", ' # request processing time in seconds with msec resolution
+                   '"upstream": "$upstream_addr", ' # upstream backend server for proxied requests
+                   '"upstream_connect_time": "$upstream_connect_time", ' # upstream handshake time incl. TLS
+                   '"upstream_header_time": "$upstream_header_time", ' # time spent receiving upstream headers
+                   '"upstream_response_time": "$upstream_response_time", ' # time spent receiving upstream body
+                   '"upstream_response_length": "$upstream_response_length", ' # upstream response length
+                   '"upstream_cache_status": "$upstream_cache_status", ' # cache HIT/MISS where applicable
+                   '"ssl_protocol": "$ssl_protocol", ' # TLS protocol
+                   '"ssl_cipher": "$ssl_cipher", ' # TLS cipher
+                   '"scheme": "$scheme", ' # http or https
+                   '"request_method": "$request_method", ' # request method
+                   '"server_protocol": "$server_protocol", ' # request protocol, like HTTP/1.1 or HTTP/2.0
+                   '"pipe": "$pipe", ' # "p" if request was pipelined, "." otherwise
+                   '"gzip_ratio": "$gzip_ratio"'
+                   '}';
+
         access_log {{ nginx_log_dir }}/access.log {{ NGINX_LOG_FORMAT_NAME }};
         error_log {{ nginx_log_dir }}/error.log;
 
@@ -85,4 +124,3 @@ http {
         include {{ nginx_conf_dir }}/*.conf;
         include {{ nginx_sites_enabled_dir }}/*;
 }
-


### PR DESCRIPTION
In order to simplify log processing it is useful to have a JSON format for the Nginx logs. This adds a detailed set of information about each Nginx request that can be used to generate a rich set of answers about usage and performance of HTTP traffic.

Configuration Pull Request
---

<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##
-->

Make sure that the following steps are done before merging:

  - [ ] A DevOps team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a DEVOPS ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
