### PR TITLE
fix: Stop insecure redirect when S3 hosting off

### DIFF
--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/prospectus.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/prospectus.j2
@@ -186,15 +186,15 @@ server {
     add_header 'Cache-Control' 'public, max-age=1800';
     try_files $uri $uri/index.html =404;
 
-  location / {
   {% if PROSPECTUS_S3_HOSTING_PROXY_ENABLED %}
+  location / {
     proxy_pass {{ PROSPECTUS_S3_HOSTING_BUCKET_URL }}/{{ PROSPECTUS_S3_HOSTING_PREFIX }}$request_uri;
     # proxy_redirect ensures redirects from s3 are rewritten
     # For example it will fix a redirect from s3 to prevent /school/mitx from trying to redirect to /924c142-1/school/mitx/
     # The second parameter being " " is to prevent nginx sticking http://hostname in front of the location directive
     proxy_redirect "/{{ PROSPECTUS_S3_HOSTING_PREFIX }}" " ";
-  {% endif %}
   }
+  {% endif %}
 
   # PROSPECTUS_STATIC_SITES will be a list of dictionaries which have a:
   #   - router_path: The path you will go to on the router to access the content


### PR DESCRIPTION
This code was meant to be a no-op with
PROSPECTUS_S3_HOSTING_PROXY_ENABLED off, but instead it adds `location / {}` to nginx,
which causes nginx to produce redirects to http://hostname/url/ if a trailing slash is omitted.

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A SRE team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a SRE ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/spaces/SRE/pages/28967861/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
