### PR TITLE
fix: use npm v8 for discovery

### DIFF
--- a/playbooks/roles/discovery/defaults/main.yml
+++ b/playbooks/roles/discovery/defaults/main.yml
@@ -35,6 +35,7 @@ discovery_home: "{{ COMMON_APP_DIR }}/{{ discovery_service_name }}"
 discovery_code_dir: "{{ discovery_home }}/{{ discovery_service_name }}"
 
 DISCOVERY_NODE_VERSION: '16.14.0'
+DISCOVERY_NPM_VERSION: '8.5.5'
 DISCOVERY_USE_PYTHON38: True
 
 #

--- a/playbooks/roles/discovery/meta/main.yml
+++ b/playbooks/roles/discovery/meta/main.yml
@@ -48,6 +48,7 @@ dependencies:
     edx_django_service_extra_apps: '{{ DISCOVERY_EXTRA_APPS }}'
     edx_django_service_session_expire_at_browser_close: '{{ DISCOVERY_SESSION_EXPIRE_AT_BROWSER_CLOSE }}'
     edx_django_service_node_version: '{{ DISCOVERY_NODE_VERSION }}'
+    edx_django_service_npm_version: '{{ DISCOVERY_NPM_VERSION }}'
     edx_django_service_automated_users: '{{ DISCOVERY_AUTOMATED_USERS }}'
     edx_django_service_post_migrate_commands: '{{ DISCOVERY_POST_MIGRATE_COMMANDS }}'
     edx_django_service_enable_newrelic_distributed_tracing: '{{ DISCOVERY_ENABLE_NEWRELIC_DISTRIBUTED_TRACING }}'


### PR DESCRIPTION
Configuration Pull Request
---

<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##
-->

Make sure that the following steps are done before merging:

  - [ ] A SRE team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a SRE ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/spaces/SRE/pages/28967861/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
