### PR TITLE
Dubey sandeep/aws logs agent

### DIFF
--- a/playbooks/cloudwatch_server_logs.yml
+++ b/playbooks/cloudwatch_server_logs.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Set up aws_logs_agent to send server logs to cloudwatch
-  hosts: localhost
+  hosts: all
   become: true
   roles:
     - role: aws_logs_agent

--- a/playbooks/cloudwatch_server_logs.yml
+++ b/playbooks/cloudwatch_server_logs.yml
@@ -1,0 +1,7 @@
+---
+
+- name: Set up aws_logs_agent to send server logs to cloudwatch
+  hosts: localhost
+  become: true
+  roles:
+    - role: aws_logs_agent

--- a/playbooks/roles/aws_logs_agent/defaults/main.yml
+++ b/playbooks/roles/aws_logs_agent/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+
+AWS_LOGS_AGENT_SCRIPT_URL: "https://s3.amazonaws.com/aws-cloudwatch/downloads/latest/awslogs-agent-setup.py"

--- a/playbooks/roles/aws_logs_agent/tasks/main.yml
+++ b/playbooks/roles/aws_logs_agent/tasks/main.yml
@@ -16,6 +16,4 @@
     mode: "0664"
 
 - name: Run AWS Logs Agent script
-  script: /tmp/aws-logs-agent.py --region {{ AWS_EC2_INSTANCE_REGION }} -c /etc/aws_logs_agent.conf
-  args:
-    executable: python2.7
+  shell: "python2.7 /tmp/aws-logs-agent.py -n --region {{ AWS_EC2_INSTANCE_REGION }} -c /etc/aws_logs_agent.conf"

--- a/playbooks/roles/aws_logs_agent/tasks/main.yml
+++ b/playbooks/roles/aws_logs_agent/tasks/main.yml
@@ -1,0 +1,21 @@
+---
+
+- name: Download the AWS Logs Agent python script
+  get_url:
+    url: "{{ AWS_LOGS_AGENT_SCRIPT_URL }}"
+    dest: /tmp/aws-logs-agent.py
+    mode: "1777"
+  tags:
+    - install
+    - install:base
+
+- name: Copy aws_logs_agent.conf template
+  template:
+    src: "aws_logs_agent.conf.j2"
+    dest: "/etc/aws_logs_agent.conf"
+    mode: "0664"
+
+- name: Run AWS Logs Agent script
+  script: /tmp/aws-logs-agent.py --region {{ AWS_EC2_INSTANCE_REGION }} -c /etc/aws_logs_agent.conf
+  args:
+    executable: python2.7

--- a/playbooks/roles/aws_logs_agent/templates/aws_logs_agent.conf.j2
+++ b/playbooks/roles/aws_logs_agent/templates/aws_logs_agent.conf.j2
@@ -1,0 +1,12 @@
+[general]
+state_file = /var/awslogs/state/agent-state
+
+{% for log_config in CLOUDWATCH_LOG_FILES %}
+
+[{{ log_config.filename }}]
+file = {{ log_config.filename }}
+log_group_name = {{ log_config.group_name }}
+log_stream_name = {{ log_config.stream_name }}
+datetime_format = %b %d %H:%M:%S
+
+{% endfor %}


### PR DESCRIPTION
## Description

This PR adds a playbook for cloudwatch aws logs agent setup which will be further used for logging server logs to cloudwatch.

**Ticket link:** https://tasks.opencraft.com/browse/BB-6085

## Testing instructions
Prereq: All the aws resources are created for storing server logs on cloudwatch ([steps](https://github.com/open-craft/terraform-scripts/pull/40))
1. Add similar variable in any config file
```
CLOUDWATCH_LOG_FILES:
```
2. Run the following command to test the playbook
`ansible-playbook --extra-vars=@<filepath-to-config-variables> -i <inventory-path> -l <hosts-name> playbooks/cloudwatch_server_logs.yml `
