### PR TITLE
fix: apparent issue with ansible parsing

### DIFF
--- a/playbooks/roles/common/tasks/main.yml
+++ b/playbooks/roles/common/tasks/main.yml
@@ -209,7 +209,7 @@
     src: "{{ item.src }}"
     owner: root
     group: root
-    mode: "{{ item.mode | default(0644) }}"
+    mode: "{{ item.mode | default('0644') }}"
   register: config_templates
   with_items:
     - { src: 'edx_rsyslog.j2', dest: '/etc/rsyslog.d/99-edx.conf' }


### PR DESCRIPTION
Causing issues like 
<img width="1029" alt="Screenshot 2023-09-25 at 5 22 20 PM" src="https://github.com/openedx/configuration/assets/6405097/63d1ea47-9d96-4881-864e-64f853aecc78">

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A SRE team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a SRE ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/spaces/SRE/pages/28967861/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
