### PR TITLE
fix: Skip empty instances in inventory.

### DIFF
--- a/playbooks/lifecycle_inventory.py
+++ b/playbooks/lifecycle_inventory.py
@@ -86,14 +86,17 @@ class LifecycleInventory():
         for group in groups:
 
             for instance in group['Instances']:
-
-                private_ip_address = instances[instance['InstanceId']]['PrivateIpAddress']
-                if private_ip_address:
-                    environment,deployment = self.get_e_d_from_tags(group)
-                    inventory[environment + "_" + deployment + "_" + instance['LifecycleState'].replace(":","_")].append(private_ip_address)
-                    inventory[group['AutoScalingGroupName']].append(private_ip_address)
-                    inventory[group['AutoScalingGroupName'] + "_" + instance['LifecycleState'].replace(":","_")].append(private_ip_address)
-                    inventory[instance['LifecycleState'].replace(":","_")].append(private_ip_address)
+                instance_id = instance['InstanceId']
+                # We are seeing an issue in the list AWS returns where an instance does not have any data associated with it.
+                # Any valid instance should not have completely empty reservation data.
+                if len(instances[instance_id]['Reservations']) != 0:
+                    private_ip_address = instances[instance['InstanceId']]['PrivateIpAddress']
+                    if private_ip_address:
+                        environment,deployment = self.get_e_d_from_tags(group)
+                        inventory[environment + "_" + deployment + "_" + instance['LifecycleState'].replace(":","_")].append(private_ip_address)
+                        inventory[group['AutoScalingGroupName']].append(private_ip_address)
+                        inventory[group['AutoScalingGroupName'] + "_" + instance['LifecycleState'].replace(":","_")].append(private_ip_address)
+                        inventory[instance['LifecycleState'].replace(":","_")].append(private_ip_address)
 
         print(json.dumps(inventory, sort_keys=True, indent=2))
 


### PR DESCRIPTION
We are seeing an issue with AWS where an instance
returns a value but does not have any data associated.

In order to unblock deploys until AWS data is fixed,
skip invalid instances.

Configuration Pull Request
---

<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##
-->

Make sure that the following steps are done before merging:

  - [ ] A SRE team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a SRE ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
