### PR TITLE
docs: Remove repo specific CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,1 +1,0 @@
-Do not use GitHub issues for Open edX support. The mailing list and Slack channels are explained here: http://open.edx.org/getting-help. If it turns out there's a bug in the configuration scripts, we can open an issue or PR here.


### PR DESCRIPTION
We now have a org wide CONTRIBUTING.md that points to our correct
general contributing guidelines.  We don't need repo specific ones that
forward to other contributing docs.
