### PR TITLE
feat: Run all Django services with ddtrace (Datadog APM) when enabled

### DIFF
--- a/playbooks/roles/edx_django_service/tasks/main.yml
+++ b/playbooks/roles/edx_django_service/tasks/main.yml
@@ -212,6 +212,19 @@
     - install
     - install:app-requirements
 
+- name: "Install Datadog APM requirements"
+  when: COMMON_ENABLE_DATADOG and COMMON_ENABLE_DATADOG_APP
+  pip:
+    name:
+      - ddtrace
+    extra_args: "--exists-action w {{ item.extra_args|default('') }}"
+    virtualenv: "{{ edx_django_service_venv_dir }}"
+    state: present
+  become_user: "{{ edx_django_service_user }}"
+  tags:
+    - install
+    - install:app-requirements
+
 - name: Check for existing make_migrate container
   command: "docker ps -aq --filter name='{{ edx_django_service_name }}.make_migrate'"
   register: edx_django_service_make_migrate_container

--- a/playbooks/roles/edx_django_service/templates/edx/app/app/app.sh.j2
+++ b/playbooks/roles/edx_django_service/templates/edx/app/app/app.sh.j2
@@ -4,13 +4,11 @@
 
 {% set edx_django_service_venv_bin = edx_django_service_venv_dir + "/bin" %}
 
-{% if COMMON_ENABLE_NEWRELIC_APP %}
-{% set executable = edx_django_service_venv_bin + '/newrelic-admin run-program ' + edx_django_service_venv_bin + '/gunicorn' %}
-{% else %}
 {% set executable = edx_django_service_venv_bin + '/gunicorn' %}
-{% endif %}
 
 {% if COMMON_ENABLE_NEWRELIC_APP %}
+{% set executable = edx_django_service_venv_bin + '/newrelic-admin run-program ' + executable %}
+
 export NEW_RELIC_DISTRIBUTED_TRACING_ENABLED="{{ edx_django_service_enable_newrelic_distributed_tracing }}"
 export NEW_RELIC_APP_NAME="{{ edx_django_service_newrelic_appname }}"
 HOSTNAME=$(hostname)
@@ -20,6 +18,11 @@ if command -v ec2metadata >/dev/null 2>&1; then
   export NEW_RELIC_PROCESS_HOST_DISPLAY_NAME="$HOSTNAME-$INSTANCEID"
 fi
 export NEW_RELIC_LICENSE_KEY="{{ NEWRELIC_LICENSE_KEY }}"
+{% endif -%}
+
+{% if COMMON_ENABLE_DATADOG and COMMON_ENABLE_DATADOG_APP %}
+{% set executable = edx_django_service_venv_bin + '/ddtrace-run ' + executable %}
+export DD_TAGS="service:{{ edx_django_service_name }}"
 {% endif -%}
 
 export EDX_REST_API_CLIENT_NAME="{{ COMMON_ENVIRONMENT }}-{{ COMMON_DEPLOYMENT }}-{{ edx_django_service_name }}"

--- a/util/jenkins/ansible-provision.sh
+++ b/util/jenkins/ansible-provision.sh
@@ -547,6 +547,7 @@ COMMON_USER_INFO:
 USER_CMD_PROMPT: '[$name_tag] '
 COMMON_ENABLE_NEWRELIC_APP: $enable_newrelic
 COMMON_ENABLE_DATADOG: $enable_datadog
+COMMON_ENABLE_DATADOG_APP: $enable_datadog
 COMMON_OAUTH_BASE_URL: "https://${deploy_host}"
 FORUM_NEW_RELIC_ENABLE: $enable_newrelic
 ENABLE_PERFORMANCE_COURSE: $performance_course


### PR DESCRIPTION
This expands the changes in edxapp to other Django services.

Also enables Datadog APM in sandboxes when Datadog is enabled overall.

See https://github.com/edx/edx-arch-experiments/issues/573

---
Configuration Pull Request

Make sure that the following steps are done before merging:

  - [ ] Have a Site Reliability Engineer review the PR if you don't own all of the services impacted.
  - [x] If you are adding any new default values that need to be overridden when this change goes live, update internal repos and add an entry to the top of the CHANGELOG.
  - [ ] Performed the appropriate testing.
  - [x] Think about how this change will affect Open edX operators and update the wiki page for the next Open edX release if needed
