### PR TITLE
feat: npm installation doesn't perform known host checking

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -1159,6 +1159,9 @@ edxapp_environment_extra: {}
 
 edxapp_environment: "{{ edxapp_environment_default | combine(edxapp_environment_extra) }}"
 
+git_ssh_environment_mixin:
+  GIT_SSH: "{{ edxapp_git_ssh }}"
+
 edxapp_generic_contentstore_config: &edxapp_generic_default_contentstore
   ENGINE:  'xmodule.contentstore.mongo.MongoContentStore'
   #

--- a/playbooks/roles/edxapp/tasks/deploy.yml
+++ b/playbooks/roles/edxapp/tasks/deploy.yml
@@ -237,12 +237,11 @@
     - install
     - install:app-requirements
 
-#install with the shell command instead of the ansible npm module so we don't accidentally re-write package.json
 - name: install node dependencies
-  shell: "easy_install --version && npm install"
+  shell: "easy_install --version && npm ci"
   args:
     chdir: "{{ edxapp_code_dir }}"
-  environment: "{{ edxapp_environment }}"
+  environment: "{{ edxapp_environment | combine(git_ssh_environment_mixin) }}"
   become_user: "{{ edxapp_user }}"
   tags:
     - install


### PR DESCRIPTION
This PR was motivated by timeout errors in sandbox builds, where the last step ansible had attempted to execute was `[edxapp: install node dependencies]`. On investigation it looks like this was the result of new JS code we were trying to build against needing to communicate with github over ssh in a way we weren't previously dependent on, likely the result of newer/more up-to-date JS dependencies. This PR removes this blocker, and changes our edxapp deployments to use `npm ci` rather than `npm install` when pulling in JS/frontend dependencies. This last should be a build reliability improvement.

Successful sandbox build using this config branch: https://tools-edx-jenkins.edx.org/job/sandboxes/job/CreateSandbox/45283/console

Configuration Pull Request

Make sure that the following steps are done before merging:

  - [x] A SRE team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a SRE ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/spaces/SRE/pages/28967861/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
