### PR TITLE
Revert "feat: enable distributed tracing by default in newrelic.ini.j2"

### DIFF
--- a/playbooks/roles/edxapp/templates/newrelic.ini.j2
+++ b/playbooks/roles/edxapp/templates/newrelic.ini.j2
@@ -27,5 +27,3 @@
 # `course_id`.
 #
 browser_monitoring.attributes.enabled=true
-
-distributed_tracing.enabled=true


### PR DESCRIPTION
Reverts openedx/configuration#6930

It turns out that distributed tracing was already enabled. The config [distributed_tracing.enabled](https://docs.newrelic.com/docs/apm/agents/python-agent/configuration/python-agent-configuration/#distributed-tracing-enabled) already defaults to True according to the docs.

There is also a New Relic app that details Distributed Tracing status per app that was found and checked during rollout of this config change, and the app was already reporting that Distributed Tracing was enabled in the cases of apps using this config file change.

This PR cleans up the config so it is more clear what settings are required in the future.