### PR TITLE
feat: Apply DD_TRACE_LOG_STREAM_HANDLER hack to insights/ecomworker

### DIFF
--- a/playbooks/roles/ecomworker/templates/edx/app/ecomworker/ecomworker.sh.j2
+++ b/playbooks/roles/ecomworker/templates/edx/app/ecomworker/ecomworker.sh.j2
@@ -17,6 +17,10 @@ export NEW_RELIC_LICENSE_KEY='{{ NEWRELIC_LICENSE_KEY }}'
 {% if COMMON_ENABLE_DATADOG and COMMON_ENABLE_DATADOG_APP %}
 {% set executable = ecommerce_worker_venv_bin + '/ddtrace-run ' + executable %}
 export DD_TAGS="service:{{ ecommerce_worker_service_name }}"
+# Copied from edx_django_service playbook for consistency; Datadog
+# trace debug logging issue doesn't actually affect edxapp for some
+# reason.
+export DD_TRACE_LOG_STREAM_HANDLER=false
 {% endif -%}
 
 source {{ ecommerce_worker_home }}/{{ ecommerce_worker_service_name }}_env

--- a/playbooks/roles/insights/templates/edx/app/insights/insights.sh.j2
+++ b/playbooks/roles/insights/templates/edx/app/insights/insights.sh.j2
@@ -17,6 +17,10 @@ export NEW_RELIC_LICENSE_KEY="{{ NEWRELIC_LICENSE_KEY }}"
 {% if COMMON_ENABLE_DATADOG and COMMON_ENABLE_DATADOG_APP %}
 {% set executable = insights_venv_bin + '/ddtrace-run ' + executable %}
 export DD_TAGS="service:{{ insights_service_name }}"
+# Copied from edx_django_service playbook for consistency; Datadog
+# trace debug logging issue doesn't actually affect edxapp for some
+# reason.
+export DD_TRACE_LOG_STREAM_HANDLER=false
 {% endif -%}
 
 source {{ insights_app_dir }}/insights_env


### PR DESCRIPTION
Duplicates fixes from https://github.com/openedx/configuration/pull/7155

These logs were seen in insights, and added to
ecomworker for consistency.

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] Have a Site Reliability Engineer review the PR if you don't own all of the services impacted.
  - [ ] If you are adding any new default values that need to be overridden when this change goes live, update internal repos and add an entry to the top of the CHANGELOG.
  - [ ] Performed the appropriate testing.
  - [ ] Think about how this change will affect Open edX operators and update the wiki page for the next Open edX release if needed
