### PR TITLE
feat: upgrade jenkins plugins

### DIFF
--- a/playbooks/roles/jenkins_build/defaults/main.yml
+++ b/playbooks/roles/jenkins_build/defaults/main.yml
@@ -1,6 +1,6 @@
 build_jenkins_user_uid: 1002
 build_jenkins_group_gid: 1004
-BUILD_JENKINS_VERSION: jenkins_2.303.3
+BUILD_JENKINS_VERSION: jenkins_2.319.3
 build_jenkins_jvm_args: '-Djava.awt.headless=true -Xmx16384m -DsessionTimeout=60'
 
 build_jenkins_python_versions:


### PR DESCRIPTION
Description
AC: VERIFY PR passes linting  from jenkins-upgrade.sh script (script to upgrade jenkins) VERIFY docs are up to date
Implementation Details:
get the script via edx-internal/script and run it locally
Please ask any questions you have and update the document.

Configuration Pull Request
---

<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##
-->

Make sure that the following steps are done before merging:

  - [ ] A SRE team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a SRE ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/spaces/SRE/pages/28967861/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
