### PR TITLE
feat: Add IPv6 support to MFE's (Lilac backport)

### DIFF
--- a/playbooks/roles/mfe/templates/edx/app/nginx/sites-available/app.j2
+++ b/playbooks/roles/mfe/templates/edx/app/nginx/sites-available/app.j2
@@ -5,6 +5,9 @@
 server {
   server_name {{ MFE_HOSTNAME }};
   listen {{ MFE_NGINX_PORT }};
+  {% if NGINX_ENABLE_IPV6 %}
+  listen [::]:{{ MFE_NGINX_PORT }};
+  {% endif %}
 
   # Increase accepted header size to account for overenthusiastic usage of cookies
   large_client_header_buffers 8 16k;
@@ -29,6 +32,9 @@ server {
 server {
   server_name {{ MFE_HOSTNAME }};
   listen {{ MFE_SSL_NGINX_PORT }} ssl;
+  {% if NGINX_ENABLE_IPV6 %}
+  listen [::]:{{ MFE_SSL_NGINX_PORT }} ssl;
+  {% endif %}
   ssl_certificate /etc/ssl/certs/{{ NGINX_SSL_CERTIFICATE|basename }};
   ssl_certificate_key /etc/ssl/private/{{ NGINX_SSL_KEY|basename }};
   add_header Strict-Transport-Security "max-age=31536000; includeSubDomains";

--- a/playbooks/roles/mfe_deployer/templates/edx/app/nginx/sites-available/app.j2
+++ b/playbooks/roles/mfe_deployer/templates/edx/app/nginx/sites-available/app.j2
@@ -5,6 +5,9 @@
 server {
   server_name {{ MFE_DEPLOY_COMMON_HOSTNAME }};
   listen {{ MFE_DEPLOY_NGINX_PORT }};
+  {% if NGINX_ENABLE_IPV6 %}
+  listen [::]:{{ MFE_DEPLOY_NGINX_PORT }};
+  {% endif %}
 
 {% if NGINX_ENABLE_SSL %}
   {% include "concerns/handle-ip-disclosure.j2" %}
@@ -24,6 +27,9 @@ server {
 server {
   server_name {{ MFE_DEPLOY_COMMON_HOSTNAME }};
   listen {{ MFE_DEPLOY_SSL_NGINX_PORT }} ssl;
+  {% if NGINX_ENABLE_IPV6 %}
+  listen [::]:{{ MFE_DEPLOY_SSL_NGINX_PORT }} ssl;
+  {% endif %}
   ssl_certificate /etc/ssl/certs/{{ NGINX_SSL_CERTIFICATE|basename }};
   ssl_certificate_key /etc/ssl/private/{{ NGINX_SSL_KEY|basename }};
   add_header Strict-Transport-Security "max-age=31536000; includeSubDomains";


### PR DESCRIPTION
This is a follow-up change to https://github.com/edx/configuration/pull/6557 which added an option to make
nginx listen on both, IPv4 and IPv6 wildcard addresses.

This change adds that option for MFE's as well.