### PR TITLE
fix: use get_url to download and install docker-compose

### DIFF
--- a/playbooks/roles/docker-tools/defaults/main.yml
+++ b/playbooks/roles/docker-tools/defaults/main.yml
@@ -10,6 +10,7 @@ docker_tools_deps_deb_pkgs_focal:
     - ca-certificates
     - python3-pip
 
+docker_compose_pkg_url: "https://github.com/docker/compose/releases/download/v2.15.1/docker-compose-linux-x86_64"
 docker_apt_key_url: "https://download.docker.com/linux/ubuntu/gpg"
 docker_repos:
     - "deb [arch=amd64] https://download.docker.com/linux/ubuntu {{ ansible_distribution_release }} stable"

--- a/playbooks/roles/docker-tools/tasks/main.yml
+++ b/playbooks/roles/docker-tools/tasks/main.yml
@@ -80,8 +80,10 @@
     - install:configuration
 
 - name: install docker-compose
-  pip:
-    name: docker-compose
+  get_url:
+    dest: /usr/local/bin/docker-compose
+    url: "{{ docker_compose_pkg_url }}"
+    mode: 0755
   tags:
     - install
     - install:system-requirements


### PR DESCRIPTION
All sandbox builds are failing for Ansible run with the error 
```The error was: AttributeError: module 'lib' has no attribute 'X509_V_FLAG_CB_ISSUER_CHECK```
It was an issue with cryptography pkg which was installed and upgraded to version `cryptography-39.0.0`. This package was upgraded as a dependency requirement of `docker-compose`. We can download and install the latest package of docker-compose using its URL instead of installing it through pip to fix this issue.

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A SRE team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a SRE ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/spaces/SRE/pages/28967861/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
