### PR TITLE
fix: Don't run celery on web frontend servers

### DIFF
--- a/playbooks/roles/edx_django_service/tasks/main.yml
+++ b/playbooks/roles/edx_django_service/tasks/main.yml
@@ -351,7 +351,7 @@
     - install:configuration
 
 - name: enable celery worker supervisor script
-  when: edx_django_service_enable_celery_workers
+  when: edx_django_service_enable_celery_workers and not disable_edx_services
   file:
     src: "{{ supervisor_available_dir }}/{{ edx_django_service_workers_supervisor_conf }}"
     dest: "{{ supervisor_cfg_dir }}/{{ edx_django_service_workers_supervisor_conf }}"


### PR DESCRIPTION
    Fixes a bug that probably only affects edx.org where enabling the
    celery worker at build time causes it to always run, even on a frontend
    web worker node. At build time edx.org sets disable_edx_services to true.
    We have a different script that enables specific services at boot time
    based on EC2 instance tags.

Bug introduced in PR #6884 