### PR TITLE
chore!: removing lx-pathway-plugin from private requirements

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -584,7 +584,7 @@ EDXAPP_PRIVATE_REQUIREMENTS:
     - name: git+https://github.com/open-craft/labxchange-xblocks.git@a0a8a8dad13199014d4bb29cee416289880bde0b#egg=labxchange-xblocks
       extra_args: -e
     # "Pathways" learning context plugin for the LabXchange project
-    - name: git+https://github.com/irtazaakram/lx-pathway-plugin.git@8fe72de587094f81b7d28123e55ca06f7e0ac1a1#egg=lx-pathway-plugin
+    - name: git+https://github.com/open-craft/lx-pathway-plugin.git@0b695f01c79664e0dc50e5ae9a315fa10a6c0bc5#egg=lx-pathway-plugin
       extra_args: -e
     # Caliper and xAPI event routing plugin
     - name: edx-event-routing-backends==5.5.6

--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -583,6 +583,9 @@ EDXAPP_PRIVATE_REQUIREMENTS:
     # XBlocks associated with the LabXchange project
     - name: git+https://github.com/open-craft/labxchange-xblocks.git@a0a8a8dad13199014d4bb29cee416289880bde0b#egg=labxchange-xblocks
       extra_args: -e
+    # "Pathways" learning context plugin for the LabXchange project
+    - name: git+https://github.com/irtazaakram/lx-pathway-plugin.git@8fe72de587094f81b7d28123e55ca06f7e0ac1a1#egg=lx-pathway-plugin
+      extra_args: -e
     # Caliper and xAPI event routing plugin
     - name: edx-event-routing-backends==5.5.6
 

--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -583,9 +583,6 @@ EDXAPP_PRIVATE_REQUIREMENTS:
     # XBlocks associated with the LabXchange project
     - name: git+https://github.com/open-craft/labxchange-xblocks.git@a0a8a8dad13199014d4bb29cee416289880bde0b#egg=labxchange-xblocks
       extra_args: -e
-    # "Pathways" learning context plugin for the LabXchange project
-    - name: git+https://github.com/open-craft/lx-pathway-plugin.git@ba1d470217cd5908cbd8b56075628bd4eacf7b39#egg=lx-pathway-plugin
-      extra_args: -e
     # Caliper and xAPI event routing plugin
     - name: edx-event-routing-backends==5.5.6
 


### PR DESCRIPTION
**This Package is no more in use.** Need to remove this or update due to `django42` compatiblity.

~~Since mysql8 backup still going on. So instead of deleting table i am removing this package from installation. After backup completion will remove the tables completely.~~

conversation about removing/deleting tables https://github.com/open-craft/lx-pathway-plugin/pull/1#issuecomment-1727775862

They merged [PR](https://github.com/open-craft/lx-pathway-plugin/pull/4) with deletion table migration.