### PR TITLE
fix: pull in ssh key in all code paths where it may be necessary

### DIFF
--- a/util/jenkins/ansible-provision.sh
+++ b/util/jenkins/ansible-provision.sh
@@ -873,6 +873,8 @@ if [[ $enable_newrelic == "true" ]]; then
 fi
 
 if [[ $edx_exams == 'true' ]]; then
+    set +x
+    app_git_ssh_key="$($WORKSPACE/yq '._local_git_identity' $WORKSPACE/configuration-secure/ansible/vars/developer-sandbox.yml)"
 
     app_hostname="edx-exams"
     app_service_name="edx_exams"
@@ -894,6 +896,8 @@ if [[ $edx_exams == 'true' ]]; then
 fi
 
 if [[ $subscriptions == 'true' ]]; then
+    set +x
+    app_git_ssh_key="$($WORKSPACE/yq '._local_git_identity' $WORKSPACE/configuration-secure/ansible/vars/developer-sandbox.yml)"
 
     app_hostname="subscriptions"
     app_service_name="subscriptions"


### PR DESCRIPTION
JIRA:PSRE-2282

testing with https://tools-edx-jenkins.edx.org/job/Sandboxes/job/CreateSandbox/52583/ (link internal to 2U, sorry) EDIT: the test was successful, at least to the extent that the job succeeded

We saw messages like:
```
Cloning into '/edx/app/subscriptions/subscriptions'...
Warning: Permanently added 'github.com,140.82.113.4' (ECDSA) to the list of known hosts.
Load key "/tmp/subscriptions_ssh_key": invalid format
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.
```

upon checking the instance against which we'd run this it looked like the tmp file referenced didn't contain any text. I believe that's because [this line](https://github.com/openedx/configuration/blob/98461687512fdd81ba94234b531e9fe0e44212b2/util/jenkins/ansible-provision.sh#L700) occurs conditionally when we have `edxapp_container_enabled` set, which we did not for the runs in question. This duplicates the linked-to line of code (it's not going to hurt to do it multiple times, or even unnecessarily; it's just reading contents out of a file and doing quick parsing) to make sure it's set in the cases we're interested in.

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A SRE team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a SRE ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/spaces/SRE/pages/28967861/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
