### PR TITLE
fix: update git hash for all PRs which has django42 support

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -573,13 +573,13 @@ EDXAPP_PRIVATE_REQUIREMENTS:
       extra_args: -e
     - name: git+https://github.com/openedx/xblock-in-video-quiz.git@a703acd9ef82434fc7ca2bc230496f45a584bb9a#egg=invideoquiz-xblock
       extra_args: -e
-    - name: git+https://github.com/openedx/xblock-submit-and-compare@8f0b3279f36e25aff8cce3f0b1793b9f19dc8729#egg=xblock-submit-and-compare
+    - name: git+https://github.com/openedx/xblock-submit-and-compare@39dd7f96b35affab5244880672da665a8adec332#egg=xblock-submit-and-compare
       extra_args: -e
     - name: git+https://github.com/openedx/xblock-free-text-response@83a389e0a4b0a464e5d1e4a4a201678aed5eee9a#egg=xblock-free-text-response
       extra_args: -e
-    - name: git+https://github.com/openedx/xblock-sql-grader@5257b4a1aa07aa572fd3865647d91d0628f0cbd3#egg=xblock-sql-grader
+    - name: git+https://github.com/openedx/xblock-sql-grader@5ae84bb9389bccacfb19a2444ef405a8eae93b13#egg=xblock-sql-grader
       extra_args: -e
-    - name: git+https://github.com/openedx/xblock-image-modal@bef91413447e15570863ab08316a04c0b546b268#egg=xblock-image-modal
+    - name: git+https://github.com/openedx/xblock-image-modal@f280a623ae58886fb3d6b577802e9d59b04de585#egg=xblock-image-modal
       extra_args: -e
     # XBlocks associated with the LabXchange project
     - name: git+https://github.com/open-craft/labxchange-xblocks.git@a0a8a8dad13199014d4bb29cee416289880bde0b#egg=labxchange-xblocks

--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -573,14 +573,11 @@ EDXAPP_PRIVATE_REQUIREMENTS:
       extra_args: -e
     - name: git+https://github.com/openedx/xblock-in-video-quiz.git@a703acd9ef82434fc7ca2bc230496f45a584bb9a#egg=invideoquiz-xblock
       extra_args: -e
-    - name: git+https://github.com/openedx/xblock-submit-and-compare@39dd7f96b35affab5244880672da665a8adec332#egg=xblock-submit-and-compare
-      extra_args: -e
     - name: git+https://github.com/openedx/xblock-free-text-response@83a389e0a4b0a464e5d1e4a4a201678aed5eee9a#egg=xblock-free-text-response
       extra_args: -e
-    - name: git+https://github.com/openedx/xblock-sql-grader@5ae84bb9389bccacfb19a2444ef405a8eae93b13#egg=xblock-sql-grader
-      extra_args: -e
-    - name: git+https://github.com/openedx/xblock-image-modal@f280a623ae58886fb3d6b577802e9d59b04de585#egg=xblock-image-modal
-      extra_args: -e
+    - name: xblock-submit-and-compare==1.2.0
+    - name: xblock-sql-grader==0.4.0
+    - name: openedx-xblock-image-modal==3.1.0
     # XBlocks associated with the LabXchange project
     - name: git+https://github.com/open-craft/labxchange-xblocks.git@a0a8a8dad13199014d4bb29cee416289880bde0b#egg=labxchange-xblocks
       extra_args: -e


### PR DESCRIPTION
**Description:**

Update git has for the following packages which have released a new version for django42.

xblock-sql-grader
xblock-submit-and-compare
xblock-image-modal

By this PR following issues for the above mention packages would resolve.

**Issue:**
`ImportError: cannot import name 'ungettext' from 'django.utils.translation' (/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/utils/translation/__init__.py)`

