### PR TITLE
chore: enable systemd boot-start splunkforwarder (PSRE-1104)

### DIFF
--- a/playbooks/roles/splunkforwarder/tasks/main.yml
+++ b/playbooks/roles/splunkforwarder/tasks/main.yml
@@ -69,7 +69,7 @@
   when: download_rpm.changed or download_deb.changed
 
 - name: Create boot script
-  shell: "{{ splunkforwarder_output_dir }}/bin/splunk enable boot-start -systemd-unit-file-name SplunkForwarder.service -user splunk --accept-license --answer-yes --no-prompt"
+  shell: "{{ splunkforwarder_output_dir }}/bin/splunk enable boot-start -systemd-managed 1 -user splunk --accept-license --answer-yes --no-prompt"
   args:
     creates: /etc/systemd/system/SplunkForwarder.service
   register: create_boot_script


### PR DESCRIPTION
Configuration Pull Request
---

<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##
-->

Make sure that the following steps are done before merging:

  - [ ] A SRE team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a SRE ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
