### PR TITLE
fix: failure trying to create specific kind of user via ansible

### DIFF
--- a/playbooks/create_db_and_users.yml
+++ b/playbooks/create_db_and_users.yml
@@ -102,7 +102,7 @@
 
     - name: assign privileges to AWS RDS IAM users
       shell: |
-         mysql -u"{{ item.login_user }}" -p"{{ item.login_password }}" -h"{{ item.login_host }}" -e "GRANT {{ item.privileges }} to '{{ item.name }}'@'{{ item.host }}'REQUIRE SSL"
+         mysql -u"{{ item.login_user }}" -p"{{ item.login_password }}" -h"{{ item.login_host }}" -e "GRANT {{ item.privileges }} to '{{ item.name }}'@'{{ item.host }}'"
       when: item.mysql_plugin is defined and item.state == 'present' and item.mysql_plugin == 'AWSAuthenticationPlugin'
       with_items: "{{ database_users }}"
       tags:


### PR DESCRIPTION
specifically when running the create db and users runbook which is used to set up users for mysql databases as documented here: https://2u-internal.atlassian.net/wiki/spaces/SRE/pages/19252888/How+to+Create+and+Update+Databases+and+Database+Users

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] A SRE team member has approved the PR if it is code shared across multiple services and you don't own all of the services.
  - [ ] Are you adding any new default values that need to be overridden when this change goes live? If so:
    - [ ] Update the appropriate internal repo (be sure to update for all our environments)
    - [ ] If you are updating a secure value rather than an internal one, file a SRE ticket with details.
    - [ ] Add an entry to the CHANGELOG.
  - [ ] If you are making a complicated change, have you performed the proper testing specified on the [Ops Ansible Testing Checklist](https://openedx.atlassian.net/wiki/spaces/SRE/pages/28967861/Ops+Ansible+Testing+Checklist)?  Adding a new variable does not require the full list (although testing on a sandbox is a great idea to ensure it links with your downstream code changes).
  - [ ] Think about how this change will affect Open edX operators.  Have you updated the wiki page for the next Open edX release?
