### PR TITLE
Update docker-entrypoint.sh with the right commands to run devpi server

### DIFF
--- a/docker/build/devpi/docker-entrypoint.sh
+++ b/docker/build/devpi/docker-entrypoint.sh
@@ -12,20 +12,9 @@ function defaults {
 
 function initialize_devpi {
     echo "[RUN]: Initializing devpi-server..."
-    if [ ! -d  $DEVPISERVER_SERVERDIR ]; then
-        devpi-server --restrict-modify root --init --start --host 127.0.0.1 --port 3141
-    else
-        devpi-server --restrict-modify root --start --host 127.0.0.1 --port 3141
-    fi
-    devpi-server --status
-    devpi use http://localhost:3141
-    devpi login root --password=''
     DEVPI_PASSWORD=`date +%s | sha256sum | base64 | head -c 32`
-    devpi user -m root password="${DEVPI_PASSWORD}"
+    devpi-init --root-passwd ${DEVPI_PASSWORD}
     echo "[RUN]: devpi-server password set to '${DEVPI_PASSWORD}'" > $DEVPISERVER_SERVERDIR/.serverpassword
-    devpi index -y -c public pypi_whitelist='*'
-    devpi-server --stop
-    devpi-server --status
 }
 
 defaults


### PR DESCRIPTION
### Description

This fixes the problem of running devpi, since the commands have not been updated to run devpi 6.3.

When you run the devpi container at this moment it gives many errors since It doesn't recognize the commands and after some seconds it goes down.

>DEVPISERVER_SERVERDIR is /data/server
DEVPI_CLIENTDIR is /data/client
[RUN]: Initializing devpi-server...
usage: devpi-server [-h] [-c CONFIGFILE]
...
server: error: unrecognized arguments: --init --start

### Supporting information

    https://devpi.net/docs/devpi/devpi/stable/+d/userman/devpi_commands.html#devpi-command-reference-server

### Deadline

None
