### PR TITLE
feat: Remove now-unneeded call to seed permissions for demo course forums

### DIFF
--- a/playbooks/roles/demo/tasks/deploy.yml
+++ b/playbooks/roles/demo/tasks/deploy.yml
@@ -46,9 +46,3 @@
   with_items:
       - "{{ demo_test_and_staff_users }}"
   when: demo_checkout.changed
-
-- name: seed the forums for the demo course
-  shell: ". {{ demo_edxapp_env }} && {{ demo_edxapp_venv_bin }}/python ./manage.py lms --settings={{ demo_edxapp_settings }} seed_permissions_roles {{ demo_course_id }}"
-  args:
-    chdir: "{{ demo_edxapp_code_dir }}"
-  when: demo_checkout.changed

--- a/util/jenkins/demo-course-provisioner.sh
+++ b/util/jenkins/demo-course-provisioner.sh
@@ -32,8 +32,5 @@ for user in honor audit verified staff ; do
   # Enroll users in the demo course
   docker run --network=host --rm -u='www-data' -e NO_PREREQ_INSTALL="1" -e SKIP_WS_MIGRATIONS="1" -e LMS_CFG=/edx/etc/lms.yml -e DJANGO_SETTINGS_MODULE=lms.envs.docker-production -e SERVICE_VARIANT=lms -e EDX_PLATFORM_SETTINGS=docker-production -v /edx/etc/lms.yml:/edx/etc/lms.yml -v /edx/var/edx-themes:/edx/var/edx-themes -v /edx/var/edxapp:/edx/var/edxapp -v /var/run/mysqld/mysqld.sock:/var/run/mysqld/mysqld.sock ${app_repo}:latest python3 manage.py lms enroll_user_in_course -e \$email -c course-v1:edX+DemoX+Demo_Course
 done
-
-# Seed forums for the demo course
-docker run --network=host --rm -u='www-data' -e NO_PREREQ_INSTALL="1" -e SKIP_WS_MIGRATIONS="1" -e LMS_CFG=/edx/etc/lms.yml -e DJANGO_SETTINGS_MODULE=lms.envs.docker-production -e SERVICE_VARIANT=lms -e EDX_PLATFORM_SETTINGS=docker-production -v /edx/etc/lms.yml:/edx/etc/lms.yml -v /edx/var/edx-themes:/edx/var/edx-themes -v /edx/var/edxapp:/edx/var/edxapp -v /var/run/mysqld/mysqld.sock:/var/run/mysqld/mysqld.sock ${app_repo}:latest python3 manage.py lms seed_permissions_roles course-v1:edX+DemoX+Demo_Course
 EOF
 }


### PR DESCRIPTION
This is now redundant with the earlier `import` call, which at this point goes ahead and does the seeding.

One of these is probably used by sandboxes, and the other is probably not, but both are referenced by `ansible-provision.sh`. Might as well remove from both so that at least they're consistent with devstack, and so that this is not propagated forward to whatever eventually replaces the sandbox setup scripts.

See https://github.com/openedx/devstack/issues/1129 for details.

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [x] A SRE team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [x] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a SRE ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [x] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/spaces/SRE/pages/28967861/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [x] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
