### PR TITLE
feat: enable caching of prospectus pages

### DIFF
--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/prospectus.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/prospectus.j2
@@ -46,9 +46,7 @@ server {
     add_header Cache-Control "no-store, max-age=0" always;
   }
 
-  location /event/ {
-    # doesn't have any content, can be aggressively cached
-    add_header 'Cache-Control' 'public, max-age=86400';
+  location /event {
     # this page is designed to be injected into other pages via an iframe
     add_header X-Frame-Options '';
   }
@@ -56,12 +54,6 @@ server {
   # Cache js/css for a long time at the edge, they are versioned in their names
   location ~ \.(js|css)$ {
     add_header 'Cache-Control' 'public, max-age=31536000, immutable';
-  }
-
-  # data.json files are used to rehydrate the page, they can be cached for a 30 minutes at the edge.
-
-  location ~ data\.json$ {
-    add_header 'Cache-Control' 'public, max-age=1800';
   }
 
   # images sometimes change, we want to cache them for an hour at the edge to reduce bandwidth.
@@ -141,7 +133,7 @@ server {
         port_in_redirect off;
   {% endif %}
 
-    add_header 'Cache-Control' 'public, max-age=0, must-revalidate';
+    add_header 'Cache-Control' 'public, max-age=1800';
     try_files $uri $uri/index.html =404;
 
   # PROSPECTUS_STATIC_SITES will be a list of dictionaries which have a:


### PR DESCRIPTION
  - [ ] A SRE team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a SRE ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/spaces/SRE/pages/28967861/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
