### PR TITLE
fix: skip rapid7 installation if we can't pull installer

### DIFF
--- a/playbooks/roles/insightvm_agent/tasks/main.yml
+++ b/playbooks/roles/insightvm_agent/tasks/main.yml
@@ -23,6 +23,8 @@
     mode: get
     overwrite: different
     ignore_nonexistent_bucket: true
+  register: pull_rapid7_agent_installer_from_s3_result
+  ignore_errors: true
   tags:
     - manage_rapid7_pull_installer
   when: not r7_service.stat.exists|bool
@@ -33,7 +35,9 @@
     mode: "0755"
     owner: root
     group: root
+  when: pull_rapid7_agent_installer_from_s3_result is not failed
   ignore_errors: "{{ ansible_check_mode }}"
+  register: ensure_file_permissions_are_set_result
   tags:
     - manage_rapid7_file_perms
   when: not r7_service.stat.exists|bool
@@ -44,5 +48,6 @@
   tags:
     - manage_rapid7_agent_install
   ignore_errors: "{{ ansible_check_mode }}"
+  when: ensure_file_permissions_are_set_result is not failed and pull_rapid7_agent_installer_from_s3_result is not failed
   args:
     creates: /etc/systemd/system/ir_agent.service


### PR DESCRIPTION
[JIRA:DOS-4175](https://2u-internal.atlassian.net/browse/DOS-4175)

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A SRE team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a SRE ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/spaces/SRE/pages/28967861/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
