### PR TITLE
fix: ensure edx-exams can run in a sandbox

### DIFF
--- a/playbooks/edx_continuous_integration.yml
+++ b/playbooks/edx_continuous_integration.yml
@@ -16,6 +16,7 @@
       - learner_portal
       - program_console
       - prospectus
+      - edx_exams
       nginx_default_sites:
       - lms
     - docker-tools

--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -1870,6 +1870,10 @@ SERVICE_WORKER_USERS:
     username: "{{ ENTERPRISE_CATALOG_SERVICE_USER_NAME }}"
     is_staff: true
     is_superuser: false
+  - email: "{{ EDX_EXAMS_SERVICE_USER_EMAIL }}"
+    username: "{{ EDX_EXAMS_SERVICE_USER_NAME }}"
+    is_staff: true
+    is_superuser: false
   - email: "{{ ECOMMERCE_SERVICE_USER_EMAIL }}"
     username: "{{ ECOMMERCE_SERVICE_USER_NAME }}"
     is_staff: true

--- a/playbooks/roles/edxlocal/defaults/main.yml
+++ b/playbooks/roles/edxlocal/defaults/main.yml
@@ -20,6 +20,7 @@ edxlocal_databases:
   - "{{ LICENSE_MANAGER_DEFAULT_DB_NAME | default(None) }}"
   - "{{ ENTERPRISE_CATALOG_DEFAULT_DB_NAME | default(None) }}"
   - "{{ COMMERCE_COORDINATOR_DEFAULT_DB_NAME | default(None) }}"
+  - "{{ EDX_EXAMS_DEFAULT_DB_NAME | default(None) }}"
 
 edxlocal_database_users:
   - {
@@ -97,3 +98,8 @@ edxlocal_database_users:
       user: "{{ COMMERCE_COORDINATOR_MYSQL_USER | default(None) }}",
       pass: "{{ COMMERCE_COORDINATOR_MYSQL_PASSWORD | default(None) }}"
     }
+  - {
+    db: "{{ EDX_EXAMS_DEFAULT_DB_NAME | default(None) }}",
+    user: "{{ EDX_EXAMS_MYSQL_USER | default(None) }}",
+    pass: "{{ EDX_EXAMS_MYSQL_PASSWORD | default(None) }}"
+  }

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/edx_exams.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/edx_exams.j2
@@ -1,0 +1,30 @@
+server {
+   server_name ~^((stage|prod)-)?edx-exams.*;
+   listen 80;
+   rewrite ^ https://$host$request_uri? permanent;
+}
+server {
+   server_name ~^((stage|prod)-)?edx-exams.*;
+   listen 443 ssl;
+   ssl_certificate /etc/ssl/certs/wildcard.sandbox.edx.org.pem;
+   ssl_certificate_key /etc/ssl/private/wildcard.sandbox.edx.org.key;
+
+   location / {
+       try_files $uri @proxy_to_app;
+   }
+   location ~ ^/(api)/ {
+       try_files $uri @proxy_to_app;
+   }
+   location @proxy_to_app {
+       proxy_set_header X-Forwarded-Proto $scheme;
+       proxy_set_header X-Forwarded-Port $server_port;
+       proxy_set_header X-Forwarded-For $remote_addr;
+       proxy_set_header Host $http_host;
+       proxy_redirect off;
+       proxy_pass http://127.0.0.1:18740;
+   }
+   location ~ ^/static/(?P<file>.*) {
+       root /edx/var/edx_exams;
+       try_files /staticfiles/$file =404;
+   }
+}

--- a/playbooks/roles/oauth_client_setup/defaults/main.yml
+++ b/playbooks/roles/oauth_client_setup/defaults/main.yml
@@ -132,6 +132,16 @@ oauth_client_setup_oauth2_clients:
         logout_uri: "{{ COMMERCE_COORDINATOR_LOGOUT_URL | default('None') }}",
         username: "{{ COMMERCE_COORDINATOR_SERVICE_USER_NAME | default('None') }}",
       }
+    - {
+        name: "{{ edx_exams_service_name | default('None') }}",
+        url_root: "{{ EDX_EXAMS_URL_ROOT | default('None') }}",
+        sso_id: "{{ EDX_EXAMS_SOCIAL_AUTH_EDX_OAUTH2_KEY | default('None') }}",
+        sso_secret: "{{ EDX_EXAMS_SOCIAL_AUTH_EDX_OAUTH2_SECRET | default('None') }}",
+        backend_service_id: "{{ EDX_EXAMS_BACKEND_SERVICE_EDX_OAUTH2_KEY | default('None') }}",
+        backend_service_secret: "{{ EDX_EXAMS_BACKEND_SERVICE_EDX_OAUTH2_SECRET | default('None') }}",
+        logout_uri: "{{ EDX_EXAMS_LOGOUT_URL | default('None') }}",
+        username: "{{ EDX_EXAMS_SERVICE_USER_NAME | default('None') }}",
+      }
 #
 # OS packages
 #

--- a/util/jenkins/ansible-provision.sh
+++ b/util/jenkins/ansible-provision.sh
@@ -388,6 +388,21 @@ COMMERCE_COORDINATOR_ENABLED: $commerce_coordinator
 COMMERCE_COORDINATOR_DECRYPT_CONFIG_ENABLED: true
 COMMERCE_COORDINATOR_COPY_CONFIG_ENABLED: true
 
+EDX_EXAMS_NGINX_PORT: 80
+EDX_EXAMS_SSL_NGINX_PORT: 443
+EDX_EXAMS_DEFAULT_DB_NAME: 'edx_exams'
+EDX_EXAMS_MYSQL_USER: 'edx_exams001'
+EDX_EXAMS_MYSQL_PASSWORD: 'password'
+edx_exams_service_name: 'edx_exams'
+EDX_EXAMS_URL_ROOT: https://edx-exams-${deploy_host}
+EDX_EXAMS_SOCIAL_AUTH_EDX_OAUTH2_KEY: 'edx_exams-sso-key'
+EDX_EXAMS_SOCIAL_AUTH_EDX_OAUTH2_SECRET: 'edx_exams-sso-secret'
+EDX_EXAMS_BACKEND_SERVICE_EDX_OAUTH2_KEY: 'edx_exams-backend-service-key'
+EDX_EXAMS_BACKEND_SERVICE_EDX_OAUTH2_SECRET: 'edx_exams-backend-service-secret'
+EDX_EXAMS_LOGOUT_URL: '{{ EDX_EXAMS_URL_ROOT }}/logout/'
+EDX_EXAMS_SERVICE_USER_EMAIL: 'edx_exams_worker@example.com'
+EDX_EXAMS_SERVICE_USER_NAME: 'edx_exams_worker'
+
 ENTERPRISE_CATALOG_NGINX_PORT: 80
 ENTERPRISE_CATALOG_SSL_NGINX_PORT: 443
 ENTERPRISE_CATALOG_VERSION: $enterprise_catalog_version
@@ -425,6 +440,8 @@ ORA_GRADING_MFE_ENABLED: $ora_grading
 ORA_GRADING_SANDBOX_BUILD: True
 
 mysql_server_version_5_7: True
+
+edxapp_container_enabled: $edxapp_container_enabled
 
 # User provided extra vars
 $extra_vars
@@ -855,21 +872,21 @@ if [[ $edx_exams == 'true' ]]; then
 
     app_hostname="edx-exams"
     app_service_name="edx_exams"
+    app_name="edx-exams"
     app_repo="edx-exams"
     app_version=$edx_exams_version
     app_gunicorn_port=18740
     app_cfg=EDX_EXAMS_CFG
 
-    provision_script="/var/tmp/provision-script-$$.sh"
-cat << EOF > $provision_script
-$(provision_containerized_app)
-EOF
+    app_provision_script="/var/tmp/app-container-provision-script-$$.sh"
 
-    # copy app config file and run script to deploy app
+    write_app_deployment_script $app_provision_script
+    set -x
+
+    sed -i "s/deploy_host/${dns_name}.${dns_zone}/g" $WORKSPACE/configuration-internal/k8s-sandbox-config/$app_service_name.yml
     ansible -c ssh -i "${deploy_host}," $deploy_host -m copy -a "src=${WORKSPACE}/configuration-internal/k8s-sandbox-config/${app_service_name}.yml dest=/var/tmp/${app_service_name}.yml" -u ubuntu -b
-    ansible -c ssh -i "${deploy_host}," $deploy_host -m script -a "${provision_script}" -u ubuntu -b
-
-    rm -f "${provision_script}"
+    ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null ubuntu@${deploy_host} "sudo -n -s bash" < $app_provision_script
+    rm -f "${app_provision_script}"
 fi
 
 rm -f "$extra_vars_file"


### PR DESCRIPTION
## [MST-1749](https://2u-internal.atlassian.net/browse/MST-1749)
---
After changes were made to the app provision script, edx-exams would no longer spin up as expected on a sandbox. This PR follows the current guidelines of letting ansible handle both oauth and nginx, which is why additional ansible code was modified. 

Make sure that the following steps are done before merging:

  - [ ] A SRE team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a SRE ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/spaces/SRE/pages/28967861/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
