### PR TITLE
docs: swap example file storage away from deprecated lib

### DIFF
--- a/playbooks/roles/analytics_api/defaults/main.yml
+++ b/playbooks/roles/analytics_api/defaults/main.yml
@@ -121,7 +121,7 @@ ANALYTICS_API_AGGREGATE_PAGE_SIZE: 10
 # allowing temporary report downloads from secured S3 file locations.
 #
 # ANALYTICS_API_REPORT_DOWNLOAD_BACKEND:
-#   DEFAULT_FILE_STORAGE: 'storages.backends.s3boto.S3BotoStorage'
+#   DEFAULT_FILE_STORAGE: 'storages.backends.s3boto3.S3Boto3Storage'
 #   AWS_ACCESS_KEY_ID: 'put-your-access-key-id-here'
 #   AWS_SECRET_ACCESS_KEY: 'put-your-secret-access-key-here'
 #   AWS_STORAGE_BUCKET_NAME: 'report-download-bucket'

--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -789,7 +789,7 @@ EDXAPP_SOCIAL_SHARING_SETTINGS:
 
 #To use AWS S3 as your backend, you need different kwargs:
 # EDXAPP_PROFILE_IMAGE_BACKEND_CONFIG:
-#   class: storages.backends.s3boto.S3BotoStorage
+#   class: storages.backends.s3boto3.S3Boto3Storage
 #   options:
 #     location: path/to/images  # Note: The location should not begin with a leading slash.
 #     bucket: mybucket

--- a/playbooks/sample_vars/server_vars.yml
+++ b/playbooks/sample_vars/server_vars.yml
@@ -123,7 +123,7 @@
 #  ROOT_PATH: "edx-video-upload-pipeline/unprocessed"
 #
 #EDXAPP_PROFILE_IMAGE_BACKEND:
-#  class: storages.backends.s3boto.S3BotoStorage
+#  class: storages.backends.s3boto3.S3Boto3Storage
 #  options:
 #    location: /{{ ansible_ec2_public_ipv4 }}
 #    bucket: your-profile-image-bucket


### PR DESCRIPTION
The S3BotoStorage backend was deprecated in favor of the S3Boto3Storage backend. This change updates the example backend to reference the latter.

This is meant to accompany https://github.com/openedx/edx-platform/pull/32646

Fixes: FAL-3431
Fixes: public-engineering/128

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A SRE team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a SRE ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/spaces/SRE/pages/28967861/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
