### PR TITLE
fix: change fluentD configs for tail logs

### DIFF
--- a/util/jenkins/ansible-provision.sh
+++ b/util/jenkins/ansible-provision.sh
@@ -803,8 +803,8 @@ function provision_fluentd() {
     echo "cat << 'EOF' > \$fluentd_config
     <source>
         @type tail
-        path /var/tmp/logs.log
-        pos_file /var/log/log_file.pos
+        path /var/tmp/tracking_logs.log
+        pos_file /var/log/tracking_logs.pos
         tag *
         <parse>
             @type none
@@ -815,7 +815,7 @@ function provision_fluentd() {
         @type stdout
     </match>
 EOF"
-    echo "docker run -d --network host --mount type=bind,source=/var/tmp/logs.log,target=/var/tmp/logs.log -v /var/tmp/fluentd.conf:/fluentd/etc/fluentd.conf fluent/fluentd:edge-debian -c /fluentd/etc/fluentd.conf"
+    echo "docker run -d --network host -v /var/tmp/fluentd.conf:/fluentd/etc/fluentd.conf -v /var/tmp:/var/tmp fluent/fluentd:edge-debian -c /fluentd/etc/fluentd.conf"
 }
 
 if [[ $fluentd_logging == 'true' ]]; then

--- a/util/jenkins/ansible-provision.sh
+++ b/util/jenkins/ansible-provision.sh
@@ -802,9 +802,8 @@ function provision_fluentd() {
     echo "fluentd_config=/var/tmp/fluentd.conf"
     echo "cat << 'EOF' > \$fluentd_config
     <source>
-        @type syslog
-        port 5140
-        bind 0.0.0.0
+        @type tail
+        path /var/tmp/logs.log
         tag *
         <transport udp>
         </transport>
@@ -817,7 +816,7 @@ function provision_fluentd() {
         @type stdout
     </match>
 EOF"
-    echo "docker run -d --network host -v /var/tmp/fluentd.conf:/fluentd/etc/fluentd.conf fluent/fluentd:edge-debian -c /fluentd/etc/fluentd.conf"
+    echo "docker run -d --network host -v /var/tmp/fluentd.conf:/fluentd/etc/fluentd.conf fluent/fluentd:edge-debian -c /fluentd/etc/fluentd.conf --mount type=bind,source=/var/tmp/logs.log,target=/var/tmp/logs.log"
 }
 
 if [[ $fluentd_logging == 'true' ]]; then

--- a/util/jenkins/ansible-provision.sh
+++ b/util/jenkins/ansible-provision.sh
@@ -804,7 +804,7 @@ function provision_fluentd() {
     <source>
         @type tail
         path /var/tmp/logs.log
-        pos_file /var/log/td-agent/log_file.pos
+        pos_file /var/log/log_file.pos
         tag *
         <parse>
             @type none
@@ -815,7 +815,7 @@ function provision_fluentd() {
         @type stdout
     </match>
 EOF"
-    echo "docker run --user root -d --network host --mount type=bind,source=/var/tmp/logs.log,target=/var/tmp/logs.log -v /var/tmp/fluentd.conf:/fluentd/etc/fluentd.conf fluent/fluentd:edge-debian -c /fluentd/etc/fluentd.conf"
+    echo "docker run -d --network host --mount type=bind,source=/var/tmp/logs.log,target=/var/tmp/logs.log -v /var/tmp/fluentd.conf:/fluentd/etc/fluentd.conf fluent/fluentd:edge-debian -c /fluentd/etc/fluentd.conf"
 }
 
 if [[ $fluentd_logging == 'true' ]]; then

--- a/util/jenkins/ansible-provision.sh
+++ b/util/jenkins/ansible-provision.sh
@@ -805,6 +805,7 @@ function provision_fluentd() {
         @type tail
         path /var/tmp/tracking_logs.log
         pos_file /var/log/tracking_logs.pos
+        rotate_wait 10
         tag *
         <parse>
             @type none

--- a/util/jenkins/ansible-provision.sh
+++ b/util/jenkins/ansible-provision.sh
@@ -804,9 +804,8 @@ function provision_fluentd() {
     <source>
         @type tail
         path /var/tmp/logs.log
+        pos_file /var/log/td-agent/log_file.pos
         tag *
-        <transport udp>
-        </transport>
         <parse>
             @type none
         </parse>
@@ -816,7 +815,7 @@ function provision_fluentd() {
         @type stdout
     </match>
 EOF"
-    echo "docker run -d --network host -v /var/tmp/fluentd.conf:/fluentd/etc/fluentd.conf fluent/fluentd:edge-debian -c /fluentd/etc/fluentd.conf --mount type=bind,source=/var/tmp/logs.log,target=/var/tmp/logs.log"
+    echo "docker run --user root -d --network host --mount type=bind,source=/var/tmp/logs.log,target=/var/tmp/logs.log -v /var/tmp/fluentd.conf:/fluentd/etc/fluentd.conf fluent/fluentd:edge-debian -c /fluentd/etc/fluentd.conf"
 }
 
 if [[ $fluentd_logging == 'true' ]]; then


### PR DESCRIPTION
Configuration Pull Request
---

Change fluentD configurations to tail a rotating file handler

Mounts the rotating file handler on sandbox onto the container 

Make sure that the following steps are done before merging:

  - [ ] A SRE team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a SRE ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/spaces/SRE/pages/28967861/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
