### PR TITLE
fix: Payment MFE GIT Version

### DIFF
--- a/playbooks/roles/payment/tasks/main.yml
+++ b/playbooks/roles/payment/tasks/main.yml
@@ -3,3 +3,4 @@
     name: mfe
   vars:
     MFE_ENVIRONMENT_EXTRA: '{{ payment_env_extra | default(MFE_DEPLOY_ENVIRONMENT_EXTRA) }}'
+    MFE_VERSION: "{{ PAYMENT_MFE_VERSION | default('master') }}"


### PR DESCRIPTION
Payment MFE (frontend-app-payment) ignored the selected git branch (`version` in ansible's git plugin) this simply allows it to funnel through.

This is part of THES-268.