### PR TITLE
Upgrade Node and Npm version for edxapp

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -1092,6 +1092,8 @@ edxapp_venv_dir: "{{ edxapp_venvs_dir }}/edxapp"
 edxapp_venv_bin: "{{ edxapp_venv_dir }}/bin"
 edxapp_nodeenv_dir: "{{ edxapp_app_dir }}/nodeenvs/edxapp"
 edxapp_nodeenv_bin: "{{ edxapp_nodeenv_dir }}/bin"
+edxapp_npm_dir: "{{ edxapp_app_dir }}/.npm"
+edxapp_npm_bin: "{{ edxapp_npm_dir }}/bin"
 edxapp_settings: '{{ EDXAPP_SETTINGS }}'
 EDXAPP_NODE_VERSION: "16"
 EDXAPP_NPM_VERSION: "8.5.0"
@@ -1100,7 +1102,7 @@ edxapp_node_bin: "{{ edxapp_code_dir }}/node_modules/.bin"
 edxapp_user: edxapp
 edxapp_user_createhome: 'no'
 edxapp_user_shell: '/bin/false'
-edxapp_deploy_path: "{{ edxapp_venv_bin }}:{{ edxapp_code_dir }}/bin:{{ edxapp_node_bin }}:{{ edxapp_nodeenv_bin }}:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+edxapp_deploy_path: "{{ edxapp_venv_bin }}:{{ edxapp_code_dir }}/bin:{{ edxapp_npm_bin }}:{{ edxapp_node_bin }}:{{ edxapp_nodeenv_bin }}:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 edxapp_staticfile_dir: "{{ edxapp_data_dir }}/staticfiles"
 edxapp_media_dir: "{{ edxapp_data_dir }}/media"
 edxapp_media_dir_s3: "{{ edxapp_media_dir | regex_replace('^\\/', '') }}"
@@ -1160,6 +1162,8 @@ edxapp_environment_default:
   STUDIO_CFG: "{{ edxapp_studio_cfg }}"
   BOTO_CONFIG: "{{ edxapp_app_dir }}/.boto"
   REVISION_CFG: "{{ edxapp_revision_cfg }}"
+  NODE_PATH: "{{ edxapp_npm_dir }}/lib/modules:/usr/lib/node_modules"
+  MANPATH: "{{ edxapp_npm_dir }}/share/man:$(manpath)"
 
 edxapp_environment_extra: {}
 

--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -1093,7 +1093,8 @@ edxapp_venv_bin: "{{ edxapp_venv_dir }}/bin"
 edxapp_nodeenv_dir: "{{ edxapp_app_dir }}/nodeenvs/edxapp"
 edxapp_nodeenv_bin: "{{ edxapp_nodeenv_dir }}/bin"
 edxapp_settings: '{{ EDXAPP_SETTINGS }}'
-EDXAPP_NODE_VERSION: "12"
+EDXAPP_NODE_VERSION: "16"
+EDXAPP_NPM_VERSION: "8.5.0"
 # This is where node installs modules, not node itself
 edxapp_node_bin: "{{ edxapp_code_dir }}/node_modules/.bin"
 edxapp_user: edxapp

--- a/playbooks/roles/edxapp/tasks/deploy.yml
+++ b/playbooks/roles/edxapp/tasks/deploy.yml
@@ -250,7 +250,7 @@
     - install:app-requirements
 
 - name: install node dependencies
-  shell: "easy_install --version && npm ci"
+  shell: "easy_install --version && npm install --no-optional"
   args:
     chdir: "{{ edxapp_code_dir }}"
   environment: "{{ edxapp_environment | combine(git_ssh_environment_mixin) }}"

--- a/playbooks/roles/edxapp/tasks/deploy.yml
+++ b/playbooks/roles/edxapp/tasks/deploy.yml
@@ -250,7 +250,7 @@
     - install:app-requirements
 
 - name: install node dependencies
-  shell: "easy_install --version && npm install --no-optional"
+  shell: "easy_install --version && npm install"
   args:
     chdir: "{{ edxapp_code_dir }}"
   environment: "{{ edxapp_environment | combine(git_ssh_environment_mixin) }}"

--- a/playbooks/roles/edxapp/tasks/main.yml
+++ b/playbooks/roles/edxapp/tasks/main.yml
@@ -154,6 +154,12 @@
     - install
     - install:base
 
+- name: Pin npm to EDXAPP_NPM_VERSION
+  command: "npm install -g npm@{{ EDXAPP_NPM_VERSION }}"
+  tags:
+    - install
+    - install:base
+
 - name: set up edxapp .npmrc
   template:
     src: .npmrc.j2

--- a/playbooks/roles/edxapp/tasks/main.yml
+++ b/playbooks/roles/edxapp/tasks/main.yml
@@ -154,12 +154,6 @@
     - install
     - install:base
 
-- name: Pin npm to EDXAPP_NPM_VERSION
-  command: "npm install -g npm@{{ EDXAPP_NPM_VERSION }}"
-  tags:
-    - install
-    - install:base
-
 - name: set up edxapp .npmrc
   template:
     src: .npmrc.j2
@@ -167,6 +161,16 @@
     owner: "{{ edxapp_user }}"
     group: "{{ common_web_group }}"
     mode: 0600
+  tags:
+    - install
+    - install:base
+
+# This will install npm EDXAPP_NPM_VERSION to edxapp_npm_bin rather than updating the global npm version installed via apt.
+# As edxapp_npm_bin is already part of edxapp_environment, the npm command will always pick up the one installed in edxapp_npm_bin.
+- name: Pin npm to {{ EDXAPP_NPM_VERSION }}
+  shell: "npm install -g npm@{{ EDXAPP_NPM_VERSION }}"
+  environment: "{{ edxapp_environment | combine(git_ssh_environment_mixin) }}"
+  become_user: "{{ edxapp_user }}"
   tags:
     - install
     - install:base

--- a/playbooks/roles/edxapp/templates/.npmrc.j2
+++ b/playbooks/roles/edxapp/templates/.npmrc.j2
@@ -1,1 +1,2 @@
 registry={{ COMMON_NPM_MIRROR_URL }}
+prefix={{ edxapp_npm_dir }}


### PR DESCRIPTION
## Desc
This PR updates the Node and npm version for edxapp pipeline to 16 and 8.5.x respectively 
Changes have been tested with [sandbox](https://aht007.sandbox.edx.org/)
Related [PR](https://github.com/openedx/edx-platform/pull/30420) for adding Node16 support in edx-platform has already been merged.