### PR TITLE
fix: create ecommerce_worker user in the LMS for sandboxes

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -1816,6 +1816,10 @@ SERVICE_WORKER_USERS:
     username: "{{ ENTERPRISE_CATALOG_SERVICE_USER_NAME }}"
     is_staff: true
     is_superuser: false
+  - email: "{{ ECOMMERCE_SERVICE_USER_EMAIL }}"
+    username: "{{ ECOMMERCE_SERVICE_USER_NAME }}"
+    is_staff: true
+    is_superuser: false
   - email: "{{ EDXAPP_RETIREMENT_SERVICE_USER_EMAIL }}"
     username: "{{ EDXAPP_RETIREMENT_SERVICE_USER_NAME }}"
     is_staff: true


### PR DESCRIPTION
I am rather mystified why this was working in the past. I've looked in https://github.com/edx/ecommerce-worker/ to try to find some code change which would've created this user via non-usual means, but `¯\_(ツ)_/¯`

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A SRE team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a SRE ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
