### PR TITLE
fix: image builder for credentials

### DIFF
--- a/docker/plays/credentials.yml
+++ b/docker/plays/credentials.yml
@@ -6,7 +6,5 @@
     serial_count: 1
   serial: "{{ serial_count }}"
   roles:
-    - role: nginx
-      nginx_default_sites:
-        - credentials
+    - common
     - credentials


### PR DESCRIPTION

Ansible run for Credentials image builder is failing for nginx task 
```
09:57:46 RUNNING HANDLER [nginx : restart nginx] ****************************************
09:57:47 fatal: [127.0.0.1]: FAILED! => {"changed": false, "msg": "Service is in unknown state", "status": {}}
09:57:47 
09:57:47 RUNNING HANDLER [nginx : reload nginx] *****************************************
```

PR will remove the Nginx role from the credentials Docker CI job as we don't need Nginx in devstack Images.


Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A SRE team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a SRE ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/spaces/SRE/pages/28967861/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
