### PR TITLE
fix: allow defining MFE-specific env overrides while preserving extra defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 All notable changes to this project will be documented in this file.
 Add any new changes to the top (right below this line).
 
+- 2024-01-25
+  - Role: mfe
+    - Added `MFE_ENVIRONMENT_DEFAULT_EXTRA` to allow operators to add extra environment variables to all MFEs when
+      deploying them with the `mfe_deployer` role.
+
  - 2023-04-07
     - Changed default value of `EDXAPP_MONGO_REPLICA_SET` to `null` from existing
       empty string `""`, to make it compatible with pymongo >= 3.11 in Nutmeg and above.

--- a/playbooks/roles/mfe/defaults/main.yml
+++ b/playbooks/roles/mfe/defaults/main.yml
@@ -139,8 +139,10 @@ MFE_ENVIRONMENT_DEFAULT:
 
 MFE_STANDALONE_NGINX: true
 
+# This variable can be overridden to include extra defaults for all MFEs deployed with the `mfe_deployer` role.
+MFE_ENVIRONMENT_DEFAULT_EXTRA: {}
 # NOTE: This should be overridden by inheriting MFE-specific role.
 MFE_ENVIRONMENT_EXTRA: {}
-MFE_ENVIRONMENT: '{{ MFE_ENVIRONMENT_DEFAULT | combine(MFE_ENVIRONMENT_EXTRA) }}'
+MFE_ENVIRONMENT: '{{ MFE_ENVIRONMENT_DEFAULT | combine(MFE_ENVIRONMENT_DEFAULT_EXTRA) | combine(MFE_ENVIRONMENT_EXTRA) }}'
 
 MFE_NPM_OVERRIDES: []


### PR DESCRIPTION
This backports https://github.com/openedx/configuration/pull/7090 to Palm.