### PR TITLE
feat: add request tracing in nginx logs using X-Request-ID header

### DIFF
--- a/playbooks/roles/edx_django_service/templates/edx/app/nginx/sites-available/app.j2
+++ b/playbooks/roles/edx_django_service/templates/edx/app/nginx/sites-available/app.j2
@@ -4,6 +4,7 @@
 
 {% include "concerns/upstream.j2"%}
 {% include "concerns/cors-build-map.j2" %}
+{% include "concerns/x-request-id-map.j2" %}
 
 server {
   server_name {{ edx_django_service_hostname }};
@@ -28,6 +29,7 @@ server {
   ssl_certificate /etc/ssl/certs/{{ NGINX_SSL_CERTIFICATE|basename }};
   ssl_certificate_key /etc/ssl/private/{{ NGINX_SSL_KEY|basename }};
   add_header Strict-Transport-Security "max-age=31536000; includeSubDomains";
+  add_header X-Request-ID $uuid;
 
   {% include "concerns/app-common.j2" %}
 }

--- a/playbooks/roles/edx_django_service/templates/edx/app/nginx/sites-available/concerns/proxy-to-app.j2
+++ b/playbooks/roles/edx_django_service/templates/edx/app/nginx/sites-available/concerns/proxy-to-app.j2
@@ -22,10 +22,12 @@ location @proxy_to_app {
   proxy_set_header X-Forwarded-Proto $scheme;
   proxy_set_header X-Forwarded-Port $server_port;
   proxy_set_header X-Forwarded-For $remote_addr;
+  proxy_set_header X-Request-ID $uuid;
 {% else %}
   proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
   proxy_set_header X-Forwarded-Port $http_x_forwarded_port;
   proxy_set_header X-Forwarded-For $http_x_forwarded_for;
+  proxy_set_header X-Request-ID $uuid;
 {% endif %}
 
   # newrelic-specific header records the time when nginx handles a request.

--- a/playbooks/roles/edx_django_service/templates/edx/app/nginx/sites-available/concerns/x-request-id-map.j2
+++ b/playbooks/roles/edx_django_service/templates/edx/app/nginx/sites-available/concerns/x-request-id-map.j2
@@ -1,0 +1,14 @@
+
+
+# Maps to trace requests and identifying them across different components. First map creates a new variable named
+# trace_id, which is set to either the value of X-REQUEST-ID or Cloudflare CF-ray headers depending on whether http_x_request_id is
+# empty or not. Second map creates a new variable named uuid, which is set to either the value of trace_id or request_id, depending
+# on whether trace_id is set or not in first map.
+map $http_x_request_id $trace_id {
+  ""        "${http_cf_ray}";
+  default   "${http_x_request_id}";
+}
+map $trace_id $uuid {
+  ""        "${request_id}";
+  default   $trace_id;
+}

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/cms.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/cms.j2
@@ -25,6 +25,18 @@ upstream cms-backend {
   }
 {% endif %}
 
+# Maps to trace requests and identifying them across different components. First map creates a new variable named
+# trace_id, which is set to either the value of X-REQUEST-ID or Cloudflare CF-ray headers depending on whether http_x_request_id is
+# empty or not. Second map creates a new variable named uuid, which is set to either the value of trace_id or request_id, depending
+# on whether trace_id is set or not in first map.
+map $http_x_request_id $trace_id {
+  ""        "${http_cf_ray}";
+  default   "${http_x_request_id}";
+}
+map $trace_id $uuid {
+  ""        "${request_id}";
+  default   $trace_id;
+}
 
 server {
   # CMS configuration file for nginx, templated by ansible
@@ -79,6 +91,9 @@ error_page {{ k }} {{ v }};
 
   # Prevent invalid display courseware in IE 10+ with high privacy settings
   add_header P3P '{{ NGINX_P3P_MESSAGE }}';
+
+  # To track requests
+  add_header X-Request-ID $uuid;
 
   {% include "handle-tls-redirect-and-ip-disclosure.j2" %}
 

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/cms_proxy.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/cms_proxy.j2
@@ -2,10 +2,12 @@
     proxy_set_header X-Forwarded-Proto $scheme;
     proxy_set_header X-Forwarded-Port $server_port;
     proxy_set_header X-Forwarded-For $remote_addr;
+    proxy_set_header X-Request-ID $uuid;
 {% else %}
     proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
     proxy_set_header X-Forwarded-Port $http_x_forwarded_port;
     proxy_set_header X-Forwarded-For $http_x_forwarded_for;
+    proxy_set_header X-Request-ID $uuid;
 {% endif %}
 
     # newrelic-specific header records the time when nginx handles a request.

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
@@ -59,6 +59,18 @@ geo $http_x_forwarded_for $embargo {
   }
 {% endif %}
 
+# Maps to trace requests and identifying them across different components. First map creates a new variable named
+# trace_id, which is set to either the value of X-REQUEST-ID or Cloudflare CF-ray headers depending on whether http_x_request_id is
+# empty or not. Second map creates a new variable named uuid, which is set to either the value of trace_id or request_id, depending
+# on whether trace_id is set or not in first map.
+map $http_x_request_id $trace_id {
+  ""        "${http_cf_ray}";
+  default   "${http_x_request_id}";
+}
+map $trace_id $uuid {
+  ""        "${request_id}";
+  default   $trace_id;
+}
 
 server {
   # LMS configuration file for nginx, templated by ansible
@@ -112,6 +124,8 @@ error_page {{ k }} {{ v }};
   # Prevent invalid display courseware in IE 10+ with high privacy settings
   add_header P3P '{{ NGINX_P3P_MESSAGE }}';
 
+  # To track requests
+  add_header X-Request-ID $uuid;
 
   {% include "handle-tls-redirect-and-ip-disclosure.j2" %}
 

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms_proxy.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms_proxy.j2
@@ -2,10 +2,12 @@
     proxy_set_header X-Forwarded-Proto $scheme;
     proxy_set_header X-Forwarded-Port $server_port;
     proxy_set_header X-Forwarded-For $remote_addr;
+    proxy_set_header X-Request-ID $uuid;
 {% else %}
     proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
     proxy_set_header X-Forwarded-Port $http_x_forwarded_port;
     proxy_set_header X-Forwarded-For $http_x_forwarded_for;
+    proxy_set_header X-Request-ID $uuid;
 {% endif %}
 
     # newrelic-specific header records the time when nginx handles a request.

--- a/playbooks/roles/nginx/templates/etc/nginx/nginx.conf.j2
+++ b/playbooks/roles/nginx/templates/etc/nginx/nginx.conf.j2
@@ -39,7 +39,7 @@ http {
         # Logging Settings
         ##
 
-        log_format p_combined '$http_x_forwarded_for - $remote_addr - $remote_user $http_x_forwarded_proto [$time_local]  '
+        log_format p_combined '$http_x_forwarded_for - $remote_addr - $remote_user $http_x_forwarded_proto [$time_local] $uuid  '
                             '"$request" $status $body_bytes_sent $request_time '
                             '"$http_referer" "$http_user_agent"';
 


### PR DESCRIPTION
PR is using two map directives in Nginx config block to track and log value X-REQUEST-ID http header.
The first map, named "$http_x_request_id" is used to capture the X-Request-Id header value that matches the regular expression "~*" and assigns it to the variable "$req_id". If the header is not present, it assigns the value of ["${http_cf_ray}" ](https://developers.cloudflare.com/fundamentals/get-started/reference/http-request-headers/#cf-ray)  to "$req_id".

The second map, named "$req_id", assigns the value of "${request_id}" to the variable "$uuid" if "$req_id" is empty if it is not empty "$uuid" will be set to "$req_id" from first map directive.

Then it is setting X-Request-ID header of HTTP request to the value of the "$uuid" variable which will be logged to Nginx log files and will be forwarded to the application server. 

`Testing`

if x-requst-id is present

```
curl https://courses.stage.edx.org -H "X-Request-ID: custom-x-id-request-header"

3.230.216.2, 172.70.38.183 - 10.x.0.239 - - https [08/Mar/2023:16:04:45 +0000]  custom-x-id-request-header "GET / HTTP/1.1" 302 0 0.029 "-" "curl/7.79.1"
```
if cf-ray header is present

```
curl https://courses.stage.edx.org 
3.230.216.2, 172.70.38.201 - 10.x.0.239 - - https [08/Mar/2023:16:04:01 +0000]  7a4c4fc70c5338a0-IAD "GET / HTTP/1.1" 302 0 0.034 "-" "curl/7.79.1"
```
Nginx built in request id for missing x-requst-id and cf-ray 
```
- - 10.x.1.110 - - - [08/Mar/2023:16:05:02 +0000]  70992995c6ab1e3795f7a1143fc53aab "GET /heartbeat HTTP/1.1" 200 122 0.057 "-" "ELB-HealthChecker/1.0"
```

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A SRE team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a SRE ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/spaces/SRE/pages/28967861/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
