### PR TITLE
Set up tasks to copy the ssh public key of jenkins users

### DIFF
--- a/playbooks/roles/dbt_docs_nginx/tasks/main.yml
+++ b/playbooks/roles/dbt_docs_nginx/tasks/main.yml
@@ -75,3 +75,15 @@
   tags:
     - install
     - install:nginx
+
+# Add the jenkins user's ssh public key to the running user's autorized keys
+# This is needed so that this jenkins instance can be used to update system users
+- name: Add the jenkins user's ssh public key to the running user's autorized keys
+  lineinfile:
+    path: /home/{{ ansible_ssh_user }}/.ssh/authorized_keys
+    create: yes
+    line: "{{ lookup('file', jenkins_ssh_public_keyfile) }}"
+  when: jenkins_ssh_public_keyfile is defined and jenkins_ssh_public_keyfile
+  tags:
+    - ssh
+    - ssh:keys

--- a/playbooks/roles/jenkins_data_engineering/tasks/main.yml
+++ b/playbooks/roles/jenkins_data_engineering/tasks/main.yml
@@ -132,3 +132,14 @@
   service: name=jenkins state=restarted
   tags:
     - jenkins-auth
+
+# Add the jenkins user's ssh public key to the running user's autorized keys
+# This is needed so that this jenkins instance can be used to update system users
+- name: Add the jenkins user's ssh public key to the running user's autorized keys
+  lineinfile:
+    path: /home/{{ ansible_ssh_user }}/.ssh/authorized_keys
+    create: yes
+    line: "{{ lookup('file', JENKINS_DATA_ENGINEERING_AUTOMATION_PUBLIC_KEY_SOURCE_PATH) }}"
+  tags:
+    - ssh
+    - ssh:keys

--- a/playbooks/roles/jenkins_data_engineering_new/tasks/main.yml
+++ b/playbooks/roles/jenkins_data_engineering_new/tasks/main.yml
@@ -134,3 +134,14 @@
   service: name=jenkins state=restarted
   tags:
     - jenkins-auth
+
+# Add the jenkins user's ssh public key to the running user's autorized keys
+# This is needed so that this jenkins instance can be used to update system users
+- name: Add the jenkins user's ssh public key to the running user's autorized keys
+  lineinfile:
+    path: /home/{{ ansible_ssh_user }}/.ssh/authorized_keys
+    create: yes
+    line: "{{ lookup('file', JENKINS_DATA_ENGINEERING_AUTOMATION_PUBLIC_KEY_SOURCE_PATH) }}"
+  tags:
+    - ssh
+    - ssh:keys

--- a/playbooks/roles/tableau_de/tasks/main.yml
+++ b/playbooks/roles/tableau_de/tasks/main.yml
@@ -57,3 +57,15 @@
   tags:
     - install
     - install:base
+
+# Add the jenkins user's ssh public key to the running user's autorized keys
+# This is needed so that this jenkins instance can be used to update system users
+- name: Add the jenkins user's ssh public key to the running user's autorized keys
+  lineinfile:
+    path: /home/{{ ansible_ssh_user }}/.ssh/authorized_keys
+    create: yes
+    line: "{{ lookup('file', jenkins_ssh_public_keyfile) }}"
+  when: jenkins_ssh_public_keyfile is defined and jenkins_ssh_public_keyfile
+  tags:
+    - ssh
+    - ssh:keys


### PR DESCRIPTION
This sets up tasks to copy jenkins user's ssh public keys to target instances owned by analytics.

Configuration Pull Request
---

<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##
-->

Make sure that the following steps are done before merging:

  - [ ] A SRE team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a SRE ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/spaces/SRE/pages/28967861/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
