### PR TITLE
Add local requirements

### DIFF
--- a/playbooks/roles/edxapp/tasks/deploy.yml
+++ b/playbooks/roles/edxapp/tasks/deploy.yml
@@ -163,6 +163,12 @@
   tags:
     - install
     - install:app-requirements
+  
+- name: Install Local edxapp Requirements
+  command: "{{ edxapp_venv_dir }}/bin/pip install -e {{ edxapp_code_dir }}/."
+  tags:
+    - install
+    - install:app-requirements
 
 # Private requirements require a ssh key to install, use the same key as the private key for edx-platform
 # If EDXAPP_INSTALL_PRIVATE_REQUIREMENTS is set to true EDXAPP_USE_GIT_IDENTITY must also be true

--- a/playbooks/roles/edxapp/tasks/deploy.yml
+++ b/playbooks/roles/edxapp/tasks/deploy.yml
@@ -166,6 +166,7 @@
   
 - name: Install Local edxapp Requirements
   command: "{{ edxapp_venv_dir }}/bin/pip install -e {{ edxapp_code_dir }}/."
+  become_user: "{{ edxapp_user }}"
   tags:
     - install
     - install:app-requirements

--- a/playbooks/roles/edxapp/tasks/deploy.yml
+++ b/playbooks/roles/edxapp/tasks/deploy.yml
@@ -164,7 +164,7 @@
     - install
     - install:app-requirements
   
-- name: Install Local edxapp Requirements
+- name: Install local edxapp requirements
   command: "{{ edxapp_venv_dir }}/bin/pip install -e {{ edxapp_code_dir }}/."
   become_user: "{{ edxapp_user }}"
   tags:


### PR DESCRIPTION
## DESC
Common/lib cleanup PR removes the `local.in` requirements file which makes it necessary to install local requirements as separate step. This PR adds the local requirements installation step to Ansible task.
For context: https://github.com/openedx/edx-platform/pull/30890
Sandbox link: https://aht007.sandbox.edx.org

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A SRE team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a SRE ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/spaces/SRE/pages/28967861/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
