### PR TITLE
feat: install atlas in `edx_django_service`

### DIFF
--- a/playbooks/roles/edx_django_service/tasks/main.yml
+++ b/playbooks/roles/edx_django_service/tasks/main.yml
@@ -164,6 +164,19 @@
     - install:system-requirements
   when: edx_django_service_npm_version is defined and not edx_django_service_enable_experimental_docker_shim
 
+
+- name: install Open edX Atlas translation tool
+  pip:
+    name: "openedx-atlas"
+    version: "0.4.4"
+    extra_args: "--exists-action w"
+    virtualenv: "{{ edx_django_service_venv_dir }}"
+    state: present
+  become_user: "{{ edx_django_service_user }}"
+  tags:
+    - install
+    - install:app-requirements
+
 - name: install production requirements
   command: make production-requirements
   args:


### PR DESCRIPTION
### Description
Download the openedx-atlas executable for all edx_django_service to be used in `make pull_translations`

This installs `atlas` on all Ansible build targets such as Native Installation and Devstack.

Once merged it will make the [`atlas`](https://github.com/openedx/openedx-atlas) CLI executable available on all edx_django_service Dockerfiles and native installation such as LMS, Studio, Discovery and others. It will make the following command possible: `atlas pull` which replaces `transifex pull` as part of the [Translation Infrastructure update OEP-58](https://open-edx-proposals.readthedocs.io/en/latest/architectural-decisions/oep-0058-arch-translations-management.html#specification) project.


Testing
---------
 - [x] Re-build a devstack docker image and run `atlas pull`


Testing instructions:
```
configuration $ make docker.build.credentials 2>&1 | tee /tmp/cretentials-build-log.txt
docker pull edxops/focal-common:latest
....
 => => exporting layers
 => => writing image sha256:55ad82ed7e10cb0c03aa56d50c45fd5f6fccd7b549fc3baffbf5fa0dfec49c30

# Now, tag the credentials image with the newly built tag
configuration $ docker tag $(grep writing.image /tmp/cretentials-build-log.txt | sed -e 's/ done//' -e 's/^.*writing image sha256://') edxops/credentials:latest

# Go to devstack
configuration $ cd ../devstack
devstack $ make dev.remove-containers
devstack $ make dev.up.credentials
devstack $ docker run -it edxops/credentials:latest atlas --version

# From the credentials container, try atlas
credentials# atlas --version
credentials# rm -rf conf/locale/
credentials# atlas pull translations/credentials/credentials/conf/locale:conf/locale
credentials# ls -R conf/
```


To reset your local image:

```
$ docker pull edxops/credentials:latest
$ docker run -it edxops/credentials:latest atlas --version # Should throw an error now
```


### Test results on my machine
<details><summary>build, check and pull logs</summary>
Build credentials image:

```
$ make docker.build.credentials
docker pull edxops/focal-common:latest
latest: Pulling from edxops/focal-common
Digest: sha256:32243e53b16c7a8b333087d75f3503ff1648d3eabd2e142b9cf8e0591e9381fb
Status: Image is up to date for edxops/focal-common:latest
docker.io/edxops/focal-common:latest
docker build -f docker/build/credentials/Dockerfile .
[+] Building 150.0s (12/12) FINISHED
...
 => => writing image sha256:55ad82ed7e10cb0c03aa56d50c45fd5f6fccd7b549fc3baffbf5fa0dfec49c30
```

Test the help command:

```
$ docker run -it 55ad82ed7e10cb0 atlas --help
Atlas is a CLI tool that has essentially one command: `atlas pull`

Configuration file:
...
```

Check the version and pip status:
```
$ docker run -it 55ad82ed7e10cb0 atlas --version
v0.4.4
$ docker run -it 55ad82ed7e10cb0 pip freeze | grep atlas
openedx-atlas==0.4.4
```

Test the pull command:

```
$ docker run -it 55ad82ed7e10cb0 bash -c 'cd /edx/app/credentials/credentials/credentials/conf; rm -rf locale/; atlas pull translations/credentials/credentials/conf/locale:locale; ls -R .'
Pulling translation files
 - directory: translations/credentials/credentials/conf/locale:locale
 - repository: openedx/openedx-translations
 - branch: main
 - filter: Not Specified
Creating a temporary Git repository to pull translations into "./translations_TEMP"...
Done.
Setting git sparse-checkout rules...
Done.
Pulling translation files from the repository...
remote: Enumerating objects: 4, done.
remote: Counting objects: 100% (4/4), done.
remote: Compressing objects: 100% (3/3), done.
remote: Total 4 (delta 2), reused 1 (delta 1), pack-reused 0
Receiving objects: 100% (4/4), 7.47 KiB | 7.47 MiB/s, done.
Resolving deltas: 100% (2/2), done.
Your branch is up to date with 'origin/main'.
Done.
Copying translations from "./translations_TEMP/translations/credentials/credentials/conf/locale" to "./locale"...
Done.
Removing temporary directory...
Done.

Translations pulled successfully!
.:
locale

./locale:
en  fr_CA

./locale/en:
LC_MESSAGES

./locale/en/LC_MESSAGES:
djangojs.po  django.po

./locale/fr_CA:
LC_MESSAGES

./locale/fr_CA/LC_MESSAGES:
djangojs.po  django.po
```
</details> 



Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A SRE team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? [Omar] No, the default value is safe to be used.
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a SRE ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/spaces/SRE/pages/28967861/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?  
    - [Omar] The documentation update is work-in-progress.


References
----------

This contribution is part of the [FC-0012 project](https://openedx.atlassian.net/l/cp/XGS0iCcQ) which is sparked by the [Translation Infrastructure update OEP-58](https://open-edx-proposals.readthedocs.io/en/latest/architectural-decisions/oep-0058-arch-translations-management.html#specification).

Up-to-date project overview and details are available in the [Approach Memo and Technical Discovery: Translations Infrastructure Implementation](https://docs.google.com/document/d/11dFBCnbdHiCEdZp3pZeHdeH8m7Glla-XbIin7cnIOzU/edit#) document.

Join the conversation on [Open edX Slack #translations-project-fc-0012](https://openedx.slack.com/archives/C04R6TUJB7T).

Check the links above for full information about the overall project.

Internalization is being rearchitected in Open edX Python, XBlock, Micro-frontend, and other projects. There are a number of immediately visible changes:
 - Remove source and language translations from the repositories, hence no `.json`, `.po` or `.mo` files will be committed into the repos.
 - Add standardized `make extract_translations` in all repositories
 - Push user-facing messages strings into [openedx/openedx-translations](https://github.com/openedx/openedx-translations/).
 - Integrate root repositories with [openedx/openedx-atlas](https://github.com/openedx/openedx-atlas/) to pull translations on build/deploy time

Breaking Changes
----------------

One of the primary goals of the project is to **avoid breaking changes**. If you noticed any suspicious code, please raise your concern. But before that, please know the strategy we're following to avoid breaking changes:

 - All variable have sane-defaults.
 - The changes are backward compatible and don't break any existing deployments.