### PR TITLE
Revert "add fail2ban"

### DIFF
--- a/playbooks/roles/edx_ansible/defaults/main.yml
+++ b/playbooks/roles/edx_ansible/defaults/main.yml
@@ -19,8 +19,6 @@
 # included in the play.
 EDX_ANSIBLE_DUMP_VARS: false
 
-edx_ansible_debian_running_services: 
-  - fail2ban
 
 edx_ansible_debian_pkgs_default:
   - python-apt
@@ -46,7 +44,7 @@ edx_ansible_release_specific_debian_pkgs:
   focal:
     - python3-dev
 
-edx_ansible_debian_pkgs: "{{ edx_ansible_debian_running_services + edx_ansible_debian_pkgs_default + edx_ansible_release_specific_debian_pkgs[ansible_distribution_release] }}"
+edx_ansible_debian_pkgs: "{{ edx_ansible_debian_pkgs_default + edx_ansible_release_specific_debian_pkgs[ansible_distribution_release] }}"
 
 edx_ansible_app_dir: "{{ COMMON_APP_DIR }}/edx_ansible"
 edx_ansible_code_dir: "{{ edx_ansible_app_dir }}/edx_ansible"

--- a/playbooks/roles/edx_ansible/tasks/main.yml
+++ b/playbooks/roles/edx_ansible/tasks/main.yml
@@ -56,11 +56,3 @@
 - include: deploy.yml
   tags:
     - deploy
-    
-- name: Start and enable running services 
-  ansible.builtin.systemd:
-    state: started
-    enabled: true
-    name: "{{ edx_ansible_debian_running_services }}"
-  tags: 
-    - install:system-requirements


### PR DESCRIPTION
Reverts openedx/configuration#6916

The PR being reverted is causing sandbox builds to fail with the error 

```
14:15:31 fatal: [int.sandbox.edx.org]: FAILED! => {
14:15:31     "changed": false,
14:15:31     "invocation": {
14:15:31         "module_args": {
14:15:31             "daemon_reexec": false,
14:15:31             "daemon_reload": false,
14:15:31             "enabled": true,
14:15:31             "force": null,
14:15:31             "masked": null,
14:15:31             "name": "['fail2ban']",
14:15:31             "no_block": false,
14:15:31             "scope": "system",
14:15:31             "state": "started",
14:15:31             "user": null
14:15:31         }
14:15:31     },
14:15:31     "msg": "This module does not currently support using glob patterns, found '[' in service name: ['fail2ban']"
14:15:31 }
```