### PR TITLE
fix: add retries for ubuntu security updates

### DIFF
--- a/playbooks/roles/security/tasks/security-ubuntu.yml
+++ b/playbooks/roles/security/tasks/security-ubuntu.yml
@@ -69,3 +69,6 @@
   with_items:
     - unattended-upgrade --dry-run
     - unattended-upgrade
+  register: ubuntu_security
+  retries: 3
+  until: ubuntu_security is succeeded


### PR DESCRIPTION
Error seen in GoCD logs:
```
The URI http://security.ubuntu.com/ubuntu/pool/main/s/systemd/udev_245.4-4ubuntu3.20_amd64.deb failed to download, aborting
```

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A SRE team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a SRE ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/spaces/SRE/pages/28967861/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
