### PR TITLE
chore: upgrading `edx-event-routing-backends` to latest version.

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -585,7 +585,7 @@ EDXAPP_PRIVATE_REQUIREMENTS:
     - name: git+https://github.com/open-craft/lx-pathway-plugin.git@ba1d470217cd5908cbd8b56075628bd4eacf7b39#egg=lx-pathway-plugin
       extra_args: -e
     # Caliper and xAPI event routing plugin
-    - name: edx-event-routing-backends==4.1.1
+    - name: edx-event-routing-backends==5.5.6
 
 # List of custom middlewares that should be used in edxapp to process
 # incoming HTTP resquests. Should be a list of plain strings that fully


### PR DESCRIPTION
Bumped the `edx-event-routing-backends` to use version 5.5.6 (https://pypi.org/project/edx-event-routing-backends/5.5.6/)