### PR TITLE
feat: Apply DD_TRACE_LOG_STREAM_HANDLER hack to Ansible services

### DIFF
--- a/playbooks/roles/edx_django_service/templates/edx/app/app/app.sh.j2
+++ b/playbooks/roles/edx_django_service/templates/edx/app/app/app.sh.j2
@@ -23,6 +23,16 @@ export NEW_RELIC_LICENSE_KEY="{{ NEWRELIC_LICENSE_KEY }}"
 {% if COMMON_ENABLE_DATADOG and COMMON_ENABLE_DATADOG_APP %}
 {% set executable = edx_django_service_venv_bin + '/ddtrace-run ' + executable %}
 export DD_TAGS="service:{{ edx_django_service_name }}"
+# Workaround for
+# https://github.com/edx/edx-arch-experiments/issues/591 (heavy
+# streams of trace-debug logs from ddtrace.)
+#
+# ddtrace is behaving as if DD_TRACE_DEBUG=true, even though that
+# should be false by default, and we're not setting it anywhere that
+# we can find.  Overriding it to false doesn't work, and none of the
+# other trace-related configs that are documented seem to help, but
+# from testing DD_TRACE_LOG_STREAM_HANDLER=false seems to help.
+export DD_TRACE_LOG_STREAM_HANDLER=false
 {% endif -%}
 
 export EDX_REST_API_CLIENT_NAME="{{ COMMON_ENVIRONMENT }}-{{ COMMON_DEPLOYMENT }}-{{ edx_django_service_name }}"

--- a/playbooks/roles/edxapp/templates/edx/app/edxapp/cms.sh.j2
+++ b/playbooks/roles/edxapp/templates/edx/app/edxapp/cms.sh.j2
@@ -23,6 +23,10 @@ export NEW_RELIC_LICENSE_KEY="{{ NEWRELIC_LICENSE_KEY }}"
 {% if COMMON_ENABLE_DATADOG and COMMON_ENABLE_DATADOG_APP %}
 {% set executable = edxapp_venv_bin + '/ddtrace-run ' + executable %}
 export DD_TAGS="service:edxapp-cms"
+# Copied from edx_django_service playbook for consistency; Datadog
+# trace debug logging issue doesn't actually affect edxapp for some
+# reason.
+export DD_TRACE_LOG_STREAM_HANDLER=false
 # Datadog's instrumentation breaks pymongo: https://github.com/edx/edx-arch-experiments/issues/580
 export DD_TRACE_PYMONGO_ENABLED=false
 {% endif -%}

--- a/playbooks/roles/edxapp/templates/edx/app/edxapp/lms.sh.j2
+++ b/playbooks/roles/edxapp/templates/edx/app/edxapp/lms.sh.j2
@@ -23,6 +23,10 @@ export NEW_RELIC_LICENSE_KEY="{{ NEWRELIC_LICENSE_KEY }}"
 {% if COMMON_ENABLE_DATADOG and COMMON_ENABLE_DATADOG_APP %}
 {% set executable = edxapp_venv_bin + '/ddtrace-run ' + executable %}
 export DD_TAGS="service:edxapp-lms"
+# Copied from edx_django_service playbook for consistency; Datadog
+# trace debug logging issue doesn't actually affect edxapp for some
+# reason.
+export DD_TRACE_LOG_STREAM_HANDLER=false
 # Datadog's instrumentation breaks pymongo: https://github.com/edx/edx-arch-experiments/issues/580
 export DD_TRACE_PYMONGO_ENABLED=false
 {% endif -%}


### PR DESCRIPTION
Backports the trace-debug log fix from edx/helm-charts. Only observed in ecommerce and analytics-api, but I've added the fix to edxapp as well just in case it shows up there later (and for general consistency).

See https://github.com/edx/edx-arch-experiments/issues/591

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [x] Have a Site Reliability Engineer review the PR if you don't own all of the services impacted.
  - [x] If you are adding any new default values that need to be overridden when this change goes live, update internal repos and add an entry to the top of the CHANGELOG.
  - [x] Performed the appropriate testing.
  - [x] Think about how this change will affect Open edX operators and update the wiki page for the next Open edX release if needed
