### PR TITLE
chore: add x-request-id header in app-common.j2 nginx template

### DIFF
--- a/playbooks/roles/edx_django_service/templates/edx/app/nginx/sites-available/app.j2
+++ b/playbooks/roles/edx_django_service/templates/edx/app/nginx/sites-available/app.j2
@@ -28,10 +28,6 @@ server {
   ssl_certificate /etc/ssl/certs/{{ NGINX_SSL_CERTIFICATE|basename }};
   ssl_certificate_key /etc/ssl/private/{{ NGINX_SSL_KEY|basename }};
   add_header Strict-Transport-Security "max-age=31536000; includeSubDomains";
-  {% if NGINX_ENABLE_REQUEST_TRACKING_ID -%}
-  # To Track requests
-  add_header X-Request-ID $request_tracking_id;
-  {% endif %}
 
   {% include "concerns/app-common.j2" %}
 }

--- a/playbooks/roles/edx_django_service/templates/edx/app/nginx/sites-available/concerns/app-common.j2
+++ b/playbooks/roles/edx_django_service/templates/edx/app/nginx/sites-available/concerns/app-common.j2
@@ -8,3 +8,8 @@
 {% if edx_django_service_nginx_read_timeout %}
     proxy_read_timeout {{ edx_django_service_nginx_read_timeout }};
 {% endif %}
+{% if NGINX_ENABLE_REQUEST_TRACKING_ID %}
+
+    # To Track requests
+    add_header X-Request-ID $request_tracking_id;
+{% endif %}


### PR DESCRIPTION
Adding `x-request-id` header in app-common.j2 template so it will be available for all environments.
With the current config, it is only working for our sandbox environment.

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A SRE team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a SRE ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/spaces/SRE/pages/28967861/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
