### PR TITLE
fix: fix upgrade npm task in insights role

### DIFF
--- a/playbooks/roles/insights/tasks/main.yml
+++ b/playbooks/roles/insights/tasks/main.yml
@@ -53,12 +53,12 @@
     - install:system-requirements
 
 - name: upgrade npm
-   command: "npm install -g npm@{{ INSIGHTS_NPM_VERSION }}"
-   become_user: "{{ insights_user }}"
-   environment: "{{ insights_environment }}"
-   tags:
-     - install
-     - install:system-requirements
+  command: "npm install -g npm@{{ INSIGHTS_NPM_VERSION }}"
+  become_user: "{{ insights_user }}"
+  environment: "{{ insights_environment }}"
+  tags:
+    - install
+    - install:system-requirements
 
 # install with the shell command instead of the ansible npm module so we don't accidentally re-write package.json
 - name: install node dependencies


### PR DESCRIPTION
## DESC
A bug was introduced in the [PR](https://github.com/openedx/configuration/pull/6743) that is causing the insights nutmeg image builder job to fail. This PR fixes the bug to potentially resolve issues with Insights image builder.

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A SRE team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a SRE ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/spaces/SRE/pages/28967861/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
