### PR TITLE
feat: retry some flaky tasks

### DIFF
--- a/playbooks/roles/insightvm_agent/tasks/main.yml
+++ b/playbooks/roles/insightvm_agent/tasks/main.yml
@@ -10,6 +10,7 @@
   stat:
     path: /etc/systemd/system/ir_agent.service
   register: r7_service
+  retries: 3
   tags:
     - manage_rapid7_check_agent
 

--- a/playbooks/roles/security/tasks/security-amazon.yml
+++ b/playbooks/roles/security/tasks/security-amazon.yml
@@ -30,6 +30,7 @@
 - name: "Take security updates during ansible runs"
   command: "{{ item }}"
   when: SECURITY_UPGRADE_ON_ANSIBLE
+  retries: 3
   with_items:
     - yum check-update --security
     - yum update --security -y

--- a/playbooks/roles/security/tasks/security-ubuntu.yml
+++ b/playbooks/roles/security/tasks/security-ubuntu.yml
@@ -24,6 +24,7 @@
 - name: Disable unattended-upgrades if Xenial (16.04)
   command: "{{ item }}"
   when: ansible_distribution_release == 'xenial' and not SECURITY_UNATTENDED_UPGRADES
+  retries: 3
   with_items:
     - "systemctl disable apt-daily.service"
     - "systemctl disable apt-daily.timer"


### PR DESCRIPTION
feat: retry some flaky tests

GH Issue: https://github.com/edx/edx-arch-experiments/issues/359

Some tasks in the edxapp pipeline will occasionally fail but then succeed on rerun. Arch-BOM still gets pinged on these failures and usually ends up manually rerunning the whole pipeline. This PR adds in some automatic retries on the three tasks that have been causing problems.



Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A SRE team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a SRE ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/spaces/SRE/pages/28967861/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
