### PR TITLE
Revert "temp: Add Atlas pull_translations back in, but with debug logging"

### DIFF
--- a/playbooks/roles/edxapp/tasks/deploy.yml
+++ b/playbooks/roles/edxapp/tasks/deploy.yml
@@ -357,33 +357,6 @@
   failed_when: "'17017' not in sandbox_test3.stdout"
   when: EDXAPP_SANDBOX_ENFORCE
 
-- name: "Pull translations using Atlas (after Python dependencies and Node installed)"
-  shell: |
-    set -eu -o pipefail
-    # Pull down the Atlas binary into a bin/ dir and add it to the PATH for the Make recipe
-    mkdir -p bin
-    curl -sS -L https://github.com/openedx/openedx-atlas/releases/latest/download/atlas -o ./bin/atlas
-    chmod +x ./bin/atlas
-    source {{ edxapp_venv_dir }}/bin/activate
-    # Use production-like environment and minimal config to avoid needing dev dependencies or full config.
-    PATH="./bin/:$PATH" DJANGO_SETTINGS_MODULE=lms.envs.production \
-      LMS_CFG=lms/envs/minimal.yml STUDIO_CFG=lms/envs/minimal.yml \
-      OPENEDX_ATLAS_PULL=true make pull_translations || {
-        # Debugging for https://github.com/edx/edx-arch-experiments/issues/548
-        echo "pull_translations failed. Contents of test_root/log/npm-install.log:"
-        echo "===================================================================="
-        cat test_root/log/npm-install.log
-        echo "===================================================================="
-        exit 1
-    }
-    rm ./bin/atlas
-  args:
-    executable: /usr/bin/bash
-    chdir: "{{ edxapp_code_dir }}"
-  become_user: "{{ edxapp_user }}"
-  tags:
-    - install
-
 - name: compiling all py files in the edx-platform repo
   shell: "{{ edxapp_venv_bin }}/python -m compileall -q -x '.git/.*|node_modules/.*' {{ edxapp_code_dir }}"
   become_user: "{{ edxapp_user }}"


### PR DESCRIPTION
Reverts openedx/configuration#7122 -- the final compilejs step was producing the following npm-ci error:

```
npm ERR! While resolving: karma-selenium-webdriver-launcher@0.0.4
npm ERR! Found: selenium-webdriver@3.4.0
npm ERR! node_modules/selenium-webdriver
npm ERR!   dev selenium-webdriver@"3.4.0" from the root project
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peer selenium-webdriver@"^2.44.0" from karma-selenium-webdriver-launcher@0.0.4
npm ERR! node_modules/karma-selenium-webdriver-launcher
npm ERR!   dev karma-selenium-webdriver-launcher@"0.0.4" from the root project
npm ERR! 
npm ERR! Conflicting peer dependency: selenium-webdriver@2.53.3
npm ERR! node_modules/selenium-webdriver
npm ERR!   peer selenium-webdriver@"^2.44.0" from karma-selenium-webdriver-launcher@0.0.4
npm ERR!   node_modules/karma-selenium-webdriver-launcher
npm ERR!     dev karma-selenium-webdriver-launcher@"0.0.4" from the root project
```