### PR TITLE
temp: hardcode newrelic fluent-bit version

### DIFF
--- a/playbooks/roles/newrelic_infrastructure/defaults/main.yml
+++ b/playbooks/roles/newrelic_infrastructure/defaults/main.yml
@@ -33,6 +33,7 @@ NEWRELIC_INFRASTRUCTURE_AMAZON_REPO: 'https://download.newrelic.com/infrastructu
 
 newrelic_infrastructure_debian_pkgs:
   - newrelic-infra
+  - fluent-bit=2.0.8
 
 newrelic_infrastructure_redhat_pkgs:
   - newrelic-infra

--- a/playbooks/roles/newrelic_infrastructure/tasks/main.yml
+++ b/playbooks/roles/newrelic_infrastructure/tasks/main.yml
@@ -90,7 +90,9 @@
 
 - name: Install newrelic related system packages for Ubuntu
   apt:
-    name: "{{ newrelic_infrastructure_debian_pkgs }}"
+    name: 
+      - "{{ newrelic_infrastructure_debian_pkgs }}"
+      - "fluent-bit=2.0.8"
     install_recommends: yes
     state: latest
   tags:

--- a/playbooks/roles/newrelic_infrastructure/tasks/main.yml
+++ b/playbooks/roles/newrelic_infrastructure/tasks/main.yml
@@ -90,9 +90,7 @@
 
 - name: Install newrelic related system packages for Ubuntu
   apt:
-    name: 
-      - "{{ newrelic_infrastructure_debian_pkgs }}"
-      - "fluent-bit=2.0.8"
+    name: "{{ newrelic_infrastructure_debian_pkgs }}"
     install_recommends: yes
     state: latest
   tags:


### PR DESCRIPTION
The 2.2.2 version of fluent-bit is not available, but the 2.0.8 version is. We are temporarily hard-coding until we find a better fix.

% curl --head https://download.newrelic.com/infrastructure_agent/linux/apt/pool/main/f/fluent-bit/fluent-bit_2.2.2_ubuntu-bionic_amd64.deb HTTP/2 404 
x-amz-error-code: NoSuchKey
x-amz-error-message: The specified key does not exist. date: Tue, 13 Feb 2024 20:10:12 GMT

% curl --head https://download.newrelic.com/infrastructure_agent/linux/apt/pool/main/f/fluent-bit_2.2.2_ubuntu-bionic_amd64.deb        HTTP/2 200 
last-modified: Tue, 13 Feb 2024 18:41:25 GMT
x-amz-version-id: pxrI_0iO4EqL0GcVWWrUgCxIn84ob6t4 date: Tue, 13 Feb 2024 20:10:23 GMT

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] Have a Site Reliability Engineer review the PR if you don't own all of the services impacted.
  - [ ] If you are adding any new default values that need to be overridden when this change goes live, update internal repos and add an entry to the top of the CHANGELOG.
  - [ ] Performed the appropriate testing.
  - [ ] Think about how this change will affect Open edX operators and update the wiki page for the next Open edX release if needed
