### PR TITLE
feat: stop caching prospectus app-data.json

### DIFF
--- a/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/prospectus.j2
+++ b/playbooks/roles/nginx/templates/edx/app/nginx/sites-available/prospectus.j2
@@ -120,6 +120,15 @@ server {
   {% endif %}
   }
   
+  # want to avoid caching app-data.json file as an out-of-date hash leads to the application refreshing
+  location /page-data/app-data.json {
+    port_in_redirect off;
+    add_header Cache-Control "no-store, max-age=0";
+    proxy_pass http://edx-stage-prospectus-static.s3-website-us-east-1.amazonaws.com/71058f2-5803$request_uri;
+    # Hide client headers from S3 to prevent request headers too big error
+    proxy_pass_request_headers off;
+  }
+
   # favicon is requested a lot.  cache it at the edge.
 
   location /favicon.ico {


### PR DESCRIPTION
A retry after [this revert](https://github.com/openedx/configuration/pull/7171), targeting only the specific file that needs to get updated. 

---

For [WS-4498](https://2u-internal.atlassian.net/browse/WS-4498)

This is to ensure that page-data is cleared on the user's browser between builds, preventing any reloading behavior triggered by the browser being unable to find the most recent version of page-data.

---

Make sure that the following steps are done before merging:

  - [ ] Have a Site Reliability Engineer review the PR if you don't own all of the services impacted.
  - [ ] If you are adding any new default values that need to be overridden when this change goes live, update internal repos and add an entry to the top of the CHANGELOG.
  - [ ] Performed the appropriate testing.
  - [ ] Think about how this change will affect Open edX operators and update the wiki page for the next Open edX release if needed
