### PR TITLE
chore: update the Datadog role to be compatible with the latest agent

### DIFF
--- a/playbooks/roles/datadog/defaults/main.yml
+++ b/playbooks/roles/datadog/defaults/main.yml
@@ -1,15 +1,24 @@
 ---
 DATADOG_API_KEY: "SPECIFY_KEY_HERE"
 
-DATADOG_AGENT_VERSION: '1:5.10.1-1'
+DATADOG_SITE: datadoghq.com
 
-datadog_apt_key: "0x382E94DE"
+DATADOG_AGENT_VERSION: '1:7.50.3-1'
+
+datadog_user: "dd-agent"
+
+# Variables for Datadog MongoDB Monitoring
+datadog_mongo_host: 127.0.0.1
+datadog_mongo_port: 27017
+datadog_mongo_username: datadog
+datadog_mongo_password: password
+datadog_mongo_db: admin
+datadog_authsource_db: admin
+
+datadog_apt_key: "0xAD9589B7"
 datadog_debian_pkgs:
-  - apparmor-utils
-  - build-essential
-  - curl
-  - g++
-  - gcc
-  - ipython
-  - pkg-config
-  - rsyslog
+  - apt-transport-https 
+  - curl 
+  - gnupg
+
+DATADOG_MONGODB_MONITORING: true

--- a/playbooks/roles/datadog/tasks/main.yml
+++ b/playbooks/roles/datadog/tasks/main.yml
@@ -22,7 +22,7 @@
 
 - name: Add apt key for datadog
   apt_key:
-    id: "382E94DE"
+    id: "33EE313BAD9589B7"
     url: "{{ COMMON_UBUNTU_APT_KEYSERVER }}{{ datadog_apt_key }}"
     state: present
   tags:
@@ -30,7 +30,7 @@
 
 - name: Install apt repository for datadog
   apt_repository:
-    repo: 'deb http://apt.datadoghq.com/ stable main'
+    repo: 'deb http://apt.datadoghq.com/ stable 7'
     state: present
     update_cache: yes
   tags:
@@ -43,22 +43,45 @@
     - datadog
 
 - name: Bootstrap config
-  shell: cp datadog.conf.example datadog.conf
+  shell: cp datadog.yaml.example datadog.yaml
   args:
-    chdir: /etc/dd-agent/
-    creates: /etc/dd-agent/datadog.conf
+    chdir: /etc/datadog-agent/
+    creates: /etc/datadog-agent/datadog.yaml
   tags:
     - datadog
 
 - name: Update api-key
   lineinfile:
-    dest: "/etc/dd-agent/datadog.conf"
+    dest: "/etc/datadog-agent/datadog.yaml"
     regexp: "^api_key:.*"
-    line: "api_key:{{ DATADOG_API_KEY }}"
+    line: "api_key: {{ DATADOG_API_KEY }}"
   notify:
     - restart the datadog service
   tags:
     - datadog
+
+- name: Update site
+  lineinfile:
+    dest: "/etc/datadog-agent/datadog.yaml"
+    regexp: "^# site:.*"
+    line: "site: {{ DATADOG_SITE }}"
+  notify:
+    - restart the datadog service
+  tags:
+    - datadog
+
+- name: Write MongoDB monitoring config
+  template:
+    src: "conf.yaml.j2"
+    dest: "/etc/datadog-agent/conf.d/mongo.d/conf.yaml"
+    owner: "{{ datadog_user }}"
+    group: "{{ datadog_user }}"
+    mode: 0644
+  notify:
+    - restart the datadog service
+  tags:
+    - datadog
+  when: DATADOG_MONGODB_MONITORING | default(false) | bool
 
 - name: Ensure started and enabled
   service:

--- a/playbooks/roles/datadog/templates/conf.yaml.j2
+++ b/playbooks/roles/datadog/templates/conf.yaml.j2
@@ -1,0 +1,9 @@
+init_config:
+instances:
+  - hosts:
+      - {{ datadog_mongo_host }}:{{ datadog_mongo_port }}
+    username: {{ datadog_mongo_username }}
+    password: {{ datadog_mongo_password }}
+    database: {{ datadog_mongo_db }}
+    options:
+      authSource: {{ datadog_authsource_db }}


### PR DESCRIPTION
Updating the Datadog role to ensure compatibility with the latest agent version while also incorporating a conditional task to enable MongoDB monitoring

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] Have a Site Reliability Engineer review the PR if you don't own all of the services impacted.
  - [ ] If you are adding any new default values that need to be overridden when this change goes live, update internal repos and add an entry to the top of the CHANGELOG.
  - [ ] Performed the appropriate testing.
  - [ ] Think about how this change will affect Open edX operators and update the wiki page for the next Open edX release if needed
