### PR TITLE
fix: CORS issue for CSRF token API

### DIFF
--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
@@ -199,6 +199,11 @@ error_page {{ k }} {{ v }};
     try_files $uri @proxy_to_lms_app_api;
   }
 
+  # CSRF token API
+  location /csrf/api {
+    try_files $uri @proxy_to_lms_app_api;
+  }
+
   #enterprise API
   location /enterprise/api {
     try_files $uri @proxy_to_lms_app_api;


### PR DESCRIPTION
If basic auth is enabled on the sandbox, CSRF token endpoint is resolving to location / and setting auth_basic to `Restricted` for this endpoint. Fixed by defining its own rule.

**Reproduction steps:** 
1. Open network tab in browser inspector tool and visit https://authn-wahmed.sandbox.edx.org/login
2. Note that CSRF token endpoint failed with CORS error:
<img width="955" alt="Screenshot 2022-03-30 at 12 52 07 PM" src="https://user-images.githubusercontent.com/2851134/160780734-44f3486e-2ad9-41c0-af6e-06a81d2f5536.png">

**Sandbox with fix:** https://authn-csrf-api.sandbox.edx.org/login
1. Follow the above steps for this sandbox and notice that there is no error on CSRF token endpoint
<img width="942" alt="Screenshot 2022-03-30 at 1 00 25 PM" src="https://user-images.githubusercontent.com/2851134/160781926-23470125-62ee-43ff-b746-67c7ea891c47.png">


Configuration Pull Request
---

<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##
-->

Make sure that the following steps are done before merging:

  - [x] A SRE team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a SRE ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/spaces/SRE/pages/28967861/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
