### PR TITLE
feat: Installation of MySQL 8.0 on the sandbox

### DIFF
--- a/playbooks/roles/mysql/defaults/main.yml
+++ b/playbooks/roles/mysql/defaults/main.yml
@@ -21,7 +21,7 @@ mysql_dir: /etc/mysql
 
 mysql_socket: /var/run/mysqld/mysqld.sock
 
-mysql_8_0_install: false
+mysql_8_0_install: true
 
 mysql_server_8_0_pkgs:
    - mysql-client-8.0


### PR DESCRIPTION
I have successfully created the sandbox using MySQL 8.0 from the following link: https://tools-edx-jenkins.edx.org/job/Sandboxes/job/CreateSandbox/54324/. All services are functioning properly with MySQL 8.0.


Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A SRE team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a SRE ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/spaces/SRE/pages/28967861/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
