### PR TITLE
feat: Update node version to 18.

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -1122,8 +1122,8 @@ edxapp_nodeenv_bin: "{{ edxapp_nodeenv_dir }}/bin"
 edxapp_npm_dir: "{{ edxapp_app_dir }}/.npm"
 edxapp_npm_bin: "{{ edxapp_npm_dir }}/bin"
 edxapp_settings: '{{ EDXAPP_SETTINGS }}'
-EDXAPP_NODE_VERSION: "16"
-EDXAPP_NPM_VERSION: "8.5.0"
+EDXAPP_NODE_VERSION: "18"
+EDXAPP_NPM_VERSION: "10.5.1"
 # This is where node installs modules, not node itself
 edxapp_node_bin: "{{ edxapp_code_dir }}/node_modules/.bin"
 edxapp_user: edxapp


### PR DESCRIPTION
edx-platform has been updated to use node 18. Update deploy to use that version as well.

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] Have a Site Reliability Engineer review the PR if you don't own all of the services impacted.
  - [ ] If you are adding any new default values that need to be overridden when this change goes live, update internal repos and add an entry to the top of the CHANGELOG.
  - [ ] Performed the appropriate testing.
  - [ ] Think about how this change will affect Open edX operators and update the wiki page for the next Open edX release if needed
