### PR TITLE
Revert "Python Requirements Update"

### DIFF
--- a/playbooks/roles/aws/templates/requirements.txt.j2
+++ b/playbooks/roles/aws/templates/requirements.txt.j2
@@ -4,13 +4,13 @@
 #
 #    make upgrade
 #
-awscli==1.22.97
+awscli==1.20.63
     # via -r requirements/aws.in
 boto==2.49.0
     # via -r requirements/aws.in
-boto3==1.21.42
+boto3==1.18.63
     # via -r requirements/aws.in
-botocore==1.24.42
+botocore==1.21.63
     # via
     #   awscli
     #   boto3
@@ -19,7 +19,7 @@ colorama==0.4.3
     # via awscli
 docutils==0.15.2
     # via awscli
-jmespath==1.0.0
+jmespath==0.10.0
     # via
     #   boto3
     #   botocore
@@ -29,7 +29,7 @@ python-dateutil==2.8.2
     # via
     #   botocore
     #   s3cmd
-python-magic==0.4.25
+python-magic==0.4.24
     # via s3cmd
 pyyaml==5.3.1
     # via
@@ -39,11 +39,11 @@ rsa==4.7.2
     # via awscli
 s3cmd==2.2.0
     # via -r requirements/aws.in
-s3transfer==0.5.2
+s3transfer==0.5.0
     # via
     #   awscli
     #   boto3
 six==1.16.0
     # via python-dateutil
-urllib3==1.26.9
+urllib3==1.26.7
     # via botocore

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@
 #
 ansible==2.8.20
     # via -r requirements/base.in
-awscli==1.22.97
+awscli==1.20.63
     # via -r requirements/base.in
 bcrypt==3.1.7
     # via
@@ -14,9 +14,9 @@ bcrypt==3.1.7
     #   paramiko
 boto==2.49.0
     # via -r requirements/base.in
-boto3==1.21.42
+boto3==1.18.63
     # via -r requirements/base.in
-botocore==1.24.42
+botocore==1.21.63
     # via
     #   awscli
     #   boto3
@@ -28,17 +28,17 @@ cffi==1.15.0
     #   bcrypt
     #   cryptography
     #   pynacl
-charset-normalizer==2.0.12
+charset-normalizer==2.0.7
     # via requests
 colorama==0.4.3
     # via awscli
-cryptography==36.0.2
+cryptography==35.0.0
     # via
     #   ansible
     #   paramiko
 datadog==0.8.0
     # via -r requirements/base.in
-decorator==5.1.1
+decorator==5.1.0
     # via
     #   datadog
     #   networkx
@@ -54,14 +54,12 @@ jinja2==2.8
     # via
     #   -r requirements/base.in
     #   ansible
-jmespath==1.0.0
+jmespath==0.10.0
     # via
     #   boto3
     #   botocore
 markupsafe==2.0.1
-    # via
-    #   -r requirements/base.in
-    #   jinja2
+    # via jinja2
 mysqlclient==1.4.6
     # via -r requirements/base.in
 networkx==1.11
@@ -76,13 +74,13 @@ pyasn1==0.4.8
     # via
     #   paramiko
     #   rsa
-pycparser==2.21
+pycparser==2.20
     # via cffi
 pycrypto==2.6.1
     # via -r requirements/base.in
 pymongo==3.9.0
     # via -r requirements/base.in
-pynacl==1.5.0
+pynacl==1.4.0
     # via paramiko
 python-dateutil==2.8.2
     # via botocore
@@ -91,13 +89,13 @@ pyyaml==5.4.1
     #   -r requirements/base.in
     #   ansible
     #   awscli
-requests==2.27.1
+requests==2.26.0
     # via
     #   -r requirements/base.in
     #   datadog
 rsa==4.7.2
     # via awscli
-s3transfer==0.5.2
+s3transfer==0.5.0
     # via
     #   awscli
     #   boto3
@@ -105,8 +103,9 @@ six==1.16.0
     # via
     #   bcrypt
     #   pathlib2
+    #   pynacl
     #   python-dateutil
-urllib3==1.26.9
+urllib3==1.26.7
     # via
     #   botocore
     #   requests

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -9,7 +9,6 @@ datadog==0.8.0
 docopt==0.6.2
 ecdsa==0.13.3
 Jinja2==2.8
-markupsafe==2.0.1                  # Pining this until we upgrade jinja2, as in newer version on markupsafe soft_unicode is removed and jinja2==2.8 use this pkg
 mysqlclient==1.4.6                 # Needed for the mysql_db module, 1,4,6 is the newest version that support python 2 which we really need to stop using
 networkx==1.11
 paramiko==2.4.2

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -4,15 +4,15 @@
 #
 #    make upgrade
 #
-click==8.1.2
+click==8.0.3
     # via pip-tools
-pep517==0.12.0
+pep517==0.11.1
     # via pip-tools
-pip-tools==6.6.0
+pip-tools==6.4.0
     # via -r requirements/pip-tools.in
-tomli==2.0.1
+tomli==1.2.1
     # via pep517
-wheel==0.37.1
+wheel==0.37.0
     # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/util/elasticsearch/requirements.txt
+++ b/util/elasticsearch/requirements.txt
@@ -8,7 +8,7 @@ deepdiff==3.1.0
     # via -r requirements/elasticsearch.in
 elasticsearch==0.4.5
     # via -r requirements/elasticsearch.in
-jsonpickle==2.1.0
+jsonpickle==2.0.0
     # via deepdiff
-urllib3==1.26.9
+urllib3==1.26.7
     # via elasticsearch

--- a/util/jenkins/requirements-cloudflare.txt
+++ b/util/jenkins/requirements-cloudflare.txt
@@ -6,13 +6,13 @@
 #
 certifi==2021.10.8
     # via requests
-charset-normalizer==2.0.12
+charset-normalizer==2.0.7
     # via requests
-click==8.1.2
+click==8.0.3
     # via -r requirements/cloudflare.in
 idna==3.3
     # via requests
-requests==2.27.1
+requests==2.26.0
     # via -r requirements/cloudflare.in
-urllib3==1.26.9
+urllib3==1.26.7
     # via requests

--- a/util/jenkins/requirements.txt
+++ b/util/jenkins/requirements.txt
@@ -8,7 +8,7 @@ amqp==1.4.9
     # via kombu
 anyjson==0.3.3
     # via kombu
-awscli==1.22.97
+awscli==1.20.63
     # via -r requirements/jenkins.in
 backoff==1.4.3
     # via -r requirements/jenkins.in
@@ -16,9 +16,9 @@ billiard==3.3.0.23
     # via celery
 boto==2.49.0
     # via -r requirements/jenkins.in
-boto3==1.21.42
+boto3==1.18.63
     # via -r requirements/jenkins.in
-botocore==1.24.42
+botocore==1.21.63
     # via
     #   awscli
     #   boto3
@@ -29,7 +29,7 @@ certifi==2021.10.8
     # via
     #   opsgenie-sdk
     #   requests
-charset-normalizer==2.0.12
+charset-normalizer==2.0.7
     # via requests
 click==6.7
     # via -r requirements/jenkins.in
@@ -39,7 +39,7 @@ docutils==0.15.2
     # via awscli
 idna==3.3
     # via requests
-jmespath==1.0.0
+jmespath==0.10.0
     # via
     #   boto3
     #   botocore
@@ -56,11 +56,11 @@ python-dateutil==2.8.2
     #   botocore
     #   opsgenie-sdk
     #   s3cmd
-python-gnupg==0.4.8
+python-gnupg==0.4.7
     # via -r requirements/jenkins.in
-python-magic==0.4.25
+python-magic==0.4.24
     # via s3cmd
-pytz==2022.1
+pytz==2021.3
     # via
     #   celery
     #   opsgenie-sdk
@@ -70,13 +70,13 @@ pyyaml==5.4.1
     #   awscli
 redis==2.10.6
     # via -r requirements/jenkins.in
-requests==2.27.1
+requests==2.26.0
     # via opsgenie-sdk
 rsa==4.7.2
     # via awscli
 s3cmd==2.2.0
     # via -r requirements/jenkins.in
-s3transfer==0.5.2
+s3transfer==0.5.0
     # via
     #   awscli
     #   boto3
@@ -86,7 +86,7 @@ six==1.16.0
     #   python-dateutil
 splunk-sdk==1.6.6
     # via -r requirements/jenkins.in
-urllib3==1.26.9
+urllib3==1.26.7
     # via
     #   botocore
     #   opsgenie-sdk

--- a/util/pingdom/requirements.txt
+++ b/util/pingdom/requirements.txt
@@ -6,7 +6,7 @@
 #
 certifi==2021.10.8
     # via requests
-charset-normalizer==2.0.12
+charset-normalizer==2.0.7
     # via requests
 click==6.7
     # via -r requirements/pingdom.in
@@ -14,9 +14,9 @@ idna==3.3
     # via requests
 pyyaml==6.0
     # via -r requirements/pingdom.in
-requests==2.27.1
+requests==2.26.0
     # via -r requirements/pingdom.in
 six==1.14.0
     # via -r requirements/pingdom.in
-urllib3==1.26.9
+urllib3==1.26.7
     # via requests

--- a/util/vpc-tools/requirements.txt
+++ b/util/vpc-tools/requirements.txt
@@ -8,13 +8,13 @@ boto==2.49.0
     # via -r requirements/vpc-tools.in
 certifi==2021.10.8
     # via requests
-charset-normalizer==2.0.12
+charset-normalizer==2.0.7
     # via requests
 docopt==0.6.2
     # via -r requirements/vpc-tools.in
 idna==3.3
     # via requests
-requests==2.27.1
+requests==2.26.0
     # via -r requirements/vpc-tools.in
-urllib3==1.26.9
+urllib3==1.26.7
     # via requests


### PR DESCRIPTION
Reverts openedx/configuration#6731

We may need to revert this since some packages do not support Python 3.6 and some edx.org jobs seem to still be using 3.6

Related SRE ticket: https://openedx.atlassian.net/browse/DOS-3117