### PR TITLE
fix: correctly configure retries

### DIFF
--- a/playbooks/roles/ad_hoc_reporting/tasks/main.yml
+++ b/playbooks/roles/ad_hoc_reporting/tasks/main.yml
@@ -32,8 +32,10 @@
     url: "https://www.mongodb.org/static/pgp/server-{{ MONGO_VERSION_MAJOR_MINOR }}.asc"
     state: present
   retries: 3
+  register: add_mongo_signing_key
   tags:
     - install:system-requirements
+  until: add_mongo_signing_key is succeeded
 
 - name: add the mongodb repo to the sources list
   apt_repository:

--- a/playbooks/roles/mongo_2_6/tasks/main.yml
+++ b/playbooks/roles/mongo_2_6/tasks/main.yml
@@ -41,10 +41,12 @@
     id: "{{ MONGODB_APT_KEY }}"
     keyserver: "{{ MONGODB_APT_KEYSERVER }}"
     state: present
+  register: add_mongo_signing_key
   retries: 3
   tags:
     - install
     - install:base
+  until: add_mongo_signing_key is succeeded
 
 - name: Add the mongodb repo to the sources list
   apt_repository:

--- a/playbooks/roles/mongo_3_2/tasks/main.yml
+++ b/playbooks/roles/mongo_3_2/tasks/main.yml
@@ -47,9 +47,11 @@
     url: "https://www.mongodb.org/static/pgp/server-{{ MONGO_VERSION_MAJOR_MINOR }}.asc"
     state: present
   retries: 3
+  register: add_mongo_signing_key
   tags:
     - "install"
     - "install:app-requirements"
+  until: add_mongo_signing_key is succeeded
 
 - name: add the mongodb repo to the sources list
   apt_repository:

--- a/playbooks/roles/mongo_3_4/tasks/main.yml
+++ b/playbooks/roles/mongo_3_4/tasks/main.yml
@@ -36,9 +36,11 @@
     url: "https://www.mongodb.org/static/pgp/server-{{ MONGO_VERSION_MAJOR_MINOR }}.asc"
     state: present
   retries: 3
+  register: add_mongo_signing_key
   tags:
     - "install"
     - "install:app-requirements"
+  until: add_mongo_signing_key is succeeded
 
 - name: add the mongodb repo to the sources list
   apt_repository:

--- a/playbooks/roles/mongo_3_6/tasks/main.yml
+++ b/playbooks/roles/mongo_3_6/tasks/main.yml
@@ -47,9 +47,11 @@
     url: "https://www.mongodb.org/static/pgp/server-{{ MONGO_VERSION_MAJOR_MINOR }}.asc"
     state: present
   retries: 3
+  register: add_mongo_signing_key
   tags:
     - "install"
     - "install:app-requirements"
+  until: add_mongo_signing_key is succeeded
 
 - name: add the mongodb repo to the sources list
   apt_repository:

--- a/playbooks/roles/mongo_4_0/tasks/main.yml
+++ b/playbooks/roles/mongo_4_0/tasks/main.yml
@@ -47,9 +47,11 @@
     url: "https://www.mongodb.org/static/pgp/server-{{ MONGO_VERSION_MAJOR_MINOR }}.asc"
     state: present
   retries: 3
+  register: add_mongo_signing_key
   tags:
     - "install"
     - "install:app-requirements"
+  until: add_mongo_signing_key is succeeded
 
 - name: add the mongodb repo to the sources list
   apt_repository:

--- a/playbooks/roles/mongo_4_2/tasks/main.yml
+++ b/playbooks/roles/mongo_4_2/tasks/main.yml
@@ -36,9 +36,11 @@
     url: "https://www.mongodb.org/static/pgp/server-{{ MONGO_VERSION_MAJOR_MINOR }}.asc"
     state: present
   retries: 3
+  register: add_mongo_signing_key
   tags:
     - "install"
     - "install:app-requirements"
+  until: add_mongo_signing_key is succeeded
 
 - name: add the mongodb repo to the sources list
   apt_repository:

--- a/playbooks/roles/mongo_4_4/tasks/main.yml
+++ b/playbooks/roles/mongo_4_4/tasks/main.yml
@@ -36,9 +36,11 @@
     url: "https://www.mongodb.org/static/pgp/server-{{ MONGO_VERSION_MAJOR_MINOR }}.asc"
     state: present
   retries: 3
+  register: add_mongo_signing_key
   tags:
     - "install"
     - "install:app-requirements"
+  until: add_mongo_signing_key is succeeded
 
 - name: add the mongodb repo to the sources list
   apt_repository:

--- a/playbooks/roles/mongo_client/tasks/main.yml
+++ b/playbooks/roles/mongo_client/tasks/main.yml
@@ -4,9 +4,11 @@
     url: "https://www.mongodb.org/static/pgp/server-{{ MONGO_VERSION_MAJOR_MINOR }}.asc"
     state: present
   retries: 3
+  register: add_mongo_signing_key
   tags:
     - install
     - install:system-requirements
+  until: add_mongo_signing_key is succeeded
 
 - name: add the mongodb repo to the sources list
   apt_repository:

--- a/playbooks/roles/python/tasks/main.yml
+++ b/playbooks/roles/python/tasks/main.yml
@@ -16,5 +16,7 @@
 - name: Install packages
   raw: "apt-get install -qq {{ item }}"
   with_items: "{{ python_packages }}"
+  register: install_packages
   retries: 10
   delay: 10
+  until: install_packages is succeeded

--- a/playbooks/roles/redis/tasks/main.yml
+++ b/playbooks/roles/redis/tasks/main.yml
@@ -26,9 +26,11 @@
     url: "https://packages.redis.io/gpg"
     state: present
   retries: 3
+  register: add_repo_signing_key
   tags:
     - "install"
     - "install:app-requirements"
+  until: add_repo_signing_key is succeeded
 
 - name: add the redis repo to the sources list
   apt_repository:


### PR DESCRIPTION
Configuration Pull Request
---

Adds ``register`` and ``until`` keys to steps that use retries.

Make sure that the following steps are done before merging:

  - [ ] A SRE team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a SRE ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/spaces/SRE/pages/28967861/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
