### PR TITLE
chore: update connect_timeout for memcache server

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -1330,6 +1330,7 @@ generic_cache_config: &default_generic_cache
     no_delay: true
     ignore_exc: true
     use_pooling: true
+    connect_timeout: 0.5
 
 edxapp_revisions_config:
   EDX_PLATFORM_REVISION: "{{ EDX_PLATFORM_VERSION }}"


### PR DESCRIPTION
Update `connect_timeout` for `memcache` server

**Best practices**
- https://github.com/pinterest/pymemcache/blob/8cd0d8740e80ad29dab6decb8e81cb0c6ec5d374/docs/getting_started.rst#best-practices

**Description**
- https://github.com/pinterest/pymemcache/blob/8cd0d8740e80ad29dab6decb8e81cb0c6ec5d374/pymemcache/client/base.py#L300
![image](https://github.com/edx/edx-internal/assets/42294172/546cc525-8b25-4225-b814-7a1f615a56b3)
