### PR TITLE
Add a Groovy script in ${JENKINS_HOME}/init.groovy.d to start Jenkins in maintenance mode

### DIFF
--- a/playbooks/roles/jenkins_common/defaults/main.yml
+++ b/playbooks/roles/jenkins_common/defaults/main.yml
@@ -11,6 +11,8 @@ jenkins_common_protocol_https: true
 # When checking if Jenkins is finished initializing, expect a 200 as it should
 # be publicly available
 jenkins_common_ready_status_code: 200
+# Always start Jenkins in Quiet/Maintenance mode
+start_jenkins_in_quiet_mode: true
 
 JENKINS_SERVER_NAME: jenkins.example.org
 jenkins_node_usage: EXCLUSIVE

--- a/playbooks/roles/jenkins_data_engineering/defaults/main.yml
+++ b/playbooks/roles/jenkins_data_engineering/defaults/main.yml
@@ -10,6 +10,8 @@ jenkins_user_home: '/home/{{ jenkins_user }}'
 jenkins_port: 8080
 jenkins_nginx_port: 80
 jenkins_protocol_https: true
+# Always start Jenkins in Quiet/Maintenance mode
+start_jenkins_in_quiet_mode: true
 AUTOMATION_USER: 'edx-analytics-automation'
 jenkins_host_name: "{{ JENKINS_SERVER_NAME | default('jenkins') }}"
 

--- a/playbooks/roles/jenkins_data_engineering/meta/main.yml
+++ b/playbooks/roles/jenkins_data_engineering/meta/main.yml
@@ -25,6 +25,7 @@ dependencies:
       - 5createLoggers.groovy
       - 5addSeedJob.groovy
       - 5configureEmailExtension.groovy
+      - 9StartInQuietMode.groovy
     jenkins_common_plugins_list: '{{ de_jenkins_plugins_list }}'
     jenkins_common_ghprb_white_list_phrase: '{{ de_jenkins_ghprb_white_list_phrase }}'
     jenkins_common_ghprb_ok_phrase: '{{ de_jenkins_ghprb_ok_phrase }}'

--- a/playbooks/roles/jenkins_data_engineering/tasks/main.yml
+++ b/playbooks/roles/jenkins_data_engineering/tasks/main.yml
@@ -116,8 +116,12 @@
 
 - name: wipe initialization scripts from jenkins_commons
   file:
-    path: '{{ jenkins_home }}/init.groovy.d/'
+    path: '{{ jenkins_home }}/init.groovy.d/{{ item }}'
     state: absent
+    # Only delete files that don't match 9StartInQuietMode.groovy when start_jenkins_in_quiet_mode is on.
+    when: item != "9StartInQuietMode.groovy" and start_jenkins_in_quiet_mode
+    with_items: "{{ jenkins_common_configuration_scripts }}"
+
   tags:
     - jenkins-auth
 

--- a/playbooks/roles/jenkins_data_engineering_new/defaults/main.yml
+++ b/playbooks/roles/jenkins_data_engineering_new/defaults/main.yml
@@ -12,6 +12,8 @@ jenkins_user_home: '/home/{{ jenkins_user }}'
 jenkins_port: 8080
 jenkins_nginx_port: 80
 jenkins_protocol_https: true
+# Always start Jenkins in Quiet/Maintenance mode
+start_jenkins_in_quiet_mode: true
 AUTOMATION_USER: 'edx-analytics-automation'
 jenkins_host_name: "{{ JENKINS_SERVER_NAME | default('jenkins') }}"
 # We should expect a 403 Forbidden from Jenkins during the init stage,

--- a/playbooks/roles/jenkins_data_engineering_new/meta/main.yml
+++ b/playbooks/roles/jenkins_data_engineering_new/meta/main.yml
@@ -27,6 +27,7 @@ dependencies:
       - 5createLoggers.groovy
       - 5addSeedJob.groovy
       - 5configureEmailExtension.groovy
+      - 9StartInQuietMode.groovy
     jenkins_common_plugins_list: '{{ de_jenkins_plugins_list }}'
     jenkins_common_ghprb_white_list_phrase: '{{ de_jenkins_ghprb_white_list_phrase }}'
     jenkins_common_ghprb_ok_phrase: '{{ de_jenkins_ghprb_ok_phrase }}'

--- a/playbooks/roles/jenkins_data_engineering_new/tasks/main.yml
+++ b/playbooks/roles/jenkins_data_engineering_new/tasks/main.yml
@@ -118,8 +118,12 @@
 
 - name: wipe initialization scripts from jenkins_commons
   file:
-    path: '{{ jenkins_home }}/init.groovy.d/'
+    path: '{{ jenkins_home }}/init.groovy.d/{{ item }}'
     state: absent
+    # Only delete files that don't match 9StartInQuietMode.groovy when start_jenkins_in_quiet_mode is on.
+    when: item != "9StartInQuietMode.groovy" and start_jenkins_in_quiet_mode
+    with_items: "{{ jenkins_common_configuration_scripts }}"
+
   tags:
     - jenkins-auth
 


### PR DESCRIPTION
This PR adds a task that installs an `init.groovy` under `${JENKINS_HOME}`. This script contains some simple Groovy code to force Jenkins to always start in quiet/maintenance mode. The task is run or skipped based on the value of the boolean `start_jenkins_in_quiet_mode`. If the latter is true, then the task is run. Otherwise, it is skipped.

**UPDATE**:
The updates are now the following:
- Add a `0StartInQuietMode.groovy` Groovy script to the jenkins-configuration repo: [Related jenkins-configuration PR](https://github.com/edx/jenkins-configuration/pull/206)
- Update the `jenkins_data_engineering` and `jenkins_data_engineering_new` playbooks to make sure that when `start_jenkins_in_quiet_mode` is set to `true`, only files not matching `0StartInQuietMode.groovy` are deleted from the `init.groovy.d` directory.

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A SRE team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a SRE ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/spaces/SRE/pages/28967861/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
