### PR TITLE
[BB-6383] Implement collecting edxapp logs into CloudWatch

### DIFF
--- a/playbooks/openedx_native.yml
+++ b/playbooks/openedx_native.yml
@@ -68,6 +68,9 @@
     # For the mfe role.
     COMMON_ECOMMERCE_BASE_URL: '{{ ECOMMERCE_ECOMMERCE_URL_ROOT }}'
     ECOMMERCE_ENABLE_PAYMENT_MFE: true
+
+    EDXAPP_ENABLE_CLOUDWATCH: false
+    cloudwatch_logs_enabled: '{{ EDXAPP_ENABLE_CLOUDWATCH }}'
   roles:
     - role: swapfile
       SWAPFILE_SIZE: 4GB
@@ -128,6 +131,8 @@
       when: COMMON_ENABLE_DATADOG
     - role: splunkforwarder
       when: COMMON_ENABLE_SPLUNKFORWARDER
+    - role: aws_cloudwatch_agent
+      when: EDXAPP_ENABLE_CLOUDWATCH
     - role: postfix_queue
       when: POSTFIX_QUEUE_EXTERNAL_SMTP_HOST != ''
     - role: datadog-uninstall

--- a/playbooks/roles/aws_cloudwatch_agent/defaults/main.yml
+++ b/playbooks/roles/aws_cloudwatch_agent/defaults/main.yml
@@ -14,3 +14,9 @@ cloudwatch_namespace: Analytics/Monitor
 # Collectd installation parameters
 collectd_version: "5.9.2.g-1ubuntu5"
 collectd_install_recommends: yes
+
+# CloudWatch logs configuration
+cloudwatch_logs_enabled: false
+# List of objects with `file_path`, `log_group_name` and `log_stream_name` keys.
+# See https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Agent-Configuration-File-Details.html#CloudWatch-Agent-Configuration-File-Logssection
+cloudwatch_logs_collect_list: []

--- a/playbooks/roles/aws_cloudwatch_agent/tasks/main.yml
+++ b/playbooks/roles/aws_cloudwatch_agent/tasks/main.yml
@@ -39,7 +39,7 @@
     dest: "{{ item.dest }}"
     mode: "{{ item.mode }}"
   with_items:
-    - { src: 'amazon-cloudwatch-agent.json', dest: '/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json', mode: '0644' }
+    - { src: 'amazon-cloudwatch-agent.json.j2', dest: '/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json', mode: '0644' }
   tags:
     - install
     - install:base
@@ -53,7 +53,7 @@
     - install:base
 
 - name: Run AWS CloudWatch Agent
-  shell: " /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -s -c file:/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json"
+  shell: "/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -s -c file:/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json"
   become: yes
   tags:
     - install

--- a/playbooks/roles/aws_cloudwatch_agent/templates/amazon-cloudwatch-agent.json.j2
+++ b/playbooks/roles/aws_cloudwatch_agent/templates/amazon-cloudwatch-agent.json.j2
@@ -33,5 +33,22 @@
 				"service_address": ":8125"
 			}
 		}
+	}{% if cloudwatch_logs_enabled %},
+	"logs": {
+		"logs_collected": {
+				"files": {
+						"collect_list": [
+								{%- for log_config in cloudwatch_logs_collect_list -%}
+								{
+										"file_path": "{{ log_config.file_path }}",
+										"log_group_name": "{{ log_config.log_group_name }}",
+										"log_stream_name": "{{ log_config.log_stream_name }}"
+								}{{ ", " if not loop.last else "" }}
+								{%- endfor -%}
+						]
+				}
+		},
+		"log_stream_name": "default_server_log_stream"
 	}
+	{% endif %}
 }


### PR DESCRIPTION
## Description

- Modifies [aws_cloudwatch_agent](https://github.com/openedx/configuration/tree/master/playbooks/roles/aws_cloudwatch_agent) to support CloudWatch logs.
- Updates `openedx_native.yml` playbook with the flag to enable this role.

## Testing instructions

1. Deploy Open edX native, with `EDXAPP_ENABLE_CLOUDWATCH` set to `true`.
2. Check ` /opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log` — you should see that JSON configuration has been validated successfully. You'll see error 404 as well. That's expected, as you your server doesn't have the right role assigned. See [this PR](https://github.com/open-craft/terraform-scripts/pull/42/files) to get an idea of what's required.