### PR TITLE
chore: cloudwatch alert added to jenkins old and new server

### DIFF
--- a/playbooks/jenkins_data_engineering.yml
+++ b/playbooks/jenkins_data_engineering.yml
@@ -32,3 +32,6 @@
       when: COMMON_ENABLE_NEWRELIC_INFRASTRUCTURE
       tags:
         - newreliconly
+    - role: aws_cloudwatch_agent
+      tags:
+        - cloudwatch

--- a/playbooks/jenkins_data_engineering_new.yml
+++ b/playbooks/jenkins_data_engineering_new.yml
@@ -34,3 +34,6 @@
       when: COMMON_ENABLE_NEWRELIC_INFRASTRUCTURE
       tags:
         - newreliconly
+    - role: aws_cloudwatch_agent
+      tags:
+        - cloudwatch


### PR DESCRIPTION
Configuration Pull Request
---

<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##
-->

Make sure that the following steps are done before merging:

  - [ ] A SRE team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a SRE ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/spaces/SRE/pages/28967861/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
