### PR TITLE
chore: upgrade node version to v16 on learner_portal code base

### DIFF
--- a/playbooks/roles/learner_portal/defaults/main.yml
+++ b/playbooks/roles/learner_portal/defaults/main.yml
@@ -17,7 +17,7 @@ edx_django_service_use_python3: false
 learner_portal_repo: 'https://github.com/edx/frontend-app-learner-portal.git'
 LEARNER_PORTAL_VERSION: 'master'
 learner_portal_service_name: 'learner_portal'
-LEARNER_PORTAL_NODE_VERSION: '12.11.1'
+LEARNER_PORTAL_NODE_VERSION: '16.14.2'
 
 learner_portal_nodeenv_dir: '{{ learner_portal_home }}/nodeenvs/{{ learner_portal_service_name }}'
 learner_portal_nodeenv_bin: '{{learner_portal_nodeenv_dir}}/bin'


### PR DESCRIPTION
Configuration Pull Request

Upgrade the node version to v16 from v12 used by learner_portal on edX sandboxes. If we don't make this update, the learner_portal gatsby build will fail. Learner_portal gatsby version was recently upgraded from v2.2.32 to v3.14.6

---

<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##
-->

Make sure that the following steps are done before merging:

  - [ ] A SRE team member has approved the PR if it is code shared across multiple services and you don't own all of the services.

