### PR TITLE
Revert "chore: add APPLE_ROOT_CA environment variable in ecommerce (DOS-3642)"

### DIFF
--- a/playbooks/roles/ecommerce/defaults/main.yml
+++ b/playbooks/roles/ecommerce/defaults/main.yml
@@ -298,7 +298,6 @@ ecommerce_gunicorn_port: "8130"
 
 ecommerce_environment:
   ECOMMERCE_CFG: "{{ COMMON_CFG_DIR }}/{{ ecommerce_service_name }}.yml"
-  APPLE_ROOT_CA: "{{ COMMON_APP_DIR }}/ecommerce/ecommerce/ecommerce/extensions/iap/AppleRootCA-G3.cer"
 
 ecommerce_create_demo_data: false
 


### PR DESCRIPTION
Reverts openedx/configuration#6931
 IOS team doesn't need this key anymore