### PR TITLE
fix: Add retries for a few python requirements installations

### DIFF
--- a/playbooks/roles/edxapp/tasks/deploy.yml
+++ b/playbooks/roles/edxapp/tasks/deploy.yml
@@ -161,7 +161,7 @@
   when: item.stat.exists
   with_items: "{{ python_requirement_files.results }}"
   register: edxapp_install_python_reqs
-  until: edxapp_install_python_reqs is success
+  until: edxapp_install_python_reqs is succeeded
   retries: 5
   delay: 15
   tags:
@@ -191,7 +191,7 @@
     GIT_SSH: "{{ edxapp_git_ssh }}"
   when: EDXAPP_INSTALL_PRIVATE_REQUIREMENTS
   register: edxapp_install_private_python_reqs
-  until: edxapp_install_private_python_reqs is success
+  until: edxapp_install_private_python_reqs is succeeded
   retries: 5
   delay: 15
   tags:
@@ -209,7 +209,7 @@
   with_items: "{{ EDXAPP_EXTRA_REQUIREMENTS }}"
   become_user: "{{ edxapp_user }}"
   register: edxapp_install_extra_python_reqs
-  until: edxapp_install_extra_python_reqs is success
+  until: edxapp_install_extra_python_reqs is succeeded
   retries: 5
   delay: 15
   tags:

--- a/playbooks/roles/edxapp/tasks/deploy.yml
+++ b/playbooks/roles/edxapp/tasks/deploy.yml
@@ -160,6 +160,10 @@
   environment: "{{ edxapp_environment }}"
   when: item.stat.exists
   with_items: "{{ python_requirement_files.results }}"
+  register: edxapp_install_python_reqs
+  until: edxapp_install_python_reqs is success
+  retries: 5
+  delay: 15
   tags:
     - install
     - install:app-requirements
@@ -186,6 +190,10 @@
   environment:
     GIT_SSH: "{{ edxapp_git_ssh }}"
   when: EDXAPP_INSTALL_PRIVATE_REQUIREMENTS
+  register: edxapp_install_private_python_reqs
+  until: edxapp_install_private_python_reqs is success
+  retries: 5
+  delay: 15
   tags:
     - install
     - install:app-requirements
@@ -200,6 +208,10 @@
     state: present
   with_items: "{{ EDXAPP_EXTRA_REQUIREMENTS }}"
   become_user: "{{ edxapp_user }}"
+  register: edxapp_install_extra_python_reqs
+  until: edxapp_install_extra_python_reqs is success
+  retries: 5
+  delay: 15
   tags:
     - install
     - install:app-requirements


### PR DESCRIPTION
We've intermittently seen some connection failures to PyPI. Ideally all such tasks could be retried automatically, but Ansible doesn't provide for that. Making each task retry requires 3-4 lines, so just change a few of the more likely-to-fail ones.

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [x] A SRE team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [x] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a SRE ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [x] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/spaces/SRE/pages/28967861/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [x] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
