### PR TITLE
chore: Update systemd journal configuration

### DIFF
--- a/playbooks/roles/vhost/tasks/main.yml
+++ b/playbooks/roles/vhost/tasks/main.yml
@@ -70,12 +70,17 @@
   when: COMMON_OBJECT_STORE_LOG_SYNC
         and not (ansible_distribution_release == 'precise' or ansible_distribution_release == 'trusty')
 
-- name: Set maximum disk space usage for systemd journal
+- name: Set maximum disk space usage, free space, retention, and file age for systemd journal
   lineinfile:
     path: /etc/systemd/journald.conf
-    regexp: '^#?SystemMaxUse='
-    line: 'SystemMaxUse=1G'
+    regexp: '^#?{{ item.regexp }}'
+    line: '{{ item.line }}'
     state: present
+  with_items:
+    - { regexp: 'SystemMaxUse=', line: 'SystemMaxUse=500M' }
+    - { regexp: 'SystemKeepFree=', line: 'SystemKeepFree=1G' }
+    - { regexp: 'MaxRetentionSec=', line: 'MaxRetentionSec=1month' }
+    - { regexp: 'MaxFileSec=', line: 'MaxFileSec=1week' }
   register: journald_config_line
   when: ansible_distribution_release == 'bionic' or ansible_distribution_release == 'focal'
 


### PR DESCRIPTION
This will set maximum disk space usage, free space, retention, and file age for the systemd journal. The settings have been adjusted as follows:
- SystemMaxUse: 500M
- SystemKeepFree: 1G
- MaxRetentionSec: 1month
- MaxFileSec: 1week

These changes ensure better management of disk space and retention of journal logs.


Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] Have a Site Reliability Engineer review the PR if you don't own all of the services impacted.
  - [ ] If you are adding any new default values that need to be overridden when this change goes live, update internal repos and add an entry to the top of the CHANGELOG.
  - [ ] Performed the appropriate testing.
  - [ ] Think about how this change will affect Open edX operators and update the wiki page for the next Open edX release if needed
