### PR TITLE
chore: Add retry logic to prospectus npm build

### DIFF
--- a/playbooks/roles/prospectus/tasks/main.yml
+++ b/playbooks/roles/prospectus/tasks/main.yml
@@ -192,6 +192,10 @@
     chdir: "{{ prospectus_code_dir }}"
   environment: "{{ prospectus_env_vars }}"
   become_user: "{{ prospectus_user }}"
+  register: result
+  until: "result is not failed"
+  retries: 2
+  delay: 10
   tags:
     - install
     - install:app-requirements


### PR DESCRIPTION
This PR attempts to make the `npm build` more robust by adding retry logic.

Note this is not a solution to our intermittent Algolia errors, but it may lessen the number of failed builds.  The retry logic will also cause builds to run for much longer especially if `npm build` fails at a late stage.

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A SRE team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a SRE ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/spaces/SRE/pages/28967861/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
