### PR TITLE
Revert "temp: hardcode newrelic fluent-bit version"

### DIFF
--- a/playbooks/roles/newrelic_infrastructure/defaults/main.yml
+++ b/playbooks/roles/newrelic_infrastructure/defaults/main.yml
@@ -33,7 +33,6 @@ NEWRELIC_INFRASTRUCTURE_AMAZON_REPO: 'https://download.newrelic.com/infrastructu
 
 newrelic_infrastructure_debian_pkgs:
   - newrelic-infra
-  - fluent-bit=2.0.8
 
 newrelic_infrastructure_redhat_pkgs:
   - newrelic-infra


### PR DESCRIPTION
Reverts openedx/configuration#7104.

Previously, we were trying to pin fluent-bit because New Relic's infrastructure agent package repository had a reference to `fluent-bit` version 2.2.2 that did not exist.

As of 6:14 pm EST today, it appears New Relic's package repository is now fixed, and only contains the good version of `fluent-bit==2.0.8`.

This PR removes the pin, which was not working anyways / generating an error. (See #7105 for error.)

## Additional Information

- Jira: [DOS-4586](https://2u-internal.atlassian.net/browse/DOS-4586) [internal 2u link]
- [Slack thread](https://twou.slack.com/archives/C02N1RGCH/p1707853953314539) [internal 2u link]
- Reverts: https://github.com/openedx/configuration/pull/7104

## Testing Information

Curl output showing `fluent-bit==2.2.2` is no longer available from the package repository:

```
% curl -s https://download.newrelic.com/infrastructure_agent/linux/apt/dists/focal/main/binary-amd64/Packages | grep -A17 "Package: fluent-bit"
Package: fluent-bit
Priority: optional
Section: devel
Installed-Size: 81593
Maintainer: Eduardo Silva <eduardo@calyptia.com>
Architecture: amd64
Version: 2.0.8
Depends: libc6 (>= 2.29), libgcc-s1 (>= 4.2), libpq5 (>= 9.0~), libssl1.1 (>= 1.1.1), libsystemd0, libyaml-0-2
Filename: pool/main/f/fluent-bit/fluent-bit_2.0.8_ubuntu-focal_amd64.deb
Size: 25670308
MD5sum: c032197401011f17289ce8127cf86c4b
SHA1: a89527d346ac69d17d353439f46b6546ed8e125d
SHA256: fbf0191a84f8315e45a520f2224186e3c4ae3be4caf345c258442c98fb57b8bf
SHA512: e662ae4a575517fb5ed5093edcd503bc4609c6faf713b8157a074cb601a1cbbe6c6af07b411ab81d3964e2cde591ef2efbd0e2f6a91e282388b298df5690de9d
Description: Fast data collector for Linux
 Fluent Bit is a high performance and multi platform Log Forwarder.
 .
```

Also confirmed that apt-get install is working again for newrelic-infra with no pins on my local:

```
# apt-get install newrelic-infra
Reading package lists... Done
Building dependency tree       
Reading state information... Done
The following additional packages will be installed:
  fluent-bit libpq5 libyaml-0-2 td-agent-bit
The following NEW packages will be installed:
  fluent-bit libpq5 libyaml-0-2 newrelic-infra td-agent-bit
0 upgraded, 5 newly installed, 0 to remove and 0 not upgraded.
Need to get 92.7 MB of archives.
After this operation, 274 MB of additional disk space will be used.
Do you want to continue? [Y/n] y
Get:1 https://download.newrelic.com/infrastructure_agent/linux/apt bionic/main amd64 fluent-bit amd64 2.0.8 [25.7 MB]
Get:2 http://archive.ubuntu.com/ubuntu focal/main amd64 libyaml-0-2 amd64 0.2.2-1 [48.9 kB]
Get:3 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 libpq5 amd64 12.17-0ubuntu0.20.04.1 [116 kB]
Get:4 https://download.newrelic.com/infrastructure_agent/linux/apt bionic/main amd64 td-agent-bit amd64 1.9.3 [18.1 MB]
Get:5 https://download.newrelic.com/infrastructure_agent/linux/apt bionic/main amd64 newrelic-infra amd64 1.49.0 [48.7 MB]
Fetched 92.7 MB in 4s (24.4 MB/s)  
...
```