### PR TITLE
feat: add translatable XBlocks to private requirements

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -584,6 +584,9 @@ EDXAPP_PRIVATE_REQUIREMENTS:
       extra_args: -e
     # Caliper and xAPI event routing plugin
     - name: edx-event-routing-backends==5.5.6
+    # Whole Course Translations Experiment - https://2u-internal.atlassian.net/browse/AU-1703
+    - name: git+ssh://git@github.com/edx/translatable-xblocks.git@main#egg=translatable-xblocks
+      extra_args: -e
 
 # List of custom middlewares that should be used in edxapp to process
 # incoming HTTP resquests. Should be a list of plain strings that fully


### PR DESCRIPTION
Configuration Pull Request
---

To be coupled with the following PRs:
1. https://github.com/edx/internal-dockerfiles/pull/98
2. https://github.com/edx/edx-internal/pull/10475

Make sure that the following steps are done before merging:

  - [ ] Have a Site Reliability Engineer review the PR if you don't own all of the services impacted.

n/a 👇 
  - [ ] If you are adding any new default values that need to be overridden when this change goes live, update internal repos and add an entry to the top of the CHANGELOG.
  - [ ] Performed the appropriate testing.
  - [ ] Think about how this change will affect Open edX operators and update the wiki page for the next Open edX release if needed
