### PR TITLE
fix: Actually hide cookies from prospectus S3

### DIFF
--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/prospectus.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/prospectus.j2
@@ -57,7 +57,7 @@ server {
   {% if PROSPECTUS_S3_HOSTING_PROXY_ENABLED %}
     proxy_pass {{ PROSPECTUS_S3_HOSTING_BUCKET_URL }}/{{ PROSPECTUS_S3_HOSTING_PREFIX }}$request_uri;
     # Prevent S3 errors from cookies being too large
-    proxy_hide_header Cookie;
+    proxy_set_header Cookie "";
   {% endif %}
   }
 
@@ -67,7 +67,7 @@ server {
   {% if PROSPECTUS_S3_HOSTING_PROXY_ENABLED %}
     proxy_pass {{ PROSPECTUS_S3_HOSTING_BUCKET_URL }}/{{ PROSPECTUS_S3_HOSTING_PREFIX }}$request_uri;
     # Prevent S3 errors from cookies being too large
-    proxy_hide_header Cookie;
+    proxy_set_header Cookie "";
   {% endif %}
   }
 
@@ -77,7 +77,7 @@ server {
   {% if PROSPECTUS_S3_HOSTING_PROXY_ENABLED %}
     proxy_pass {{ PROSPECTUS_S3_HOSTING_BUCKET_URL }}/{{ PROSPECTUS_S3_HOSTING_PREFIX }}$request_uri;
     # Prevent S3 errors from cookies being too large
-    proxy_hide_header Cookie;
+    proxy_set_header Cookie "";
   {% endif %}
   }
 
@@ -88,7 +88,7 @@ server {
   {% if PROSPECTUS_S3_HOSTING_PROXY_ENABLED %}
     proxy_pass {{ PROSPECTUS_S3_HOSTING_BUCKET_URL }}/{{ PROSPECTUS_S3_HOSTING_PREFIX }}$request_uri;
     # Prevent S3 errors from cookies being too large
-    proxy_hide_header Cookie;
+    proxy_set_header Cookie "";
   {% endif %}
   }
   
@@ -99,7 +99,7 @@ server {
   {% if PROSPECTUS_S3_HOSTING_PROXY_ENABLED %}
     proxy_pass {{ PROSPECTUS_S3_HOSTING_BUCKET_URL }}/{{ PROSPECTUS_S3_HOSTING_PREFIX }}$request_uri;
     # Prevent S3 errors from cookies being too large
-    proxy_hide_header Cookie;
+    proxy_set_header Cookie "";
   {% endif %}
   }
 
@@ -109,7 +109,7 @@ server {
   {% if PROSPECTUS_S3_HOSTING_PROXY_ENABLED %}
     proxy_pass {{ PROSPECTUS_S3_HOSTING_BUCKET_URL }}/{{ PROSPECTUS_S3_HOSTING_PREFIX }}/HealthCheck/index.html;
     # Prevent S3 errors from cookies being too large
-    proxy_hide_header Cookie;
+    proxy_set_header Cookie "";
     # proxy_redirect ensures redirects from s3 are rewritten
     # For example it will fix a redirect from s3 to prevent /school/mitx from trying to redirect to /924c142-1/school/mitx/
     # The second parameter being " " is to prevent nginx sticking http://hostname in front of the location directive
@@ -123,7 +123,7 @@ server {
     rewrite ^ /{{ PROSPECTUS_S3_HOSTING_PREFIX }}/es/bio/index.html break;
     proxy_pass {{ PROSPECTUS_S3_HOSTING_BUCKET_URL }}/{{ PROSPECTUS_S3_HOSTING_PREFIX }}/es/bio/index.html;
     # Prevent S3 errors from cookies being too large
-    proxy_hide_header Cookie;
+    proxy_set_header Cookie "";
     # proxy_redirect ensures redirects from s3 are rewritten
     # For example it will fix a redirect from s3 to prevent /school/mitx from trying to redirect to /924c142-1/school/mitx/
     # The second parameter being " " is to prevent nginx sticking http://hostname in front of the location directive
@@ -138,7 +138,7 @@ server {
     rewrite ^ /{{ PROSPECTUS_S3_HOSTING_PREFIX }}/bio/index.html break;
     proxy_pass {{ PROSPECTUS_S3_HOSTING_BUCKET_URL }}/{{ PROSPECTUS_S3_HOSTING_PREFIX }}/bio/index.html;
     # Prevent S3 errors from cookies being too large
-    proxy_hide_header Cookie;
+    proxy_set_header Cookie "";
     # proxy_redirect ensures redirects from s3 are rewritten
     # For example it will fix a redirect from s3 to prevent /school/mitx from trying to redirect to /924c142-1/school/mitx/
     # The second parameter being " " is to prevent nginx sticking http://hostname in front of the location directive
@@ -206,7 +206,7 @@ server {
   location / {
     proxy_pass {{ PROSPECTUS_S3_HOSTING_BUCKET_URL }}/{{ PROSPECTUS_S3_HOSTING_PREFIX }}$request_uri;
     # Prevent S3 errors from cookies being too large
-    proxy_hide_header Cookie;
+    proxy_set_header Cookie "";
     # proxy_redirect ensures redirects from s3 are rewritten
     # For example it will fix a redirect from s3 to prevent /school/mitx from trying to redirect to /924c142-1/school/mitx/
     # The second parameter being " " is to prevent nginx sticking http://hostname in front of the location directive


### PR DESCRIPTION
It turns out that the proxy_hide_headers directive is for hiding headers sent by the upstream server (S3) from the client. Not for hiding client headers from the upstead server (S3), which is what we want to do.

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A SRE team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a SRE ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/spaces/SRE/pages/28967861/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
