### PR TITLE
Add procstat plugin to cloudwatch configuration files with nginx, jenkins, and cloudwatch

### DIFF
--- a/playbooks/roles/aws_cloudwatch_agent/defaults/main.yml
+++ b/playbooks/roles/aws_cloudwatch_agent/defaults/main.yml
@@ -11,6 +11,10 @@ cloudwatch_url: https://s3.amazonaws.com/amazoncloudwatch-agent/ubuntu/amd64/lat
 # Default cloudwatch namespace
 cloudwatch_namespace: Analytics/Monitor
 
+# Populate the cloudwatch_procstat_patterns with patterns that you want to pass to the procstat config.
+# If the list is empty, then the procstat is not enabled.
+cloudwatch_procstat_patterns: []
+
 # Collectd installation parameters
 collectd_version: "5.9.2.g-1ubuntu5"
 collectd_install_recommends: yes

--- a/playbooks/roles/aws_cloudwatch_agent/tasks/main.yml
+++ b/playbooks/roles/aws_cloudwatch_agent/tasks/main.yml
@@ -8,6 +8,7 @@
   tags:
     - install
     - install:base
+    - install:cloudwatch
 
 - name: Install xz-utils (required when using deb parameter of apt module)
   apt:
@@ -16,6 +17,7 @@
   tags:
     - install
     - install:base
+    - install:cloudwatch
 
 - name: Download the AWS CloudWatch Agent Debian package
   get_url:
@@ -24,6 +26,7 @@
   tags:
     - install
     - install:base
+    - install:cloudwatch
 
 - name: Install AWS CloudWatch Agent Debian package
   apt:
@@ -32,6 +35,7 @@
   tags:
     - install
     - install:base
+    - install:cloudwatch
 
 - name: Copy amazon-cloudwatch-agent template
   template:
@@ -43,6 +47,7 @@
   tags:
     - install
     - install:base
+    - install:cloudwatch
 
 - name: Enable AWS CloudWatch Agent
   service:
@@ -51,6 +56,7 @@
   tags:
     - install
     - install:base
+    - install:cloudwatch
 
 - name: Run AWS CloudWatch Agent
   shell: "/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -s -c file:/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json"
@@ -58,3 +64,4 @@
   tags:
     - install
     - install:code
+    - install:cloudwatch

--- a/playbooks/roles/aws_cloudwatch_agent/templates/amazon-cloudwatch-agent.json.j2
+++ b/playbooks/roles/aws_cloudwatch_agent/templates/amazon-cloudwatch-agent.json.j2
@@ -9,6 +9,24 @@
 			"InstanceId": "${aws:InstanceId}"
 		},
 		"metrics_collected": {
+		{% if cloudwatch_procstat_patterns -%}
+			"procstat": [
+			{%- for procstat_pattern in cloudwatch_procstat_patterns -%}
+                {
+                    "pattern": "{{ procstat_pattern }}",
+                    "measurement": [
+                        "cpu_time",
+                        "cpu_time_system",
+                        "cpu_time_user"
+                    ]
+				{%- if not loop.last -%}
+                },
+				{%- else -%}
+				}
+				{% endif -%}
+			{% endfor -%}
+            ],
+		{% endif -%}
 			"collectd": {
 				"metrics_aggregation_interval": 60
 			},

--- a/playbooks/roles/dbt_docs_nginx/defaults/main.yml
+++ b/playbooks/roles/dbt_docs_nginx/defaults/main.yml
@@ -1,0 +1,2 @@
+# Populate the cloudwatch_procstat_patterns with patterns that you want to pass to the procstat config.
+cloudwatch_procstat_patterns: ['nginx', 'cloudwatch-agent']

--- a/playbooks/roles/jenkins_data_engineering/defaults/main.yml
+++ b/playbooks/roles/jenkins_data_engineering/defaults/main.yml
@@ -254,3 +254,6 @@ jenkins_public_keyfile: "{{ jenkins_private_keyfile }}.pub"
 # use ZZ for Jenkins < 2.222.x
 # use XX for Jenkins >= 2.222.x
 de_jenkins_timestamper_system_time: "'<b>'HH:mm:ssZZ'</b> '"
+
+# Populate the cloudwatch_procstat_patterns with patterns that you want to pass to the procstat config.
+cloudwatch_procstat_patterns: ['nginx', 'jenkins.war', 'cloudwatch-agent']

--- a/playbooks/roles/jenkins_data_engineering_new/defaults/main.yml
+++ b/playbooks/roles/jenkins_data_engineering_new/defaults/main.yml
@@ -299,3 +299,6 @@ jenkins_public_keyfile: "{{ jenkins_private_keyfile }}.pub"
 # use ZZ for Jenkins < 2.222.x
 # use XX for Jenkins >= 2.222.x
 de_jenkins_timestamper_system_time: "'<b>'HH:mm:ssXX'</b> '"
+
+# Populate the cloudwatch_procstat_patterns with patterns that you want to pass to the procstat config.
+cloudwatch_procstat_patterns: ['nginx', 'jenkins.war', 'cloudwatch-agent']


### PR DESCRIPTION
---
This change adds two variables: `enable_cloudwatch_procstat` (boolean) and `procstat_patterns` (array of patterns to use with the `procstat` plugin).
`enable_cloudwatch_procstat`: Set this to `true`, if you want to the cloudwatch-agent config file to be updated with `procstat` configuration values.
`procstat_patterns`: This is a list of patterns/strings that are used by procstat to match running processes.

[Read the docs](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Agent-procstat-process-metrics.html) for more information.


Configuration Pull Request

Make sure that the following steps are done before merging:

  - [ ] A SRE team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a SRE ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/spaces/SRE/pages/28967861/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
