### PR TITLE
Test Docker Compose for use in in Sandboxes

### DIFF
--- a/util/jenkins/ansible-provision.sh
+++ b/util/jenkins/ansible-provision.sh
@@ -617,6 +617,10 @@ if [[ $reconfigure != "true" && $server_type == "full_edx_installation" ]]; then
     done
 fi
 
+# TODO: Add if block
+pip install docker-compose
+docker-compose up ../util/jenkins/docker-compose.yml
+
 # deploy the edx_ansible play
 run_ansible edx_ansible.yml -i "${deploy_host}," $extra_var_arg --user ubuntu
 cat $sandbox_secure_vars_file $sandbox_internal_vars_file $extra_vars_file | grep -v -E "_version|migrate_db" > ${extra_vars_file}_clean

--- a/util/jenkins/ansible-provision.sh
+++ b/util/jenkins/ansible-provision.sh
@@ -617,9 +617,10 @@ if [[ $reconfigure != "true" && $server_type == "full_edx_installation" ]]; then
     done
 fi
 
-# TODO: Add if block
-pip install docker-compose
-docker-compose up ../util/jenkins/docker-compose.yml
+if [[ -z $edx_exams ]]; then
+  pip install docker-compose
+    docker-compose up ../util/jenkins/docker_compose/edx-exams-docker-compose.yml
+fi
 
 # deploy the edx_ansible play
 run_ansible edx_ansible.yml -i "${deploy_host}," $extra_var_arg --user ubuntu

--- a/util/jenkins/docker-compose.yml
+++ b/util/jenkins/docker-compose.yml
@@ -1,0 +1,50 @@
+version: "2.1"
+services:
+  mysql:
+    image: mysql:8.0.28-oracle
+    container_name: mysql
+    environment:
+      MYSQL_ROOT_PASSWORD: ""
+      MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
+      MYSQL_DATABASE: "exams"
+    networks:
+      - network_mode: "host"
+    volumes:
+      - mysql8:/var/lib/mysql
+
+  app:
+    image: openedx/edx_exams
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: exams.app
+    # Use the Django devserver, so that we can hot-reload code changes
+    # TODO: What port do we want here?
+    command: bash -c 'while true; do python /edx/app/exams/manage.py runserver 0.0.0.0:18180; sleep 2; done'
+    ports:
+      - "18180:18180"
+    depends_on:
+      - mysql
+      - worker
+    networks:
+    # TODO: Figure out if the host network is viable to use https://stackoverflow.com/a/44544841
+      - network_mode: "host"
+    # Allows attachment to this container using 'docker attach <containerID>'.
+    stdin_open: true
+    tty: true
+    environment:
+      CELERY_ALWAYS_EAGER: 'false'
+      CELERY_BROKER_TRANSPORT: redis
+      CELERY_BROKER_HOSTNAME: edx.devstack.redis:6379
+      CELERY_BROKER_VHOST: 0
+      CELERY_BROKER_PASSWORD: password
+      DJANGO_SETTINGS_MODULE: exams.settings.devstack
+      DJANGO_WATCHMAN_TIMEOUT: 30
+      ENABLE_DJANGO_TOOLBAR: 1
+
+  memcached:
+    image: memcached:1.4.24
+    container_name: exams.memcache
+
+volumes:
+  mysql8:

--- a/util/jenkins/docker_compose/edx-exams-docker-compose.yml
+++ b/util/jenkins/docker_compose/edx-exams-docker-compose.yml
@@ -18,14 +18,11 @@ services:
       context: .
       dockerfile: Dockerfile
     container_name: exams.app
-    # Use the Django devserver, so that we can hot-reload code changes
-    # TODO: What port do we want here?
-    command: bash -c 'while true; do python /edx/app/exams/manage.py runserver 0.0.0.0:18180; sleep 2; done'
+    command: bash -c 'while true; do python /edx/app/exams/manage.py runserver 0.0.0.0:18740; sleep 2; done'
     ports:
-      - "18180:18180"
+      - "18740:18740"
     depends_on:
       - mysql
-      - worker
     networks:
     # TODO: Figure out if the host network is viable to use https://stackoverflow.com/a/44544841
       - network_mode: "host"
@@ -33,18 +30,9 @@ services:
     stdin_open: true
     tty: true
     environment:
-      CELERY_ALWAYS_EAGER: 'false'
-      CELERY_BROKER_TRANSPORT: redis
-      CELERY_BROKER_HOSTNAME: edx.devstack.redis:6379
-      CELERY_BROKER_VHOST: 0
-      CELERY_BROKER_PASSWORD: password
-      DJANGO_SETTINGS_MODULE: exams.settings.devstack
+      DJANGO_SETTINGS_MODULE: exams.settings.production
       DJANGO_WATCHMAN_TIMEOUT: 30
       ENABLE_DJANGO_TOOLBAR: 1
-
-  memcached:
-    image: memcached:1.4.24
-    container_name: exams.memcache
 
 volumes:
   mysql8:


### PR DESCRIPTION
The goal of this PR is to enable our sandbox users to use images like https://hub.docker.com/r/openedx/edx_exams rather than Ansible roles to deploy services.

Make sure that the following steps are done before merging:

  - [ ] A SRE team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a SRE ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/spaces/SRE/pages/28967861/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?