### PR TITLE
chore: Bump AMI creation timeout from 60 to 90 minutes.

### DIFF
--- a/playbooks/continuous_delivery/create_ami.yml
+++ b/playbooks/continuous_delivery/create_ami.yml
@@ -37,7 +37,7 @@
   vars:
     ec2_region: us-east-1
     ami_wait: yes
-    ami_creation_timeout: 3600
+    ami_creation_timeout: 5400
     no_reboot: no
     artifact_path: /tmp/ansible-runtime
     extra_name_identifier: 0


### PR DESCRIPTION
Private edX Ticket: https://openedx.atlassian.net/browse/WS-2351

TL;DR We ran into an issue where https://gocd.tools.edx.org/go/tab/build/detail/stage-prospectus/1389/cut_amis/1/stage_edx took more than an hour to build, this change will bump the timeout to 90 minutes.  We hope to speed up the build later.

 

Make sure that the following steps are done before merging:

  - [ ] A SRE team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a SRE ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
