### PR TITLE
chore: update firefox and chrome versions

### DIFF
--- a/docker/build/chrome/Dockerfile
+++ b/docker/build/chrome/Dockerfile
@@ -1,4 +1,4 @@
-FROM selenium/standalone-chrome-debug:3.14.0-arsenic
+FROM selenium/standalone-chrome-debug:4.1.2-20220217
 LABEL maintainer="edxops"
 
 USER root

--- a/docker/build/firefox/Dockerfile
+++ b/docker/build/firefox/Dockerfile
@@ -1,4 +1,4 @@
-FROM selenium/standalone-firefox-debug:3.14.0-arsenic
+FROM selenium/standalone-firefox-debug:4.1.2-20220217
 LABEL maintainer="edxops"
 
 USER root

--- a/playbooks/roles/browsers/defaults/main.yml
+++ b/playbooks/roles/browsers/defaults/main.yml
@@ -21,28 +21,28 @@ browser_deb_pkgs:
     - wget
 
 # Firefox for Xenial
-FIREFOX_VERSION: version 59.*
+FIREFOX_VERSION: version 97.*
 
 # Packages we host in S3 to ensure correct browser version Both Chrome and
 # FireFox update their apt repos with the latest version, which often causes
 # spurious acceptance test failures.
 browser_s3_deb_pkgs:
-  - name: firefox_61.0.1+build1-0ubuntu0.16.04.1_amd64.deb
-    url: https://s3.amazonaws.com/vagrant.testeng.edx.org/firefox_61.0.1%2Bbuild1-0ubuntu0.16.04.1_amd64.deb
-  - name: google-chrome-stable_68.0.3440.84-1_amd64.deb
-    url: https://s3.amazonaws.com/vagrant.testeng.edx.org/google-chrome-stable_68.0.3440.84-1_amd64.deb
+  - name: firefox_97.0+build2-0ubuntu0.20.04.1_amd64.deb
+    url: https://s3.amazonaws.com/vagrant.testeng.edx.org/firefox_97.0%2Bbuild2-0ubuntu0.20.04.1_amd64.deb
+  - name: google-chrome-stable_current_amd64.deb
+    url: https://s3.amazonaws.com/vagrant.testeng.edx.org/google-chrome-stable_current_amd64.deb
 
 trusty_browser_s3_deb_pkgs:
   - name: firefox-mozilla-build_42.0-0ubuntu1_amd64.deb
     url: https://s3.amazonaws.com/vagrant.testeng.edx.org/firefox-mozilla-build_42.0-0ubuntu1_amd64.deb
-  - name: google-chrome-stable_68.0.3440.84-1_amd64.deb
-    url: https://s3.amazonaws.com/vagrant.testeng.edx.org/google-chrome-stable_68.0.3440.84-1_amd64.deb
+  - name: google-chrome-stable_current_amd64.deb
+    url: https://s3.amazonaws.com/vagrant.testeng.edx.org/google-chrome-stable_current_amd64.deb
 
 # GeckoDriver
-geckodriver_url: "https://github.com/mozilla/geckodriver/releases/download/v0.21.0/geckodriver-v0.21.0-linux64.tar.gz"
+geckodriver_url: "https://github.com/mozilla/geckodriver/releases/download/v0.30.0/geckodriver-v0.30.0-linux64.tar.gz"
 
 # ChromeDriver
-chromedriver_version: 2.41
+chromedriver_version: 98.0.4758.102
 chromedriver_url: "http://chromedriver.storage.googleapis.com/{{ chromedriver_version }}/chromedriver_linux64.zip"
 
 # PhantomJS


### PR DESCRIPTION
We have an ecommerce testing failing in selenium because it doesn't recognize the relatively new globalThis.  Based on research in [REV-2624](https://openedx.atlassian.net/browse/REV-2624), we need to update the browser versions used by these tests. 

I'm following and updating the steps [here](https://openedx.atlassian.net/wiki/spaces/TE/pages/814022796/How+to+upgrade+browser+versions), and comparing with previous update [here](https://github.com/openedx/configuration/commit/9882a1d59eba947941534481e3e2ffc6eff31de9)

Configuration Pull Request
---

<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##
-->

Make sure that the following steps are done before merging:

  - [x] A SRE team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  -  [ ] Other testing: **we need to identify an appropriate sanity check that new docker containers work**. I'd planned to do the sanity check in step 3 [here](https://openedx.atlassian.net/wiki/spaces/TE/pages/814022796/How+to+upgrade+browser+versions), but those steps (from 2018) don't work on master as a baseline, so I have a ticket here to find out what a suitable baseline check would be: https://2u-internal.atlassian.net/browse/PSRE-1430

  - [n/a] Are you adding any new default values that need to be overridden when this change goes live? 
  - [n/a] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/spaces/SRE/pages/28967861/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  -   [n/a] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?