### PR TITLE
feat: enterprise-catalog - bump up worker concurrency to 4

### DIFF
--- a/playbooks/roles/enterprise_catalog/defaults/main.yml
+++ b/playbooks/roles/enterprise_catalog/defaults/main.yml
@@ -162,6 +162,6 @@ ENTERPRISE_CATALOG_ADMIN_URLS:
 worker_django_settings_module: "{{ ENTERPRISE_CATALOG_DJANGO_SETTINGS_MODULE }}"
 ENTERPRISE_CATALOG_CELERY_WORKERS:
   - queue: '{{ enterprise_catalog_celery_default_queue }}'
-    concurrency: 1
+    concurrency: 4
     monitor: True
 enterprise_catalog_workers: "{{ ENTERPRISE_CATALOG_CELERY_WORKERS }}"


### PR DESCRIPTION
Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A SRE team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a SRE ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/spaces/SRE/pages/28967861/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
