### PR TITLE
fix: Warnings due to duplicate registers on tasks

### DIFF
--- a/playbooks/roles/newrelic_infrastructure/tasks/main.yml
+++ b/playbooks/roles/newrelic_infrastructure/tasks/main.yml
@@ -41,8 +41,8 @@
   when: ansible_distribution == 'Ubuntu'
   retries: 10
   delay: 10
-  register: result
-  until: result is succeeded
+  register: nr_apt_key
+  until: nr_apt_key is succeeded
 
 # For focal, use the bionic repo for now.
 - name: Install apt repository for New Relic Infrastructure if neither bionic nor focal
@@ -85,8 +85,6 @@
   when: ansible_distribution == 'Ubuntu' and ansible_distribution_release == 'focal'
   retries: 10
   delay: 10
-  register: result
-  until: result is succeeded
   register: nr_apt_repo_focal
   until: nr_apt_repo_focal is succeeded
 
@@ -118,8 +116,6 @@
   when: ansible_distribution == 'Amazon'
   retries: 10
   delay: 10
-  register: result
-  until: result is succeeded
   register: nr_yum_repo
   until: nr_yum_repo is succeeded
 
@@ -135,8 +131,6 @@
   when: ansible_distribution == 'Amazon'
   retries: 10
   delay: 10
-  register: result
-  until: result is succeeded
   register: nr_yum_pkg
   until: nr_yum_pkg is succeeded
 


### PR DESCRIPTION
Configuration Pull Request
---

<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##
-->

Make sure that the following steps are done before merging:

  - [ ] A SRE team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a SRE ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
