### PR TITLE
fix: repair neo4j role and upgrade it to 3.5.28 (maple backport)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Add any new changes to the top (right below this line).
 
  - 2021-10-20
     - Role neo4j
+       - Upgrade Neo4j from 3.3.1 to 3.5.28.
+
+ - 2021-08-26
+    - Role neo4j
       - Bring Neo4j role closer in with what we really deploy:
         - Change Neo4j version from 3.2.2 to 3.3.1.
         - Expose Bolt on 0.0.0.0:7687 with optional encryption.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 All notable changes to this project will be documented in this file.
 Add any new changes to the top (right below this line).
 
+ - 2021-10-20
+    - Role neo4j
+      - Bring Neo4j role closer in with what we really deploy:
+        - Change Neo4j version from 3.2.2 to 3.3.1.
+        - Expose Bolt on 0.0.0.0:7687 with optional encryption.
+        - Enable `dbms.allow_upgrade`, which is the new name of the `dbms.allow_format_migration` key.
+        - Remove http->https redirection logic when NGINX_ENABLE_SSL is false.
+
  - 2021-09-28
     - Role nginx
       - Add `NGINX_ENABLE_IPV6` configuration variable to make nginx

--- a/playbooks/roles/neo4j/defaults/main.yml
+++ b/playbooks/roles/neo4j/defaults/main.yml
@@ -19,10 +19,19 @@
 NEO4J_SERVER_NAME: "localhost"
 NEO4J_AUTH_ENABLED: "true"
 
-neo4j_gpg_key_url: https://debian.neo4j.org/neotechnology.gpg.key
-neo4j_apt_repository: "deb http://debian.neo4j.org/repo stable/"
+# When updating this version, please update the corresponding
+# neo4j Docker image tag used by the Devstack coursegraph service
+# (see github.com/edx/devstack/tree/master/docker-compose.yml).
+# Note that the corresponding docker image tag does not include the
+# epoch prefix ('1:') -- it's just 'Major.Minor.Patch'.
+NEO4J_VERSION: "1:3.5.28"
+
+# If upgrading to a Major.Minor series other than 3.5, you'll need
+# to change the '3.5' repository component below accordingly.
+neo4j_apt_repository: "deb https://debian.neo4j.com stable 3.5"
+
+neo4j_gpg_key_url: https://debian.neo4j.com/neotechnology.gpg.key
 neo4j_defaults_file: "/etc/default/neo4j"
-NEO4J_VERSION: "3.3.1"
 neo4j_server_config_file: "/etc/neo4j/neo4j.conf"
 neo4j_bolt_port: 7687  # default in package is 7687
 neo4j_https_port: 7473  # default in package is 7473

--- a/playbooks/roles/neo4j/defaults/main.yml
+++ b/playbooks/roles/neo4j/defaults/main.yml
@@ -22,8 +22,9 @@ NEO4J_AUTH_ENABLED: "true"
 neo4j_gpg_key_url: https://debian.neo4j.org/neotechnology.gpg.key
 neo4j_apt_repository: "deb http://debian.neo4j.org/repo stable/"
 neo4j_defaults_file: "/etc/default/neo4j"
-NEO4J_VERSION: "3.2.2"
+NEO4J_VERSION: "3.3.1"
 neo4j_server_config_file: "/etc/neo4j/neo4j.conf"
+neo4j_bolt_port: 7687  # default in package is 7687
 neo4j_https_port: 7473  # default in package is 7473
 neo4j_http_port: 7474  # default in package is 7474
 neo4j_listen_address: "0.0.0.0"
@@ -32,6 +33,8 @@ neo4j_page_cache_size: "6000m"
 neo4j_log_dir: "/var/log/neo4j"
 
 # Properties file settings
+neo4j_bolt_settings_key: "dbms.connector.bolt.listen_address"
+neo4j_bolt_tls_key: "dbms.connector.bolt.tls_level"
 neo4j_https_settings_key: "dbms.connector.https.listen_address"
 neo4j_http_settings_key: "dbms.connector.http.listen_address"
 

--- a/playbooks/roles/neo4j/tasks/main.yml
+++ b/playbooks/roles/neo4j/tasks/main.yml
@@ -98,8 +98,28 @@
 - name: allow format migration (when updating neo4j versions)
   lineinfile:
     dest: "{{ neo4j_server_config_file }}"
-    regexp: "dbms.allow_format_migration="
-    line: "dbms.allow_format_migration=true"
+    regexp: "dbms.allow_upgrade="
+    line: "dbms.allow_upgrade=true"
+  tags:
+    - install
+    - install:configuration
+
+- name: set to listen on specific port for bolt
+  lineinfile:
+    create: yes
+    dest: "{{ neo4j_server_config_file }}"
+    regexp: "{{ neo4j_bolt_settings_key }}="
+    line: "{{ neo4j_bolt_settings_key }}={{ neo4j_listen_address }}:{{ neo4j_bolt_port }}"
+  tags:
+    - install
+    - install:configuration
+
+- name: allow both encrypted and unencrypted bolt connections
+  lineinfile:
+    create: yes
+    dest: "{{ neo4j_server_config_file }}"
+    regexp: "{{ neo4j_bolt_tls_key }}="
+    line: "{{ neo4j_bolt_tls_key }}=OPTIONAL"
   tags:
     - install
     - install:configuration

--- a/playbooks/roles/neo4j/tasks/main.yml
+++ b/playbooks/roles/neo4j/tasks/main.yml
@@ -65,6 +65,16 @@
   register: neo4j_apt_pkg
   until: neo4j_apt_pkg is succeeded
 
+# For what it's worth: We purposely do not prefix these line-replacement
+# regex with ^ or suffix them with $. That's because we cannot be
+# confident whether these lines initially (i) exist in file commented-out,
+# or (ii) exist in the file with a value already set. So, we purposefully
+# leave the regexes without beginning- or end-of-line matches so that
+# they can handle both scenario (i) and (ii).
+# In the future, it'd be good to get rid of these tasks, and instead
+# just include j2-templated configuration files to wholesale replace
+# what's on the box.
+
 - name: enable or disable authentication
   lineinfile:
     dest: "{{ neo4j_server_config_file }}"

--- a/playbooks/roles/neo4j/templates/edx/app/nginx/sites-available/coursegraph.j2
+++ b/playbooks/roles/neo4j/templates/edx/app/nginx/sites-available/coursegraph.j2
@@ -39,6 +39,8 @@ server {
     proxy_pass http://127.0.0.1:{{ neo4j_http_port }};
   }
 
+  {% if NGINX_ENABLE_SSL %}
+
   # Forward to HTTPS if we're an HTTP request...
   if ($http_x_forwarded_proto = "http") {
     set $do_redirect "true";
@@ -48,4 +50,7 @@ server {
   if ($do_redirect = "true") {
     rewrite ^ https://$host$request_uri? permanent;
   }
+
+  {% endif %}
+
 }


### PR DESCRIPTION
## Context

Back in August/October while I was at edX, I did a project to update and begin improving documentation for [the CourseGraph tool](https://github.com/edx/edx-platform/blob/master/openedx/core/djangoapps/coursegraph/README.rst), which edX engineers and support specialists use internally to introspect course data. I think it could be a useful part of an Open edX operator's tool belt if it were made more widely availble.

As a step towards this, @sarina is planning to write a blog post explaining CourseGraph and some starter tips on setting it up.  Although there is no official way (via Tutor or the Ansible install) to provision and run CourseGraph, we suspect some more experienced community members would be interested in working with the information in the blog post. For the post, we're hoping for all the code changes to be included in `maple.1`. 

Of all the PRs in the project, four of them made it in ahead of the Maple cut:
* https://github.com/edx/edx-platform/pull/28480
* https://github.com/edx/edx-platform/pull/28489
* https://github.com/edx/devstack/pull/820
* https://github.com/edx/devstack/pull/824 

And one missed the cut:
* https://github.com/edx/configuration/pull/6502

This PR is a backport of the PR that missed the cut.

## How this would affect Maple

This PR includes no new features -- it just fixes the aging `neo4j` Ansible role.

For operators who **do not** know or care about CourseGraph:
* They would not be affected by this PR, since its code changes are entirely contained within the `neo4j` role, which is not used in the community installation.

For operators who **do** care about CourseGraph (which, as far as I can tell, will only be those who read about it in the blog post): 
* If they deploy using Ansible, then these changes to the `neo4j` role would allow them to provision an Ubuntu 20.04 box to run Neo4j v3.5.28. Unlike the Neo4j version currently in our Ansible code, v3.5 is both vendor-supported and works with Maple edx-platform's [`dump_to_neo4j`](https://github.com/edx/edx-platform/blob/open-release/maple.master/openedx/core/djangoapps/coursegraph/management/commands/dump_to_neo4j.py) management command.
* If they deploy using Tutor, then in absence of a real CourseGraph plugin for Tutor, the updated Ansible here could serve as a reference guide for an intrepid engineer to spin up CourseGraph using the `neo4j:3.5` docker image.

## Specifics of the change

For technical details, see the commit messages and/or the included CHANGELOG entry.
