### PR TITLE
fix: ensure that neo4j auto-starts when coursegraph boots

### DIFF
--- a/playbooks/roles/neo4j/tasks/main.yml
+++ b/playbooks/roles/neo4j/tasks/main.yml
@@ -199,6 +199,7 @@
   service:
     name: neo4j
     state: restarted
+    enabled: yes
   tags:
     - manage
     - manage:start


### PR DESCRIPTION
A freshly built and run CourseGraph box will start
the Neo4j application. However, after rebooting the box, Neo4j
needed to be explicitly started again.

This 'enables' the Neo4j service, which means that
it'll now auto-start whenever CourseGraph is booted up.
