### PR TITLE
chore: use variable to install decrypt config private key, and NGINX SSL cert and key

### DIFF
--- a/playbooks/roles/edx_service/tasks/main.yml
+++ b/playbooks/roles/edx_service/tasks/main.yml
@@ -105,6 +105,21 @@
     - install:configuration
     - install:app-configuration
 
+- name: Install decrypt config private key from variable
+  local_action:
+    module: copy
+    content: "{{ DECRYPT_CONFIG_PRIVATE_KEY_VAR }}"
+    dest: "{{ DECRYPT_CONFIG_PRIVATE_KEY_PATH | default('/var/tmp') }}/private.key"
+    force: yes
+    mode: "0644"
+  become: false
+  no_log: True
+  when: edx_service_decrypt_config_enabled and DECRYPT_CONFIG_PRIVATE_KEY_VAR is defined
+  tags:
+    - install
+    - install:configuration
+    - install:app-configuration
+
 - name: Decrypt app config file
   local_action: command asym_crypto_yaml decrypt-encrypted-yaml --secrets_file_path {{ ENCRYPTED_CFG_DIR }}/{{ edx_service_name }}.yml --private_key_path {{ DECRYPT_CONFIG_PRIVATE_KEY }} --outfile_path {{ UNENCRYPTED_CFG_DIR }}/{{ edx_service_name }}.yml
   become: false

--- a/playbooks/roles/edxapp/tasks/service_variant_config.yml
+++ b/playbooks/roles/edxapp/tasks/service_variant_config.yml
@@ -77,6 +77,22 @@
     - edxapp_cfg # Old deprecated tag, will remove when possible
     - edxapp_cfg_yaml_only # Used to render the yaml without the json until we remove the json configs
 
+- name: Install decrypt config private key from variable
+  local_action:
+    module: copy
+    content: "{{ DECRYPT_CONFIG_PRIVATE_KEY_VAR }}"
+    dest: "{{ DECRYPT_CONFIG_PRIVATE_KEY_PATH | default('/var/tmp') }}/private.key"
+    force: yes
+    mode: "0644"
+  become: false
+  no_log: True
+  when: EDXAPP_DECRYPT_CONFIG_ENABLED and DECRYPT_CONFIG_PRIVATE_KEY_VAR is defined
+  tags:
+    - install
+    - install:configuration
+    - install:app-configuration
+    - edxapp_cfg # Old deprecated tag, will remove when possible
+
 - name: Decrypt lms config
   local_action: command asym_crypto_yaml decrypt-encrypted-yaml --secrets_file_path {{ ENCRYPTED_CFG_DIR }}/lms.yml --private_key_path {{ DECRYPT_CONFIG_PRIVATE_KEY }} --outfile_path {{ UNENCRYPTED_CFG_DIR }}/lms.yml
   become: false

--- a/playbooks/roles/nginx/tasks/main.yml
+++ b/playbooks/roles/nginx/tasks/main.yml
@@ -361,6 +361,35 @@
     - install
     - install:configuration
 
+- name: copy ssl cert from variable
+  copy:
+    content: "{{ NGINX_SSL_CERT_VAR }}"
+    dest: "/etc/ssl/certs/{{ NGINX_SSL_CERTIFICATE|basename }}"
+    owner: root
+    group: root
+    mode: 0644
+  when: 
+    - not ssl_cert.stat.exists and NGINX_ENABLE_SSL and NGINX_SSL_CERTIFICATE != 'ssl-cert-snakeoil.pem'
+    - NGINX_SSL_CERT_VAR is defined
+  tags:
+    - install
+    - install:configuration
+
+- name: copy ssl key from variable
+  copy:
+    content: "{{ NGINX_SSL_KEY_VAR }}"
+    dest: "/etc/ssl/private/{{ NGINX_SSL_KEY|basename }}"
+    owner: root
+    group: root
+    mode: 0640
+  when: 
+    - not ssl_key.stat.exists and NGINX_ENABLE_SSL and NGINX_SSL_KEY != 'ssl-cert-snakeoil.key'
+    - NGINX_SSL_KEY_VAR is defined
+  no_log: True
+  tags:
+    - install
+    - install:configuration
+
 # removing default link
 - name: Removing default nginx config and restart (enabled)
   file:


### PR DESCRIPTION
Implementing this change to enhance the process of retrieving and installing both the decrypt config private key and the NGINX SSL certificate and key as part of an Ansible task. This update is to establish these secrets as variables, with the added intention of enhancing the security and ease of management in our deployment process. This adaptation positions us to efficiently store and retrieve these secrets from either Vault or AWS Secrets Manager.



Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A SRE team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a SRE ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/spaces/SRE/pages/28967861/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
