### PR TITLE
perf: speed up designer runbooks by not installing py3 pre 3.8

### DIFF
--- a/playbooks/roles/designer/meta/main.yml
+++ b/playbooks/roles/designer/meta/main.yml
@@ -13,6 +13,7 @@
 dependencies:
   - role: edx_django_service
     edx_django_service_use_python38: '{{ DESIGNER_USE_PYTHON38 }}'
+    edx_django_service_use_python3: '{{ not DESIGNER_USE_PYTHON38 }}'
     edx_django_service_version: '{{ DESIGNER_VERSION }}'
     edx_django_service_name: '{{ designer_service_name }}'
     edx_django_service_config_overrides: '{{ designer_service_config_overrides }}'


### PR DESCRIPTION
If this works ok we may want to do https://github.com/edx/configuration/pull/6577

Configuration Pull Request
---

<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##
-->

Make sure that the following steps are done before merging:

  - [ ] A SRE team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a SRE ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
