### PR TITLE
fix: Updated Tableau Server to version 2021.4.2

### DIFF
--- a/util/tableau/installer.sh
+++ b/util/tableau/installer.sh
@@ -17,7 +17,7 @@ mkdir tableau
 cd tableau/
 git clone https://github.com/tableau/server-install-script-samples.git
 cd server-install-script-samples/linux/automated-installer/
-wget https://downloads.tableau.com/tssoftware/tableau-server-2020-4-1_amd64.deb
+wget https://downloads.tableau.com/tssoftware/tableau-server-2021-4-2_amd64.deb
 
 cat > secrets <<- EOM
 # You can use this as a template for the secrets file used with the
@@ -47,4 +47,4 @@ tableau_server_admin_user="$ADMIN_USER"
 tableau_server_admin_pass="$ADMIN_PASS"
 EOM
 
-sudo ./automated-installer -s secrets -f config.json -r registration.json --accepteula tableau-server-2020-4-1_amd64.deb
+sudo ./automated-installer -s secrets -f config.json -r registration.json --accepteula tableau-server-2021-4-2_amd64.deb


### PR DESCRIPTION
Updated Tableau Server to version 2021.4.2, the latest
currently available, and one that addresses the
CVE-2021-44228 and CVE-2021-45046 vulnerabilities.

SEC-1347
