### PR TITLE
fix: Activate Python venv for pull_translations

### DIFF
--- a/playbooks/roles/edxapp/tasks/deploy.yml
+++ b/playbooks/roles/edxapp/tasks/deploy.yml
@@ -253,6 +253,7 @@
     mkdir -p bin
     curl -sS -L https://github.com/openedx/openedx-atlas/releases/latest/download/atlas -o ./bin/atlas
     chmod +x ./bin/atlas
+    source {{ edxapp_venv_dir }}/bin/activate
     # Use production-like environment and minimal config to avoid needing dev dependencies or full config.
     PATH="./bin/:$PATH" DJANGO_SETTINGS_MODULE=lms.envs.production \
       LMS_CFG=lms/envs/minimal.yml STUDIO_CFG=lms/envs/minimal.yml \


### PR DESCRIPTION
Was getting `python: Command not found` after adding this block in https://github.com/openedx/configuration/pull/7116

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [x] Have a Site Reliability Engineer review the PR if you don't own all of the services impacted.
  - [x] If you are adding any new default values that need to be overridden when this change goes live, update internal repos and add an entry to the top of the CHANGELOG.
  - [x] Performed the appropriate testing.
  - [x] Think about how this change will affect Open edX operators and update the wiki page for the next Open edX release if needed
