### PR TITLE
feat: add nginx server names hash override [BB-5512]

### DIFF
--- a/playbooks/roles/nginx/defaults/main.yml
+++ b/playbooks/roles/nginx/defaults/main.yml
@@ -21,6 +21,10 @@ NGINX_OVERRIDE_DEFAULT_MAP_HASH_SIZE: False
 NGINX_MAP_HASH_MAX_SIZE: 2048
 NGINX_MAP_HASH_BUCKET_SIZE: 64
 
+# Override these vars to alter the memory allocated to server_names_hash
+NGINX_OVERRIDE_DEFAULT_SERVER_NAMES_HASH_SIZE: False
+NGINX_SERVER_NAMES_HASH_BUCKET_SIZE: 64
+
 # Override these vars for adding user to nginx.htpasswd
 NGINX_USERS:
   - name: "{{ COMMON_HTPASSWD_USER }}"

--- a/playbooks/roles/nginx/templates/etc/nginx/nginx.conf.j2
+++ b/playbooks/roles/nginx/templates/etc/nginx/nginx.conf.j2
@@ -27,7 +27,9 @@ http {
         large_client_header_buffers 8 16k;
         server_tokens off;
 
-        # server_names_hash_bucket_size 64;
+        {% if NGINX_OVERRIDE_DEFAULT_SERVER_NAMES_HASH_SIZE %}
+        server_names_hash_bucket_size {{ NGINX_SERVER_NAMES_HASH_BUCKET_SIZE }};
+        {% endif %}
         # server_name_in_redirect off;
 
         include /etc/nginx/mime.types;


### PR DESCRIPTION
Configuration Pull Request
---
## Description

This PR adds support for optional configuration of nginx server_names_hash_bucket_size in case length of the hostname exceeds the default hash bucket size.

## Supporting information

[BB-5512](https://tasks.opencraft.com/browse/BB-5512)

## TODO

Cherry-pick to `open-release/lilac.master` and `open-release/maple.master` once this is merged.

Make sure that the following steps are done before merging:

  - [ ] A SRE team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a SRE ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/spaces/SRE/pages/28967861/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
