### PR TITLE
fix: Remove an extraneous `-A ecommerce_worker` from the ecomworker startup script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 All notable changes to this project will be documented in this file.
 Add any new changes to the top (right below this line).
 
+ - 2022-01-05
+	- Remove an extraneous `-A ecommerce_worker` from the ecomworker startup script,
+	  which was preventing the celery worker process from starting.
+
  - 2021-11-30
     - Upgrade celery to 5.2.0 and adjust CLI call parameters too
     - Bumped single-beat to use a more supported fork of the project

--- a/playbooks/roles/ecomworker/templates/edx/app/ecomworker/ecomworker.sh.j2
+++ b/playbooks/roles/ecomworker/templates/edx/app/ecomworker/ecomworker.sh.j2
@@ -17,4 +17,4 @@ export NEW_RELIC_LICENSE_KEY='{{ NEWRELIC_LICENSE_KEY }}'
 
 source {{ ecommerce_worker_home }}/{{ ecommerce_worker_service_name }}_env
 # We exec so that celery is the child of supervisor and can be managed properly
-exec {{ executable }} --app ecommerce_worker.celery_app:app worker -A ecommerce_worker --concurrency={{ ECOMMERCE_WORKER_CONCURRENCY }} --loglevel=info --hostname=ecomworker.%%h --queue=ecommerce.fulfillment,ecommerce.email_marketing
+exec {{ executable }} -A ecommerce_worker.celery_app:app worker --concurrency={{ ECOMMERCE_WORKER_CONCURRENCY }} --loglevel=info --hostname=ecomworker.%%h --queue=ecommerce.fulfillment,ecommerce.email_marketing


### PR DESCRIPTION
This was preventing the celery worker process from starting, because it overrode
the correct `--app ecommmerce_worker.celery_app:app` option.  `-A ecommerce_worker`
tells celery to look for an app named "celery" inside ecommerce_worker, and no
app with that name exists.
ENT-5285

The logged symptom of what's being fixed here:
```
$ head /edx/var/log/supervisor/ecomworker-stderr.log
Error: 
Unable to load celery application.
Module 'ecommerce_worker' has no attribute 'celery'

Error: 
Unable to load celery application.
Module 'ecommerce_worker' has no attribute 'celery'

Error: 
Unable to load celery application.
```

How did this ever work?
This commit https://github.com/openedx/configuration/commit/b8ab26c654a54d754cd01448f72f8b783c95ef6c changed the order of the `-A` and `--app` options, but no deploy for ecomworker went out for that commit until yesterday.  So we were basically just lucky before that the order of the competing options had the correct app name last.

Make sure that the following steps are done before merging:

  - [ ] A SRE team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a SRE ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/spaces/SRE/pages/28967861/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
