### PR TITLE
fix: Update retry logic for certain ansible tasks.

### DIFF
--- a/playbooks/roles/insightvm_agent/tasks/main.yml
+++ b/playbooks/roles/insightvm_agent/tasks/main.yml
@@ -11,6 +11,7 @@
     path: /etc/systemd/system/ir_agent.service
   register: r7_service
   retries: 3
+  until: r7_service is succeeded
   tags:
     - manage_rapid7_check_agent
 

--- a/playbooks/roles/security/tasks/security-amazon.yml
+++ b/playbooks/roles/security/tasks/security-amazon.yml
@@ -30,7 +30,9 @@
 - name: "Take security updates during ansible runs"
   command: "{{ item }}"
   when: SECURITY_UPGRADE_ON_ANSIBLE
+  register: result_amazon
   retries: 3
+  until: result_amazon is succeeded
   with_items:
     - yum check-update --security
     - yum update --security -y

--- a/playbooks/roles/security/tasks/security-ubuntu.yml
+++ b/playbooks/roles/security/tasks/security-ubuntu.yml
@@ -24,7 +24,9 @@
 - name: Disable unattended-upgrades if Xenial (16.04)
   command: "{{ item }}"
   when: ansible_distribution_release == 'xenial' and not SECURITY_UNATTENDED_UPGRADES
+  register: result_ubuntu
   retries: 3
+  until: result_ubuntu is succeeded
   with_items:
     - "systemctl disable apt-daily.service"
     - "systemctl disable apt-daily.timer"


### PR DESCRIPTION
When we added retry logic, we missed that we also needed to register a variable and add an until condition to ensure that retries happen. This should ensure that this matches.

https://github.com/edx/edx-arch-experiments/issues/359

Ansible documentation: https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_loops.html#retrying-a-task-until-a-condition-is-met

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A SRE team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/spaces/SRE/pages/28967861/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
