### PR TITLE
chore: Set max size limit for Journal

### DIFF
--- a/playbooks/roles/vhost/tasks/main.yml
+++ b/playbooks/roles/vhost/tasks/main.yml
@@ -70,6 +70,22 @@
   when: COMMON_OBJECT_STORE_LOG_SYNC
         and not (ansible_distribution_release == 'precise' or ansible_distribution_release == 'trusty')
 
+- name: Set maximum disk space usage for systemd journal
+  lineinfile:
+    path: /etc/systemd/journald.conf
+    regexp: '^#?SystemMaxUse='
+    line: 'SystemMaxUse=1G'
+    state: present
+  register: journald_config_line
+  when: ansible_distribution_release == 'bionic' or ansible_distribution_release == 'focal'
+
+- name: Restart systemd-journald (ubuntu/debian)
+  service:
+    name: systemd-journald
+    state: restarted
+  when: >
+    journald_config_line.changed and ansible_distribution in common_debian_variants
+
 - name: Update /etc/dhcp/dhclient.conf
   template:
     src: etc/dhcp/dhclient.conf.j2


### PR DESCRIPTION
Setting a maximum size limit for the journal volume to facilitate the removal of excess logs

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] Have a Site Reliability Engineer review the PR if you don't own all of the services impacted.
  - [ ] If you are adding any new default values that need to be overridden when this change goes live, update internal repos and add an entry to the top of the CHANGELOG.
  - [ ] Performed the appropriate testing.
  - [ ] Think about how this change will affect Open edX operators and update the wiki page for the next Open edX release if needed
