### PR TITLE
feat: Report custom telemetry to Datadog via its OpenTelemetry exporter

### DIFF
--- a/playbooks/roles/edxapp/templates/edx/app/edxapp/lms.sh.j2
+++ b/playbooks/roles/edxapp/templates/edx/app/edxapp/lms.sh.j2
@@ -25,6 +25,12 @@ export NEW_RELIC_LICENSE_KEY="{{ NEWRELIC_LICENSE_KEY }}"
 export DD_TAGS="service:edxapp-lms"
 # Datadog's instrumentation breaks pymongo: https://github.com/edx/edx-arch-experiments/issues/580
 export DD_TRACE_PYMONGO_ENABLED=false
+# Allow edx-django-utils to report to Datadog via OpenTelemetry API
+export DD_TRACE_OTEL_ENABLED=true
+# Not sure what this does, but if we don't include it we get a startup failure:
+# TypeError: Couldn't build proto file into descriptor pool: duplicate file name opentelemetry/proto/common/v1/common.proto
+export PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION="python"
+
 {% endif -%}
 
 export PORT="{{ edxapp_lms_gunicorn_port }}"


### PR DESCRIPTION
This is part of https://github.com/edx/edx-arch-experiments/issues/571

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [x] Have a Site Reliability Engineer review the PR if you don't own all of the services impacted.
  - [x] If you are adding any new default values that need to be overridden when this change goes live, update internal repos and add an entry to the top of the CHANGELOG.
  - [x] Performed the appropriate testing.
  - [x] Think about how this change will affect Open edX operators and update the wiki page for the next Open edX release if needed
