### PR TITLE
feat: Switch to Atlas translations in edxapp (attempt 3)

### DIFF
--- a/playbooks/roles/edxapp/tasks/deploy.yml
+++ b/playbooks/roles/edxapp/tasks/deploy.yml
@@ -357,6 +357,26 @@
   failed_when: "'17017' not in sandbox_test3.stdout"
   when: EDXAPP_SANDBOX_ENFORCE
 
+- name: "Pull translations using Atlas (after Python dependencies and Node installed)"
+  shell: |
+    set -eu -o pipefail
+    # Pull down the Atlas binary into a bin/ dir and add it to the PATH for the Make recipe
+    mkdir -p bin
+    curl -sS -L https://github.com/openedx/openedx-atlas/releases/latest/download/atlas -o ./bin/atlas
+    chmod +x ./bin/atlas
+    source {{ edxapp_venv_dir }}/bin/activate
+    # Use production-like environment and minimal config to avoid needing dev dependencies or full config.
+    PATH="./bin/:$PATH" DJANGO_SETTINGS_MODULE=lms.envs.production \
+      LMS_CFG=lms/envs/minimal.yml STUDIO_CFG=lms/envs/minimal.yml \
+      OPENEDX_ATLAS_PULL=true make pull_translations
+    rm ./bin/atlas
+  args:
+    executable: /usr/bin/bash
+    chdir: "{{ edxapp_code_dir }}"
+  become_user: "{{ edxapp_user }}"
+  tags:
+    - install
+
 - name: compiling all py files in the edx-platform repo
   shell: "{{ edxapp_venv_bin }}/python -m compileall -q -x '.git/.*|node_modules/.*' {{ edxapp_code_dir }}"
   become_user: "{{ edxapp_user }}"


### PR DESCRIPTION
The previous attempt (#7117) was failing with an error in the call to `paver i18n_compilejs` after the Atlas-specific part of pull_translations, in the part where it runs `npm ci`. I don't have access to the npm log, but I bet it's just that our npm setup wasn't ready yet at this point in the playbook.

I think we just need to move this call to after the npm setup.

Part of OEP-58 and https://github.com/edx/edx-arch-experiments/issues/548

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [x] Have a Site Reliability Engineer review the PR if you don't own all of the services impacted.
  - [x] If you are adding any new default values that need to be overridden when this change goes live, update internal repos and add an entry to the top of the CHANGELOG.
  - [ ] Performed the appropriate testing.
  - [x] Think about how this change will affect Open edX operators and update the wiki page for the next Open edX release if needed
