### PR TITLE
fix: convert PROSPECTUS_RETAIN_CACHE_PUBLIC_DIRS to boolean

### DIFF
--- a/playbooks/roles/prospectus/tasks/main.yml
+++ b/playbooks/roles/prospectus/tasks/main.yml
@@ -19,11 +19,11 @@
   file:
     path: "/tmp/cache-data"
     state: directory
-  when: PROSPECTUS_RETAIN_CACHE_PUBLIC_DIRS and register_cache_dir.stat.exists
+  when: PROSPECTUS_RETAIN_CACHE_PUBLIC_DIRS|bool and register_cache_dir.stat.exists
 
 - name: move cache dir to temp
   command: mv {{ prospectus_code_dir }}/.cache /tmp/cache-data/
-  when: PROSPECTUS_RETAIN_CACHE_PUBLIC_DIRS and register_cache_dir.stat.exists
+  when: PROSPECTUS_RETAIN_CACHE_PUBLIC_DIRS|bool and register_cache_dir.stat.exists
 
 - name: Remove old git repo
   file:
@@ -39,7 +39,7 @@
   file:
     state: absent
     path: "{{ PROSPECTUS_DATA_DIR }}"
-  when: not PROSPECTUS_RETAIN_CACHE_PUBLIC_DIRS
+  when: not PROSPECTUS_RETAIN_CACHE_PUBLIC_DIRS|bool
 
 - name: Create prospectus app folder
   file:
@@ -82,7 +82,7 @@
 
 - name: move cache dir to {{ prospectus_code_dir }}
   command: mv /tmp/cache-data/.cache "{{ prospectus_code_dir }}/"
-  when: PROSPECTUS_RETAIN_CACHE_PUBLIC_DIRS and register_cache_dir.stat.exists
+  when: PROSPECTUS_RETAIN_CACHE_PUBLIC_DIRS|bool and register_cache_dir.stat.exists
 
 - name: create prospectus public folder
   file:
@@ -90,11 +90,11 @@
     state: directory
     owner: "{{ prospectus_user }}"
     group: "{{ prospectus_user }}"
-  when: PROSPECTUS_RETAIN_CACHE_PUBLIC_DIRS and register_data_dir.stat.exists
+  when: PROSPECTUS_RETAIN_CACHE_PUBLIC_DIRS|bool and register_data_dir.stat.exists
 
 - name: move data dir to {{ prospectus_code_dir }}/public
   shell: "mv {{ PROSPECTUS_DATA_DIR }}/* {{ prospectus_code_dir }}/public/"
-  when: PROSPECTUS_RETAIN_CACHE_PUBLIC_DIRS and register_data_dir.stat.exists
+  when: PROSPECTUS_RETAIN_CACHE_PUBLIC_DIRS|bool and register_data_dir.stat.exists
 
 - name: install python3.8
   apt:


### PR DESCRIPTION
The conditional check is evaluating  `PROSPECTUS_RETAIN_CACHE_PUBLIC_DIRS` to true even when it is set to False and passed through extra vars. Converting the variable to boolean to set it appropriately. 


Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A SRE team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a SRE ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/spaces/SRE/pages/28967861/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
