### PR TITLE
fix: Don't download PyPI indexes at devpi startup

### DIFF
--- a/docker/build/devpi/docker-entrypoint.sh
+++ b/docker/build/devpi/docker-entrypoint.sh
@@ -27,7 +27,11 @@ if [ "$1" = 'devpi' ]; then
     fi
 
     echo "[RUN]: Launching devpi-server..."
-    exec devpi-server --restrict-modify root --host 0.0.0.0 --port 3141
+    # Use `--indexer-backend null` to prevent devpi from downloading PyPI indexes
+    # on startup, which consumes 100% CPU for 20 minutes. These indexes only
+    # seem to be used for the devpi web interface, which doesn't seem to be
+    # in use.
+    exec devpi-server --restrict-modify root --host 0.0.0.0 --port 3141 --indexer-backend null
 fi
 
 echo "[RUN]: Builtin command not provided [devpi]"


### PR DESCRIPTION
Addresses https://github.com/openedx/devstack/issues/1131

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A SRE team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a SRE ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/spaces/SRE/pages/28967861/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
