### PR TITLE
feat: update flowerconfig to add basic_auth support (PSRE-1441)

### DIFF
--- a/playbooks/roles/flower/defaults/main.yml
+++ b/playbooks/roles/flower/defaults/main.yml
@@ -13,6 +13,9 @@ FLOWER_OAUTH2_KEY: "A Client ID from Google's OAUTH2 provider"
 FLOWER_OAUTH2_SECRET: "A Client Secret from Google's OAUTH2 provider"
 FLOWER_OAUTH2_REDIRECT: "A URL registered with Google's OAUTH2 provider"
 FLOWER_AUTH_REGEX: ".*@example.com" # Can be blank to disable auth
+# A list of user:password pairs seperated by a comma to restrict flower access
+# using usernames and passwords
+FLOWER_BASIC_AUTH: []
 
 FLOWER_USER: "flower"
 flower_app_dir: "{{ COMMON_APP_DIR }}/{{ FLOWER_USER }}"

--- a/playbooks/roles/flower/templates/edx/app/flower/flowerconfig.py.j2
+++ b/playbooks/roles/flower/templates/edx/app/flower/flowerconfig.py.j2
@@ -5,3 +5,4 @@ oauth2_key          = "{{ FLOWER_OAUTH2_KEY }}"
 oauth2_secret       = "{{ FLOWER_OAUTH2_SECRET }}"
 oauth2_redirect_uri = "{{ FLOWER_OAUTH2_REDIRECT }}"
 auth                = "{{ FLOWER_AUTH_REGEX }}"
+basic_auth          = {{ FLOWER_BASIC_AUTH }}


### PR DESCRIPTION
The purpose of this PR is to add support in flower config to use basic access authentication to restrict flower access via usernames and passwords. In sandbox builds we have different URLs and we can not use oAuth to limit sandboxes so alternatively, we can use basic auth here.