### PR TITLE
chore: Update PROSPECTUS_NODE_VERSION 16.13.0 -> 18.13.0

### DIFF
--- a/playbooks/roles/prospectus/defaults/main.yml
+++ b/playbooks/roles/prospectus/defaults/main.yml
@@ -37,7 +37,7 @@ PROSPECTUS_GIT_IDENTITY: "none"
 prospectus_repo: 'ssh://git@github.com/edx/prospectus.git'
 PROSPECTUS_VERSION: 'master'
 edx_django_service_use_python3: false
-PROSPECTUS_NODE_VERSION:  '16.13.0'
+PROSPECTUS_NODE_VERSION:  '18.13.0'
 prospectus_service_name: 'prospectus'
 prospectus_home: '{{ COMMON_APP_DIR }}/{{ prospectus_service_name }}'
 prospectus_venv_dir: '{{ prospectus_home }}/venvs/{{ prospectus_service_name }}'


### PR DESCRIPTION
https://2u-internal.atlassian.net/browse/SEO-90

Prospectus is updating to Gatsby 5 and it requires at least Node 18

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A SRE team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a SRE ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/spaces/SRE/pages/28967861/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
