### PR TITLE
feat: add enterprise_catalog to update.sh

### DIFF
--- a/playbooks/roles/edx_ansible/templates/update.j2
+++ b/playbooks/roles/edx_ansible/templates/update.j2
@@ -16,7 +16,7 @@ IFS=","
     <repo> - must be one of edx-platform, edx-workers, xqueue, cs_comments_service, credentials, configuration,
     read-only-certificate-code, edx-analytics-data-api, edx-ora2, insights, ecommerce, discovery,
     video_web_frontend, video_delivery_worker, veda_pipeline_worker, video_encode_worker, veda_ffmpeg,
-    registrar, program_console, learner_portal
+    registrar, program_console, learner_portal, prospectus, authn, payment, learning, ora_grading, enterprise_catalog
     <version> - can be a commit or tag
     <extra_vars> - specify extra_vars to any of the ansible plays with the -e switch and then ecaptulating your vars in "double quotes"
                    example: update <repo> <version> -e "-e 'hallo=bye' -e 'bye=hallo'"
@@ -82,6 +82,7 @@ repos_to_cmd["authn"]="$edx_ansible_cmd authn_frontend.yml -e 'AUTHN_MFE_VERSION
 repos_to_cmd["payment"]="$edx_ansible_cmd payment.yml -e 'PAYMENT_MFE_VERSION=$2'"
 repos_to_cmd["learning"]="$edx_ansible_cmd learning.yml -e 'LEARNING_MFE_VERSION=$2'"
 repos_to_cmd["ora_grading"]="$edx_ansible_cmd ora_grading.yml -e 'ORA_GRADING_MFE_VERSION=$2'"
+repos_to_cmd["enterprise_catalog"]="$edx_ansible_cmd enterprise_catalog.yml -e 'ENTERPRISE_CATALOG_MFE_VERSION=$2'"
 
 if [[ -z $1 || -z $2 ]]; then
     echo


### PR DESCRIPTION
## Description

Add [enterprise-catalog](https://github.com/openedx/enterprise-catalog) as an option to the update.sh script used to re-deploy services.

Also update help strings to bring list of supported services up-to-date.

## Testing instructions

Tested by running change on a sandbox and verifying it works. Sandbox must have had enterprise-catalog originally deployed on it.

## Checklist

  - [X] A SRE team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [X] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a SRE ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [X] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/spaces/SRE/pages/28967861/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [X] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
