### PR TITLE
feat: optionally collect JS translations on deploy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 Add any new changes to the top (right below this line).
 
  - 2022-04-06
+    - Role: edxapp
+        - Added a new `EDXAPP_COMPILE_JSI18N` variable to control whether
+          to run the `compilejsi18n` management command on edxapp deploy.
+          Defaults to false.
+
+ - 2022-04-06
     - Role: simple_theme
        - Added a new `SIMPLETHEME_I18N_DJANGO` setting to allow operators to provide
          additional translations, or override existing django translations.

--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -629,6 +629,9 @@ EDXAPP_DCS_SESSION_COOKIE_SAMESITE_FORCE_ALL: True
 # Whether to run reindex_course on deploy
 EDXAPP_REINDEX_ALL_COURSES: false
 
+# Whether to run compilejsi18n on deploy
+EDXAPP_COMPILE_JSI18N: false
+
 # XML Course related flags
 EDXAPP_XML_FROM_GIT: false
 EDXAPP_XML_S3_BUCKET: !!null

--- a/playbooks/roles/edxapp/tasks/deploy.yml
+++ b/playbooks/roles/edxapp/tasks/deploy.yml
@@ -381,6 +381,15 @@
   when:
     - celery_worker is not defined
 
+- name: compile JS translations
+  shell: ". {{ edxapp_app_dir }}/edxapp_env && {{ edxapp_venv_bin }}/python ./manage.py lms --settings={{ edxapp_settings }} compilejsi18n"
+  args:
+    chdir: "{{ edxapp_code_dir }}"
+  become_user: "{{ edxapp_user }}"
+  when: EDXAPP_COMPILE_JSI18N and celery_worker is not defined
+  tags:
+    - assets
+
 # creates the supervisor jobs for the
 # service variants configured, runs
 # gather_assets and db migrations


### PR DESCRIPTION
If the `EDXAPP_COMPILE_JSI18N` is enabled, this will invoke the `compilejsi18n` management command when deploying edxapp.

This is useful when you use custom JS translations for example via a theme.

**Test instructions**:

I set up [a sandbox](https://mtyaka.opencraft.hosting/) using code from https://github.com/openedx/configuration/pull/6679 to automatically install some custom JS translations. These are the relevant ansible vars:

```
EDXAPP_DEFAULT_SITE_THEME: simple-theme
SIMPLETHEME_ENABLE_DEPLOY: true
EDXAPP_COMPILE_JSI18N: true
EDXAPP_PREPEND_LOCALE_PATHS:
  - "{{ EDXAPP_COMPREHENSIVE_THEME_DIRS[0] }}/simple-theme/i18n/conf/locale"
SIMPLETHEME_I18N_DJANGO:
  - lang: ar
    domain: djangojs
    messages: |
      msgid "Submit"
      msgstr "تقديم YYY"
      msgid "Add a Post"
      msgstr "إضافة منشور ZZZ"
```

1. Create an account and log into [the sandbox](https://mtyaka.opencraft.hosting/).
2. Enroll into the Demo course.
3. Go to https://mtyaka.opencraft.hosting/update_lang/ and switch the language to Arabic (`ar`).
4. Go to [the forum](https://mtyaka.opencraft.hosting/courses/course-v1:edX+DemoX+Demo_Course/discussion/forum/), click the button to create a new post, and verify that the submit button at the bottom contains the custom translation "تقديم YYY" and that one of the headings on the page says "إضافة منشور ZZZ".
5. If you have SSH access to the sandbox (213.32.74.79), go to the `/edx/app/edxapp/edx-platform` folder and run `git status`. You should see some modified files under `lms/static/js/i18n` (the files were modified because the `compilejsi18n` management comment modifies them after collecting JS translations from `LOCALE_PATHS`).

**Sandbox**:

- https://mtyaka.opencraft.hosting/

Configuration Pull Request
---

<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##
-->

Make sure that the following steps are done before merging:

  - [ ] A SRE team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a SRE ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/spaces/SRE/pages/28967861/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
