### PR TITLE
fix: Mark all directories as safe for git on devstack (#6732)

### DIFF
--- a/playbooks/roles/edxapp/tasks/deploy.yml
+++ b/playbooks/roles/edxapp/tasks/deploy.yml
@@ -27,6 +27,18 @@
     - install
     - install:base
 
+# On devstack, tell Git that repos owner by other users are safe.
+# This is necessary in git 2.35.2 and higher. Devstack uses a mix of
+# root and edxapp and git+https pip dependencies end up cloning repos
+# into an open-ended set of directories, so our best bet is to just
+# say every dir on devstack is safe.
+- name: Mark all directories as safe for git on devstack
+  shell: "git config --global --add safe.directory '*'"
+  become: true
+  when: "({{ devstack | default(False) }} or {{ edx_django_service_is_devstack | default(False) }})"
+  tags:
+    - devstack
+
 - name: set git fetch.prune to ignore deleted remote refs
   shell: git config --global fetch.prune true
   become_user: "{{ edxapp_user }}"

--- a/playbooks/roles/git_clone/tasks/main.yml
+++ b/playbooks/roles/git_clone/tasks/main.yml
@@ -20,6 +20,18 @@
 # Rewrite this task using the ansible git-config module once we'll migrate to Ansible 2.x
 # https://docs.ansible.com/ansible/git_config_module.html#git-config
 
+# On devstack, tell Git that repos owner by other users are safe.
+# This is necessary in git 2.35.2 and higher. Devstack uses a mix of
+# root and edxapp and git+https pip dependencies end up cloning repos
+# into an open-ended set of directories, so our best bet is to just
+# say every dir on devstack is safe.
+- name: Mark all directories as safe for git on devstack
+  shell: "git config --global --add safe.directory '*'"
+  become: true
+  when: "({{ devstack | default(False) }} or {{ edx_django_service_is_devstack | default(False) }})"
+  tags:
+    - devstack
+
 - name: Set git fetch.prune to ignore deleted remote refs
   shell: git config --global fetch.prune true
   become_user: "{{ repo_owner }}"


### PR DESCRIPTION
When a user runs make requirements inside devstack's lms-shell (or
tries to provision), pip pulls some from dependencies from git URLs
and then tries to use git commands against those directories in the
virtualenv. However, in devstack, the owner of those repo directories
doesn't match the current user (root), and git versions 2.35.2 will
refuse to read repositories from a different user (since this could
allow code execution).

This change tells git to consider all directories safe, at least on
devstack. (Listing out specific directories to consider safe isn't
really feasible, since the set of git-based dependencies changes on a
regular basis.)

Notes:

- edxapp doesn't use git_clone, but it looks like everything else
  does, so I had to duplicate the task
- There's no one, convenient way of marking something to run only on
  devstack; apparently the devstack tag isn't used universally when
  building devstack, but it turns out that either `devstack` or
  `edx_django_service_is_devstack` is set (and true) in the
  `docker/build/*/ansible_overrides.yml` files, so we can check if
  *either* of those is true. This approach is used in various other
  playbooks already. I also threw on the `devstack` tag for good
  measure, and again because some other tasks use that approach in
  combination.

ref: ARCHBOM-2096

(cherry picked from commit e9a270bd/PR #6732)

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A SRE team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [x] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a SRE ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [x] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/spaces/SRE/pages/28967861/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [x] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
