### PR TITLE
docs: comment on EDXAPP_PRIVATE_REQUIREMENTS

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -540,7 +540,7 @@ EDXAPP_EXTRA_REQUIREMENTS: []
 # Example:
 # EDXAPP_PRIVATE_REQUIREMENTS:
 #   - name: git+https://git.myproject.org/MyProject#egg=MyProject
-# Note: This list contains edx.org specific dependencies, even thought this is
+# Note: This list contains edx.org specific dependencies, even though this is
 #  a public repo. The plan is to phase this out along with the rest of this
 #  repo as part of the DEPR https://github.com/openedx/public-engineering/issues/51.
 EDXAPP_PRIVATE_REQUIREMENTS:

--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -540,6 +540,9 @@ EDXAPP_EXTRA_REQUIREMENTS: []
 # Example:
 # EDXAPP_PRIVATE_REQUIREMENTS:
 #   - name: git+https://git.myproject.org/MyProject#egg=MyProject
+# Note: This list contains edx.org specific dependencies, even thought this is
+#  a public repo. The plan is to phase this out along with the rest of this
+#  repo as part of the DEPR https://github.com/openedx/public-engineering/issues/51.
 EDXAPP_PRIVATE_REQUIREMENTS:
     # For Harvard courses:
     - name: xblock-problem-builder==5.1.3


### PR DESCRIPTION
Add a note to clarify that EDXAPP_PRIVATE_REQUIREMENTS contains edx.org specific details, which is not ideal. The plan is to ultimately retire this repo according to the DEPR: https://github.com/openedx/public-engineering/issues/51

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A SRE team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a SRE ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/spaces/SRE/pages/28967861/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
