### PR TITLE
feat: enable distributed tracing by default in newrelic.ini.j2

### DIFF
--- a/playbooks/roles/edxapp/templates/newrelic.ini.j2
+++ b/playbooks/roles/edxapp/templates/newrelic.ini.j2
@@ -27,3 +27,5 @@
 # `course_id`.
 #
 browser_monitoring.attributes.enabled=true
+
+distributed_tracing.enabled=true


### PR DESCRIPTION
This repo is being DEPRed, and at some point these configs will be easier to config per service. For now, we just need to set a global default to enable this.

Note: The community was informed a long while ago here: https://discuss.openedx.org/t/planned-changes-to-shared-new-relic-default-configs/9573

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A SRE team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a SRE ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/spaces/SRE/pages/28967861/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
