### PR TITLE
chore: add stop instance task to create_ami play

### DIFF
--- a/playbooks/continuous_delivery/create_ami.yml
+++ b/playbooks/continuous_delivery/create_ami.yml
@@ -37,6 +37,7 @@
   vars:
     ec2_region: us-east-1
     ami_wait: yes
+    stop_wait: yes
     ami_creation_timeout: 5400
     no_reboot: no
     artifact_path: /tmp/ansible-runtime
@@ -51,6 +52,13 @@
       resource: "{{ instance_id }}"
       state: list
     register: instance_tags
+
+  - name: Stop instance
+    ec2:
+      instance_ids: "{{ instance_id }}"
+      state: stopped
+      wait: "{{ stop_wait }}"
+      region: "{{ ec2_region }}"
 
   - name: Create AMI
     ec2_ami:


### PR DESCRIPTION
Creating the AMI while OS is not running will speed up the AMI creation time also provide a consistent snapshot.
I’ve done testing and AMI setup from a running instance (50Gig EBS volume size) took ~30 minutes while AMI setup, while the instance is stopped, took ~17 minutes to complete.

Configuration Pull Request
---

<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##
-->

Make sure that the following steps are done before merging:

  - [ ] A SRE team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a SRE ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/spaces/SRE/pages/28967861/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
