### PR TITLE
chore: retain cache and data folders for prospectus builds

### DIFF
--- a/playbooks/roles/prospectus/defaults/main.yml
+++ b/playbooks/roles/prospectus/defaults/main.yml
@@ -58,3 +58,5 @@ prospectus_git_identity: "{{ prospectus_app_dir }}/prospectus-git-identity"
 prospectus_code_dir: "{{ prospectus_app_dir }}/prospectus"
 prospectus_ssl_nginx_port: 443
 prospectus_use_python3: true
+
+PROSPECTUS_RETAIN_CACHE_PUBLIC_DIRS: False

--- a/playbooks/roles/prospectus/tasks/main.yml
+++ b/playbooks/roles/prospectus/tasks/main.yml
@@ -5,6 +5,20 @@
     state: absent
   when: PROSPECTUS_GIT_IDENTITY != "none"
 
+- name: check if cache dir exists
+  stat:
+     path: "{{ prospectus_code_dir }}/.cache"
+  register: register_cache_dir
+
+- name: check if data dir exists
+  stat:
+     path: "{{ PROSPECTUS_DATA_DIR }}"
+  register: register_data_dir
+
+- name: move cache dir to temp
+  command: mv {{ prospectus_code_dir }}/.cache /tmp/
+  when: PROSPECTUS_RETAIN_CACHE_PUBLIC_DIRS and register_cache_dir.stat.exists
+
 - name: Remove old git repo
   file:
     state: absent
@@ -19,6 +33,7 @@
   file:
     state: absent
     path: "{{ PROSPECTUS_DATA_DIR }}"
+  when: not PROSPECTUS_RETAIN_CACHE_PUBLIC_DIRS
 
 - name: Create prospectus app folder
   file:
@@ -58,6 +73,22 @@
   become_user: "{{ prospectus_user }}"
   register: prospectus_checkout
   when: PROSPECTUS_GIT_IDENTITY == "none"
+
+- name: move cache dir to {{ prospectus_code_dir }}
+  command: mv /tmp/.cache "{{ prospectus_code_dir }}/"
+  when: PROSPECTUS_RETAIN_CACHE_PUBLIC_DIRS and register_cache_dir.stat.exists
+
+- name: create prospectus public folder
+  file:
+    path: "{{ prospectus_code_dir }}/public"
+    state: directory
+    owner: "{{ prospectus_user }}"
+    group: "{{ prospectus_user }}"
+  when: PROSPECTUS_RETAIN_CACHE_PUBLIC_DIRS and register_data_dir.stat.exists
+
+- name: move data dir to {{ prospectus_code_dir }}/public
+  shell: "mv {{ PROSPECTUS_DATA_DIR }}/* {{ prospectus_code_dir }}/public/"
+  when: PROSPECTUS_RETAIN_CACHE_PUBLIC_DIRS and register_data_dir.stat.exists
 
 - name: install python3.8
   apt:

--- a/playbooks/roles/prospectus/tasks/main.yml
+++ b/playbooks/roles/prospectus/tasks/main.yml
@@ -15,8 +15,14 @@
      path: "{{ PROSPECTUS_DATA_DIR }}"
   register: register_data_dir
 
+- name: create prospectus temp cache folder
+  file:
+    path: "/tmp/cache-data"
+    state: directory
+  when: PROSPECTUS_RETAIN_CACHE_PUBLIC_DIRS and register_cache_dir.stat.exists
+
 - name: move cache dir to temp
-  command: mv {{ prospectus_code_dir }}/.cache /tmp/
+  command: mv {{ prospectus_code_dir }}/.cache /tmp/cache-data/
   when: PROSPECTUS_RETAIN_CACHE_PUBLIC_DIRS and register_cache_dir.stat.exists
 
 - name: Remove old git repo
@@ -75,7 +81,7 @@
   when: PROSPECTUS_GIT_IDENTITY == "none"
 
 - name: move cache dir to {{ prospectus_code_dir }}
-  command: mv /tmp/.cache "{{ prospectus_code_dir }}/"
+  command: mv /tmp/cache-data/.cache "{{ prospectus_code_dir }}/"
   when: PROSPECTUS_RETAIN_CACHE_PUBLIC_DIRS and register_cache_dir.stat.exists
 
 - name: create prospectus public folder


### PR DESCRIPTION
PR will ensure that cache and data directories for prospectus builds are not removed so we can speed up its build process in GoCD
Ticket: https://2u-internal.atlassian.net/browse/PSRE-2174

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A SRE team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a SRE ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/spaces/SRE/pages/28967861/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
