### PR TITLE
feat: Run ddtarce for insights and ecomworker

### DIFF
--- a/playbooks/roles/ecomworker/tasks/main.yml
+++ b/playbooks/roles/ecomworker/tasks/main.yml
@@ -21,6 +21,19 @@
     - install
     - install:app-requirements
 
+- name: "Install Datadog APM requirements"
+  when: COMMON_ENABLE_DATADOG and COMMON_ENABLE_DATADOG_APP
+  pip:
+    name:
+      - ddtrace
+    extra_args: "--exists-action w"
+    virtualenv: '{{ ecommerce_worker_home }}/venvs/{{ ecommerce_worker_service_name }}'
+    state: present
+  become_user: "{{ ecommerce_worker_user }}"
+  tags:
+    - install
+    - install:app-requirements
+
 - name: write out the supervisor wrapper
   template:
     src: edx/app/ecomworker/ecomworker.sh.j2

--- a/playbooks/roles/ecomworker/templates/edx/app/ecomworker/ecomworker.sh.j2
+++ b/playbooks/roles/ecomworker/templates/edx/app/ecomworker/ecomworker.sh.j2
@@ -3,16 +3,20 @@
 # {{ ansible_managed }}
 
 {% set ecommerce_worker_venv_bin = ecommerce_worker_home + '/venvs/' + ecommerce_worker_service_name + '/bin' %}
-{% if COMMON_ENABLE_NEWRELIC_APP %}
-{% set executable = ecommerce_worker_venv_bin + '/newrelic-admin run-program ' + ecommerce_worker_venv_bin + '/celery' %}
-{% else %}
+
 {% set executable = ecommerce_worker_venv_bin + '/celery' %}
-{% endif %}
 
 {% if COMMON_ENABLE_NEWRELIC_APP %}
+{% set executable = ecommerce_worker_venv_bin + '/newrelic-admin run-program ' + ecommerce_worker_venv_bin + '/celery' %}
+
 export NEW_RELIC_DISTRIBUTED_TRACING_ENABLED='{{ ECOMMERCE_WORKER_ENABLE_NEWRELIC_DISTRIBUTED_TRACING }}'
 export NEW_RELIC_APP_NAME='{{ ECOMMERCE_WORKER_NEWRELIC_APPNAME }}'
 export NEW_RELIC_LICENSE_KEY='{{ NEWRELIC_LICENSE_KEY }}'
+{% endif -%}
+
+{% if COMMON_ENABLE_DATADOG and COMMON_ENABLE_DATADOG_APP %}
+{% set executable = ecommerce_worker_venv_bin + '/ddtrace-run ' + executable %}
+export DD_TAGS="service:{{ ecommerce_worker_service_name }}"
 {% endif -%}
 
 source {{ ecommerce_worker_home }}/{{ ecommerce_worker_service_name }}_env

--- a/playbooks/roles/insights/tasks/main.yml
+++ b/playbooks/roles/insights/tasks/main.yml
@@ -45,6 +45,19 @@
     - install
     - install:app-requirements
 
+- name: "Install Datadog APM requirements"
+  when: COMMON_ENABLE_DATADOG and COMMON_ENABLE_DATADOG_APP
+  pip:
+    name:
+      - ddtrace
+    extra_args: "--exists-action w"
+    virtualenv: "{{ insights_venv_dir }}"
+    state: present
+  become_user: "{{ insights_user }}"
+  tags:
+    - install
+    - install:app-requirements
+
 - name: create nodeenv
   shell: "{{ insights_venv_dir }}/bin/nodeenv {{ insights_nodeenv_dir }}  --node={{ INSIGHTS_NODE_VERSION }} --prebuilt --force"
   become_user: "{{ insights_user }}"

--- a/playbooks/roles/insights/templates/edx/app/insights/insights.sh.j2
+++ b/playbooks/roles/insights/templates/edx/app/insights/insights.sh.j2
@@ -3,16 +3,20 @@
 # {{ ansible_managed }}
 
 {% set insights_venv_bin = insights_home + '/venvs/' + insights_service_name + '/bin' %}
-{% if COMMON_ENABLE_NEWRELIC_APP %}
-{% set executable = insights_venv_bin + '/newrelic-admin run-program ' + insights_venv_bin + '/gunicorn' %}
-{% else %}
+
 {% set executable = insights_venv_bin + '/gunicorn' %}
-{% endif %}
 
 {% if COMMON_ENABLE_NEWRELIC_APP %}
+{% set executable = insights_venv_bin + '/newrelic-admin run-program ' + insights_venv_bin + '/gunicorn' %}
+
 export NEW_RELIC_DISTRIBUTED_TRACING_ENABLED="{{ INSIGHTS_ENABLE_NEWRELIC_DISTRIBUTED_TRACING }}"
 export NEW_RELIC_APP_NAME="{{ INSIGHTS_NEWRELIC_APPNAME }}"
 export NEW_RELIC_LICENSE_KEY="{{ NEWRELIC_LICENSE_KEY }}"
+{% endif -%}
+
+{% if COMMON_ENABLE_DATADOG and COMMON_ENABLE_DATADOG_APP %}
+{% set executable = insights_venv_bin + '/ddtrace-run ' + executable %}
+export DD_TAGS="service:{{ insights_service_name }}"
 {% endif -%}
 
 source {{ insights_app_dir }}/insights_env


### PR DESCRIPTION
Enable the ddtrace run for insights and ecomworker apps based on override flags.

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] Have a Site Reliability Engineer review the PR if you don't own all of the services impacted.
  - [ ] If you are adding any new default values that need to be overridden when this change goes live, update internal repos and add an entry to the top of the CHANGELOG.
  - [ ] Performed the appropriate testing.
  - [ ] Think about how this change will affect Open edX operators and update the wiki page for the next Open edX release if needed
