### PR TITLE
feat: let conductor proxy s3 file paths containing hyphens

### DIFF
--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/conductor.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/conductor.j2
@@ -51,13 +51,8 @@ server {
     }
 
     # Matches: <router>/<organization>/[.../]<file.ext>
-    location ~ ^/{{ static_site.router_path }}/((?:\w+\/+)*)([\w\-\.]+\.[\w\-\.]+) {
+    location ~ ^/{{ static_site.router_path }}/((?:[\w\-]+\/+)*)([\w\-\.]+\.[\w\-\.]+) {
         proxy_pass {{ static_site.proxied_path }}/$1$2;
-    }
-
-    # Matches: <router>/<organization>/page-data/[.../]<file.ext>
-    location ~ ^/{{ static_site.router_path }}/page-data/((?:\w+\/+)*)([\w\-\.]+\.[\w\-\.]+) {
-        proxy_pass {{ static_site.proxied_path }}/page-data/$1$2;
     }
 
     # Matches: <router>/<organization>/<subpage>/[.../]


### PR DESCRIPTION
generalization of https://github.com/openedx/configuration/pull/6713

Configuration Pull Request
---

<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##
-->

Make sure that the following steps are done before merging:

  - [ ] A SRE team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a SRE ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/spaces/SRE/pages/28967861/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
