### PR TITLE
fix: Move hashed filenames to common path GSRE-991

### DIFF
--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/prospectus.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/prospectus.j2
@@ -81,15 +81,33 @@ server {
   {% endif %}
   }
 
-  # Cache js/css for a long time at the edge, they are versioned in their names
-  location ~ \.(js|css)$ {
+  # Look for hashed .css, .js and .map files in bucket/static_hashed to prevent 404 when cloudflare cache is cleared
+  # Regex only looks in root path, which are the only .css, .js and .map files with content hash filenames
+  location ~* ^/[^/]+\.(css|js|map)$ {
+    # Cache js/css for a long time at the edge, they are versioned in their names
     add_header 'Cache-Control' 'public, max-age=31536000, immutable';
   {% if PROSPECTUS_S3_HOSTING_PROXY_ENABLED %}
-    proxy_pass {{ PROSPECTUS_S3_HOSTING_BUCKET_URL }}/{{ PROSPECTUS_S3_HOSTING_PREFIX }}$request_uri;
+    proxy_pass {{ PROSPECTUS_S3_HOSTING_BUCKET_URL }}/static_hashed$request_uri;
     # Hide client headers from S3 to prevent request headers too big error
     proxy_pass_request_headers off;
   {% endif %}
   }
+
+  {% if PROSPECTUS_S3_HOSTING_PROXY_ENABLED %}
+  # Look for /page-data/sq/d/*.js files in bucket/static_hashed to prevent 404 when cloudflare cache is cleared
+  location /page-data/sq/d/ {
+    proxy_pass {{ PROSPECTUS_S3_HOSTING_BUCKET_URL }}/static_hashed$request_uri;
+    # Hide client headers from S3 to prevent request headers too big error
+    proxy_pass_request_headers off;
+  }
+
+  # Look for /static/* files in bucket/static_hashed to prevent 404 when cloudflare cache is cleared
+  location /static/ {
+    proxy_pass {{ PROSPECTUS_S3_HOSTING_BUCKET_URL }}/static_hashed$request_uri;
+    # Hide client headers from S3 to prevent request headers too big error
+    proxy_pass_request_headers off;
+  }
+  {% endif %}
 
   # images sometimes change, we want to cache them for an hour at the edge to reduce bandwidth.
 

--- a/playbooks/roles/prospectus/tasks/main.yml
+++ b/playbooks/roles/prospectus/tasks/main.yml
@@ -241,7 +241,15 @@
 
   - name: Upload prospectus to S3
     become_user: "{{ prospectus_user }}"
-    shell: 'aws s3 sync --quiet {{ PROSPECTUS_DATA_DIR }} s3://{{ PROSPECTUS_S3_HOSTING_BUCKET }}/{{ PROSPECTUS_S3_HOSTING_PREFIX | default(PROSPECTUS_VERSION, true) }}'
+    shell: "aws s3 sync --quiet {{ PROSPECTUS_DATA_DIR }} s3://{{ PROSPECTUS_S3_HOSTING_BUCKET }}/{{ PROSPECTUS_S3_HOSTING_PREFIX | default(PROSPECTUS_VERSION, true) }}"
+    when: PROSPECTUS_S3_UPLOAD_ENABLED|bool
+    tags:
+      - install
+      - install:system-requirements
+
+  - name: Upload prospectus hashed static files to S3
+    become_user: "{{ prospectus_user }}"
+    shell: "aws s3 cp --recursive {{ PROSPECTUS_DATA_DIR }} s3://{{ PROSPECTUS_S3_HOSTING_BUCKET }}/static_hashed --exclude '*' --include '/*.css' --include '/*.js' --include '/*.map' --exclude '*/*' --include 'static/*' --include 'page-data/sq/d/*'"
     when: PROSPECTUS_S3_UPLOAD_ENABLED|bool
     tags:
       - install


### PR DESCRIPTION
Move filenames that are hashed based on content to a common bucket path in S3 so that we don't have search glitches from 404s on deploys

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A SRE team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a SRE ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/spaces/SRE/pages/28967861/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
