### PR TITLE
chore: Removing unused path from config.

### DIFF
--- a/playbooks/roles/edxapp/templates/code.sandbox.j2
+++ b/playbooks/roles/edxapp/templates/code.sandbox.j2
@@ -4,7 +4,6 @@
     #include <abstractions/base>
 
     {{ edxapp_sandbox_venv_dir }}/** mr,
-    {{ edxapp_code_dir }}/common/lib/sandbox-packages/** r,
     /tmp/codejail-*/ rix,
     /tmp/codejail-*/** wrix,
 


### PR DESCRIPTION
Removing unused path from config.

Removed /common/lib/sandbox-packages folder to new library https://pypi.org/project/codejail-includes/
So this folder does't not exists any more. `env_dir` already exists there which seems enough.