### PR TITLE
fix: enable Celery workers in supervisor for edx_django_service role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 All notable changes to this project will be documented in this file.
 Add any new changes to the top (right below this line).
 
+- 2023-02-27
+     - Role: edx_django_service
+        - Enable Celery workers in supervisor when
+          `edx_django_service_enable_celery_workers` is true.
+
  - 2023-02-23
      - Role: payment
         - Add `PAYMENT_STRIPE_PUBLISHABLE_KEY` & `PAYMENT_STRIPE_RESPONSE_URL`

--- a/playbooks/roles/edx_django_service/tasks/main.yml
+++ b/playbooks/roles/edx_django_service/tasks/main.yml
@@ -347,6 +347,17 @@
     - install
     - install:configuration
 
+- name: enable celery worker supervisor script
+  when: edx_django_service_enable_celery_workers
+  file:
+    src: "{{ supervisor_available_dir }}/{{ edx_django_service_workers_supervisor_conf }}"
+    dest: "{{ supervisor_cfg_dir }}/{{ edx_django_service_workers_supervisor_conf }}"
+    state: link
+    force: yes
+  tags:
+    - install
+    - install:configuration
+
 - name: update supervisor configuration
   command: "{{ supervisor_ctl }} -c {{ supervisor_cfg }} update"
   when: not disable_edx_services


### PR DESCRIPTION
Previously, these configurations were added only to the `supervisor_available_dir`.  No step would enable these configurations, though.

This can be verified by deploying the `enterprise_catalog` playbook.