### PR TITLE
Redirect http traffic to DE services back to ELBs with https for protocol

### DIFF
--- a/playbooks/roles/dbt_docs_nginx/templates/nginx/nginx.conf.j2
+++ b/playbooks/roles/dbt_docs_nginx/templates/nginx/nginx.conf.j2
@@ -54,12 +54,11 @@ http {
 
 	include /etc/nginx/conf.d/*.conf;
 	include /etc/nginx/sites-enabled/*;
-	server{
-
-	server_name {{ hostname_variable }}.edx.org;
-	root /usr/share/nginx/html;
-
+	server {
+		server_name {{ hostname_variable }}.edx.org;
+		if ($http_x_forwarded_proto = "http") {
+			return 301 https://$host$request_uri;
+		}
+		root /usr/share/nginx/html;
 	}
-
-
 }

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/jenkins.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/jenkins.j2
@@ -4,7 +4,11 @@ server {
   listen [::]:{{ jenkins_nginx_port }};
   {% endif %}
   server_name {{ jenkins_server_name }};
-
+  {%- if jenkins_protocol_https %}
+  if ($http_x_forwarded_proto = "http") {
+    return 301 https://$host$request_uri;
+  }
+  {%- endif %}
   location / {
     proxy_pass              http://localhost:{{ jenkins_port }};
 


### PR DESCRIPTION
Configuration Pull Request
---
This PR adds a conditional gninx config to jinja2 templates to allow to make it possible for Data Engineering services to send traffic with `$x_forwarded_for_proto` of "http" back to the load balancers with "https" for protocol.

Make sure that the following steps are done before merging:

  - [ ] A SRE team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a SRE ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/spaces/SRE/pages/28967861/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
