### PR TITLE
temp: hardcode newrelic-infra version to unblock

### DIFF
--- a/playbooks/roles/newrelic_infrastructure/tasks/main.yml
+++ b/playbooks/roles/newrelic_infrastructure/tasks/main.yml
@@ -121,7 +121,7 @@
 
 - name: Install newrelic related system packages for Amazon
   yum:
-    name: "{{ newrelic_infrastructure_redhat_pkgs }}"
+    name: "newrelic-infra=2.0.8"
     enablerepo: "newrelic-infra"
     state: latest
     update_cache: yes


### PR DESCRIPTION
E: Failed to fetch https://download.newrelic.com/infrastructure_agent/linux/apt/pool/main/f/fluent-bit/fluent-bit_2.2.2_ubuntu-bionic_amd64.deb  404  Not Found [IP: 146.75.34.137 443]

It looks like 2.2.2 is not available where the 2.0.8 package is, so we may try getting 2.0.8 until fixed or we find another workaround.

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] Have a Site Reliability Engineer review the PR if you don't own all of the services impacted.
  - [ ] If you are adding any new default values that need to be overridden when this change goes live, update internal repos and add an entry to the top of the CHANGELOG.
  - [ ] Performed the appropriate testing.
  - [ ] Think about how this change will affect Open edX operators and update the wiki page for the next Open edX release if needed
