### PR TITLE
feat: run edxapp workers in docker containers on sandbox

### DIFF
--- a/playbooks/edx_continuous_integration.yml
+++ b/playbooks/edx_continuous_integration.yml
@@ -25,7 +25,6 @@
     - memcache
     - mongo_4_2
     - role: redis
-    - { role: 'edxapp', celery_worker: True }
     - edxapp
     - testcourses
     - oraclejdk

--- a/playbooks/edx_continuous_integration.yml
+++ b/playbooks/edx_continuous_integration.yml
@@ -25,6 +25,7 @@
     - memcache
     - mongo_4_2
     - role: redis
+    - { role: 'edxapp', celery_worker: True, when: edxapp_celery_worker is defined and edxapp_celery_worker }
     - edxapp
     - testcourses
     - oraclejdk

--- a/playbooks/roles/edxapp/tasks/main.yml
+++ b/playbooks/roles/edxapp/tasks/main.yml
@@ -219,6 +219,6 @@
      app_name: 'lms'
      app_config_file: "{{ COMMON_CFG_DIR }}/lms.yml"
      app_config_owner: "{{ edxapp_user }}"
-     app_config_group: root
-     app_config_mode: 0644
+     app_config_group: "{{ common_web_group }}"
+     app_config_mode: 0640
      CAN_GENERATE_NEW_JWT_SIGNATURE: True

--- a/util/jenkins/ansible-provision.sh
+++ b/util/jenkins/ansible-provision.sh
@@ -601,10 +601,11 @@ done
 # run non-deploy tasks for all plays
 if [[ $reconfigure == "true" || $server_type == "full_edx_installation_from_scratch" || $server_type == "ubuntu_20.04" ]]; then
     cat $extra_vars_file
-    run_ansible edx_continuous_integration.yml -i "${deploy_host}," $extra_var_arg --user ubuntu
-    # Export LC_* vars. To be passed to remote instance via SSH where SSH configuration allows LC_* to be accepted as environment variables.
-    # LC_* is normally used for passing through locale settings of SSH clients to SSH servers.
-    export LC_WORKER_CFG=$(cat <<EOF
+    if [[ $edxapp_workers_docker_container_enabled == "true" ]]; then
+      run_ansible edx_continuous_integration.yml -i "${deploy_host}," $extra_var_arg -e edxapp_celery_worker=false --user ubuntu
+      # Export LC_* vars. To be passed to remote instance via SSH where SSH configuration allows LC_* to be accepted as environment variables.
+      # LC_* is normally used for passing through locale settings of SSH clients to SSH servers.
+      export LC_WORKER_CFG=$(cat <<EOF
 worker_cfg:
   - queue: default
     service_variant: cms
@@ -628,16 +629,19 @@ worker_cfg:
     prefetch_optimization: default
 EOF
 )
-    # Remote SSH configuration allows using LC_* (normally for locale variables) to be passed as environment variables to the remote instance.
-    export LC_WORKER_OF="edxapp"
-    export LC_WORKER_IMAGE_NAME="$LC_WORKER_OF"
-    export LC_WORKER_SERVICE_REPO="edx-platform"
-    export LC_SANDBOX_USER="$github_username"
-    ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null ubuntu@${deploy_host} "sudo -n -s bash" < $WORKSPACE/configuration/util/jenkins/worker-container-provisioner.sh
-    unset LC_WORKER_OF
-    unset LC_WORKER_IMAGE_NAME
-    unset LC_WORKER_SERVICE_REPO
-    unset LC_SANDBOX_USER
+      # Remote SSH configuration allows using LC_* (normally for locale variables) to be passed as environment variables to the remote instance.
+      export LC_WORKER_OF="edxapp"
+      export LC_WORKER_IMAGE_NAME="$LC_WORKER_OF"
+      export LC_WORKER_SERVICE_REPO="edx-platform"
+      export LC_SANDBOX_USER="$github_username"
+      ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null ubuntu@${deploy_host} "sudo -n -s bash" < $WORKSPACE/configuration/util/jenkins/worker-container-provisioner.sh
+      unset LC_WORKER_OF
+      unset LC_WORKER_IMAGE_NAME
+      unset LC_WORKER_SERVICE_REPO
+      unset LC_SANDBOX_USER
+    else
+      run_ansible edx_continuous_integration.yml -i "${deploy_host}," $extra_var_arg -e edxapp_celery_worker=true --user ubuntu
+    fi
 fi
 
 if [[ $reconfigure != "true" && $server_type == "full_edx_installation" ]]; then

--- a/util/jenkins/worker-container-provisioner.sh
+++ b/util/jenkins/worker-container-provisioner.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+
+set -ex
+
+# Install pre-reqs packages
+function install_pre_reqs() {
+  YQ_VERSION="4.27.5"
+  wget https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_amd64 -O /usr/bin/yq
+  chmod +x /usr/bin/yq
+}
+
+# Render docker-compose file for celery workers
+function render_docker_compose() {
+  # Set common environment variables and volumes for edxapp celery workers
+  if [ "${LC_WORKER_OF}" == "edxapp" ] ; then
+    worker_service_volume_mappings=("/edx/var/edxapp:/edx/var/edxapp" "/edx/app/edxapp/edx-platform:/edx/app/edxapp/edx-platform" "/edx/etc/lms.yml:/edx/etc/lms.yml" "/edx/etc/studio.yml:/edx/etc/studio.yml" "/edx/app/${LC_WORKER_OF}/.boto:/edx/app/${LC_WORKER_OF}/.boto" "/var/run/mysqld/mysqld.sock:/var/run/mysqld/mysqld.sock" "/dev/log:/dev/log")
+    worker_service_env_mappings=("CONCURRENCY=1" "LOGLEVEL=info" "LANG=en_US.UTF-8" "PYTHONPATH=/edx/app/${LC_WORKER_OF}/${LC_WORKER_SERVICE_REPO}" "BOTO_CONFIG=/edx/app/${LC_WORKER_OF}/.boto" "LMS_CFG=/edx/etc/lms.yml" "STUDIO_CFG=/edx/etc/studio.yml" "CMS_CFG=/edx/etc/studio.yml")
+  fi
+
+  worker_celery_path="/edx/app/${LC_WORKER_OF}/venvs/${LC_WORKER_OF}/bin/celery"
+  readarray worker_cfg < <(echo "${LC_WORKER_CFG}" | yq e -o=j -I=0 '.worker_cfg[]')
+
+  cat <<EOF > $1
+---
+version: "3.9"
+services:
+$(
+  for worker_config in "${worker_cfg[@]}"; do
+    worker_service_variant=$(echo "${worker_config}" | yq -e '.service_variant' -)
+    worker_queue=$(echo "${worker_config}" | yq -e '.queue' -)
+    worker_concurrency=$(echo "${worker_config}" | yq -e '.concurrency' -)
+    prefetch_optimization=$(echo "${worker_config}" | yq -e '.prefetch_optimization' -)
+    worker_service_name="${worker_service_variant}_${worker_queue}_${worker_concurrency}"
+    echo -e "  ${worker_service_name}:"
+    echo -e "    network_mode: host"
+    echo -e "    image: ${LC_WORKER_IMAGE_NAME}:latest"
+    echo -e "    container_name: $worker_service_name"
+    echo -e "    user: \"www-data:www-data\""
+    echo -e "    command: ${worker_celery_path} --app=${worker_service_variant}.celery:APP worker --loglevel=info --queues=edx.${worker_service_variant}.core.${worker_queue} --hostname=edx.${worker_service_variant}.core.${worker_queue}.%%h --concurrency=${worker_concurrency} -O ${prefetch_optimization}"
+    echo -e "    volumes:"
+    for volume_map in ${worker_service_volume_mappings[@]} ; do
+      echo -e "      - ${volume_map}"
+    done
+      echo -e "    environment:"
+      echo -e "      - SERVICE_VARIANT=${worker_service_variant}"
+      echo -e "      - DJANGO_SETTINGS_MODULE=${worker_service_variant}.envs.production"
+      echo -e "      - EDX_REST_API_CLIENT_NAME=edx.${worker_service_variant}.core.${worker_queue}"
+    for env_map in ${worker_service_env_mappings[@]} ; do
+      echo -e "      - ${env_map}"
+    done
+  done
+)
+EOF
+}
+
+install_pre_reqs
+
+# Check if docker image already exists. If it doesn't, build it.
+if ! $(docker image inspect ${LC_WORKER_IMAGE_NAME}:latest >/dev/null 2>&1 && echo true || echo false) ; then
+  cd /edx/app/${LC_WORKER_OF}/${LC_WORKER_SERVICE_REPO}
+  docker build . -t ${LC_WORKER_IMAGE_NAME}:latest --target base
+fi
+
+# Render a docker-compose file for workers
+render_docker_compose "/home/$LC_SANDBOX_USER/docker-compose-${LC_WORKER_OF}-workers.yaml"
+
+# Run the docker-compose file
+docker-compose -f "/home/$LC_SANDBOX_USER/docker-compose-${LC_WORKER_OF}-workers.yaml" up -d

--- a/util/jenkins/worker-container-provisioner.sh
+++ b/util/jenkins/worker-container-provisioner.sh
@@ -58,7 +58,7 @@ install_pre_reqs
 # Check if docker image already exists. If it doesn't, build it.
 if ! $(docker image inspect ${LC_WORKER_IMAGE_NAME}:latest >/dev/null 2>&1 && echo true || echo false) ; then
   cd /edx/app/${LC_WORKER_OF}/${LC_WORKER_SERVICE_REPO}
-  docker build . -t ${LC_WORKER_IMAGE_NAME}:latest --target base
+  time DOCKER_BUILDKIT=1 docker build . -t ${LC_WORKER_IMAGE_NAME}:latest --target base
 fi
 
 # Render a docker-compose file for workers


### PR DESCRIPTION
Configuration Pull Request
---
This PR attempts to use bash scripting with docker containers to run edxapp celery workers instead of using ansible.

The `playbooks/edx_continuous_integration.yml` playbook is updated and the line where `edxapp` role is run with `celery_worker` set to `true` is removed. This way the edxapp celery worker configuration taken away from ansible.

The main script `ansible-provision.sh` is updated to include the worker configuration. The worker configuration is defined in `LC_*` variables. These variables are normally used to pass ssh client locale configuration to an ssh server. However, it can also be used to pass other information through to the remote instance (such as the worker configuration).

once the configuration is exported with `LC_*` prefix, we then initiate an SSH connection to the sandbox and pass in `worker-container-provisioner.sh` script. This script installs `yq` on the sandbox. It uses `yq` to process the configuration passed via `LC_*` variables and checks if the required docker image exists or not. If the image doesn't exist, it builds the docker image. After that, it renders a `docker-compose` file for running all the `edxapp` workers and runs containers using the `docker-compose` file.

At the moment `worker-container-provisioner.sh` script is setup to only work with `edxapp` workers, however it can be updated in the future to work with other celery workers as well.