### PR TITLE
BOM-2894: Remove sandbox python35 requirements path

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -1710,7 +1710,7 @@ base_requirements_file:   "{{ edxapp_code_dir }}/requirements/edx/base.txt"
 django_requirements_file:   "{{ edxapp_code_dir }}/requirements/edx/django.txt"
 openstack_requirements_file: "{{ edxapp_code_dir }}/requirements/edx/openstack.txt"
 
-sandbox_base_requirements:  "{{ edxapp_code_dir }}/requirements/edx-sandbox/{% if edxapp_sandbox_python_version == 'python3.5' %}py35.txt{% else %}py38.txt{% endif %}"
+sandbox_base_requirements:  "{{ edxapp_code_dir }}/requirements/edx-sandbox/py38.txt"
 
 # The Python requirements files in the order they should be installed.  This order should
 # match the order of PYTHON_REQ_FILES in edx-platform/pavelib/prereqs.py.


### PR DESCRIPTION
**Issue:** [BOM-2894](https://openedx.atlassian.net/browse/BOM-2894)

### Description
- After sandbox & codejail upgrade to `Python 3.8`, we don't need `Python 3.5` requirements check anymore so removing the unnecessary check.