### PR TITLE
fix: Skip Datadog instrumentation of pymongo

### DIFF
--- a/playbooks/roles/edxapp/templates/edx/app/edxapp/cms.sh.j2
+++ b/playbooks/roles/edxapp/templates/edx/app/edxapp/cms.sh.j2
@@ -22,6 +22,8 @@ export NEW_RELIC_LICENSE_KEY="{{ NEWRELIC_LICENSE_KEY }}"
 
 {% if COMMON_ENABLE_DATADOG and COMMON_ENABLE_DATADOG_APP %}
 {% set executable = edxapp_venv_bin + '/ddtrace-run ' + executable %}
+# Datadog's instrumentation breaks pymongo: https://github.com/edx/edx-arch-experiments/issues/580
+export DD_TRACE_PYMONGO_ENABLED=false
 {% endif -%}
 
 export PORT="{{ edxapp_cms_gunicorn_port }}"

--- a/playbooks/roles/edxapp/templates/edx/app/edxapp/lms.sh.j2
+++ b/playbooks/roles/edxapp/templates/edx/app/edxapp/lms.sh.j2
@@ -22,6 +22,8 @@ export NEW_RELIC_LICENSE_KEY="{{ NEWRELIC_LICENSE_KEY }}"
 
 {% if COMMON_ENABLE_DATADOG and COMMON_ENABLE_DATADOG_APP %}
 {% set executable = edxapp_venv_bin + '/ddtrace-run ' + executable %}
+# Datadog's instrumentation breaks pymongo: https://github.com/edx/edx-arch-experiments/issues/580
+export DD_TRACE_PYMONGO_ENABLED=false
 {% endif -%}
 
 export PORT="{{ edxapp_lms_gunicorn_port }}"


### PR DESCRIPTION
Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [x] Have a Site Reliability Engineer review the PR if you don't own all of the services impacted.
  - [x] If you are adding any new default values that need to be overridden when this change goes live, update internal repos and add an entry to the top of the CHANGELOG.
  - [x] Performed the appropriate testing.
  - [x] Think about how this change will affect Open edX operators and update the wiki page for the next Open edX release if needed
