### PR TITLE
build: fail builds which attempt to install multiple versions of py

### DIFF
--- a/playbooks/roles/analytics_api/meta/main.yml
+++ b/playbooks/roles/analytics_api/meta/main.yml
@@ -22,6 +22,7 @@
 dependencies:
   - role: edx_django_service
     edx_django_service_use_python38: '{{ ANALYTICS_API_USE_PYTHON38 }}'
+    edx_django_service_use_python3: '{{ not ANALYTICS_API_USE_PYTHON38 }}'
     edx_django_service_repos: '{{ ANALYTICS_API_REPOS }}'
     edx_django_service_name: '{{ analytics_api_service_name }}'
     edx_django_service_user: '{{ analytics_api_user }}'

--- a/playbooks/roles/blockstore/meta/main.yml
+++ b/playbooks/roles/blockstore/meta/main.yml
@@ -9,6 +9,7 @@
 dependencies:
   - role: edx_django_service
     edx_django_service_use_python38: "{{ BLOCKSTORE_USE_PYTHON38 }}"
+    edx_django_service_use_python3: "{{ not BLOCKSTORE_USE_PYTHON38 }}"
     edx_django_service_name: '{{ blockstore_service_name }}'
     edx_django_service_user: '{{ blockstore_user }}'
     edx_django_service_home: '{{ COMMON_APP_DIR }}/{{ blockstore_service_name }}'

--- a/playbooks/roles/credentials/meta/main.yml
+++ b/playbooks/roles/credentials/meta/main.yml
@@ -13,6 +13,7 @@
 dependencies:
   - role: edx_django_service
     edx_django_service_use_python38: true
+    edx_django_service_use_python3: false
     edx_django_service_version: '{{ CREDENTIALS_VERSION }}'
     edx_django_service_name: '{{ credentials_service_name }}'
     edx_django_service_config_overrides: '{{ credentials_service_config_overrides }}'

--- a/playbooks/roles/discovery/meta/main.yml
+++ b/playbooks/roles/discovery/meta/main.yml
@@ -21,6 +21,7 @@
 dependencies:
   - role: edx_django_service
     edx_django_service_use_python38: '{{ DISCOVERY_USE_PYTHON38 }}'
+    edx_django_service_use_python3: '{{ not DISCOVERY_USE_PYTHON38 }}'
     edx_django_service_repos: '{{ DISCOVERY_REPOS }}'
     edx_django_service_name: '{{ discovery_service_name }}'
     edx_django_service_user: '{{ discovery_user }}'

--- a/playbooks/roles/ecommerce/meta/main.yml
+++ b/playbooks/roles/ecommerce/meta/main.yml
@@ -33,6 +33,7 @@ dependencies:
     edx_django_service_nginx_port: '{{ ECOMMERCE_NGINX_PORT }}'
     edx_django_service_ssl_nginx_port: '{{ ECOMMERCE_SSL_NGINX_PORT }}'
     edx_django_service_use_python38: '{{ ECOMMERCE_USE_PYTHON38 }}'
+    edx_django_service_use_python3: '{{ not ECOMMERCE_USE_PYTHON38 }}'
     edx_django_service_language_code: '{{ ECOMMERCE_LANGUAGE_CODE }}'
     edx_django_service_secret_key: '{{ ECOMMERCE_SECRET_KEY }}'
     edx_django_service_memcache: '{{ ECOMMERCE_MEMCACHE }}'

--- a/playbooks/roles/edx_django_service/tasks/main.yml
+++ b/playbooks/roles/edx_django_service/tasks/main.yml
@@ -61,6 +61,10 @@
     - install
     - install:configuration
 
+- name: check python version to install and fail if parameters make no sense
+  command: /bin/true
+  failed_when: edx_django_service_use_python38 and edx_django_service_use_python3
+
 - name: install python3.8
   apt:
     pkg:

--- a/playbooks/roles/enterprise_catalog/meta/main.yml
+++ b/playbooks/roles/enterprise_catalog/meta/main.yml
@@ -13,6 +13,7 @@
 dependencies:
   - role: edx_django_service
     edx_django_service_use_python38: '{{ ENTERPRISE_CATALOG_USE_PYTHON38 }}'
+    edx_django_service_use_python3: '{{ not ENTERPRISE_CATALOG_USE_PYTHON38 }}'
     edx_django_service_enable_experimental_docker_shim: '{{ ENTERPRISE_CATALOG_ENABLE_EXPERIMENTAL_DOCKER_SHIM }}'
     edx_django_service_version: '{{ ENTERPRISE_CATALOG_VERSION }}'
     edx_django_service_name: '{{ enterprise_catalog_service_name }}'

--- a/playbooks/roles/license_manager/meta/main.yml
+++ b/playbooks/roles/license_manager/meta/main.yml
@@ -13,6 +13,7 @@
 dependencies:
   - role: edx_django_service
     edx_django_service_use_python38: '{{ LICENSE_MANAGER_USE_PYTHON38 }}'
+    edx_django_service_use_python3: '{{ not LICENSE_MANAGER_USE_PYTHON38 }}'
     edx_django_service_version: '{{ LICENSE_MANAGER_VERSION }}'
     edx_django_service_name: '{{ license_manager_service_name }}'
     edx_django_service_home: '{{ COMMON_APP_DIR }}/{{ license_manager_service_name }}'

--- a/playbooks/roles/registrar/meta/main.yml
+++ b/playbooks/roles/registrar/meta/main.yml
@@ -13,6 +13,7 @@
 dependencies:
   - role: edx_django_service
     edx_django_service_use_python38: '{{ REGISTRAR_USE_PYTHON38 }}'
+    edx_django_service_use_python3: '{{ not REGISTRAR_USE_PYTHON38 }}'
     edx_django_service_version: '{{ REGISTRAR_VERSION }}'
     edx_django_service_name: '{{ registrar_service_name }}'
     edx_django_service_home: '{{ COMMON_APP_DIR }}/{{ registrar_service_name }}'


### PR DESCRIPTION
It doesn't make sense and erodes confidence that these services will
work without python 3 prior to 3.8 installed

Configuration Pull Request
---

<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##
-->

Make sure that the following steps are done before merging:

  - [ ] A SRE team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a SRE ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
