### PR TITLE
fix: remove edx-zoom dependency

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -567,7 +567,6 @@ EDXAPP_PRIVATE_REQUIREMENTS:
       extra_args: -e
     - name: git+https://github.com/open-craft/xblock-activetable.git@d3fb772435c382b59293e4e688a6a3096c4f6fd7#egg=activetable-xblock
       extra_args: -e
-    - name: edx-zoom==2.0.1
     # Stanford-developed XBlocks (technically unsupported, but here to ease migration of courses from Lagunita)
     - name: git+https://github.com/edx/xblock-qualtrics-survey.git@02d87f567ec2af4579642cf795bb851507d6edf9#egg=xblock_qualtrics_survey
       extra_args: -e


### PR DESCRIPTION
Remove the edx-zoom installation from edx-platform because the xblock is being deprecated.
All the courses that uses edx-zoom was edited and the units contain the xblock was removed from course content tree.


Make sure that the following steps are done before merging:

  - [x] A SRE team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [x] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
