### PR TITLE
fix: Remove broken Atlas task

### DIFF
--- a/playbooks/roles/edxapp/tasks/deploy.yml
+++ b/playbooks/roles/edxapp/tasks/deploy.yml
@@ -246,26 +246,6 @@
     - install
     - install:app-requirements
 
-- name: "Pull translations using Atlas"
-  shell: |
-    set -eu -o pipefail
-    # Pull down the Atlas binary into a bin/ dir and add it to the PATH for the Make recipe
-    mkdir -p bin
-    curl -sS -L https://github.com/openedx/openedx-atlas/releases/latest/download/atlas -o ./bin/atlas
-    chmod +x ./bin/atlas
-    source {{ edxapp_venv_dir }}/bin/activate
-    # Use production-like environment and minimal config to avoid needing dev dependencies or full config.
-    PATH="./bin/:$PATH" DJANGO_SETTINGS_MODULE=lms.envs.production \
-      LMS_CFG=lms/envs/minimal.yml STUDIO_CFG=lms/envs/minimal.yml \
-      OPENEDX_ATLAS_PULL=true make pull_translations
-    rm ./bin/atlas
-  args:
-    executable: /usr/bin/bash
-    chdir: "{{ edxapp_code_dir }}"
-  become_user: "{{ edxapp_user }}"
-  tags:
-    - install
-
 # Set the npm registry
 # This needs to be done as root since npm is weird about
 # chown - https://github.com/npm/npm/issues/3565


### PR DESCRIPTION
pull_translations now appears to be failing with a more mysterious error:

```
rmdir: failed to remove 'common/static/common/css': No such file or directory
```

This should be suppressed by the `|| true`, unless this *isn't* coming from node_prereqs_installation in pavelib... reverting for now to unblock pipeline.

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [x] Have a Site Reliability Engineer review the PR if you don't own all of the services impacted.
  - [x] If you are adding any new default values that need to be overridden when this change goes live, update internal repos and add an entry to the top of the CHANGELOG.
  - [x] Performed the appropriate testing.
  - [x] Think about how this change will affect Open edX operators and update the wiki page for the next Open edX release if needed
