### PR TITLE
fix: update runbook to use python3-compatible python library

### DIFF
--- a/playbooks/create_db_and_users.yml
+++ b/playbooks/create_db_and_users.yml
@@ -59,7 +59,7 @@
     - name: install python mysqldb module
       pip: name={{item}} state=present
       with_items:
-        - MySQL-python
+        - mysqlclient
 
     - name: create mysql databases
       mysql_db:


### PR DESCRIPTION
This resolves the "you must use python 2 to run this thing" issue, not sure it resolves another known issue regarding M1 macs which I didn't encounter.

JIRA:PSRE-2153

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A SRE team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a SRE ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/spaces/SRE/pages/28967861/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
