### PR TITLE
feat: Set Datadog resource name to just the handler in all apps

### DIFF
--- a/playbooks/roles/ecomworker/templates/edx/app/ecomworker/ecomworker.sh.j2
+++ b/playbooks/roles/ecomworker/templates/edx/app/ecomworker/ecomworker.sh.j2
@@ -17,6 +17,7 @@ export NEW_RELIC_LICENSE_KEY='{{ NEWRELIC_LICENSE_KEY }}'
 {% if COMMON_ENABLE_DATADOG and COMMON_ENABLE_DATADOG_APP %}
 {% set executable = ecommerce_worker_venv_bin + '/ddtrace-run ' + executable %}
 export DD_TAGS="service:{{ ecommerce_worker_service_name }}"
+export DD_DJANGO_USE_LEGACY_RESOURCE_FORMAT=true
 # Copied from edx_django_service playbook for consistency; Datadog
 # trace debug logging issue doesn't actually affect edxapp for some
 # reason.

--- a/playbooks/roles/edx_django_service/templates/edx/app/app/app.sh.j2
+++ b/playbooks/roles/edx_django_service/templates/edx/app/app/app.sh.j2
@@ -23,6 +23,7 @@ export NEW_RELIC_LICENSE_KEY="{{ NEWRELIC_LICENSE_KEY }}"
 {% if COMMON_ENABLE_DATADOG and COMMON_ENABLE_DATADOG_APP %}
 {% set executable = edx_django_service_venv_bin + '/ddtrace-run ' + executable %}
 export DD_TAGS="service:{{ edx_django_service_name }}"
+export DD_DJANGO_USE_LEGACY_RESOURCE_FORMAT=true
 # Workaround for
 # https://github.com/edx/edx-arch-experiments/issues/591 (heavy
 # streams of trace-debug logs from ddtrace.)

--- a/playbooks/roles/edxapp/templates/edx/app/edxapp/cms.sh.j2
+++ b/playbooks/roles/edxapp/templates/edx/app/edxapp/cms.sh.j2
@@ -23,6 +23,7 @@ export NEW_RELIC_LICENSE_KEY="{{ NEWRELIC_LICENSE_KEY }}"
 {% if COMMON_ENABLE_DATADOG and COMMON_ENABLE_DATADOG_APP %}
 {% set executable = edxapp_venv_bin + '/ddtrace-run ' + executable %}
 export DD_TAGS="service:edxapp-cms"
+export DD_DJANGO_USE_LEGACY_RESOURCE_FORMAT=true
 # Copied from edx_django_service playbook for consistency; Datadog
 # trace debug logging issue doesn't actually affect edxapp for some
 # reason.

--- a/playbooks/roles/edxapp/templates/edx/app/edxapp/lms.sh.j2
+++ b/playbooks/roles/edxapp/templates/edx/app/edxapp/lms.sh.j2
@@ -23,6 +23,7 @@ export NEW_RELIC_LICENSE_KEY="{{ NEWRELIC_LICENSE_KEY }}"
 {% if COMMON_ENABLE_DATADOG and COMMON_ENABLE_DATADOG_APP %}
 {% set executable = edxapp_venv_bin + '/ddtrace-run ' + executable %}
 export DD_TAGS="service:edxapp-lms"
+export DD_DJANGO_USE_LEGACY_RESOURCE_FORMAT=true
 # Copied from edx_django_service playbook for consistency; Datadog
 # trace debug logging issue doesn't actually affect edxapp for some
 # reason.

--- a/playbooks/roles/forum/defaults/main.yml
+++ b/playbooks/roles/forum/defaults/main.yml
@@ -91,6 +91,7 @@ forum_base_env: &forum_base_env
   LISTEN_HOST: "{{ FORUM_LISTEN_HOST }}"
   LISTEN_PORT: "{{ FORUM_LISTEN_PORT }}"
   DD_TAGS: "{{ FORUM_DD_TAGS }}"
+  DD_DJANGO_USE_LEGACY_RESOURCE_FORMAT: "true"
   DD_TRACE_LOG_STREAM_HANDLER: "false"
 
 forum_env:

--- a/playbooks/roles/insights/templates/edx/app/insights/insights.sh.j2
+++ b/playbooks/roles/insights/templates/edx/app/insights/insights.sh.j2
@@ -17,6 +17,7 @@ export NEW_RELIC_LICENSE_KEY="{{ NEWRELIC_LICENSE_KEY }}"
 {% if COMMON_ENABLE_DATADOG and COMMON_ENABLE_DATADOG_APP %}
 {% set executable = insights_venv_bin + '/ddtrace-run ' + executable %}
 export DD_TAGS="service:{{ insights_service_name }}"
+export DD_DJANGO_USE_LEGACY_RESOURCE_FORMAT=true
 # Copied from edx_django_service playbook for consistency; Datadog
 # trace debug logging issue doesn't actually affect edxapp for some
 # reason.

--- a/playbooks/roles/xqueue/templates/xqueue.conf.j2
+++ b/playbooks/roles/xqueue/templates/xqueue.conf.j2
@@ -17,7 +17,7 @@ directory={{ xqueue_code_dir }}
 
 # Copied DD_TRACE_LOG_STREAM_HANDLER config from edx_django_service. This is required
 # to disable Datadog trace debug logging.
-environment={% if COMMON_ENABLE_NEWRELIC_APP %}NEW_RELIC_APP_NAME={{ XQUEUE_NEWRELIC_APPNAME }},NEW_RELIC_LICENSE_KEY={{ NEWRELIC_LICENSE_KEY }},{% endif -%}{% if COMMON_ENABLE_DATADOG and COMMON_ENABLE_DATADOG_APP %}DD_TAGS=service:{{ XQUEUE_DATADOG_APPNAME }},DD_TRACE_LOG_STREAM_HANDLER=false,{% endif -%}PID=/var/tmp/xqueue.pid,PORT={{ xqueue_gunicorn_port }},ADDRESS={{ xqueue_gunicorn_host }},LANG={{ XQUEUE_LANG }},DJANGO_SETTINGS_MODULE=xqueue.{{ XQUEUE_SETTINGS }},XQUEUE_CFG={{ COMMON_CFG_DIR }}/xqueue.yml
+environment={% if COMMON_ENABLE_NEWRELIC_APP %}NEW_RELIC_APP_NAME={{ XQUEUE_NEWRELIC_APPNAME }},NEW_RELIC_LICENSE_KEY={{ NEWRELIC_LICENSE_KEY }},{% endif -%}{% if COMMON_ENABLE_DATADOG and COMMON_ENABLE_DATADOG_APP %}DD_DJANGO_USE_LEGACY_RESOURCE_FORMAT=true,DD_TAGS=service:{{ XQUEUE_DATADOG_APPNAME }},DD_TRACE_LOG_STREAM_HANDLER=false,{% endif -%}PID=/var/tmp/xqueue.pid,PORT={{ xqueue_gunicorn_port }},ADDRESS={{ xqueue_gunicorn_host }},LANG={{ XQUEUE_LANG }},DJANGO_SETTINGS_MODULE=xqueue.{{ XQUEUE_SETTINGS }},XQUEUE_CFG={{ COMMON_CFG_DIR }}/xqueue.yml
 
 stdout_logfile={{ supervisor_log_dir }}/%(program_name)s-stdout.log
 stderr_logfile={{ supervisor_log_dir }}/%(program_name)s-stderr.log

--- a/playbooks/roles/xqueue/templates/xqueue_consumer.conf.j2
+++ b/playbooks/roles/xqueue/templates/xqueue_consumer.conf.j2
@@ -17,7 +17,7 @@ directory={{ xqueue_code_dir }}
 
 # Copied DD_TRACE_LOG_STREAM_HANDLER config from edx_django_service. This is required
 # to disable Datadog trace debug logging.
-environment={% if COMMON_ENABLE_NEWRELIC_APP %}NEW_RELIC_STARTUP_TIMEOUT=10,NEW_RELIC_APP_NAME={{ XQUEUE_CONSUMER_NEWRELIC_APPNAME }},NEW_RELIC_LICENSE_KEY={{ NEWRELIC_LICENSE_KEY }},{% endif -%}{% if COMMON_ENABLE_DATADOG and COMMON_ENABLE_DATADOG_APP %}DD_TAGS=service:{{ XQUEUE_CONSUMER_DATADOG_APPNAME }},DD_TRACE_LOG_STREAM_HANDLER=false,{% endif -%}LANG={{ XQUEUE_LANG }},XQUEUE_CFG={{ COMMON_CFG_DIR }}/xqueue.yml
+environment={% if COMMON_ENABLE_NEWRELIC_APP %}NEW_RELIC_STARTUP_TIMEOUT=10,NEW_RELIC_APP_NAME={{ XQUEUE_CONSUMER_NEWRELIC_APPNAME }},NEW_RELIC_LICENSE_KEY={{ NEWRELIC_LICENSE_KEY }},{% endif -%}{% if COMMON_ENABLE_DATADOG and COMMON_ENABLE_DATADOG_APP %}DD_DJANGO_USE_LEGACY_RESOURCE_FORMAT=true,DD_TAGS=service:{{ XQUEUE_CONSUMER_DATADOG_APPNAME }},DD_TRACE_LOG_STREAM_HANDLER=false,{% endif -%}LANG={{ XQUEUE_LANG }},XQUEUE_CFG={{ COMMON_CFG_DIR }}/xqueue.yml
 
 stdout_logfile={{ supervisor_log_dir }}/%(program_name)s-stdout.log
 stderr_logfile={{ supervisor_log_dir }}/%(program_name)s-stderr.log

--- a/playbooks/roles/xqwatcher/templates/edx/app/supervisor/conf.d/xqwatcher.conf.j2
+++ b/playbooks/roles/xqwatcher/templates/edx/app/supervisor/conf.d/xqwatcher.conf.j2
@@ -21,6 +21,6 @@ stdout_logfile={{ supervisor_log_dir }}/%(program_name)s-stdout.log
 stderr_logfile={{ supervisor_log_dir }}/%(program_name)s-stderr.log
 # Copied DD_TRACE_LOG_STREAM_HANDLER config from edx_django_service. This is required
 # to disable Datadog trace debug logging.
-environment={% if COMMON_ENABLE_NEWRELIC_APP %}NEW_RELIC_APP_NAME={{ XQWATCHER_NEWRELIC_APPNAME }},NEW_RELIC_LICENSE_KEY={{ NEWRELIC_LICENSE_KEY }},{% endif -%}{% if COMMON_ENABLE_DATADOG and COMMON_ENABLE_DATADOG_APP %}DD_TAGS=service:{{ XQWATCHER_DATADOG_APPNAME }},DD_TRACE_LOG_STREAM_HANDLER=false,{% endif -%}
+environment={% if COMMON_ENABLE_NEWRELIC_APP %}NEW_RELIC_APP_NAME={{ XQWATCHER_NEWRELIC_APPNAME }},NEW_RELIC_LICENSE_KEY={{ NEWRELIC_LICENSE_KEY }},{% endif -%}{% if COMMON_ENABLE_DATADOG and COMMON_ENABLE_DATADOG_APP %}DD_DJANGO_USE_LEGACY_RESOURCE_FORMAT=true,DD_TAGS=service:{{ XQWATCHER_DATADOG_APPNAME }},DD_TRACE_LOG_STREAM_HANDLER=false,{% endif -%}
 killasgroup=true
 stopasgroup=true


### PR DESCRIPTION
This switches us from method+urlpattern resource naming (e.g. `GET ^/`) to using handler (e.g. `lms.djangoapps.branding.views.index`).

This is applied to the root span as the `resource_name` tag. As method and urlpattern are available on the root span as `http.method` and `http.route` but there doesn't seem to be any other way to get the handler info, this is our only option for ensuring that the handler will be available as a tag (without having to parse after the fact or write more custom code.)

Part of https://github.com/edx/edx-arch-experiments/issues/620

Configuration Pull Request
---

Make sure that the following steps are done before merging:

  - [ ] Have a Site Reliability Engineer review the PR if you don't own all of the services impacted.
  - [x] If you are adding any new default values that need to be overridden when this change goes live, update internal repos and add an entry to the top of the CHANGELOG.
  - [x] Performed the appropriate testing.
  - [x] Think about how this change will affect Open edX operators and update the wiki page for the next Open edX release if needed
