### PR TITLE
feat: upgrade redis to 7.2 for sandbox

### DIFF
--- a/playbooks/roles/redis/defaults/main.yml
+++ b/playbooks/roles/redis/defaults/main.yml
@@ -9,7 +9,7 @@
 #
 ##
 # Defaults for role redis
-# 
+#
 REDIS_PASSWORD: !!null
 REDIS_BIND_IP: 127.0.0.1
 REDIS_PERSISTENCE_DIR: "/var/lib/redis"
@@ -28,7 +28,7 @@ redis_group: redis
 #
 
 REDIS_REPO: "deb https://packages.redis.io/deb {{ ansible_distribution_release }} main"
-REDIS_VERSION: "6:6.2.6-3rl1~focal1"
+REDIS_VERSION: "6:7.2.0-1rl1~focal1"
 
 redis_debian_pkgs:
   - "redis-tools={{ REDIS_VERSION }}"


### PR DESCRIPTION
Upgrading Redis version to 7.2

**Ticket link**
- https://github.com/openedx/platform-roadmap/issues/283

**Tested on**
- https://mumarkhan999.sandbox.edx.org/

**Tested the following things on sandbox**

- Generated Reports
- Course Rerun
- Course Import/Exports

---

**Previous Version**
<img width="1086" alt="image" src="https://github.com/openedx/configuration/assets/42294172/544d6af1-d636-4032-a456-a53c0df81289">

**New Version**
<img width="1093" alt="image" src="https://github.com/openedx/configuration/assets/42294172/dda807da-1712-4305-91d7-470cad700d42">
