### PR TITLE
feat: add profile and learner-dashboard to sandbox

### DIFF
--- a/playbooks/edx_continuous_integration.yml
+++ b/playbooks/edx_continuous_integration.yml
@@ -74,6 +74,12 @@
     - role: mfe
       MFE_NAME: ora-grading
       when: ORA_GRADING_MFE_ENABLED
+    - role: mfe
+      MFE_NAME: profile
+      when: PROFILE_MFE_ENABLED
+    - role: mfe
+      MFE_NAME: learner-dashboard
+      when: LEARNER_DASHBOARD_MFE_ENABLED
     - { role: oauth_client_setup, when: edxapp_containerized is defined and not edxapp_containerized }
     - role: datadog
       when: COMMON_ENABLE_DATADOG

--- a/playbooks/learner_dashboard.yml
+++ b/playbooks/learner_dashboard.yml
@@ -1,0 +1,16 @@
+- name: Deploy Learner Dashboard Frontend
+  hosts: all
+  become: True
+  gather_facts: True
+  vars:
+    ENABLE_NEWRELIC: False
+    CLUSTER_NAME: 'learner-dashboard'
+    LEARNER_DASHBOARD_MFE_ENABLED: True
+    LEARNER_DASHBOARD_MFE_SANDBOX_BUILD: False
+  roles:
+    - role: mfe
+      MFE_NAME: learner-dashboard
+    - role: splunkforwarder
+      when: COMMON_ENABLE_SPLUNKFORWARDER
+    - role: newrelic_infrastructure
+      when: COMMON_ENABLE_NEWRELIC_INFRASTRUCTURE

--- a/playbooks/profile.yml
+++ b/playbooks/profile.yml
@@ -1,0 +1,16 @@
+- name: Deploy profile Frontend
+  hosts: all
+  become: True
+  gather_facts: True
+  vars:
+    ENABLE_NEWRELIC: False
+    CLUSTER_NAME: 'profile'
+    PROFILE_MFE_ENABLED: True
+    PROFILE_MFE_SANDBOX_BUILD: False
+  roles:
+    - role: mfe
+      MFE_NAME: profile
+    - role: splunkforwarder
+      when: COMMON_ENABLE_SPLUNKFORWARDER
+    - role: newrelic_infrastructure
+      when: COMMON_ENABLE_NEWRELIC_INFRASTRUCTURE

--- a/playbooks/roles/edx_ansible/templates/update.j2
+++ b/playbooks/roles/edx_ansible/templates/update.j2
@@ -85,6 +85,8 @@ repos_to_cmd["course_authoring"]="$edx_ansible_cmd course_authoring.yml -e 'COUR
 repos_to_cmd["library_authoring"]="$edx_ansible_cmd library_authoring.yml -e 'COURSE_AUTHORING_MFE_VERSION=$2'"
 repos_to_cmd["ora_grading"]="$edx_ansible_cmd ora_grading.yml -e 'ORA_GRADING_MFE_VERSION=$2'"
 repos_to_cmd["enterprise_catalog"]="$edx_ansible_cmd enterprise_catalog.yml -e 'ENTERPRISE_CATALOG_MFE_VERSION=$2'"
+repos_to_cmd["profile"]="$edx_ansible_cmd profile.yml -e 'PROFILE_MFE_VERSION=$2'"
+repos_to_cmd["learner_dashboard"]="$edx_ansible_cmd learner_dashboard.yml -e 'LEARNER_DASHBOARD_MFE_VERSION=$2'"
 
 if [[ -z $1 || -z $2 ]]; then
     echo

--- a/playbooks/roles/launch_ec2/tasks/main.yml
+++ b/playbooks/roles/launch_ec2/tasks/main.yml
@@ -91,7 +91,7 @@
     - "{{ ec2.instances }}"
     - ['studio', 'ecommerce', 'preview', 'discovery', 'credentials', 'veda', 'analytics-api', 'registrar', 'program-console', 
     'learner-portal', 'prospectus', 'authn', 'payment', 'license-manager', 'learning', 'enterprise-catalog', 'ora-grading', 
-    'course-authoring','library-authoring', 'commerce-coordinator', 'edx-exams', 'subscriptions']
+    'course-authoring','library-authoring', 'commerce-coordinator', 'edx-exams', 'subscriptions', 'profile', 'learner-dashboard']
 
 - name: Add new instance to host group
   local_action:

--- a/util/jenkins/ansible-provision.sh
+++ b/util/jenkins/ansible-provision.sh
@@ -308,6 +308,22 @@ if [[ -z $library_authoring_version ]]; then
   LIBRARY_AUTHORING_MFE_VERSION="master"
 fi
 
+if [[ -z $profile ]]; then
+  profile="false"
+fi
+
+if [[ -z $profile_version ]]; then
+  PROFILE_MFE_VERSION="master"
+fi
+
+if [[ -z $learner_dashboard ]]; then
+  learner_dashboard="false"
+fi
+
+if [[ -z $learner_dashboard_version ]]; then
+  LEARNER_DASHBOARD_MFE_VERSION="master"
+fi
+
 # Lowercase the dns name to deal with an ansible bug
 dns_name="${dns_name,,}"
 
@@ -467,6 +483,18 @@ LIBRARY_AUTHORING_SSL_NGINX_PORT: 443
 LIBRARY_AUTHORING_MFE_VERSION: $library_authoring_version
 LIBRARY_AUTHORING_MFE_ENABLED: $library_authoring
 LIBRARY_AUTHORING_SANDBOX_BUILD: True
+
+PROFILE_NGINX_PORT: 80
+PROFILE_SSL_NGINX_PORT: 443
+PROFILE_MFE_VERSION: $profile_version
+PROFILE_MFE_ENABLED: $profile
+PROFILE_SANDBOX_BUILD: True
+
+LEARNER_DASHBOARD_NGINX_PORT: 80
+LEARNER_DASHBOARD_SSL_NGINX_PORT: 443
+LEARNER_DASHBOARD_MFE_VERSION: $learner_dashboard_version
+LEARNER_DASHBOARD_MFE_ENABLED: $learner_dashboard
+LEARNER_DASHBOARD_SANDBOX_BUILD: True
 
 mysql_server_version_5_7: True
 


### PR DESCRIPTION
Configuration Pull Request
Based on the instructions at https://2u-internal.atlassian.net/wiki/spaces/FEDX/pages/11764240/How+To+Add+an+MFE+to+a+Sandbox
Adding profile and learner-dashboard to the sandbox configuration to enable POC work for a pluggable interface
---

Make sure that the following steps are done before merging:

  - [ ] A SRE team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a SRE ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/spaces/SRE/pages/28967861/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
