### PR TITLE
temp: set state=present to allow install of non-latest packages

### DIFF
--- a/playbooks/roles/newrelic_infrastructure/tasks/main.yml
+++ b/playbooks/roles/newrelic_infrastructure/tasks/main.yml
@@ -92,7 +92,7 @@
   apt:
     name: "{{ newrelic_infrastructure_debian_pkgs }}"
     install_recommends: yes
-    state: latest
+    state: present
   tags:
     - install
     - install:app-requirements


### PR DESCRIPTION
In https://github.com/openedx/configuration/pull/7104, we tried to pin fluent-bit to a particular version.

While deploying, we got error:

    version number inconsistent with state=latest: fluent-bit=2.0.8

Changing to `state=present` to allow non-latest versions.

Docs:

    https://docs.ansible.com/ansible/latest/collections/ansible/builtin/apt_module.html#parameter-state

## Additional Information

* Jira: [DOS-4586](https://2u-internal.atlassian.net/browse/DOS-4586)
* [Slack thread](https://twou.slack.com/archives/C02N1RGCH/p1707853953314539)
* Fixes: https://github.com/openedx/configuration/pull/7104

## Checklist

Make sure that the following steps are done before merging:

  - [ ] Have a Site Reliability Engineer review the PR if you don't own all of the services impacted.
  - [ ] If you are adding any new default values that need to be overridden when this change goes live, update internal repos and add an entry to the top of the CHANGELOG.
  - [x] Performed the appropriate testing.
  - [x] Think about how this change will affect Open edX operators and update the wiki page for the next Open edX release if needed
