### PR TITLE
feat: Pull edxapp translations via Atlas

### DIFF
--- a/playbooks/roles/edxapp/tasks/deploy.yml
+++ b/playbooks/roles/edxapp/tasks/deploy.yml
@@ -216,6 +216,22 @@
     - install
     - install:app-requirements
 
+- name: "Pull translations using Atlas after Python dependencies installed"
+  shell: |
+    set -eu -o pipefail
+    source {{ edxapp_venv_dir }}/bin/activate
+    # Use production Django settings because otherwise debug_toolbar will be referenced and cause
+    # an error (we don't have developer Python deps installed.) Use minimal configs because the
+    # real configs aren't installed until later in the playbook.
+    DJANGO_SETTINGS_MODULE=lms.envs.production LMS_CFG=lms/envs/minimal.yml STUDIO_CFG=lms/envs/minimal.yml \
+      OPENEDX_ATLAS_PULL=true make pull_translations
+  args:
+    executable: /usr/bin/bash
+    chdir: "{{ edxapp_code_dir }}"
+  become_user: "{{ edxapp_user }}"
+  tags:
+    - install
+
 # If using CAS and you have a function for mapping attributes, install
 # the module here.  The next few tasks set up the python code sandbox
 - name: install CAS attribute module

--- a/playbooks/roles/edxapp/tasks/deploy.yml
+++ b/playbooks/roles/edxapp/tasks/deploy.yml
@@ -216,18 +216,25 @@
     - install
     - install:app-requirements
 
-- name: "Pull translations using Atlas after Python dependencies installed"
+# Pulling Atlas translations into the repo needs to happen after
+# Python dependencies have been installed. Note: This task leaves the
+# git working directory in a "dirty" state.
+- name: "Pull translations using Atlas"
   shell: |
-    set -eu -o pipefail
-    source {{ edxapp_venv_dir }}/bin/activate
-    # Use production Django settings because otherwise debug_toolbar will be referenced and cause
-    # an error (we don't have developer Python deps installed.) Use minimal configs because the
-    # real configs aren't installed until later in the playbook.
-    DJANGO_SETTINGS_MODULE=lms.envs.production LMS_CFG=lms/envs/minimal.yml STUDIO_CFG=lms/envs/minimal.yml \
-      OPENEDX_ATLAS_PULL=true make pull_translations
+    source "{{ edxapp_venv_dir }}/bin/activate"
+    make pull_translations
   args:
     executable: /usr/bin/bash
     chdir: "{{ edxapp_code_dir }}"
+  environment:
+    # Use production Django settings because otherwise debug_toolbar will be
+    # referenced and cause an error (we don't have developer Python deps installed.)
+    EDX_PLATFORM_SETTINGS: production
+    # Use minimal configs because the real configs aren't installed until
+    # later in the playbook.
+    LMS_CFG: lms/envs/minimal.yml
+    STUDIO_CFG: lms/envs/minimal.yml
+    OPENEDX_ATLAS_PULL: true
   become_user: "{{ edxapp_user }}"
   tags:
     - install


### PR DESCRIPTION
This is to support OEP-58:
https://docs.openedx.org/projects/openedx-proposals/en/latest/architectural-decisions/oep-0058-arch-translations-management.html

Changes since the https://github.com/openedx/configuration/pull/7119 attempt:

- Move to just after main requirements are installed (just for faster feedback during testing, really)
- Use already-installed `openedx-atlas`
- Use variant-agnostic `EDX_PLATFORM_SETTINGS` rather than `DJANGO_SETTINGS_MODULE`
- Use Ansible `environment` field for env vars
- Drop `set -eu -o pipefail` since the script is now simple

Most importantly, https://github.com/openedx/edx-platform/pull/34306 has since merged, so we don't have to worry about the NPM conflicts we were getting previously.

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [x] Have a Site Reliability Engineer review the PR if you don't own all of the services impacted.
  - [x] If you are adding any new default values that need to be overridden when this change goes live, update internal repos and add an entry to the top of the CHANGELOG.
  - [x] Performed the appropriate testing.
  - [x] Think about how this change will affect Open edX operators and update the wiki page for the next Open edX release if needed
