### PR TITLE
fix: encrypt sandbox volumes

### DIFF
--- a/playbooks/roles/launch_ec2/tasks/main.yml
+++ b/playbooks/roles/launch_ec2/tasks/main.yml
@@ -52,6 +52,7 @@
         volume_size: "{{ root_ebs_size }}"
         delete_on_termination: true
         volume_type: "gp2"
+        encrypted: true
     zone: "{{ zone }}"
     instance_profile_name: "{{ instance_profile_name }}"
     user_data: "{{ user_data }}"


### PR DESCRIPTION
Configuration Pull Request
---

[PSRE-2708](https://2u-internal.atlassian.net/browse/PSRE-2708): Ensures that ec2 volumes have an encrypted volume

Make sure that the following steps are done before merging:

  - [ ] A SRE team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a SRE ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/spaces/SRE/pages/28967861/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
