### PR TITLE
feat: Add cairo dev package in discovery container

### DIFF
--- a/playbooks/roles/discovery/defaults/main.yml
+++ b/playbooks/roles/discovery/defaults/main.yml
@@ -46,6 +46,7 @@ discovery_debian_pkgs:
   - libxml2-dev
   - libxslt1-dev
   - libjpeg-dev
+  - libcairo2-dev
 
 
 DISCOVERY_NGINX_PORT: "1{{ discovery_gunicorn_port }}"


### PR DESCRIPTION
Configuration Pull Request

## Description: 
In the scope of this ticket [Use logos provided by the Exec Ed team in the GEAG API](https://2u-internal.atlassian.net/browse/PROD-2818) We need a new package [libcairo2-dev](https://www.cairographics.org/download/) to be installed in our discovery container. So in this PR this required package is added in `discovery_debian_pkgs`

---

Make sure that the following steps are done before merging:

  - [ ] A SRE team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a SRE ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/spaces/SRE/pages/28967861/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
