### PR TITLE
Fixing a bug with beat_scheduler.sh.j2  

### DIFF
--- a/playbooks/roles/edxapp/templates/edx/app/edxapp/beat_scheduler.sh.j2
+++ b/playbooks/roles/edxapp/templates/edx/app/edxapp/beat_scheduler.sh.j2
@@ -14,7 +14,7 @@ if command -v ec2metadata >/dev/null 2>&1; then
   export NEW_RELIC_PROCESS_HOST_DISPLAY_NAME="$HOSTNAME-$INSTANCEID"
 fi
 {% else %}
-{% set executable = edxapp_venv_bin + '/single-beat' + edxapp_venv_bin + '/celery' %}
+{% set executable = edxapp_venv_bin + '/single-beat ' + edxapp_venv_bin + '/celery' %}
 {% endif %}
 
 # We exec so that celery is the child of supervisor and can be managed properly


### PR DESCRIPTION
Adding a missing space to the single-beat binary call in beat_scheduler.sh.j2.

This is a small bugfix which adds a space after the single-beat binary specification in the executable definition. Compare against line 8 in the same file. 

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A SRE team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a SRE ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/spaces/SRE/pages/28967861/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
