### PR TITLE
Revert "Add retry logic to AMI registration"

### DIFF
--- a/playbooks/continuous_delivery/create_ami.yml
+++ b/playbooks/continuous_delivery/create_ami.yml
@@ -70,9 +70,6 @@
                 'deployment':'{{ deployment }}'
             }"
     register: ami_register
-    retries: 5
-    delay: 10
-    until: ami_register is succeeded
 
   - name: Add any tags that are on the instance to the AMI
     ec2_tag:


### PR DESCRIPTION
Reverts edx/configuration#6637

It appeared that the retry logic causes the new AMI to be created with the same ID, which fails. For now we will need to manually re-trigger that build stage so that the new AMI is created with a fresh ID.