### PR TITLE
feat: add request tracing in nginx logs using X-Request-ID header

### DIFF
--- a/playbooks/roles/edx_django_service/templates/edx/app/nginx/sites-available/app.j2
+++ b/playbooks/roles/edx_django_service/templates/edx/app/nginx/sites-available/app.j2
@@ -28,6 +28,10 @@ server {
   ssl_certificate /etc/ssl/certs/{{ NGINX_SSL_CERTIFICATE|basename }};
   ssl_certificate_key /etc/ssl/private/{{ NGINX_SSL_KEY|basename }};
   add_header Strict-Transport-Security "max-age=31536000; includeSubDomains";
+  {% if NGINX_ENABLE_REQUEST_TRACKING_ID -%}
+  # To Track requests
+  add_header X-Request-ID $request_tracking_id;
+  {% endif %}
 
   {% include "concerns/app-common.j2" %}
 }

--- a/playbooks/roles/edx_django_service/templates/edx/app/nginx/sites-available/concerns/proxy-to-app.j2
+++ b/playbooks/roles/edx_django_service/templates/edx/app/nginx/sites-available/concerns/proxy-to-app.j2
@@ -22,10 +22,16 @@ location @proxy_to_app {
   proxy_set_header X-Forwarded-Proto $scheme;
   proxy_set_header X-Forwarded-Port $server_port;
   proxy_set_header X-Forwarded-For $remote_addr;
+  {% if NGINX_ENABLE_REQUEST_TRACKING_ID -%}
+  proxy_set_header X-Request-ID $request_tracking_id;
+  {% endif %}
 {% else %}
   proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
   proxy_set_header X-Forwarded-Port $http_x_forwarded_port;
   proxy_set_header X-Forwarded-For $http_x_forwarded_for;
+  {% if NGINX_ENABLE_REQUEST_TRACKING_ID -%}
+  proxy_set_header X-Request-ID $request_tracking_id;
+  {% endif %}
 {% endif %}
 
   # newrelic-specific header records the time when nginx handles a request.

--- a/playbooks/roles/nginx/defaults/main.yml
+++ b/playbooks/roles/nginx/defaults/main.yml
@@ -67,6 +67,7 @@ NGINX_SSL_PROTOCOLS: "TLSv1.1 TLSv1.2"
 NGINX_DH_PARAMS_PATH: "/etc/ssl/private/dhparams.pem"
 NGINX_DH_KEYSIZE: 2048
 
+NGINX_ENABLE_REQUEST_TRACKING_ID: False
 # This can be one of 'p_combined' or 'ssl_combined' by default. If you
 # wish to specify your own format then define it in a configuration file
 # located under `nginx_conf_dir` and then use the format name specified

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/cms.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/cms.j2
@@ -80,6 +80,11 @@ error_page {{ k }} {{ v }};
   # Prevent invalid display courseware in IE 10+ with high privacy settings
   add_header P3P '{{ NGINX_P3P_MESSAGE }}';
 
+  {% if NGINX_ENABLE_REQUEST_TRACKING_ID -%}
+  # To track requests
+  add_header X-Request-ID $request_tracking_id;
+  {% endif %}
+
   {% include "handle-tls-redirect-and-ip-disclosure.j2" %}
 
   server_name {{ CMS_HOSTNAME }};

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/cms_proxy.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/cms_proxy.j2
@@ -2,10 +2,16 @@
     proxy_set_header X-Forwarded-Proto $scheme;
     proxy_set_header X-Forwarded-Port $server_port;
     proxy_set_header X-Forwarded-For $remote_addr;
+    {% if NGINX_ENABLE_REQUEST_TRACKING_ID -%}
+    proxy_set_header X-Request-ID $request_tracking_id;
+    {% endif %}
 {% else %}
     proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
     proxy_set_header X-Forwarded-Port $http_x_forwarded_port;
     proxy_set_header X-Forwarded-For $http_x_forwarded_for;
+    {% if NGINX_ENABLE_REQUEST_TRACKING_ID -%}
+    proxy_set_header X-Request-ID $request_tracking_id;
+    {% endif %}
 {% endif %}
 
     # newrelic-specific header records the time when nginx handles a request.

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms.j2
@@ -112,7 +112,11 @@ error_page {{ k }} {{ v }};
   # Prevent invalid display courseware in IE 10+ with high privacy settings
   add_header P3P '{{ NGINX_P3P_MESSAGE }}';
 
-
+  {% if NGINX_ENABLE_REQUEST_TRACKING_ID -%}
+  # To track requests
+  add_header X-Request-ID $request_tracking_id;
+  {% endif %}
+ 
   {% include "handle-tls-redirect-and-ip-disclosure.j2" %}
 
   access_log {{ nginx_log_dir }}/access.log {{ NGINX_LOG_FORMAT_NAME }};

--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms_proxy.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/lms_proxy.j2
@@ -2,10 +2,16 @@
     proxy_set_header X-Forwarded-Proto $scheme;
     proxy_set_header X-Forwarded-Port $server_port;
     proxy_set_header X-Forwarded-For $remote_addr;
+    {% if NGINX_ENABLE_REQUEST_TRACKING_ID -%}
+    proxy_set_header X-Request-ID $request_tracking_id;
+    {% endif %}
 {% else %}
     proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
     proxy_set_header X-Forwarded-Port $http_x_forwarded_port;
     proxy_set_header X-Forwarded-For $http_x_forwarded_for;
+    {% if NGINX_ENABLE_REQUEST_TRACKING_ID -%}
+    proxy_set_header X-Request-ID $request_tracking_id;
+    {% endif %}
 {% endif %}
 
     # newrelic-specific header records the time when nginx handles a request.

--- a/playbooks/roles/nginx/templates/etc/nginx/nginx.conf.j2
+++ b/playbooks/roles/nginx/templates/etc/nginx/nginx.conf.j2
@@ -35,6 +35,20 @@ http {
         include /etc/nginx/mime.types;
         default_type application/octet-stream;
 
+        {% if NGINX_ENABLE_REQUEST_TRACKING_ID -%}
+        # Setting variables based on HTTP headers to track and differentiate requests across components: the first creates a new
+        # variable called trace_id based on X-REQUEST-ID or Cloudflare CF-ray headers, while the second creates a variable named
+        # request_tracking_id based on whether trace_id is set or not.
+        map $http_x_request_id $trace_id {
+          ""        "${http_cf_ray}";
+          default   "${http_x_request_id}";
+        }
+        map $trace_id $request_tracking_id {
+          ""        "${request_id}";
+          default   $trace_id;
+        }
+        {% endif %}
+
         ##
         # Logging Settings
         ##
@@ -52,7 +66,13 @@ http {
                                'referer=$http_referer user_agent="$http_user_agent" upstream_addr=$upstream_addr upstream_status=$upstream_status '
                                'request_time=$request_time request_id=$request_id upstream_response_time=$upstream_response_time '
                                'upstream_connect_time=$upstream_connect_time upstream_header_time=$upstream_header_time';
-
+        
+        {% if NGINX_ENABLE_REQUEST_TRACKING_ID -%}
+        log_format cf_custom '$http_x_forwarded_for - $remote_addr - $remote_user $http_x_forwarded_proto [$time_local] $request_tracking_id  '
+                            '"$request" $status $body_bytes_sent $request_time '
+                            '"$http_referer" "$http_user_agent"';
+        {% endif %}
+        
         log_format json_analytics escape=json '{'
                    '"msec": "$msec", ' # request unixtime in seconds with a milliseconds resolution
                    '"connection": "$connection", ' # connection serial number


### PR DESCRIPTION
Reverts openedx/configuration#6891
The Discovery GoCD pipeline failed with the below error after I merged this PR to enable request tracing in Nginx https://github.com/openedx/configuration/pull/6889

```
fatal: [10.3.120.228]: FAILED! => {
    "changed": true,
    "cmd": [
        "nginx",
        "-t"
    ],
    "delta": "0:00:00.006049",
    "end": "2023-03-09 10:04:53.233906",
    "rc": 1,
    "start": "2023-03-09 10:04:53.227857"
}
```
I debugged the cause and found that in my PR https://github.com/openedx/configuration/pull/6889 I have defined the maps in the virtual host config to set a value for the custom variable `uuid` and used it in `nginx.conf` file to add its value to logs. During Nginx installation, we are testing Nginx configs with Ansible task https://github.com/openedx/configuration/blob/master/playbooks/roles/nginx/tasks/main.yml#L399 which was giving an error for undefined `uuid` variable as virtual host was not yet created where I have defined this variable. So I reverted my PR https://github.com/openedx/configuration/pull/6891 to unblock the pipelines and made this PR with fix to define the `uuid` maps in `nginx.conf` file.
Also made this PR https://github.com/edx/edx-internal/pull/7960 to turn on this feature for our environments. 
