### PR TITLE
feat!: Drop settings related to importing the demo-test-course.

### DIFF
--- a/playbooks/sample_vars/server_vars.yml
+++ b/playbooks/sample_vars/server_vars.yml
@@ -14,7 +14,6 @@
 #COMMON_ENABLE_DATADOG: $enable_datadog
 #FORUM_NEW_RELIC_ENABLE: $enable_newrelic
 #ENABLE_PERFORMANCE_COURSE: $performance_course
-#ENABLE_DEMO_TEST_COURSE: $demo_test_course
 #ENABLE_EDX_DEMO_COURSE: $edx_demo_course
 #EDXAPP_NEWRELIC_LMS_APPNAME: sandbox-${dns_name}-edxapp-lms
 #EDXAPP_NEWRELIC_CMS_APPNAME: sandbox-${dns_name}-edxapp-cms
@@ -159,12 +158,6 @@
 #ANALYTICS_API_GIT_IDENTITY: "{{ _local_git_identity }}"
 #
 #TESTCOURSES_EXPORTS:
-#  - github_url: "https://github.com/edx/demo-performance-course.git"
-#    install: "{{ ENABLE_PERFORMANCE_COURSE }}"
-#    course_id: "course-v1:DemoX+PERF101+course"
-#  - github_url: "https://github.com/edx/demo-test-course.git"
-#    install: "{{ ENABLE_DEMO_TEST_COURSE }}"
-#    course_id: "course-v1:edX+Test101+course"
 #  - github_url: "https://github.com/edx/edx-demo-course.git"
 #    install: "{{ ENABLE_EDX_DEMO_COURSE }}"
 #    course_id: "course-v1:edX+DemoX+Demo_Course"

--- a/util/jenkins/ansible-provision.sh
+++ b/util/jenkins/ansible-provision.sh
@@ -158,10 +158,6 @@ if [[ -z $performance_course ]]; then
   performance_course="false"
 fi
 
-if [[ -z $demo_test_course ]]; then
-  demo_test_course="false"
-fi
-
 if [[ -z $edx_demo_course ]]; then
   edx_demo_course="false"
 fi
@@ -423,7 +419,6 @@ COMMON_ENABLE_DATADOG: $enable_datadog
 COMMON_OAUTH_BASE_URL: "https://${deploy_host}"
 FORUM_NEW_RELIC_ENABLE: $enable_newrelic
 ENABLE_PERFORMANCE_COURSE: $performance_course
-ENABLE_DEMO_TEST_COURSE: $demo_test_course
 ENABLE_EDX_DEMO_COURSE: $edx_demo_course
 EDXAPP_ENABLE_AUTO_AUTH: $enable_automatic_auth_for_testing
 EDXAPP_NEWRELIC_LMS_APPNAME: sandbox-${dns_name}-edxapp-lms


### PR DESCRIPTION
That course is being removed per https://github.com/openedx/public-engineering/issues/73

It looks like the mentions in here were vestigial as there were settings set
to import the course but no use of the settings once they were set.

BREAKING_CHANGE: We're removing the ENABLE_DEMO_TEST_COURSE from ansible_provision.sh
meaning if there is something elsewhere in the system making use of that, it may no longer
import this course.