### PR TITLE
feat: install atlas in `mfe` role FC-0012

### DIFF
--- a/playbooks/roles/mfe/tasks/main.yml
+++ b/playbooks/roles/mfe/tasks/main.yml
@@ -74,6 +74,14 @@
     - install
     - install:system-requirements
 
+- name: install Open edX Atlas translation tool
+  command: "npm install -g @edx/openedx-atlas@'<1.0.0'"
+  become_user: "{{ MFE_USER }}"
+  environment: "{{ MFE_ENVIRONMENT }}"
+  tags:
+    - install
+    - install:app-requirements
+
 - name: install npm dependencies
   shell: "npm install --include=dev --no-save"
   args:


### PR DESCRIPTION
### Description
Download the openedx-atlas executable for all Micro-frontends to be used in `make pull_translations`

This installs `atlas` on all Ansible build targets such as Native Installation and Devstack.

Once merged it will make the [`atlas`](https://github.com/openedx/openedx-atlas) CLI executable available on all Micro-frontend Dockerfiles and native installation such as Profile, Account, Learning and others. It will make the following command possible: `atlas pull` which replaces `transifex pull` as part of the [Translation Infrastructure update OEP-58](https://open-edx-proposals.readthedocs.io/en/latest/architectural-decisions/oep-0058-arch-translations-management.html#specification) project.


Testing
---------
 - [ ] Re-build a devstack docker image and run `atlas pull`

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A SRE team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? [Omar] No, the default value is safe to be used.
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a SRE ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/spaces/SRE/pages/28967861/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?  
    - [Omar] The documentation update is work-in-progress.


References
----------

This contribution is part of the [FC-0012 project](https://openedx.atlassian.net/l/cp/XGS0iCcQ) which is sparked by the [Translation Infrastructure update OEP-58](https://open-edx-proposals.readthedocs.io/en/latest/architectural-decisions/oep-0058-arch-translations-management.html#specification).

Up-to-date project overview and details are available in the [Approach Memo and Technical Discovery: Translations Infrastructure Implementation](https://docs.google.com/document/d/11dFBCnbdHiCEdZp3pZeHdeH8m7Glla-XbIin7cnIOzU/edit#) document.

Join the conversation on [Open edX Slack #translations-project-fc-0012](https://openedx.slack.com/archives/C04R6TUJB7T).

Check the links above for full information about the overall project.

Internalization is being rearchitected in Open edX Python, XBlock, Micro-frontend, and other projects. There are a number of immediately visible changes:
 - Remove source and language translations from the repositories, hence no `.json`, `.po` or `.mo` files will be committed into the repos.
 - Add standardized `make extract_translations` in all repositories
 - Push user-facing messages strings into [openedx/openedx-translations](https://github.com/openedx/openedx-translations/).
 - Integrate root repositories with [openedx/openedx-atlas](https://github.com/openedx/openedx-atlas/) to pull translations on build/deploy time

Breaking Changes
----------------

One of the primary goals of the project is to **avoid breaking changes**. If you noticed any suspicious code, please raise your concern. But before that, please know the strategy we're following to avoid breaking changes:

 - All variable have sane-defaults.
 - The changes are backward compatible and don't break any existing deployments.