### PR TITLE
chore: set environment variable DD_TAGS for forum

### DIFF
--- a/playbooks/roles/forum/defaults/main.yml
+++ b/playbooks/roles/forum/defaults/main.yml
@@ -49,6 +49,9 @@ FORUM_NEW_RELIC_ENABLE: '{{ COMMON_ENABLE_NEWRELIC_APP }}'
 FORUM_NEW_RELIC_LICENSE_KEY: '{{ NEWRELIC_LICENSE_KEY | default("") }}'
 FORUM_NEW_RELIC_APP_NAME: "{{ COMMON_ENVIRONMENT }}-{{ COMMON_DEPLOYMENT }}-forum"
 
+# Datadog CONFIG
+FORUM_DD_TAGS: "service:forum"
+
 FORUM_WORKER_PROCESSES: "4"
 FORUM_LISTEN_HOST: "0.0.0.0"
 FORUM_LISTEN_PORT: "4567"
@@ -87,7 +90,7 @@ forum_base_env: &forum_base_env
   DATA_DIR: "{{ forum_data_dir }}"
   LISTEN_HOST: "{{ FORUM_LISTEN_HOST }}"
   LISTEN_PORT: "{{ FORUM_LISTEN_PORT }}"
-
+  DD_TAGS: "{{ FORUM_DD_TAGS }}"
 
 forum_env:
   <<: *forum_base_env


### PR DESCRIPTION
Setting this DD_TAGS environment variable so will allow us to enhance the filtering of the forum app in Datadog.

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] Have a Site Reliability Engineer review the PR if you don't own all of the services impacted.
  - [ ] If you are adding any new default values that need to be overridden when this change goes live, update internal repos and add an entry to the top of the CHANGELOG.
  - [ ] Performed the appropriate testing.
  - [ ] Think about how this change will affect Open edX operators and update the wiki page for the next Open edX release if needed
