### PR TITLE
style: separate parameter controlling integration env. sandbox build

### DIFF
--- a/util/jenkins/ansible-provision.sh
+++ b/util/jenkins/ansible-provision.sh
@@ -541,7 +541,7 @@ veda_encode_worker=${video_encode_worker:-false}
 video_pipeline_integration=${video_pipeline:-false}
 
 # ansible overrides for master's integration environment setup
-if [[ $registrar == "true" ]]; then
+if [[ $masters_integration_environment == "true" ]]; then
     cat << EOF >> $extra_vars_file
 COMMON_ENABLE_SPLUNKFORWARDER: true
 EDXAPP_ENABLE_ENROLLMENT_RESET: true
@@ -609,7 +609,7 @@ fi
 run_ansible set_hostname.yml -i "${deploy_host}," -e hostname_fqdn=${deploy_host} --user ubuntu
 
 # master's integration environment setup
-if [[ $registrar == "true" ]]; then
+if [[ $masters_integration_environment == "true" ]]; then
   # vars specific to master's integration environment
   cat << EOF >> $extra_vars_file
 username: $registrar_user_email


### PR DESCRIPTION
JIRA:EDUCATOR-5920

Configuration Pull Request
---

<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##
-->

Make sure that the following steps are done before merging:

  - [ ] A SRE team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a SRE ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
