### PR TITLE
Revert "feat: Update node version to 18."

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -1122,8 +1122,8 @@ edxapp_nodeenv_bin: "{{ edxapp_nodeenv_dir }}/bin"
 edxapp_npm_dir: "{{ edxapp_app_dir }}/.npm"
 edxapp_npm_bin: "{{ edxapp_npm_dir }}/bin"
 edxapp_settings: '{{ EDXAPP_SETTINGS }}'
-EDXAPP_NODE_VERSION: "18"
-EDXAPP_NPM_VERSION: "10.5.1"
+EDXAPP_NODE_VERSION: "16"
+EDXAPP_NPM_VERSION: "8.5.0"
 # This is where node installs modules, not node itself
 edxapp_node_bin: "{{ edxapp_code_dir }}/node_modules/.bin"
 edxapp_user: edxapp


### PR DESCRIPTION
We were having problems with the rollout of the node 18 upgrade to edx-platform.

See: https://github.com/openedx/edx-platform/pull/34496

Reverts openedx/configuration#7153