### PR TITLE
fix: ddtrace-run path for xqwatcher

### DIFF
--- a/playbooks/roles/xqwatcher/templates/edx/app/supervisor/conf.d/xqwatcher.conf.j2
+++ b/playbooks/roles/xqwatcher/templates/edx/app/supervisor/conf.d/xqwatcher.conf.j2
@@ -9,7 +9,7 @@
 {% set executable = xqwatcher_venv_dir + '/bin/python' %}
 {% endif %}
 {% if COMMON_ENABLE_DATADOG and COMMON_ENABLE_DATADOG_APP %}
-{% set executable = xqwatcher_venv_dir + '/ddtrace-run ' + executable %}
+{% set executable = xqwatcher_venv_dir + '/bin/ddtrace-run ' + executable %}
 {% endif -%}
 
 [program:{{ xqwatcher_service_name }}]


### PR DESCRIPTION
Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] Have a Site Reliability Engineer review the PR if you don't own all of the services impacted.
  - [ ] If you are adding any new default values that need to be overridden when this change goes live, update internal repos and add an entry to the top of the CHANGELOG.
  - [ ] Performed the appropriate testing.
  - [ ] Think about how this change will affect Open edX operators and update the wiki page for the next Open edX release if needed
