### PR TITLE
feat: jenkins update Automation

### DIFF
--- a/playbooks/roles/aws/tasks/main.yml
+++ b/playbooks/roles/aws/tasks/main.yml
@@ -53,7 +53,8 @@
     state: present
     update_cache: yes
   register: install_pkgs
-  until: install_pkgs|success
+  until: install_pkgs is succeeded
+    ###until: install_pkgs|success
   retries: 10
   delay: 5
   when: ansible_distribution in common_debian_variants

--- a/playbooks/roles/common/tasks/main.yml
+++ b/playbooks/roles/common/tasks/main.yml
@@ -61,7 +61,8 @@
     repo: "{{ common_git_ppa }}"
     update_cache: yes
   register: add_repo
-  until: add_repo|success
+  until: add_repo is succeeded
+    ###until: add_repo|success
   retries: 10
   delay: 5
   when: ansible_distribution in common_debian_variants
@@ -71,7 +72,8 @@
     repo: "ppa:linuxuprising/apps"
     update_cache: yes
   register: add_repo
-  until: add_repo|success
+  until: add_repo is succeeded
+    ###until: add_repo|success
   retries: 10
   delay: 5
   when: >
@@ -112,7 +114,8 @@
     repo: "ppa:deadsnakes/ppa"
     update_cache: yes
   register: add_repo
-  until: add_repo|success
+  until: add_repo is succeeded
+  ###until: add_repo|success
   retries: 10
   delay: 5
   when: ansible_distribution_release == 'bionic' or ansible_distribution_release == 'focal'
@@ -128,7 +131,8 @@
     state: present
     update_cache: yes
   register: install_pkgs
-  until: install_pkgs|success
+  until: install_pkgs is succeeded
+    ###until: install_pkgs|success
   retries: 10
   delay: 5
   when: ansible_distribution in common_debian_variants
@@ -153,7 +157,8 @@
     state: present
     update_cache: yes
   register: install_pkgs
-  until: install_pkgs|success
+  until: install_pkgs is succeeded
+    ###until: install_pkgs|success
   retries: 10
   delay: 5
   when: >

--- a/playbooks/roles/edx_django_service/tasks/main.yml
+++ b/playbooks/roles/edx_django_service/tasks/main.yml
@@ -68,7 +68,8 @@
       - python3.8-distutils
     update_cache: yes
   register: install_pkgs
-  until: install_pkgs|success
+  until: install_pkgs is succeeded
+    ###until: install_pkgs|success
   retries: 10
   delay: 5
   when: edx_django_service_use_python38 and not edx_django_service_enable_experimental_docker_shim
@@ -81,7 +82,8 @@
     name: "{{ item }}"
     update_cache: yes
   register: install_pkgs
-  until: install_pkgs|success
+  until: install_pkgs is succeeded
+    ###until: install_pkgs|success
   retries: 10
   delay: 5
   when: edx_django_service_use_python3 and not edx_django_service_enable_experimental_docker_shim

--- a/playbooks/roles/edx_service/tasks/main.yml
+++ b/playbooks/roles/edx_service/tasks/main.yml
@@ -122,7 +122,8 @@
       - python3.8-distutils
     update_cache: yes
   register: install_pkgs
-  until: install_pkgs|success
+  until: install_pkgs is succeeded
+    ###until: install_pkgs|success
   retries: 10
   delay: 5
   when: edx_service_use_python38
@@ -135,7 +136,8 @@
     name: "{{ item }}"
     update_cache: yes
   register: install_pkgs
-  until: install_pkgs|success
+  until: install_pkgs is succeeded
+    ###until: install_pkgs|success
   retries: 10
   delay: 5
   when: edx_service_use_python3 and not edx_service_use_python38
@@ -199,7 +201,8 @@
     update_cache: true
     cache_valid_time: 3600
   register: install_pkgs
-  until: install_pkgs|success
+  until: install_pkgs is succeeded
+    ###until: install_pkgs|success
   retries: 10
   delay: 5
   when: ansible_distribution in common_debian_variants

--- a/playbooks/roles/edxapp/tasks/main.yml
+++ b/playbooks/roles/edxapp/tasks/main.yml
@@ -110,7 +110,8 @@
     state: present
     update_cache: yes
   register: install_pkgs
-  until: install_pkgs|success
+  until: install_pkgs is succeeded
+    ###until: install_pkgs|success
   retries: 10
   delay: 5
   with_flattened:
@@ -134,7 +135,8 @@
     state: present
     update_cache: yes
   register: add_repo
-  until: add_repo|success
+  until: add_repo is succeeded
+    ###until: add_repo|success
   retries: 10
   delay: 5
   tags:
@@ -147,7 +149,8 @@
     state: present
     update_cache: yes
   register: install_pkgs
-  until: install_pkgs|success
+  until: install_pkgs is succeeded
+    ###until: install_pkgs|success
   retries: 10
   delay: 5
   tags:
@@ -172,7 +175,8 @@
       - python3.8-distutils
     update_cache: yes
   register: install_pkgs
-  until: install_pkgs|success
+  until: install_pkgs is succeeded
+    ###until: install_pkgs|success
   retries: 10
   delay: 5
   tags:

--- a/playbooks/roles/edxapp_common/tasks/main.yml
+++ b/playbooks/roles/edxapp_common/tasks/main.yml
@@ -5,7 +5,8 @@
     state: present
     update_cache: yes
   register: install_pkgs
-  until: install_pkgs|success
+  until: install_pkgs is succeeded
+    ###until: install_pkgs|success
   retries: 10
   delay: 5
   tags:

--- a/playbooks/roles/hermes/tasks/main.yml
+++ b/playbooks/roles/hermes/tasks/main.yml
@@ -26,7 +26,8 @@
     name: "{{ item }}"
     update_cache: yes
   register: install_pkgs
-  until: install_pkgs|success
+  until: install_pkgs is succeeded
+    ###until: install_pkgs|success
   retries: 10
   delay: 5
   with_items:

--- a/playbooks/roles/neo4j/meta/main.yml
+++ b/playbooks/roles/neo4j/meta/main.yml
@@ -2,7 +2,7 @@
 dependencies:
   - common
   - role: oraclejdk
-    ORACLEJDK_VERSION: "8u131"
-    oraclejdk_base: "jdk1.8.0_131"
-    oraclejdk_build: "b11"
-    oraclejdk_link: "/usr/lib/jvm/java-8-oracle"
+    ORACLEJDK_VERSION: "11.0.13"
+    oraclejdk_base: "jdk-11.0.13"
+    oraclejdk_build: "13"
+    oraclejdk_link: "/usr/lib/jvm/jdk-11.0.13"

--- a/playbooks/roles/nginx/tasks/main.yml
+++ b/playbooks/roles/nginx/tasks/main.yml
@@ -46,7 +46,8 @@
     state: present
     update_cache: yes
   register: install_pkgs
-  until: install_pkgs|success
+  until: install_pkgs is succeeded
+    ###until: install_pkgs|success
   retries: 10
   delay: 5
   notify: restart nginx
@@ -69,7 +70,8 @@
     state: present
     update_cache: yes
   register: add_repo
-  until: add_repo|success
+  until: add_repo is succeeded
+    ###until: add_repo|success
   retries: 10
   delay: 5
   notify: restart nginx
@@ -97,7 +99,8 @@
     state: latest
     update_cache: yes
   register: install_pkgs
-  until: install_pkgs|success
+  until: install_pkgs is succeeded
+    ###until: install_pkgs|success
   retries: 10
   delay: 5
   notify: restart nginx

--- a/playbooks/roles/nltk/tasks/main.yml
+++ b/playbooks/roles/nltk/tasks/main.yml
@@ -3,7 +3,8 @@
 - name: Install unzip
   apt: pkg=unzip state=present update_cache=yes
   register: install_pkgs
-  until: install_pkgs|success
+  until: install_pkgs is succeeded
+    ###until: install_pkgs|success
   retries: 10
   delay: 5
 
@@ -28,6 +29,7 @@
   args:
     chdir: "{{ NLTK_DATA_DIR }}/{{ item.path|dirname }}"
   with_items: "{{ NLTK_DATA }}"
-  when: nltk_download|changed
+  when: nltk_download is changed
+    ###when: nltk_download|changed
   tags:
     - deploy

--- a/playbooks/roles/oraclejdk/defaults/main.yml
+++ b/playbooks/roles/oraclejdk/defaults/main.yml
@@ -1,16 +1,16 @@
 ---
 
-ORACLEJDK_VERSION: "8u131"
+ORACLEJDK_VERSION: "11.0.14"
 # what the archive unpacks to
-oraclejdk_base: "jdk1.8.0_131"
-oraclejdk_build: "b11"
+oraclejdk_base: "jdk-11.0.14"
+oraclejdk_build: "14"
 oraclejdk_platform: "linux"
 oraclejdk_arch: "x64"
-oraclejdk_file: "jdk-{{ ORACLEJDK_VERSION }}-{{ oraclejdk_platform }}-{{ oraclejdk_arch }}.tar.gz"
+oraclejdk_file: "jdk-{{ ORACLEJDK_VERSION }}_{{ oraclejdk_platform }}-{{ oraclejdk_arch }}_bin.tar.gz"
 
-oraclejdk_url: "http://download.oracle.com/otn-pub/java/jdk/{{ ORACLEJDK_VERSION }}-{{ oraclejdk_build }}/d54c1d3a095b4ff2b6607d096fa80163/{{ oraclejdk_file }}"
+oraclejdk_url: "https://edx-testeng-oel8man-java11.s3.amazonaws.com/{{ oraclejdk_file }}"
 
-oraclejdk_link: "/usr/lib/jvm/java-8-oracle"
+oraclejdk_link: "/usr/lib/jvm/jdk-11.0.14"
 
 oraclejdk_debian_pkgs:
-  - curl
+  - wget

--- a/playbooks/roles/prospectus/tasks/main.yml
+++ b/playbooks/roles/prospectus/tasks/main.yml
@@ -66,7 +66,8 @@
       - python3.8-distutils
     update_cache: yes
   register: install_pkgs
-  until: install_pkgs|success
+  until: install_pkgs is succeeded
+    ###until: install_pkgs|success
   retries: 10
   delay: 5
   when: prospectus_use_python3
@@ -89,7 +90,8 @@
   become_user: "{{ prospectus_user }}"
   environment: "{{ prospectus_env_vars }}"
   register: install_pkgs
-  until: install_pkgs|success
+  until: install_pkgs is succeeded
+    ###until: install_pkgs|success
   retries: 10
   delay: 5
   tags:
@@ -164,7 +166,8 @@
     name: "pngquant"
     update_cache: yes
   register: install_pkgs
-  until: install_pkgs|success
+  until: install_pkgs is succeeded
+    ###until: install_pkgs|success
   retries: 10
   delay: 5
   tags:


### PR DESCRIPTION
De[script](https://github.com/edx/edx-internal/pull/6222)ion
As an owner of Jenkins I know that we are able to use an automated script to update it so that we can ensure it is on a recent version.

<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##
-->

Make sure that the following steps are done before merging:

  - [ ] A SRE team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a SRE ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/spaces/SRE/pages/28967861/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
