### PR TITLE
feat: Attempt to use edx-atlas to pull translations.

### DIFF
--- a/playbooks/roles/edx_django_service_with_rendered_config/tasks/main.yml
+++ b/playbooks/roles/edx_django_service_with_rendered_config/tasks/main.yml
@@ -233,6 +233,16 @@
     - assets
     - assets:gather
 
+# Translations step
+- name: Pull translations via Atlas
+  shell: make OPENEDX_ATLAS_PULL=true pull_translations
+  args:
+    chdir: "{{ edx_django_service_with_rendered_config_code_dir }}"
+  become_user: "{{ edx_django_service_with_rendered_config_user }}"
+  environment: "{{ edx_django_service_with_rendered_config_environment }}"
+  tags:
+    - assets
+
 - name: restart the application
   supervisorctl:
     state: restarted

--- a/playbooks/roles/edxapp/tasks/deploy.yml
+++ b/playbooks/roles/edxapp/tasks/deploy.yml
@@ -412,24 +412,6 @@
   when:
     - celery_worker is not defined
 
-# Translations steps
-- name: Pull translations via Atlas
-  shell: ". {{ edxapp_app_dir }}/edxapp_env && make OPENEDX_ATLAS_PULL=true pull_translations"
-  args:
-    chdir: "{{ edxapp_code_dir }}"
-  become_user: "{{ edxapp_user }}"
-  tags:
-    - assets
-
-- name: compile JS translations
-  shell: ". {{ edxapp_app_dir }}/edxapp_env && {{ edxapp_venv_bin }}/python ./manage.py lms --settings={{ edxapp_settings }} compilejsi18n"
-  args:
-    chdir: "{{ edxapp_code_dir }}"
-  become_user: "{{ edxapp_user }}"
-  when: EDXAPP_COMPILE_JSI18N and celery_worker is not defined
-  tags:
-    - assets
-
 # creates the supervisor jobs for the
 # service variants configured, runs
 # gather_assets and db migrations


### PR DESCRIPTION
Previous attempt did not have access to the proper configs. I think this is the correct spot.

https://github.com/edx/edx-arch-experiments/issues/548

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] Have a Site Reliability Engineer review the PR if you don't own all of the services impacted.
  - [ ] If you are adding any new default values that need to be overridden when this change goes live, update internal repos and add an entry to the top of the CHANGELOG.
  - [ ] Performed the appropriate testing.
  - [ ] Think about how this change will affect Open edX operators and update the wiki page for the next Open edX release if needed
