### PR TITLE
fix: add retries to jdk download

### DIFF
--- a/playbooks/roles/oraclejdk/tasks/main.yml
+++ b/playbooks/roles/oraclejdk/tasks/main.yml
@@ -22,6 +22,10 @@
     headers:
       Cookie: oraclelicense=accept-securebackup-cookie
     dest: "/var/tmp/{{ oraclejdk_file }}"
+  retries: 3
+  delay: 10
+  register: oracle_jdk_download_retry
+  until: oracle_jdk_download_retry is succeeded
 
 - name: Create jvm dir
   file:


### PR DESCRIPTION
this endpoint evidently sometimes throws spurious 403s, so bandaid

e.g. https://tools-edx-jenkins.edx.org/job/Sandboxes/job/CreateSandbox/43500/console (internal-to-edx link, sorry folks)
and another that's more recent: https://tools-edx-jenkins.edx.org/job/Sandboxes/job/CreateSandbox/57497/console (similarly internal)

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A SRE team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a SRE ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/display/EdxOps/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
