### PR TITLE
feat: update celery flower (PSRE-1267)

### DIFF
--- a/docker/build/flower/Dockerfile
+++ b/docker/build/flower/Dockerfile
@@ -1,10 +1,10 @@
-FROM ubuntu:xenial
+FROM ubuntu:focal
 
 # Update and get pip.
 RUN apt-get update && apt-get install -y python3-pip
 
 # Install the required packages
-RUN pip3 install --no-cache-dir redis==3.2.0 celery==4.4.7 flower==0.9.5
+RUN pip3 install --no-cache-dir celery==5.2.3 https://github.com/mher/flower/zipball/v1.0.0#egg=flower redis==4.1.1
 
 # PYTHONUNBUFFERED: Force stdin, stdout and stderr to be totally unbuffered. (equivalent to `python -u`)
 # PYTHONHASHSEED: Enable hash randomization (equivalent to `python -R`)
@@ -22,4 +22,4 @@ USER nobody
 # Mount a config here if you want to enable OAuth etc
 ADD docker/build/flower/flowerconfig.py /flowerconfig.py
 
-ENTRYPOINT [ "flower" ]
+ENTRYPOINT [ "celery" ]

--- a/docker/build/flower/Dockerfile
+++ b/docker/build/flower/Dockerfile
@@ -4,7 +4,7 @@ FROM ubuntu:focal
 RUN apt-get update && apt-get install -y python3-pip
 
 # Install the required packages
-RUN pip3 install --no-cache-dir celery==5.2.3 https://github.com/mher/flower/zipball/v1.0.0#egg=flower redis==4.1.1
+RUN pip3 install --no-cache-dir celery==5.2.3 flower==1.0.0 redis==4.1.1
 
 # PYTHONUNBUFFERED: Force stdin, stdout and stderr to be totally unbuffered. (equivalent to `python -u`)
 # PYTHONHASHSEED: Enable hash randomization (equivalent to `python -R`)

--- a/docker/build/flower/README.txt
+++ b/docker/build/flower/README.txt
@@ -1,6 +1,6 @@
 Example:
 $ docker build . -t edxops/flower:latest
-$ docker run -it --rm -p 127.0.0.1:5555:5555 edxops/flower:latest flower --broker=redis://:@some-redis-url.com:6379 --conf=flowerconfig.py
+$ docker run -it --rm -p 127.0.0.1:5555:5555 edxops/flower:latest --broker=redis://:@some-redis-url.com:6379 flower --conf=flowerconfig.py
 
 $ curl localhost:5555
 

--- a/playbooks/roles/flower/defaults/main.yml
+++ b/playbooks/roles/flower/defaults/main.yml
@@ -22,14 +22,13 @@ flower_conf_dir: "{{ flower_app_dir }}"
 
 flower_venv_dir: "{{ flower_app_dir }}/venvs/flower"
 flower_venv_bin: "{{ flower_venv_dir }}/bin"
-flower_python_version: "python3.5"
+flower_python_version: "python3.8"
 
 flower_python_reqs:
 # Celery version must match version used by edx-platform
-  - "celery==4.4.7"
-  - "flower==0.9.5"
-  - "redis==3.2.0"
-  - "tornado==5.1.1"
+  - "https://github.com/mher/flower/zipball/v1.0.0#egg=flower"
+  - "celery==5.2.3"
+  - "redis==4.1.1"
 
 flower_deploy_path: "{{ flower_venv_bin }}:/usr/local/sbin:/usr/local/bin:/usr/bin:/sbin:/bin"
 

--- a/playbooks/roles/flower/defaults/main.yml
+++ b/playbooks/roles/flower/defaults/main.yml
@@ -26,7 +26,7 @@ flower_python_version: "python3.8"
 
 flower_python_reqs:
 # Celery version must match version used by edx-platform
-  - "https://github.com/mher/flower/zipball/v1.0.0#egg=flower"
+  - "flower==1.0.0"
   - "celery==5.2.3"
   - "redis==4.1.1"
 

--- a/playbooks/roles/flower/templates/edx/app/supervisor/conf.d.available/flower.conf.j2
+++ b/playbooks/roles/flower/templates/edx/app/supervisor/conf.d.available/flower.conf.j2
@@ -2,6 +2,6 @@
 
 environment=PATH="{{ flower_deploy_path }}"
 user={{ common_web_user }}
-command={{ flower_venv_bin }}/celery flower --broker {{ flower_broker }} --conf={{ flower_conf_dir }}/flowerconfig.py
+command={{ flower_venv_bin }}/celery --broker {{ flower_broker }} flower --conf={{ flower_conf_dir }}/flowerconfig.py
 stdout_logfile={{ supervisor_log_dir }}/{{ FLOWER_USER }}-stdout.log
 stderr_logfile={{ supervisor_log_dir }}/{{ FLOWER_USER }}-stderr.log


### PR DESCRIPTION
This PR upgrades our Flower Dockerfile to use focal instead of xenial.  It also upgrades `redis` from 3.2.0 to 4.1.1, `celery` from 4.4.7 to 5.2.3 and `flower` from 0.9.5 to 1.0.0.

Make sure that the following steps are done before merging:

  - [ ] A SRE team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a SRE ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/spaces/SRE/pages/28967861/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
