### PR TITLE
chore: enable dd agent role for prospectus and conductor

### DIFF
--- a/playbooks/conductor.yml
+++ b/playbooks/conductor.yml
@@ -23,3 +23,5 @@
       when: COMMON_ENABLE_SPLUNKFORWARDER
     - role: newrelic_infrastructure
       when: COMMON_ENABLE_NEWRELIC_INFRASTRUCTURE
+    - role: datadog
+      when: COMMON_ENABLE_DATADOG

--- a/playbooks/prospectus.yml
+++ b/playbooks/prospectus.yml
@@ -32,3 +32,5 @@
       when: COMMON_ENABLE_SPLUNKFORWARDER|bool and PROSPECTUS_ENABLE_POST_BUILD|bool
     - role: newrelic_infrastructure
       when: COMMON_ENABLE_NEWRELIC_INFRASTRUCTURE|bool and PROSPECTUS_ENABLE_POST_BUILD|bool
+    - role: datadog
+      when: COMMON_ENABLE_DATADOG|bool and PROSPECTUS_ENABLE_POST_BUILD|bool


### PR DESCRIPTION
Enabling datadog agent role for Prospectus and conductor builds

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] Have a Site Reliability Engineer review the PR if you don't own all of the services impacted.
  - [ ] If you are adding any new default values that need to be overridden when this change goes live, update internal repos and add an entry to the top of the CHANGELOG.
  - [ ] Performed the appropriate testing.
  - [ ] Think about how this change will affect Open edX operators and update the wiki page for the next Open edX release if needed
