### PR TITLE
feat: add SIMPLETHEME_I18N_DJANGO variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 All notable changes to this project will be documented in this file.
 Add any new changes to the top (right below this line).
 
+ - 2022-04-06
+    - Role: simple_theme
+       - Added a new `SIMPLETHEME_I18N_DJANGO` setting to allow operators to provide
+         additional translations, or override existing django translations.
+
  - 2022-03-25
     - Role: edxapp
         - Added a new `CUSTOM_RESOURCE_TEMPLATES_DIRECTORY` setting to allow operators to

--- a/playbooks/roles/simple_theme/defaults/main.yml
+++ b/playbooks/roles/simple_theme/defaults/main.yml
@@ -106,3 +106,37 @@ SIMPLETHEME_STATIC_FILES_URLS: []
 #     border-top: 3px solid $main-color;
 #   }
 SIMPLETHEME_EXTRA_SASS: ""
+
+
+# Use this variable to configure django translations.
+# Note that edx-platform does not pick up translations from themes by default.
+# You will have to manually configure either `COMPREHENSIVE_THEME_LOCALE_PATHS` or
+# `PREPEND_LOCALE_PATHS` to include the path to the theme's i18n/locale folder for
+# these translations to get picked up.
+#
+# The SIMPLETHEME_I18n_DJANGO variable should contain a list of dictionaries with these keys:
+# - `lang`: the language code
+# - `domain`: the i18n domain (typically one of "django" or "djangojs")
+# - `headers`: (optional) Additional PO file headers.
+# - `messages`: Translation messages. It should be a raw string of PO formatted messages.
+#
+# Samle:
+# SIMPLETHEME_I18N_DJANGO:
+#   - lang: en
+#     domain: django
+#     headers: |
+#       "Plural-Forms: nplurals=2; plural=(n > 1);\n"
+#     messages: |
+#       msgid "my id"
+#       msgstr "my translation"
+#
+#       msgid "one"
+#       msgid_plural "many"
+#       msgstr[0] "just one"
+#       msgstr[1] "a lot"
+#   - lang: en
+#     domain: djangojs
+#     messages: |
+#       msgid "my id"
+#       msgstr "my JS translation"
+SIMPLETHEME_I18N_DJANGO: []

--- a/playbooks/roles/simple_theme/tasks/deploy.yml
+++ b/playbooks/roles/simple_theme/tasks/deploy.yml
@@ -137,3 +137,45 @@
       owner: "{{ edxapp_user }}"
       group: "{{ common_web_group }}"
     with_items: "{{ SIMPLETHEME_STATIC_FILES_URLS }}"
+
+# Handle translations.
+- block:
+  - name: Install needed packages
+    apt:
+      name: gettext
+      state: present
+      update_cache: true
+      cache_valid_time: 3600
+  - name: Create directories for django translations
+    file:
+      path: "{{ simpletheme_folder }}/i18n/conf/locale/{{ item.lang }}/LC_MESSAGES"
+      state: directory
+      owner: "{{ edxapp_user }}"
+      group: "{{ common_web_group }}"
+    with_items: "{{ SIMPLETHEME_I18N_DJANGO }}"
+  - name: Make sure .po files exist
+    file:
+      path: "{{ simpletheme_folder }}/i18n/conf/locale/{{ item.lang }}/LC_MESSAGES/{{ item.domain }}.po"
+      state: touch
+      owner: "{{ edxapp_user }}"
+      group: "{{ common_web_group }}"
+    with_items: "{{ SIMPLETHEME_I18N_DJANGO }}"
+  - name: Create temporary .po files with custom translations
+    template:
+      src: "i18n/domain.po.j2"
+      dest: "{{ simpletheme_folder }}/i18n/conf/locale/{{ item.lang }}/LC_MESSAGES/{{ item.domain }}.po_"
+      owner: "{{ edxapp_user }}"
+      group: "{{ common_web_group }}"
+    with_items: "{{ SIMPLETHEME_I18N_DJANGO }}"
+  - name: Merge temporary .po files into default translations
+    shell: >
+      msgcat --use-first {{ simpletheme_folder }}/i18n/conf/locale/{{ item.lang }}/LC_MESSAGES/{{ item.domain }}.po_
+      {{ simpletheme_folder }}/i18n/conf/locale/{{ item.lang }}/LC_MESSAGES/{{ item.domain }}.po >
+      {{ simpletheme_folder }}/i18n/conf/locale/{{ item.lang }}/LC_MESSAGES/{{ item.domain }}.po
+    with_items: "{{ SIMPLETHEME_I18N_DJANGO }}"
+  - name: Compile .po files into .mo
+    shell: >
+      msgfmt {{ simpletheme_folder }}/i18n/conf/locale/{{ item.lang }}/LC_MESSAGES/{{ item.domain }}.po
+      -o {{ simpletheme_folder }}/i18n/conf/locale/{{ item.lang }}/LC_MESSAGES/{{ item.domain }}.mo
+    with_items: "{{ SIMPLETHEME_I18N_DJANGO }}"
+  when: SIMPLETHEME_I18N_DJANGO | length > 0

--- a/playbooks/roles/simple_theme/templates/i18n/domain.po.j2
+++ b/playbooks/roles/simple_theme/templates/i18n/domain.po.j2
@@ -1,0 +1,12 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: {{ item.lang }}\n"
+{% if 'headers' in item -%}
+{{ item.headers }}
+{%- endif %}
+
+{% if 'messages' in item -%}
+{{ item.messages }}
+{%- endif %}


### PR DESCRIPTION
This makes it possible to add or override django translations via the simple-theme role.

This adds a new `SIMPLETHEME_I18N_DJANGO` configuration variable to the `simple_theme` role, which makes it possible to set or override theme translations via configuration variables without having to check po/mo files into any theme repo. When combined with the `EDXAPP_PREPEND_LOCALE_PATHS` variable, it can also be used to override default edx-platform translations.

**Test instructions**

1. Create an account and log into [the sandbox](https://mtyaka.opencraft.hosting/).
2. Enroll into the Demo course.
3. Go to https://mtyaka.opencraft.hosting/update_lang/ and switch the language to Arabic (`ar`).
4. Go to [the dashboard](https://mtyaka.opencraft.hosting/dashboard) and verify that the "View Course" button contains the following custom translation: "XXX استعراض المحتوى"
5. Go to [the forum](https://mtyaka.opencraft.hosting/courses/course-v1:edX+DemoX+Demo_Course/discussion/forum/), click the button to create a new post, and verify that the submit button at the bottom contains the custom translation: "إضافة منشور ZZZ"

Note: the sandbox is running lilac. It was provisioned with this patch cherry-picked into the lilac branch (without any conflicts).

**Sandbox**:

- https://mtyaka.opencraft.hosting/

The sandbox was provisioned with the following settings:

```
EDXAPP_DEFAULT_SITE_THEME: simple-theme
SIMPLETHEME_ENABLE_DEPLOY: true

EDXAPP_COMPREHENSIVE_THEME_LOCALE_PATHS:
  - "{{ EDXAPP_COMPREHENSIVE_THEME_DIRS[0] }}/conf/locale"

SIMPLETHEME_I18N_DJANGO:
  - lang: ar
    domain: django
    headers: |
      "Plural-Forms: nplurals=6; plural=n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 && n%100<=10 ? 3 : n%100>=11 && n%100<=99 ? 4 : 5;\n"
    messages: |
      msgid "View Course"
      msgstr "XXX استعراض المحتوى"
  - lang: ar
    domain: djangojs
    headers: |
      "Plural-Forms: nplurals=6; plural=n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 && n%100<=10 ? 3 : n%100>=11 && n%100<=99 ? 4 : 5;\n"
    messages: |
      msgid "Submit"
      msgstr "تقديم YYY"
      msgid "Add a Post"
      msgstr "إضافة منشور ZZZ"
```

Configuration Pull Request
---

<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##
-->

Make sure that the following steps are done before merging:

  - [ ] A SRE team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [x] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a SRE ticket with details.
    - [x] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/spaces/SRE/pages/28967861/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
