### PR TITLE
build: replace django-admin.py with django-admin

### DIFF
--- a/playbooks/roles/xqueue/tasks/main.yml
+++ b/playbooks/roles/xqueue/tasks/main.yml
@@ -178,7 +178,7 @@
 # If there is a common user for migrations run migrations using his username
 # and credentials. If not we use the xqueue mysql user
 - name: Migrate
-  shell: "{{ xqueue_venv_bin }}/django-admin.py migrate --noinput --settings=xqueue.{{ XQUEUE_SETTINGS }} --pythonpath={{ xqueue_code_dir }}"
+  shell: "{{ xqueue_venv_bin }}/django-admin migrate --noinput --settings=xqueue.{{ XQUEUE_SETTINGS }} --pythonpath={{ xqueue_code_dir }}"
   become_user: "{{ xqueue_user }}"
   environment:
     DB_MIGRATION_USER: "{{ COMMON_MYSQL_MIGRATE_USER }}"
@@ -191,7 +191,7 @@
     - migrate:db
 
 - name: Create users
-  shell: "{{ xqueue_venv_bin }}/django-admin.py update_users --settings=xqueue.{{ XQUEUE_SETTINGS }} --pythonpath={{ xqueue_code_dir }}"
+  shell: "{{ xqueue_venv_bin }}/django-admin update_users --settings=xqueue.{{ XQUEUE_SETTINGS }} --pythonpath={{ xqueue_code_dir }}"
   become_user: "{{ xqueue_user }}"
   environment:
     XQUEUE_CFG: '{{ COMMON_CFG_DIR }}/xqueue.yml'

--- a/playbooks/roles/xqueue/templates/xqueue_consumer.conf.j2
+++ b/playbooks/roles/xqueue/templates/xqueue_consumer.conf.j2
@@ -1,9 +1,9 @@
 [program:xqueue_consumer]
 
 {% if COMMON_ENABLE_NEWRELIC_APP %}
-{% set executable = xqueue_venv_bin + '/newrelic-admin run-program ' + xqueue_venv_bin + '/django-admin.py run_consumer' %}
+{% set executable = xqueue_venv_bin + '/newrelic-admin run-program ' + xqueue_venv_bin + '/django-admin run_consumer' %}
 {% else %}
-{% set executable = xqueue_venv_bin + '/django-admin.py run_consumer' %}
+{% set executable = xqueue_venv_bin + '/django-admin run_consumer' %}
 {% endif %}
 
 command={{ executable }} --pythonpath={{ xqueue_code_dir }} --settings=xqueue.{{ XQUEUE_SETTINGS }}


### PR DESCRIPTION
## Description
- Under the Django 4.2 upgrade progress, replaced the deprecated `django-admin.py` with `django-admin`. 
- `django-admin.py` was [deprecated in django 3.1](https://docs.djangoproject.com/en/4.2/releases/3.1/#id2) and [removed in django 4.0](https://docs.djangoproject.com/en/4.2/releases/4.0/#features-removed-in-4-0)