### PR TITLE
fix: Fix edx-platform repo URLs after repo move

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1398,8 +1398,8 @@ Add any new changes to the top (right below this line).
 
  - 2015-05-27
      - Role: edxapp
-       - Removed deprecated variables EDXAPP_PLATFORM_TWITTER_URL, EDXAPP_PLATFORM_MEETUP_URL, EDXAPP_PLATFORM_LINKEDIN_URL, and EDXAPP_PLATFORM_GOOGLE_PLUS_URL in favor of EDXAPP_SOCIAL_MEDIA_FOOTER_URLS.  These variables haven't been used in edx-platform since March 17, 2015 (when https://github.com/edx/edx-platform/pull/7383 was merged).  This change is backwards incompatible with versions of edx-platform from before March 17, 2015.
-       - Added EDXAPP_MOBILE_STORE_URLS and EDXAPP_FOOTER_ORGANIZATION_IMAGE variables, used in https://github.com/edx/edx-platform/pull/8175 (v3 version of the edx.org footer).
+       - Removed deprecated variables EDXAPP_PLATFORM_TWITTER_URL, EDXAPP_PLATFORM_MEETUP_URL, EDXAPP_PLATFORM_LINKEDIN_URL, and EDXAPP_PLATFORM_GOOGLE_PLUS_URL in favor of EDXAPP_SOCIAL_MEDIA_FOOTER_URLS.  These variables haven't been used in edx-platform since March 17, 2015 (when https://github.com/openedx/edx-platform/pull/7383 was merged).  This change is backwards incompatible with versions of edx-platform from before March 17, 2015.
+       - Added EDXAPP_MOBILE_STORE_URLS and EDXAPP_FOOTER_ORGANIZATION_IMAGE variables, used in https://github.com/openedx/edx-platform/pull/8175 (v3 version of the edx.org footer).
 
 
        - We now remove the default syslog.d conf file (50-default.conf) this will
@@ -1526,7 +1526,7 @@ Add any new changes to the top (right below this line).
  - 2014-05-28
      - Role: Edxapp
        - The repo.txt requirements file is no longer being processed in anyway.  This file was removed from edxplatform
-         via pull #3487(https://github.com/edx/edx-platform/pull/3487)
+         via pull #3487(https://github.com/openedx/edx-platform/pull/3487)
 
  - 2014-05-19
 

--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -1754,7 +1754,7 @@ edxapp_theme_source_repo: 'https://{{ COMMON_GIT_MIRROR }}/Stanford-Online/edx-t
 EDXAPP_THEME_VERSION: 'master'
 
 # make this the public URL instead of writable
-edx_platform_repo: "https://{{ COMMON_GIT_MIRROR }}/edx/edx-platform.git"
+edx_platform_repo: "https://{{ COMMON_GIT_MIRROR }}/openedx/edx-platform.git"
 # `EDX_PLATFORM_VERSION` can be anything that git recognizes as a commit
 # reference, including a tag, a branch name, or a commit hash
 EDX_PLATFORM_VERSION: 'release'


### PR DESCRIPTION
See https://github.com/edx/edx-arch-experiments/issues/558

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [x] Have a Site Reliability Engineer review the PR if you don't own all of the services impacted.
  - [x] If you are adding any new default values that need to be overridden when this change goes live, update internal repos and add an entry to the top of the CHANGELOG.
  - [x] Performed the appropriate testing.
  - [x] Think about how this change will affect Open edX operators and update the wiki page for the next Open edX release if needed
