### PR TITLE
[FC-0006] feat: Add settings for Verifiable Credentials

### DIFF
--- a/playbooks/roles/credentials/defaults/main.yml
+++ b/playbooks/roles/credentials/defaults/main.yml
@@ -99,6 +99,7 @@ CREDENTIALS_FILE_STORAGE_BACKEND: {}
 CREDENTIALS_CORS_ORIGIN_ALLOW_ALL: false
 CREDENTIALS_CORS_ORIGIN_WHITELIST_DEFAULT:
  - '{{ CREDENTIALS_DOMAIN }}'
+ - '{{ CREDENTIALS_LEARNER_RECORD_MFE_HOSTNAME }}'
 
 CREDENTIALS_CORS_ORIGIN_WHITELIST_EXTRA: []
 CREDENTIALS_CORS_ORIGIN_WHITELIST: '{{ CREDENTIALS_CORS_ORIGIN_WHITELIST_DEFAULT + CREDENTIALS_CORS_ORIGIN_WHITELIST_EXTRA }}'
@@ -124,8 +125,12 @@ credentials_service_config_overrides:
   CREDENTIALS_SERVICE_USER: '{{ CREDENTIALS_SERVICE_USER }}'
   FILE_STORAGE_BACKEND: '{{ CREDENTIALS_FILE_STORAGE_BACKEND }}'
   LANGUAGE_COOKIE_NAME: '{{ CREDENTIALS_LANGUAGE_COOKIE_NAME }}'
+  USE_LEARNER_RECORD_MFE: '{{ CREDENTIALS_USE_LEARNER_RECORD_MFE }}'
+  LEARNER_RECORD_MFE_RECORDS_PAGE_URL: "https://{{ CREDENTIALS_LEARNER_RECORD_MFE_HOSTNAME }}/"
   CSRF_COOKIE_SECURE: "{{ CREDENTIALS_CSRF_COOKIE_SECURE }}"
+  CSRF_TRUSTED_ORIGINS: "{{ CREDENTIALS_CSRF_TRUSTED_ORIGINS }}"
   USERNAME_REPLACEMENT_WORKER: "{{ CREDENTIALS_USERNAME_REPLACEMENT_WORKER }}"
+  VERIFIABLE_CREDENTIALS: "{{ CREDENTIALS_VERIFIABLE_CREDENTIALS }}"
 
 # See edx_django_service_automated_users for an example of what this should be
 CREDENTIALS_AUTOMATED_USERS: {}
@@ -137,6 +142,8 @@ CREDENTIALS_LMS_URL_ROOT: !!null
 CREDENTIALS_DISCOVERY_API_URL:  !!null
 
 CREDENTIALS_CSRF_COOKIE_SECURE: false
+CREDENTIALS_CSRF_TRUSTED_ORIGINS:
+  - "{{ CREDENTIALS_LEARNER_RECORD_MFE_HOSTNAME }}"
 
 CREDENTIALS_ENABLE_NEWRELIC_DISTRIBUTED_TRACING: false
 
@@ -155,3 +162,26 @@ CREDENTIALS_COPY_CONFIG_ENABLED: "{{ COMMON_COPY_CONFIG_ENABLED }}"
 CREDENTIALS_ENABLE_ADMIN_URLS_RESTRICTION: false
 CREDENTIALS_ADMIN_URLS:
   - admin
+
+CREDENTIALS_USE_LEARNER_RECORD_MFE: false
+CREDENTIALS_LEARNER_RECORD_MFE_HOSTNAME: "learner-record.mfe.CHANGE-ME"
+
+# TODO: Link to VC documentation
+#
+# TODO: Comment about adding wallet python module to CREDENTIALS_EXTRA_REQUIREMENTS variable
+#
+CREDENTIALS_VERIFIABLE_CREDENTIALS:
+  DEFAULT_DATA_MODELS:
+    - "credentials.apps.verifiable_credentials.composition.verifiable_credentials.VerifiableCredentialsDataModel"
+    - "credentials.apps.verifiable_credentials.composition.open_badges.OpenBadgesDataModel"
+  DEFAULT_STORAGES:
+    - "credentials.apps.verifiable_credentials.storages.learner_credential_wallet.LCWallet"
+  DEFAULT_ISSUER:
+    NAME: "Default (system-wide)"
+    ID: "generate-me-with-didkit-lib"
+    KEY: "generate-me-with-didkit-lib"
+  DEFAULT_ISSUANCE_REQUEST_SERIALIZER: "credentials.apps.verifiable_credentials.issuance.serializers.IssuanceLineSerializer"
+  DEFAULT_RENDERER: "credentials.apps.verifiable_credentials.issuance.renderers.JSONLDRenderer"
+  STATUS_LIST_STORAGE: "credentials.apps.verifiable_credentials.storages.status_list.StatusList2021"
+  STATUS_LIST_DATA_MODEL: "credentials.apps.verifiable_credentials.composition.status_list.StatusListDataModel"
+  STATUS_LIST_LENGTH: 10000

--- a/playbooks/roles/credentials/defaults/main.yml
+++ b/playbooks/roles/credentials/defaults/main.yml
@@ -166,10 +166,9 @@ CREDENTIALS_ADMIN_URLS:
 CREDENTIALS_USE_LEARNER_RECORD_MFE: false
 CREDENTIALS_LEARNER_RECORD_MFE_HOSTNAME: "learner-record.mfe.CHANGE-ME"
 
-# TODO: Link to VC documentation
-#
-# TODO: Comment about adding wallet python module to CREDENTIALS_EXTRA_REQUIREMENTS variable
-#
+# NOTE: Optional Verifiable Credentials feature
+# Documentation can be found at
+# https://edx-credentials.readthedocs.io/en/latest/verifiable_credentials/overview.html
 CREDENTIALS_VERIFIABLE_CREDENTIALS:
   DEFAULT_DATA_MODELS:
     - "credentials.apps.verifiable_credentials.composition.verifiable_credentials.VerifiableCredentialsDataModel"


### PR DESCRIPTION
This changes allow to configure Verifiable Credentials settings for the "credentials" service.

Related PR:
https://github.com/openedx/credentials/pull/1973

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A SRE team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a SRE ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/spaces/SRE/pages/28967861/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
