### PR TITLE
chore: Update the default Node version of the Credentials IDA

### DIFF
--- a/playbooks/roles/credentials/defaults/main.yml
+++ b/playbooks/roles/credentials/defaults/main.yml
@@ -21,7 +21,8 @@ credentials_environment:
   CREDENTIALS_CFG: '{{ COMMON_CFG_DIR }}/{{ credentials_service_name }}.yml'
 
 credentials_gunicorn_port: 8150
-CREDENTIALS_NODE_VERSION: '12.11.1'
+CREDENTIALS_NODE_VERSION: '16.14.0'
+CREDENTIALS_NPM_VERSION: '8.5.5'
 
 #
 # OS packages

--- a/playbooks/roles/credentials/meta/main.yml
+++ b/playbooks/roles/credentials/meta/main.yml
@@ -43,6 +43,7 @@ dependencies:
     edx_django_service_extra_requirements: '{{ CREDENTIALS_EXTRA_REQUIREMENTS }}'
     edx_django_service_session_expire_at_browser_close: '{{ CREDENTIALS_SESSION_EXPIRE_AT_BROWSER_CLOSE }}'
     edx_django_service_node_version: '{{ CREDENTIALS_NODE_VERSION }}'
+    edx_django_service_npm_version: '{{ CREDENTIALS_NPM_VERSION }}'
     edx_django_service_automated_users: '{{ CREDENTIALS_AUTOMATED_USERS }}'
     edx_django_service_cors_whitelist: '{{ CREDENTIALS_CORS_ORIGIN_WHITELIST }}'
     edx_django_service_post_migrate_commands: '{{ credentials_post_migrate_commands }}'


### PR DESCRIPTION
[APER-2040]
* Update the Credentials IDA to install Node16 by default, updating from Node 12.11.x.

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A SRE team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a SRE ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/spaces/SRE/pages/28967861/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
