### PR TITLE
Aed/revert app perms service check

### DIFF
--- a/playbooks/manage_edxapp_users_and_groups.yml
+++ b/playbooks/manage_edxapp_users_and_groups.yml
@@ -129,7 +129,7 @@
         {% if item.get('permissions', []) | length %}--permissions {{ item.permissions | default([]) | map('quote') | join(' ') }}{% endif %}
         {% if item.get('remove') %}--remove{% endif %}
       with_items: "{{ django_groups }}"
-      when: (not service) and (not group_environment) or group_environment in item.environments
+      when: (not group_environment) or group_environment in item.environments
       become: true
       become_user: "{{ common_web_user }}"
 
@@ -142,7 +142,7 @@
         {% if item.get('permissions', []) | length %}--permissions {{ item.permissions | default([]) | map('quote') | join(' ') }}{% endif %}
         {% if item.get('remove') %}--remove{% endif %}
       with_items: "{{ django_groups }}"
-      when: (not service) and (not group_environment) or group_environment in item.environments
+      when: (not group_environment) or group_environment in item.environments
       become: true
       become_user: "{{ common_web_user }}"
 
@@ -159,7 +159,7 @@
         {% if item.get('unusable_password') %}--unusable-password{% endif %}
         {% if item.get('initial_password_hash') %}--initial-password-hash {{ item.initial_password_hash | quote }}{% endif %}
       with_items: "{{ django_users }}"
-      when: (not service) and (not item.get('unusable_password'))
+      when: not item.get('unusable_password')
       register: manage_users_result
       failed_when: (manage_users_result is failed) and not (ignore_user_creation_errors | bool)
       retries: 3
@@ -180,7 +180,7 @@
         {% if item.get('unusable_password') %}--unusable-password{% endif %}
         {% if item.get('initial_password_hash') %}--initial-password-hash {{ item.initial_password_hash | quote }}{% endif %}
       with_items: "{{ django_users }}"
-      when: (not service) and item.get('unusable_password')
+      when: item.get('unusable_password')
       register: manage_users_result
       failed_when: (manage_users_result is failed) and not (ignore_user_creation_errors | bool)
       retries: 3

--- a/playbooks/manage_edxapp_users_and_groups.yml
+++ b/playbooks/manage_edxapp_users_and_groups.yml
@@ -197,7 +197,7 @@
         {% if item.get('permissions', []) | length %}--permissions {{ item.permissions | default([]) | map('quote') | join(' ') }}{% endif %}
         {% if item.get('remove') %}--remove{% endif %}
       with_items: "{{ django_groups }}"
-      when: (service | length > 0) and (not group_environment) or group_environment in item.environments
+      when: (not group_environment) or group_environment in item.environments
       become: true
       become_user: "{{ common_web_user }}"
 
@@ -214,7 +214,7 @@
         {% if item.get('unusable_password') %}--unusable-password{% endif %}
         {% if item.get('initial_password_hash') %}--initial-password-hash {{ item.initial_password_hash | quote }}{% endif %}
       with_items: "{{ django_users }}"
-      when: (service | length > 0) and not item.get('unusable_password')
+      when: not item.get('unusable_password')
       register: manage_users_result
       failed_when: (manage_users_result is failed) and not (ignore_user_creation_errors | bool)
       retries: 3
@@ -235,7 +235,7 @@
         {% if item.get('unusable_password') %}--unusable-password{% endif %}
         {% if item.get('initial_password_hash') %}--initial-password-hash {{ item.initial_password_hash | quote }}{% endif %}
       with_items: "{{ django_users }}"
-      when: (service | length > 0) and item.get('unusable_password')
+      when: item.get('unusable_password')
       register: manage_users_result
       failed_when: (manage_users_result is failed) and not (ignore_user_creation_errors | bool)
       retries: 3


### PR DESCRIPTION
Configuration Pull Request
---
Reverts changes in https://github.com/openedx/configuration/pull/6783
edxapp user changes currently aren't being applied, seemingly because `service` is truthy in this check: https://github.com/openedx/configuration/blob/6e7b4a0d9d47306b2ce70338ea173c78cab718ec/playbooks/manage_edxapp_users_and_groups.yml#L162

Make sure that the following steps are done before merging:

  - [x] A SRE team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a SRE ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/spaces/SRE/pages/28967861/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
