### PR TITLE
[BB-6154] Fix "send-logs-to-object-store" to use the correct python executable

### DIFF
--- a/playbooks/roles/aws/templates/send-logs-to-s3.j2
+++ b/playbooks/roles/aws/templates/send-logs-to-s3.j2
@@ -97,7 +97,7 @@ onerror() {
     message_file=/var/tmp/message-$$.json
     message_string="Error syncing $s3_path: inst_id=$instance_id ip=$ip region={{ aws_region }}"
     if [[ -r "{{ aws_s3_logfile }}" ]]; then
-      python -c "import json; d={'Subject':{'Data':'$message_string'},'Body':{'Text':{'Data':open('"{{ aws_s3_logfile }}"').read()}}};print json.dumps(d)" > $message_file
+      python3 -c "import json; d={'Subject':{'Data':'$message_string'},'Body':{'Text':{'Data':open('"{{ aws_s3_logfile }}"').read()}}};print(json.dumps(d))" > $message_file
     else
       cat << EOF > $message_file
       {"Subject": { "Data": "$message_string" }, "Body": { "Text": { "Data": "!! ERROR !! no logfile" } } }


### PR DESCRIPTION
## Description

`pytnon` doesn't  exist in Ubuntu 20.04. So, when this script fails, it can't dump the email message:
```
ubuntu@server:~$ sudo /edx/bin/send-logs-to-object-store -d "/edx/var/log/tracking" -b "oc-edxapp-stage-tracking-logs" -p "logs/tracking/"
/edx/bin/send-logs-to-object-store: line 113: 1/0: No such file or directory
/edx/bin/send-logs-to-object-store: line 98: python: command not found
```

## Supporting information

- [BB-6154](https://tasks.opencraft.com/browse/BB-6154) - internal OpenCraft ticket.

## Testing instructions

1. Edit `/edx/bin/send-logs-to-object-store` file and insert `1/0` after [this line](https://github.com/open-craft/configuration/blob/64acd164a3560e21ff8cdd7da540322c288dbb18/playbooks/roles/aws/templates/send-logs-to-s3.j2#L113).
2. Run ` sudo /edx/bin/send-logs-to-object-store -d "/edx/var/log/tracking" -b "oc-edxapp-stage-tracking-logs" -p "logs/tracking/"`. The script should successfully send an email with logs.