### PR TITLE
chore: remove aws credentials for rapid7 package download

### DIFF
--- a/playbooks/roles/insightvm_agent/defaults/main.yml
+++ b/playbooks/roles/insightvm_agent/defaults/main.yml
@@ -2,6 +2,4 @@
 
 r7_installer_location: /tmp/rapid7_agent_installer.sh
 R7_TOKEN: "SET-ME-PLEASE"
-R7_IAM_USER_ACCESS_KEY: "SET-ME-PLEASE"
-R7_IAM_USER_SECRET_KEY: "SET-ME-PLEASE"
 R7_BUCKET: "SET-ME-PLEASE (ex. bucket-name)" 

--- a/playbooks/roles/insightvm_agent/tasks/main.yml
+++ b/playbooks/roles/insightvm_agent/tasks/main.yml
@@ -17,8 +17,6 @@
 
 - name: Pull Rapid7 Agent Installer from S3
   aws_s3:
-    aws_access_key: "{{ R7_IAM_USER_ACCESS_KEY }}"
-    aws_secret_key: "{{ R7_IAM_USER_SECRET_KEY }}"
     bucket: "{{ R7_BUCKET }}"
     object: rapid7/rapid7_agent_installer.sh
     dest: "{{ r7_installer_location }}"


### PR DESCRIPTION
We can grant IAM role permissions for downloading packages from an S3 bucket without the necessity of generating credentials or establishing an IAM user.

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A SRE team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a SRE ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/spaces/SRE/pages/28967861/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
