### PR TITLE
build: remove ppa for watchman as it is available by default in ubuntu 20.04

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 All notable changes to this project will be documented in this file.
 Add any new changes to the top (right below this line).
 
+ - 2022-06-06
+    - Role: common
+        - Remove PPA for `watchman` as we have shifted to Ubuntu 20.04,
+          if you are running this against Ubuntu version less than 20.04
+          then installation will fail.
+
  - 2022-06-01
     - Upgrade ansible to 2.9
 

--- a/playbooks/roles/common/tasks/main.yml
+++ b/playbooks/roles/common/tasks/main.yml
@@ -66,20 +66,6 @@
   delay: 5
   when: ansible_distribution in common_debian_variants
 
-- name: Add ppa for watchman package
-  apt_repository:
-    repo: "ppa:linuxuprising/apps"
-    update_cache: yes
-  register: add_repo
-  until: add_repo is success
-  retries: 10
-  delay: 5
-  when: >
-      ansible_distribution in common_debian_variants and 
-      ({{ devstack | default(False) }} or {{ edx_django_service_is_devstack | default(False) }})
-  tags:
-    - "devstack"
-
 # Ensure that we can install old software if need be.
 - name: Add edX PPA apt key
   apt_key:
@@ -140,7 +126,7 @@
     state: present
     update_cache: yes
   when: >
-      ansible_distribution in common_debian_variants and 
+      ansible_distribution in common_debian_variants and
       ({{ devstack | default(False) }} or {{ edx_django_service_is_devstack | default(False) }})
   tags:
     - "devstack"


### PR DESCRIPTION
As we have switched to Ubuntu 20.04, `watchman` is available out of the box so we don't need to include this PPA

**Ref:** https://packages.ubuntu.com/focal/utils/watchman

**JIRA:** [BOM-2097](https://2u-internal.atlassian.net/browse/BOM-2097)