### PR TITLE
fix: allow defining MFE-specific env overrides while preserving extra defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 All notable changes to this project will be documented in this file.
 Add any new changes to the top (right below this line).
 
+- 2024-01-25
+  - Role: mfe
+    - Added `MFE_ENVIRONMENT_DEFAULT_EXTRA` to allow operators to add extra environment variables to all MFEs when
+      deploying them with the `mfe_deployer` role.
+
 - 2023-10-09
 
   - Role: edxapp

--- a/playbooks/roles/mfe/defaults/main.yml
+++ b/playbooks/roles/mfe/defaults/main.yml
@@ -139,8 +139,10 @@ MFE_ENVIRONMENT_DEFAULT:
 
 MFE_STANDALONE_NGINX: true
 
+# This variable can be overridden to include extra defaults for all MFEs deployed with the `mfe_deployer` role.
+MFE_ENVIRONMENT_DEFAULT_EXTRA: {}
 # NOTE: This should be overridden by inheriting MFE-specific role.
 MFE_ENVIRONMENT_EXTRA: {}
-MFE_ENVIRONMENT: '{{ MFE_ENVIRONMENT_DEFAULT | combine(MFE_ENVIRONMENT_EXTRA) }}'
+MFE_ENVIRONMENT: '{{ MFE_ENVIRONMENT_DEFAULT | combine(MFE_ENVIRONMENT_DEFAULT_EXTRA) | combine(MFE_ENVIRONMENT_EXTRA) }}'
 
 MFE_NPM_OVERRIDES: []


### PR DESCRIPTION
## User story

When deploying MFEs through the `mfe_deployer` role ([used](https://github.com/openedx/configuration/blob/82d60c0281443c5e67b7d6dcf5f68662e96e3447/playbooks/openedx_native.yml#L142-L143) in the `openedx_native.yml` playbook), you can specify the following configuration:
```yaml
MFES:
  - name: gradebook
    repo: frontend-app-gradebook
    public_path: /gradebook/
```

Then, you define some common env variables that will be shared between your MFEs, like:
```yaml
MFE_DEPLOY_ENVIRONMENT_EXTRA:
  ACCOUNT_PROFILE_URL: /profile
  ACCOUNT_SETTINGS_URL: '{{ COMMON_LMS_BASE_URL }}/account/settings'
```

However, now you want to use the [MFE config API](https://github.com/openedx/edx-platform/blob/89f5f69682a5e1422f89e867491e8974dd0a8208/lms/djangoapps/mfe_config_api/views.py#L16-L16), as some of the MFE variables are not populated at build time. You also want to use overrides for individual MFEs (with `/api/mfe_config/v1?mfe=name_of_mfe`), but it doesn't work. That's because the `APP_ID` is not defined anywhere (so the MFE sends queries to `/api/mfe_config/v1?mfe=undefined`).

To avoid this (without making further modifications to the MFE env defaults or the `mfe_deployer` role), you could use the following config:
```yaml
MFES:
  - name: gradebook
    repo: frontend-app-gradebook
    public_path: /gradebook/
    env_extra:
      APP_ID: gradebook
```

However, after the deployment, you notice that none of the variables defined in `MFE_DEPLOY_ENVIRONMENT_EXTRA` were used when running `npm build` for each MFE. That's because the `mfe_deployer` role overrides the whole `MFE_DEPLOY_ENVIRONMENT_EXTRA` variable with anything you define in `env_extra`:
https://github.com/openedx/configuration/blob/1909bafde44584ec7bd04f7cb6ee6ac0bfa6b521/playbooks/roles/mfe_deployer/tasks/main.yml#L16

To mitigate this, I added `MFE_ENVIRONMENT_DEFAULT_EXTRA`, which you can use in Ansible variables (instead of `MFE_DEPLOY_ENVIRONMENT_EXTRA`) to share env variables between MFEs, while still allowing to use `env_extra` for each of them.

## Alternatives
1. Technically, you don't need to make any changes if you overwrite `MFE_ENVIRONMENT_DEFAULT` in your Ansible vars, but you would need to duplicate [all these helpful defaults](https://github.com/openedx/configuration/blob/5e086513bd2a74a76475abd2bb6670d930f820e4/playbooks/roles/mfe/defaults/main.yml#L97-L138), which is not an elegant approach.
2. I thought about changing `default` to `combine` in [this line](https://github.com/openedx/configuration/blob/1909bafde44584ec7bd04f7cb6ee6ac0bfa6b521/playbooks/roles/mfe_deployer/tasks/main.yml#L16), but this would be a breaking change because it alters the current behavior of the Ansible roles.
3. I also considered changing `MFE_ENVIRONMENT_EXTRA` to something like `MFE_DEPLOYER_CUSTOM_MFE_ENVIRONMENT` [here](https://github.com/openedx/configuration/blob/1909bafde44584ec7bd04f7cb6ee6ac0bfa6b521/playbooks/roles/mfe_deployer/tasks/main.yml#L16), but this is also a breaking change for anybody who relies on the existing behavior.

## Author's note
I know the `APP_ID` is not the best example here, as we could modify the `mfe_deployer` role to populate this value automatically. We have a slightly more complex use case for the `frontend-app-learner-portal-enterprise`, but I wanted to keep the user story simple.

_Private-ref: [BB-8397](https://tasks.opencraft.com/browse/BB-8397)_

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] Have a Site Reliability Engineer review the PR if you don't own all of the services impacted.
  - [x] If you are adding any new default values that need to be overridden when this change goes live, update internal repos and add an entry to the top of the CHANGELOG.
  - [x] Performed the appropriate testing.
  - [x] Think about how this change will affect Open edX operators and update the wiki page for the next Open edX release if needed
