### PR TITLE
chore: Safeguard secure keys to prevent them from being displayed in Ansible output within the Datadog role

### DIFF
--- a/playbooks/roles/datadog/defaults/main.yml
+++ b/playbooks/roles/datadog/defaults/main.yml
@@ -21,4 +21,4 @@ datadog_debian_pkgs:
   - curl 
   - gnupg
 
-DATADOG_MONGODB_MONITORING: true
+DATADOG_MONGODB_MONITORING: false

--- a/playbooks/roles/datadog/tasks/main.yml
+++ b/playbooks/roles/datadog/tasks/main.yml
@@ -55,6 +55,7 @@
     dest: "/etc/datadog-agent/datadog.yaml"
     regexp: "^api_key:.*"
     line: "api_key: {{ DATADOG_API_KEY }}"
+  no_log: true
   notify:
     - restart the datadog service
   tags:
@@ -77,6 +78,7 @@
     owner: "{{ datadog_user }}"
     group: "{{ datadog_user }}"
     mode: 0644
+  no_log: true
   notify:
     - restart the datadog service
   tags:


### PR DESCRIPTION


Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] Have a Site Reliability Engineer review the PR if you don't own all of the services impacted.
  - [ ] If you are adding any new default values that need to be overridden when this change goes live, update internal repos and add an entry to the top of the CHANGELOG.
  - [ ] Performed the appropriate testing.
  - [ ] Think about how this change will affect Open edX operators and update the wiki page for the next Open edX release if needed
