### PR TITLE
chore: remove key tasks from mysql8 installation

### DIFF
--- a/playbooks/roles/mysql/tasks/mysql.yml
+++ b/playbooks/roles/mysql/tasks/mysql.yml
@@ -59,7 +59,7 @@
   apt_key:
     keyserver: "{{ MYSQL_APT_KEYSERVER }}"
     id: "{{ MYSQL_APT_KEY }}"
-  when: ansible_distribution_release == 'focal'
+  when: ansible_distribution_release == 'focal' and not mysql_8_0_install
 
 - name: add the mysql-5.7 repo to the sources list
   apt_repository:


### PR DESCRIPTION
the tasks is not required for mysql8, sandbox builds are failing so added a condition to add keys just for mysql5.7 and not for mysql8.

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A SRE team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a SRE ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/spaces/SRE/pages/28967861/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
