### PR TITLE
chore:  implementing a conditional build for MongoDB versions 4.2 and mongo 4.4 on sandbox

### DIFF
--- a/playbooks/edx_continuous_integration.yml
+++ b/playbooks/edx_continuous_integration.yml
@@ -25,7 +25,10 @@
     - role: edxlocal
       tags: edxlocal
     - memcache
-    - mongo_4_2
+    - role: mongo_4_2
+      when: MONGO_4_2_ENABLED
+    - role: mongo_4_4
+      when: MONGO_4_4_ENABLED
     - role: redis
     - { role: "edxapp", celery_worker: True, when: edxapp_containerized is defined and not edxapp_containerized }
     - { role: "edxapp", when: edxapp_containerized is defined and not edxapp_containerized }

--- a/util/jenkins/ansible-provision.sh
+++ b/util/jenkins/ansible-provision.sh
@@ -468,6 +468,19 @@ EOF_AUTH
 
 fi
 
+if [[ $mongo_version == "4.2" ]]; then
+    cat << MONGO_VERSION >> $extra_vars_file
+MONGO_4_2_ENABLED: True
+MONGO_4_4_ENABLED: False
+MONGO_VERSION
+fi
+if [[ $mongo_version == "4.4" ]]; then
+    cat << MONGO_VERSION >> $extra_vars_file
+MONGO_4_2_ENABLED: False
+MONGO_4_4_ENABLED: True
+MONGO_VERSION
+fi
+
 if [[ -n $nginx_users ]]; then
    cat << EOF_AUTH >> $extra_vars_file
 NGINX_USERS: $nginx_users
@@ -671,7 +684,7 @@ edxapp_containerized: true
 CAN_GENERATE_NEW_JWT_SIGNATURE: false
 EOF
       ansible -i "${deploy_host}," $deploy_host -m include_role -a "name=memcache" -u ubuntu -b
-      for playbook in redis mongo_4_2; do
+      for playbook in redis $mongo_version; do
           run_ansible $playbook.yml -i "${deploy_host}," $extra_var_arg --user ubuntu
       done
       run_ansible edx_continuous_integration.yml -i "${deploy_host}," $extra_var_arg --user ubuntu --tags "edxlocal"


### PR DESCRIPTION
This modification allows individuals to switch between MongoDB versions 4.2 and 4.4 in order to create a sandbox environment and test any changes.
Ticket: https://2u-internal.atlassian.net/browse/PSRE-896

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A SRE team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a SRE ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/spaces/SRE/pages/28967861/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
