### PR TITLE
feat: [REV-2514] new url for major release of SDN API

### DIFF
--- a/docker/build/ecommerce/ecommerce.yml
+++ b/docker/build/ecommerce/ecommerce.yml
@@ -127,5 +127,5 @@ STATIC_ROOT: /edx/var/ecommerce/staticfiles
 THEME_SCSS: sass/themes/default.scss
 TIME_ZONE: UTC
 USERNAME_REPLACEMENT_WORKER: OVERRIDE THIS WITH A VALID USERNAME
-SDN_CHECK_API_URL: https://api.trade.gov/gateway/v1/consolidated_screening_list/search
+SDN_CHECK_API_URL: https://data.trade.gov/consolidated_screening_list/v1/search
 SDN_CHECK_API_KEY: sdn search key here


### PR DESCRIPTION
# Description

The API we use for checking the SDN, the [CSL API](https://www.trade.gov/consolidated-screening-list), had a [major update](https://developer.trade.gov/csl-api-is-changing) which changed:
* the API url
* all API keys
* the names of some of the API parameters

This PR updates the environmental variable for the API URL to the one used by the new API.

# Supporting information

* Jira
   * [PSRE-1254](https://openedx.atlassian.net/browse/PSRE-1254)
   * [REV-2514](https://openedx.atlassian.net/browse/REV-2514)
* Research: [Confluence](https://openedx.atlassian.net/wiki/spaces/~931919476/pages/3312844819/REV-2514)

# Other information

* Related PRs:
   * https://github.com/openedx/ecommerce/pull/3629

# Checks
  - [x] A SRE team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [X] ~~Are you adding any new default values that need to be overridden when this change goes live? If so:~~
    - [X] ~~Update the appropriate internal repo (be sure to update for all our environments)~~
    - [X] ~~If you are updating a secure value rather than an internal one, file a SRE ticket with details.~~
    - [X] ~~Add an entry to the CHANGELOG.~~
  - [X] ~~If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/spaces/SRE/pages/28967861/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).~~
  - [X] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?