### PR TITLE
fix: refactor condition for browsers role task using multiverse_installed.changed attribute

### DIFF
--- a/playbooks/roles/browsers/tasks/main.yml
+++ b/playbooks/roles/browsers/tasks/main.yml
@@ -26,7 +26,7 @@
 - name: Update cache when adding multiverse repos
   apt:
     update_cache: true
-  when: multiverse_installed | changed
+  when: multiverse_installed.changed
   tags:
     - install
     - install:system-requirements


### PR DESCRIPTION
This pull request addresses an issue where the browsers playbook encountered a template error due to the incorrect use of the changed attribute as a filter in the when condition for the apt task. The error message is:


```
TASK [browsers : Update cache when adding multiverse repos] ********************
13:32:19 fatal: [127.0.0.1]: FAILED! => {"msg": "The conditional check 'multiverse_installed | changed' failed. The error was: template error while templating string: no filter named 'changed'. String: {% if multiverse_installed | changed %} True {% else %} False {% endif %}\n\nThe error appears to be in '/edx/app/edx_ansible/edx_ansible/playbooks/roles/browsers/tasks/main.yml': line 26, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: Update cache when adding multiverse repos\n  ^ here\n"}
```



Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A SRE team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a SRE ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/spaces/SRE/pages/28967861/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
