### PR TITLE
chore: Upgrade build-name-setter to see if it fixes job errors

### DIFF
--- a/playbooks/roles/jenkins_build/defaults/main.yml
+++ b/playbooks/roles/jenkins_build/defaults/main.yml
@@ -289,7 +289,7 @@ build_jenkins_plugins_list:
     version: '1.14'
     group: 'org.jenkins-ci.plugins'
   - name: 'token-macro'
-    version: '2.13'
+    version: '2.15'
     group: 'org.jenkins-ci.plugins'
   - name: 'translation'
     version: '1.16'

--- a/playbooks/roles/jenkins_build/defaults/main.yml
+++ b/playbooks/roles/jenkins_build/defaults/main.yml
@@ -58,7 +58,7 @@ build_jenkins_plugins_list:
     version: '2.25'
     group: 'org.jenkins-ci.plugins'
   - name: 'build-name-setter'
-    version: '2.1.0'
+    version: '2.2.0'
     group: 'org.jenkins-ci.plugins'
   - name: 'build-timeout'
     version: '1.20'


### PR DESCRIPTION
This is in an attempt to fix the following error by upgrading the `build-name-setter` Jenkins plugin from 2.1.0 to 2.2.0:

```
[EnvInject] - Loading node environment variables.
Building remotely on EC2 (us-east-1) - <>-worker (i-<>) (<>-worker) in workspace /home/jenkins/workspace/user-<>
FATAL: Error creating extended parser class: null
```

Internal edx.org ticket: https://openedx.atlassian.net/browse/PSRE-1204 

Make sure that the following steps are done before merging:

  - [ ] A SRE team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a SRE ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
